### PR TITLE
Specify code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@Amsterdam/design-system-maintainers


### PR DESCRIPTION
This should automatically assign Aram and me as reviewers of each new PR.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners