### PR TITLE
Scaffold Select component, tokens and scss only

### DIFF
--- a/packages/css/src/select/select.scss
+++ b/packages/css/src/select/select.scss
@@ -1,0 +1,9 @@
+@import "../../node_modules/@amsterdam/design-system-tokens/dist/variables";
+@import "../../node_modules/@utrecht/components/select/css/mixin";
+@import "../../node_modules/@utrecht/components/select/css";
+
+// Override rules because they are static in @utrecht/component-library-react
+.utrecht-select {
+  background-position: var(--utrecht-select-background-position);
+  background-size: var(--utrecht-select-background-size);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,6 +343,9 @@ importers:
       '@types/react-dom':
         specifier: 18.2.4
         version: 18.2.4
+      '@utrecht/component-library-react':
+        specifier: 1.0.0-alpha.319
+        version: 1.0.0-alpha.319(react-dom@18.2.0)(react@18.2.0)
       '@vitejs/plugin-react':
         specifier: 4.0.0
         version: 4.0.0(vite@4.3.8)
@@ -439,6 +442,9 @@ importers:
       '@types/react':
         specifier: 18.2.6
         version: 18.2.6
+      '@utrecht/component-library-react':
+        specifier: 1.0.0-alpha.319
+        version: 1.0.0-alpha.319(react-dom@18.2.0)(react@18.2.0)
       '@vitejs/plugin-react':
         specifier: 4.0.0
         version: 4.0.0(vite@4.3.8)
@@ -5146,7 +5152,6 @@ packages:
       lodash.chunk: 4.2.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /@utrecht/components@1.0.0-alpha.471:
     resolution: {integrity: sha512-evG0EQAHux7tMAPNtwDrmFlPilVkyNdLodp1bJdS8+mNp76hK7ySLyxLIrtvxddgDNQKte0frrzxEUESvrMcdg==}
@@ -10509,7 +10514,6 @@ packages:
 
   /lodash.chunk@4.2.0:
     resolution: {integrity: sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==}
-    dev: false
 
   /lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}

--- a/proprietary/tokens/src/components/utrecht/select.tokens.json
+++ b/proprietary/tokens/src/components/utrecht/select.tokens.json
@@ -1,0 +1,39 @@
+{
+  "utrecht": {
+    "select": {
+      "background-color": { "value": "{amsterdam.color.primary-white}" },
+      "background-image": {
+        "value": "url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMTUiIHZpZXdCb3g9IjAgMCAyNCAxNSIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xMiAxNC4zMTc0TDAgMi4zMTczOUwyLjE4MjUyIDAuMTQyNTc4TDEyIDkuOTUyMzVMMjEuODE3NSAwLjE0MjU3OEwyNCAyLjMxNzM5TDEyIDE0LjMxNzRaIiBmaWxsPSJjdXJyZW50Q29sb3IiLz4KPC9zdmc+Cg==')"
+      },
+      "background-position": { "value": "right 23px center" },
+      "background-size": { "value": "24px 15px" },
+      "border-bottom-width": {},
+      "border-color": { "value": "{amsterdam.color.primary-black}" },
+      "border-radius": { "value": "0" },
+      "border-width": { "value": "1px" },
+      "color": { "value": "{amsterdam.color.primary-black}" },
+      "font-family": { "value": "{amsterdam.typography.font-family}" },
+      "font-size": {},
+      "max-inline-size": {},
+      "padding-block-end": { "value": "14px" },
+      "padding-block-start": { "value": "15px" },
+      "padding-inline-end": { "value": "28px" },
+      "padding-inline-start": { "value": "28px" },
+      "disabled": {
+        "background-color": {},
+        "border-color": { "value": "{amsterdam.color.neutral-grey2}" },
+        "color": { "value": "{amsterdam.color.neutral-grey2}" }
+      },
+      "focus": {
+        "background-color": {},
+        "border-color": { "value": "{amsterdam.color.primary-blue}" },
+        "color": {}
+      },
+      "invalid": {
+        "background-color": {},
+        "border-color": { "value": "{amsterdam.color.primary-red}" },
+        "border-width": {}
+      }
+    }
+  }
+}

--- a/storybook/storybook-css/package.json
+++ b/storybook/storybook-css/package.json
@@ -40,6 +40,7 @@
     "@storybook/testing-library": "0.1.0",
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",
+    "@utrecht/component-library-react": "1.0.0-alpha.319",
     "@vitejs/plugin-react": "4.0.0",
     "clsx": "1.2.1",
     "react": "18.2.0",

--- a/storybook/storybook-css/src/components/Select/Select.stories.tsx
+++ b/storybook/storybook-css/src/components/Select/Select.stories.tsx
@@ -23,7 +23,7 @@ const options: SelectOptions[] = [
 ]
 
 const meta = {
-  title: 'Select',
+  title: 'CSS Components/Select',
   id: 'select',
   component: Select,
   argTypes: {
@@ -84,6 +84,21 @@ export default meta
 
 export const Default: StoryObj<typeof Select> = {
   name: 'Default',
+  parameters: {
+    docs: {
+      source: {
+        language: 'html',
+        code: `
+<select class="utrecht-select utrecht-select--html-select">
+  <option disabled="" value="" class="utrecht-select__option utrecht-select__option--disabled">Select an option</option>
+  <option value="1" class="utrecht-select__option">Option #1</option>
+  <option value="2" class="utrecht-select__option">Option #2</option>
+  <option value="3" class="utrecht-select__option">Option #3</option>
+  <option value="4" class="utrecht-select__option">Option #4</option>
+</select>`,
+      },
+    },
+  },
 }
 
 export const Disabled: StoryObj<typeof Select> = {
@@ -91,11 +106,41 @@ export const Disabled: StoryObj<typeof Select> = {
   args: {
     disabled: true,
   },
+  parameters: {
+    docs: {
+      source: {
+        language: 'html',
+        code: `
+<select disabled class="utrecht-select utrecht-select--html-select">
+  <option disabled="" value="" class="utrecht-select__option utrecht-select__option--disabled">Select an option</option>
+  <option value="1" class="utrecht-select__option">Option #1</option>
+  <option value="2" class="utrecht-select__option">Option #2</option>
+  <option value="3" class="utrecht-select__option">Option #3</option>
+  <option value="4" class="utrecht-select__option">Option #4</option>
+</select>`,
+      },
+    },
+  },
 }
 
 export const Invalid: StoryObj<typeof Select> = {
   name: 'Invalid',
   args: {
     invalid: true,
+  },
+  parameters: {
+    docs: {
+      source: {
+        language: 'html',
+        code: `
+<select aria-invalid="true" class="utrecht-select utrecht-select--html-select utrecht-select--invalid">
+  <option disabled="" value="" class="utrecht-select__option utrecht-select__option--disabled">Select an option</option>
+  <option value="1" class="utrecht-select__option">Option #1</option>
+  <option value="2" class="utrecht-select__option">Option #2</option>
+  <option value="3" class="utrecht-select__option">Option #3</option>
+  <option value="4" class="utrecht-select__option">Option #4</option>
+</select>`,
+      },
+    },
   },
 }

--- a/storybook/storybook-react/package.json
+++ b/storybook/storybook-react/package.json
@@ -43,6 +43,7 @@
     "@storybook/react-vite": "7.0.12",
     "@storybook/testing-library": "0.1.0",
     "@types/react": "18.2.6",
+    "@utrecht/component-library-react": "1.0.0-alpha.319",
     "@vitejs/plugin-react": "4.0.0",
     "date-fns": "2.30.0",
     "http-server": "14.1.1",

--- a/storybook/storybook-react/src/components/Select/Select.stories.tsx
+++ b/storybook/storybook-react/src/components/Select/Select.stories.tsx
@@ -1,0 +1,103 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright (c) 2023 Gemeente Amsterdam
+ */
+
+// import { Link } from '@amsterdam/design-system-react/src'
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { Select, SelectOption } from '@utrecht/component-library-react'
+
+import '@amsterdam/design-system-css/src/select/select.scss'
+
+interface SelectOptions {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+const options: SelectOptions[] = [
+  { value: '', label: 'Select an option', disabled: true },
+  { value: '1', label: 'Option #1' },
+  { value: '2', label: 'Option #2' },
+  { value: '3', label: 'Option #3' },
+  { value: '4', label: 'Option #4' },
+]
+
+const meta = {
+  title: 'Select',
+  id: 'select',
+  component: Select,
+  argTypes: {
+    disabled: {
+      name: 'disabled',
+      type: { name: 'boolean', required: false },
+      table: {
+        category: 'HTML attribute',
+        defaultValue: { summary: false },
+      },
+    },
+    invalid: {
+      name: 'invalid',
+      type: { name: 'boolean', required: false },
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
+    required: {
+      name: 'required',
+      type: { name: 'boolean', required: false },
+      table: {
+        category: 'HTML attribute',
+        defaultValue: { summary: false },
+      },
+    },
+    noscript: {
+      name: 'noscript',
+      type: { name: 'boolean', required: false },
+      table: {
+        category: 'HTML attribute',
+        defaultValue: { summary: false },
+      },
+    },
+    value: {
+      name: 'value',
+      type: { name: 'string' },
+      table: {
+        category: 'HTML attribute',
+        defaultValue: { summary: '' },
+      },
+    },
+  },
+  render: ({ ...args }) => (
+    <Select {...args}>
+      {options &&
+        options.length > 0 &&
+        options.map(({ label, value, disabled }, index) => (
+          <SelectOption key={index} value={value} disabled={disabled}>
+            {label}
+          </SelectOption>
+        ))}
+    </Select>
+  ),
+} satisfies Meta<typeof Select>
+
+export default meta
+
+export const Default: StoryObj<typeof Select> = {
+  name: 'Default',
+}
+
+export const Disabled: StoryObj<typeof Select> = {
+  name: 'Disabled',
+  args: {
+    disabled: true,
+  },
+}
+
+export const Invalid: StoryObj<typeof Select> = {
+  name: 'Invalid',
+  args: {
+    invalid: true,
+  },
+}


### PR DESCRIPTION
As discussed we can init a NLDS component pretty quick using only the story, tokens and scss override we would need. Doing this allows the design to quickly view the tokens and results of the barebones NLDS component.