### PR TITLE
Add toptask link

### DIFF
--- a/packages/css/src/top-task-link/README.md
+++ b/packages/css/src/top-task-link/README.md
@@ -1,0 +1,1 @@
+# Top task link

--- a/packages/css/src/top-task-link/README.md
+++ b/packages/css/src/top-task-link/README.md
@@ -1,1 +1,15 @@
 # Top task link
+
+De toptask link is een navigatie-element dat opvallender is dan een link, om de aandacht te trekken voor de meest belangrijke informatie.
+Zet de toptask link in zodat de gebruiker snel de juiste informatie vindt én een bijbehorende taak makkelijk kan uitvoeren.
+
+## Richtlijnen
+
+<!-- TODO: moet er een max van 2 regels in het component worden ingebouwd voor title en description? -->
+
+- Een toptask link moet een titel hebben. Hou deze titel zo kort mogelijk, hij mag maximaal over 2 regels lopen.
+- Een toptask link kan een omschrijving hebben, maar dat is niet verplicht. De omschrijving staat onder de titel en is ook maximaal 2 regels.
+
+## Relevante WCAG eisen
+
+Voor de toptask link gelden dezelfde eisen als voor [reguliere links](/docs/link--docs).

--- a/packages/css/src/top-task-link/README.md
+++ b/packages/css/src/top-task-link/README.md
@@ -5,8 +5,6 @@ Zet de toptask link in zodat de gebruiker snel de juiste informatie vindt én ee
 
 ## Richtlijnen
 
-<!-- TODO: moet er een max van 2 regels in het component worden ingebouwd voor title en description? -->
-
 - Een toptask link moet een titel hebben. Hou deze titel zo kort mogelijk, hij mag maximaal over 2 regels lopen.
 - Een toptask link kan een omschrijving hebben, maar dat is niet verplicht. De omschrijving staat onder de titel en is ook maximaal 2 regels.
 

--- a/packages/css/src/top-task-link/README.md
+++ b/packages/css/src/top-task-link/README.md
@@ -10,4 +10,4 @@ Zet de toptask link in zodat de gebruiker snel de juiste informatie vindt én ee
 
 ## Relevante WCAG eisen
 
-Voor de toptask link gelden dezelfde eisen als voor [reguliere links](/docs/link--docs).
+Voor de toptask link gelden dezelfde eisen als voor [reguliere links](https://amsterdam.github.io/design-system/?path=/docs/react_link--docs).

--- a/packages/css/src/top-task-link/top-task-link.scss
+++ b/packages/css/src/top-task-link/top-task-link.scss
@@ -24,12 +24,12 @@
 .amsterdam-top-task-link__title {
   color: var(--amsterdam-top-task-link-title-color);
   font-family: var(--amsterdam-top-task-link-title-font-family);
-  font-size: var(--amsterdam-top-task-link-title-font-size-narrow);
+  font-size: var(--amsterdam-top-task-link-title-narrow-font-size);
   font-weight: var(--amsterdam-top-task-link-title-font-weight);
   line-height: var(--amsterdam-top-task-link-title-line-height);
 
   @media screen and (width > $amsterdam-breakpoint) {
-    font-size: var(--amsterdam-top-task-link-title-font-size-wide);
+    font-size: var(--amsterdam-top-task-link-title-wide-font-size);
   }
 
   @include reset;

--- a/packages/css/src/top-task-link/top-task-link.scss
+++ b/packages/css/src/top-task-link/top-task-link.scss
@@ -1,0 +1,44 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright (c) 2023 Gemeente Amsterdam
+ */
+
+@import "../../utils/breakpoint";
+
+@mixin reset {
+  box-sizing: border-box;
+  break-after: avoid;
+  break-inside: avoid;
+  margin-block: 0;
+  margin-inline: 0;
+}
+
+.amsterdam-top-task-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  outline-offset: var(--amsterdam-top-task-link-outline-offset);
+  text-decoration: none;
+}
+
+.amsterdam-top-task-link__title {
+  color: var(--amsterdam-top-task-link-title-color);
+  font-family: var(--amsterdam-top-task-link-title-font-family);
+  font-size: var(--amsterdam-top-task-link-title-font-size-narrow);
+  font-weight: var(--amsterdam-top-task-link-title-font-weight);
+  line-height: var(--amsterdam-top-task-link-title-line-height);
+
+  @media screen and (width > $amsterdam-breakpoint) {
+    font-size: var(--amsterdam-top-task-link-title-font-size-wide);
+  }
+
+  @include reset;
+}
+
+.amsterdam-top-task-link:hover .amsterdam-top-task-link__title,
+.amsterdam-top-task-link:focus .amsterdam-top-task-link__title {
+  color: var(--amsterdam-top-task-link-title-focus-color);
+  text-decoration: underline;
+  text-decoration-thickness: 3px;
+  text-underline-offset: 0.5rem;
+}

--- a/packages/css/src/top-task-link/top-task-link.scss
+++ b/packages/css/src/top-task-link/top-task-link.scss
@@ -7,13 +7,10 @@
 
 @mixin reset {
   box-sizing: border-box;
-  break-after: avoid;
-  break-inside: avoid;
-  margin-block: 0;
-  margin-inline: 0;
 }
 
 .amsterdam-top-task-link {
+  break-inside: avoid;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;

--- a/packages/css/src/top-task-link/top-task-link.scss
+++ b/packages/css/src/top-task-link/top-task-link.scss
@@ -18,23 +18,23 @@
   text-decoration: none;
 }
 
-.amsterdam-top-task-link__title {
-  color: var(--amsterdam-top-task-link-title-color);
-  font-family: var(--amsterdam-top-task-link-title-font-family);
-  font-size: var(--amsterdam-top-task-link-title-narrow-font-size);
-  font-weight: var(--amsterdam-top-task-link-title-font-weight);
-  line-height: var(--amsterdam-top-task-link-title-line-height);
+.amsterdam-top-task-link__label {
+  color: var(--amsterdam-top-task-link-label-color);
+  font-family: var(--amsterdam-top-task-link-label-font-family);
+  font-size: var(--amsterdam-top-task-link-label-narrow-font-size);
+  font-weight: var(--amsterdam-top-task-link-label-font-weight);
+  line-height: var(--amsterdam-top-task-link-label-line-height);
 
   @media screen and (width > $amsterdam-breakpoint) {
-    font-size: var(--amsterdam-top-task-link-title-wide-font-size);
+    font-size: var(--amsterdam-top-task-link-label-wide-font-size);
   }
 
   @include reset;
 }
 
-.amsterdam-top-task-link:hover .amsterdam-top-task-link__title,
-.amsterdam-top-task-link:focus .amsterdam-top-task-link__title {
-  color: var(--amsterdam-top-task-link-title-focus-color);
+.amsterdam-top-task-link:hover .amsterdam-top-task-link__label,
+.amsterdam-top-task-link:focus .amsterdam-top-task-link__label {
+  color: var(--amsterdam-top-task-link-label-focus-color);
   text-decoration: underline;
   text-decoration-thickness: 3px;
   text-underline-offset: 0.5rem;

--- a/packages/css/src/top-task-link/top-task-link.scss
+++ b/packages/css/src/top-task-link/top-task-link.scss
@@ -5,10 +5,6 @@
 
 @import "../../utils/breakpoint";
 
-@mixin reset {
-  box-sizing: border-box;
-}
-
 .amsterdam-top-task-link {
   break-inside: avoid;
   display: flex;
@@ -16,6 +12,11 @@
   gap: 0.5rem;
   outline-offset: var(--amsterdam-top-task-link-outline-offset);
   text-decoration: none;
+}
+
+@mixin reset {
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
 }
 
 .amsterdam-top-task-link__label {
@@ -32,10 +33,23 @@
   @include reset;
 }
 
-.amsterdam-top-task-link:hover .amsterdam-top-task-link__label,
-.amsterdam-top-task-link:focus .amsterdam-top-task-link__label {
-  color: var(--amsterdam-top-task-link-label-focus-color);
+.amsterdam-top-task-link:hover .amsterdam-top-task-link__label {
+  color: var(--amsterdam-top-task-link-label-hover-color);
   text-decoration: underline;
   text-decoration-thickness: 3px;
   text-underline-offset: 0.5rem;
+}
+
+.amsterdam-top-task-link__description {
+  color: var(--amsterdam-top-task-link-description-color);
+  font-family: var(--amsterdam-top-task-link-description-font-family);
+  font-size: var(--amsterdam-top-task-link-description-narrow-font-size);
+  font-weight: var(--amsterdam-top-task-link-description-font-weight);
+  line-height: var(--amsterdam-top-task-link-description-line-height);
+
+  @media screen and (width > $amsterdam-breakpoint) {
+    font-size: var(--amsterdam-top-task-link-description-wide-font-size);
+  }
+
+  @include reset;
 }

--- a/packages/react/src/TopTaskLink/README.md
+++ b/packages/react/src/TopTaskLink/README.md
@@ -1,0 +1,3 @@
+# React Top task link component
+
+[Top task link documentation](../../../css/src/top-task-link/README.md)

--- a/packages/react/src/TopTaskLink/TopTaskLink.test.tsx
+++ b/packages/react/src/TopTaskLink/TopTaskLink.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { TopTaskLink } from './TopTaskLink'
+import '@testing-library/jest-dom'
+
+describe('Top task link', () => {
+  it('renders a link role element', () => {
+    render(<TopTaskLink href="/" />)
+
+    const link = screen.getByRole('link')
+
+    expect(link).toBeInTheDocument()
+    expect(link).toBeVisible()
+  })
+
+  it('renders a design system BEM class name', () => {
+    const linkRender = render(<TopTaskLink href="/" />)
+    const { container: linkTitleRender } = render(<TopTaskLink.Title />)
+    const { container: linkDescriptionRender } = render(<TopTaskLink.Description />)
+
+    const link = linkRender.getByRole('link')
+    const linkTitle = linkTitleRender.querySelector(':only-child')
+    const linkDescription = linkDescriptionRender.querySelector('p:only-child')
+
+    expect(link).toHaveClass('amsterdam-top-task-link')
+    expect(linkTitle).toHaveClass('amsterdam-top-task-link__title')
+    expect(linkDescription).toHaveClass('amsterdam-top-task-link__description')
+  })
+
+  it('can have a custom class name', () => {
+    const linkRender = render(<TopTaskLink href="/" className="extra" />)
+    const { container: linkTitleRender } = render(<TopTaskLink.Title className="extra" />)
+    const { container: linkDescriptionRender } = render(<TopTaskLink.Description className="extra" />)
+
+    const link = linkRender.getByRole('link')
+    const linkTitle = linkTitleRender.querySelector(':only-child')
+    const linkDescription = linkDescriptionRender.querySelector('p:only-child')
+
+    expect(link).toHaveClass('extra')
+    expect(linkTitle).toHaveClass('extra')
+    expect(linkDescription).toHaveClass('extra')
+  })
+
+  it('can have a additional class name', () => {
+    const linkRender = render(<TopTaskLink href="/" className="extra" />)
+    const { container: linkTitleRender } = render(<TopTaskLink.Title className="extra" />)
+    const { container: linkDescriptionRender } = render(<TopTaskLink.Description className="extra" />)
+
+    const link = linkRender.getByRole('link')
+    const linkTitle = linkTitleRender.querySelector(':only-child')
+    const linkDescription = linkDescriptionRender.querySelector('p:only-child')
+
+    expect(link).toHaveClass('extra')
+    expect(linkTitle).toHaveClass('extra')
+    expect(linkDescription).toHaveClass('extra')
+
+    expect(link).toHaveClass('amsterdam-top-task-link')
+    expect(linkTitle).toHaveClass('amsterdam-top-task-link__title')
+    expect(linkDescription).toHaveClass('amsterdam-top-task-link__description')
+  })
+
+  it('supports ForwardRef in React', () => {
+    const linkRef = createRef<HTMLAnchorElement>()
+    const linkTitleRef = createRef<HTMLElement>()
+    const linkDescriptionRef = createRef<HTMLParagraphElement>()
+
+    const linkRender = render(<TopTaskLink href="/" ref={linkRef} />)
+    const { container: linkTitleRender } = render(<TopTaskLink.Title ref={linkTitleRef} />)
+    const { container: linkDescriptionRender } = render(<TopTaskLink.Description ref={linkDescriptionRef} />)
+
+    const link = linkRender.getByRole('link')
+    const linkTitle = linkTitleRender.querySelector(':only-child')
+    const linkDescription = linkDescriptionRender.querySelector('p:only-child')
+
+    expect(linkRef.current).toBe(link)
+    expect(linkTitleRef.current).toBe(linkTitle)
+    expect(linkDescriptionRef.current).toBe(linkDescription)
+  })
+})

--- a/packages/react/src/TopTaskLink/TopTaskLink.test.tsx
+++ b/packages/react/src/TopTaskLink/TopTaskLink.test.tsx
@@ -5,75 +5,50 @@ import '@testing-library/jest-dom'
 
 describe('Top task link', () => {
   it('renders a link role element', () => {
-    render(<TopTaskLink href="/" />)
+    render(<TopTaskLink label="Label" href="/" />)
 
-    const link = screen.getByRole('link')
+    const link = screen.getByRole('link', {
+      name: 'Label',
+    })
 
     expect(link).toBeInTheDocument()
     expect(link).toBeVisible()
   })
 
   it('renders a design system BEM class name', () => {
-    const linkRender = render(<TopTaskLink href="/" />)
-    const { container: linkTitleRender } = render(<TopTaskLink.Title />)
-    const { container: linkDescriptionRender } = render(<TopTaskLink.Description />)
+    render(<TopTaskLink label="Label" description="Description" href="/" />)
 
-    const link = linkRender.getByRole('link')
-    const linkTitle = linkTitleRender.querySelector(':only-child')
-    const linkDescription = linkDescriptionRender.querySelector('p:only-child')
+    const link = screen.getByRole('link', {
+      name: 'Label, Description',
+    })
+    const label = screen.getByText('Label')
+    const description = screen.getByText('Description')
 
     expect(link).toHaveClass('amsterdam-top-task-link')
-    expect(linkTitle).toHaveClass('amsterdam-top-task-link__title')
-    expect(linkDescription).toHaveClass('amsterdam-top-task-link__description')
-  })
-
-  it('can have a custom class name', () => {
-    const linkRender = render(<TopTaskLink href="/" className="extra" />)
-    const { container: linkTitleRender } = render(<TopTaskLink.Title className="extra" />)
-    const { container: linkDescriptionRender } = render(<TopTaskLink.Description className="extra" />)
-
-    const link = linkRender.getByRole('link')
-    const linkTitle = linkTitleRender.querySelector(':only-child')
-    const linkDescription = linkDescriptionRender.querySelector('p:only-child')
-
-    expect(link).toHaveClass('extra')
-    expect(linkTitle).toHaveClass('extra')
-    expect(linkDescription).toHaveClass('extra')
+    expect(label).toHaveClass('amsterdam-top-task-link__label')
+    expect(description).toHaveClass('amsterdam-top-task-link__description')
   })
 
   it('can have a additional class name', () => {
-    const linkRender = render(<TopTaskLink href="/" className="extra" />)
-    const { container: linkTitleRender } = render(<TopTaskLink.Title className="extra" />)
-    const { container: linkDescriptionRender } = render(<TopTaskLink.Description className="extra" />)
+    render(<TopTaskLink href="/" label="Label" className="extra" />)
 
-    const link = linkRender.getByRole('link')
-    const linkTitle = linkTitleRender.querySelector(':only-child')
-    const linkDescription = linkDescriptionRender.querySelector('p:only-child')
+    const link = screen.getByRole('link', {
+      name: 'Label',
+    })
 
     expect(link).toHaveClass('extra')
-    expect(linkTitle).toHaveClass('extra')
-    expect(linkDescription).toHaveClass('extra')
-
     expect(link).toHaveClass('amsterdam-top-task-link')
-    expect(linkTitle).toHaveClass('amsterdam-top-task-link__title')
-    expect(linkDescription).toHaveClass('amsterdam-top-task-link__description')
   })
 
   it('supports ForwardRef in React', () => {
-    const linkRef = createRef<HTMLAnchorElement>()
-    const linkTitleRef = createRef<HTMLElement>()
-    const linkDescriptionRef = createRef<HTMLParagraphElement>()
+    const ref = createRef<HTMLAnchorElement>()
 
-    const linkRender = render(<TopTaskLink href="/" ref={linkRef} />)
-    const { container: linkTitleRender } = render(<TopTaskLink.Title ref={linkTitleRef} />)
-    const { container: linkDescriptionRender } = render(<TopTaskLink.Description ref={linkDescriptionRef} />)
+    render(<TopTaskLink href="/" ref={ref} label="Label" />)
 
-    const link = linkRender.getByRole('link')
-    const linkTitle = linkTitleRender.querySelector(':only-child')
-    const linkDescription = linkDescriptionRender.querySelector('p:only-child')
+    const link = screen.getByRole('link', {
+      name: 'Label',
+    })
 
-    expect(linkRef.current).toBe(link)
-    expect(linkTitleRef.current).toBe(linkTitle)
-    expect(linkDescriptionRef.current).toBe(linkDescription)
+    expect(ref.current).toBe(link)
   })
 })

--- a/packages/react/src/TopTaskLink/TopTaskLink.tsx
+++ b/packages/react/src/TopTaskLink/TopTaskLink.tsx
@@ -1,0 +1,73 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright (c) 2023 Gemeente Amsterdam
+ */
+
+import clsx from 'clsx'
+import {
+  AnchorHTMLAttributes,
+  ForwardedRef,
+  forwardRef,
+  ForwardRefExoticComponent,
+  HTMLAttributes,
+  PropsWithChildren,
+  RefAttributes,
+} from 'react'
+import { Paragraph } from '../Paragraph'
+
+export const TopTaskLinkTitle = forwardRef(
+  (
+    { children, className, ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>,
+    ref: ForwardedRef<HTMLElement>,
+  ) => (
+    <span {...restProps} ref={ref} className={clsx('amsterdam-top-task-link__title', className)}>
+      {children}
+    </span>
+  ),
+)
+
+TopTaskLinkTitle.displayName = 'TopTaskLinkTitle'
+
+export const TopTaskLinkDescription = forwardRef(
+  (
+    { children, className, ...restProps }: PropsWithChildren<HTMLAttributes<HTMLParagraphElement>>,
+    ref: ForwardedRef<HTMLParagraphElement>,
+  ) => (
+    <Paragraph
+      {...restProps}
+      size="small"
+      ref={ref}
+      className={clsx('amsterdam-top-task-link__description', className)}
+    >
+      {children}
+    </Paragraph>
+  ),
+)
+
+TopTaskLinkDescription.displayName = 'TopTaskLinkDescription'
+
+interface TopTaskLinkComponent
+  extends ForwardRefExoticComponent<
+    PropsWithChildren<AnchorHTMLAttributes<HTMLAnchorElement>> & RefAttributes<HTMLAnchorElement>
+  > {
+  Title: typeof TopTaskLinkTitle
+  Description: typeof TopTaskLinkDescription
+}
+
+export const TopTaskLink = forwardRef(
+  (
+    { children, className, ...restProps }: PropsWithChildren<AnchorHTMLAttributes<HTMLAnchorElement>>,
+    ref: ForwardedRef<HTMLAnchorElement>,
+  ) => (
+    <a {...restProps} ref={ref} className={clsx('amsterdam-top-task-link', className)}>
+      {children}
+    </a>
+  ),
+) as TopTaskLinkComponent
+
+TopTaskLink.Title = TopTaskLinkTitle
+TopTaskLink.Description = TopTaskLinkDescription
+
+TopTaskLink.displayName = 'TopTaskLink'
+TopTaskLink.Title.displayName = 'TopTaskLink.Title'
+TopTaskLink.Description.displayName = 'TopTaskLink.Description'

--- a/packages/react/src/TopTaskLink/TopTaskLink.tsx
+++ b/packages/react/src/TopTaskLink/TopTaskLink.tsx
@@ -18,7 +18,7 @@ export const TopTaskLink = forwardRef(
       ref={ref}
       className={clsx('amsterdam-top-task-link', className)}
       // Add an aria-label with a comma between label and description, so screenreaders have a slight pause between the two.
-      aria-label={`${label}, ${description}`}
+      aria-label={`${label}${description ? `, ${description}` : ''}`}
     >
       <span className="amsterdam-top-task-link__label">{label}</span>
       {description && <span className="amsterdam-top-task-link__description">{description}</span>}

--- a/packages/react/src/TopTaskLink/TopTaskLink.tsx
+++ b/packages/react/src/TopTaskLink/TopTaskLink.tsx
@@ -13,7 +13,13 @@ export interface TopTaskLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement
 
 export const TopTaskLink = forwardRef(
   ({ className, label, description, ...restProps }: TopTaskLinkProps, ref: ForwardedRef<HTMLAnchorElement>) => (
-    <a {...restProps} ref={ref} className={clsx('amsterdam-top-task-link', className)}>
+    <a
+      {...restProps}
+      ref={ref}
+      className={clsx('amsterdam-top-task-link', className)}
+      // Add an aria-label with a comma between label and description, so screenreaders have a slight pause between the two.
+      aria-label={`${label}, ${description}`}
+    >
       <span className="amsterdam-top-task-link__label">{label}</span>
       {description && <span className="amsterdam-top-task-link__description">{description}</span>}
     </a>

--- a/packages/react/src/TopTaskLink/TopTaskLink.tsx
+++ b/packages/react/src/TopTaskLink/TopTaskLink.tsx
@@ -4,70 +4,20 @@
  */
 
 import clsx from 'clsx'
-import {
-  AnchorHTMLAttributes,
-  ForwardedRef,
-  forwardRef,
-  ForwardRefExoticComponent,
-  HTMLAttributes,
-  PropsWithChildren,
-  RefAttributes,
-} from 'react'
-import { Paragraph } from '../Paragraph'
+import { AnchorHTMLAttributes, ForwardedRef, forwardRef } from 'react'
 
-export const TopTaskLinkTitle = forwardRef(
-  (
-    { children, className, ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>,
-    ref: ForwardedRef<HTMLElement>,
-  ) => (
-    <span {...restProps} ref={ref} className={clsx('amsterdam-top-task-link__title', className)}>
-      {children}
-    </span>
-  ),
-)
-
-TopTaskLinkTitle.displayName = 'TopTaskLinkTitle'
-
-export const TopTaskLinkDescription = forwardRef(
-  (
-    { children, className, ...restProps }: PropsWithChildren<HTMLAttributes<HTMLParagraphElement>>,
-    ref: ForwardedRef<HTMLParagraphElement>,
-  ) => (
-    <Paragraph
-      {...restProps}
-      size="small"
-      ref={ref}
-      className={clsx('amsterdam-top-task-link__description', className)}
-    >
-      {children}
-    </Paragraph>
-  ),
-)
-
-TopTaskLinkDescription.displayName = 'TopTaskLinkDescription'
-
-interface TopTaskLinkComponent
-  extends ForwardRefExoticComponent<
-    PropsWithChildren<AnchorHTMLAttributes<HTMLAnchorElement>> & RefAttributes<HTMLAnchorElement>
-  > {
-  Title: typeof TopTaskLinkTitle
-  Description: typeof TopTaskLinkDescription
+export interface TopTaskLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  label: string
+  description?: string
 }
 
 export const TopTaskLink = forwardRef(
-  (
-    { children, className, ...restProps }: PropsWithChildren<AnchorHTMLAttributes<HTMLAnchorElement>>,
-    ref: ForwardedRef<HTMLAnchorElement>,
-  ) => (
+  ({ className, label, description, ...restProps }: TopTaskLinkProps, ref: ForwardedRef<HTMLAnchorElement>) => (
     <a {...restProps} ref={ref} className={clsx('amsterdam-top-task-link', className)}>
-      {children}
+      <span className="amsterdam-top-task-link__label">{label}</span>
+      {description && <span className="amsterdam-top-task-link__description">{description}</span>}
     </a>
   ),
-) as TopTaskLinkComponent
-
-TopTaskLink.Title = TopTaskLinkTitle
-TopTaskLink.Description = TopTaskLinkDescription
+)
 
 TopTaskLink.displayName = 'TopTaskLink'
-TopTaskLink.Title.displayName = 'TopTaskLink.Title'
-TopTaskLink.Description.displayName = 'TopTaskLink.Description'

--- a/packages/react/src/TopTaskLink/index.ts
+++ b/packages/react/src/TopTaskLink/index.ts
@@ -1,0 +1,1 @@
+export { TopTaskLink } from './TopTaskLink'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 /* Append here */
+import '../../css/src/top-task-link/top-task-link.scss'
 import '../../css/src/ordered-list/ordered-list.scss'
 import '../../css/src/accordion/accordion.scss'
 import '../../css/src/breadcrumb/breadcrumb.scss'

--- a/packages/react/src/unstyled/index.ts
+++ b/packages/react/src/unstyled/index.ts
@@ -4,6 +4,7 @@
  */
 
 /* Append here */
+export * from '../TopTaskLink'
 export * from '../OrderedList'
 export * from '../Heading'
 export * from '../Breadcrumb'

--- a/proprietary/tokens/src/components/amsterdam/top-task-link.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/top-task-link.tokens.json
@@ -1,0 +1,20 @@
+{
+  "amsterdam": {
+    "top-task-link": {
+      "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
+      "title": {
+        "color": { "value": "{amsterdam.color.primary-blue}" },
+        "font-family": { "value": "{amsterdam.typography.font-family}" },
+        "font-weight": { "value": "{amsterdam.typography.font-weight.bold}" },
+        "focus": {
+          "color": { "value": "{amsterdam.color.dark-blue}" }
+        },
+        "font-size": {
+          "narrow": { "value": "{amsterdam.typography.text-level.4.font-size.narrow}" },
+          "wide": { "value": "{amsterdam.typography.text-level.4.font-size.wide}" }
+        },
+        "line-height": { "value": "{amsterdam.typography.text-level.4.line-height}" }
+      }
+    }
+  }
+}

--- a/proprietary/tokens/src/components/amsterdam/top-task-link.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/top-task-link.tokens.json
@@ -9,11 +9,13 @@
         "focus": {
           "color": { "value": "{amsterdam.color.dark-blue}" }
         },
-        "font-size": {
-          "narrow": { "value": "{amsterdam.typography.text-level.4.font-size.narrow}" },
-          "wide": { "value": "{amsterdam.typography.text-level.4.font-size.wide}" }
+        "line-height": { "value": "{amsterdam.typography.text-level.4.line-height}" },
+        "narrow": {
+          "font-size": { "value": "{amsterdam.typography.text-level.4.narrow.font-size}" }
         },
-        "line-height": { "value": "{amsterdam.typography.text-level.4.line-height}" }
+        "wide": {
+          "font-size": { "value": "{amsterdam.typography.text-level.4.wide.font-size}" }
+        }
       }
     }
   }

--- a/proprietary/tokens/src/components/amsterdam/top-task-link.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/top-task-link.tokens.json
@@ -1,12 +1,23 @@
 {
   "amsterdam": {
     "top-task-link": {
-      "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
+      "description": {
+        "color": { "value": "{amsterdam.color.primary-black}" },
+        "font-family": { "value": "{amsterdam.typography.font-family}" },
+        "font-weight": { "value": "{amsterdam.typography.font-weight.normal}" },
+        "line-height": { "value": "{amsterdam.typography.text-level.7.line-height}" },
+        "narrow": {
+          "font-size": { "value": "{amsterdam.typography.text-level.7.narrow.font-size}" }
+        },
+        "wide": {
+          "font-size": { "value": "{amsterdam.typography.text-level.7.wide.font-size}" }
+        }
+      },
       "label": {
         "color": { "value": "{amsterdam.color.primary-blue}" },
         "font-family": { "value": "{amsterdam.typography.font-family}" },
         "font-weight": { "value": "{amsterdam.typography.font-weight.bold}" },
-        "focus": {
+        "hover": {
           "color": { "value": "{amsterdam.color.dark-blue}" }
         },
         "line-height": { "value": "{amsterdam.typography.text-level.4.line-height}" },
@@ -16,7 +27,8 @@
         "wide": {
           "font-size": { "value": "{amsterdam.typography.text-level.4.wide.font-size}" }
         }
-      }
+      },
+      "outline-offset": { "value": "{amsterdam.focus.outline-offset}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/amsterdam/top-task-link.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/top-task-link.tokens.json
@@ -2,7 +2,7 @@
   "amsterdam": {
     "top-task-link": {
       "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
-      "title": {
+      "label": {
         "color": { "value": "{amsterdam.color.primary-blue}" },
         "font-family": { "value": "{amsterdam.typography.font-family}" },
         "font-weight": { "value": "{amsterdam.typography.font-weight.bold}" },

--- a/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.docs.mdx
+++ b/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.docs.mdx
@@ -10,14 +10,10 @@ import README from "../../../../../packages/css/src/top-task-link/README.md?raw"
 
 <Controls />
 
-### Three columns
+### Without description
 
-Drie toptask links naast elkaar in een rij.
+<Canvas of={TopTaskLinkStories.WithoutDescription} />
 
-<Canvas of={TopTaskLinkStories.ThreeColumns} />
+### With description
 
-### Four columns
-
-Vier toptask links naast elkaar in een rij.
-
-<Canvas of={TopTaskLinkStories.FourColumns} />
+<Canvas of={TopTaskLinkStories.WithDescription} />

--- a/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.docs.mdx
+++ b/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.docs.mdx
@@ -1,0 +1,19 @@
+import { Canvas, Controls, Markdown, Meta, Primary } from "@storybook/blocks";
+import * as TopTaskLinkStories from "./TopTaskLink.stories.tsx";
+import README from "../../../../../packages/css/src/top-task-link/README.md?raw";
+
+<Meta of={TopTaskLinkStories} />
+
+<Markdown>{README}</Markdown>
+
+<Primary />
+
+<Controls />
+
+### Three columns
+
+<Canvas of={TopTaskLinkStories.ThreeColumns} />
+
+### Four columns
+
+<Canvas of={TopTaskLinkStories.FourColumns} />

--- a/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.docs.mdx
+++ b/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.docs.mdx
@@ -12,8 +12,12 @@ import README from "../../../../../packages/css/src/top-task-link/README.md?raw"
 
 ### Three columns
 
+Drie toptask links naast elkaar in een rij.
+
 <Canvas of={TopTaskLinkStories.ThreeColumns} />
 
 ### Four columns
+
+Vier toptask links naast elkaar in een rij.
 
 <Canvas of={TopTaskLinkStories.FourColumns} />

--- a/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.stories.tsx
+++ b/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.stories.tsx
@@ -37,45 +37,34 @@ export const Default: Story = {
   },
 }
 
-export const ThreeColumns: Story = {
+export const WithoutDescription: Story = {
+  args: {
+    label: 'Titel',
+  },
   render: () => (
     <PageGrid>
       <GridCell gridColumns={4}>
-        <TopTaskLink
-          href="/"
-          label="Staat van de Stad"
-          description="De Staat van de Stad Amsterdam biedt een overzicht van hoe de stad ervoor staat op tal van terreinen."
-        />
+        <TopTaskLink href="/" label="Melding openbare ruimte en overlast" />
       </GridCell>
       <GridCell gridColumns={4}>
-        <TopTaskLink
-          href="/"
-          label="Metropoolregio Amsterdam"
-          description="Onderzoek en Statistiek verzamelt cijfers over de MRA en doet onderzoek naar onder meer de woningmarkt en
-          het toerisme in de regio."
-        />
+        <TopTaskLink href="/" label="Verhuizing doorgeven" />
       </GridCell>
       <GridCell gridColumns={4}>
-        <TopTaskLink
-          href="/"
-          label="Armoede"
-          description="In Amsterdam leven meer mensen in armoede dan gemiddeld in Nederland. De afgelopen jaren daalde hun aantal
-          in Amsterdam wel geleidelijk."
-        />
+        <TopTaskLink href="/" label="Kennisgevingen en bekendmakingen" />
       </GridCell>
     </PageGrid>
   ),
   parameters: {
     docs: {
       source: { type: 'dynamic' },
-      canvas: {
-        sourceState: 'hidden',
-      },
     },
   },
 }
 
-export const FourColumns: Story = {
+export const WithDescription: Story = {
+  args: {
+    label: 'Titel',
+  },
   render: () => (
     <PageGrid>
       <GridCell gridColumns={3}>
@@ -95,9 +84,6 @@ export const FourColumns: Story = {
   parameters: {
     docs: {
       source: { type: 'dynamic' },
-      canvas: {
-        sourceState: 'hidden',
-      },
     },
   },
 }

--- a/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.stories.tsx
+++ b/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.stories.tsx
@@ -32,10 +32,8 @@ export const Default: Story = {
   ],
   args: {
     href: '/',
-    children: [
-      <TopTaskLink.Title key={1}>Titel</TopTaskLink.Title>,
-      <TopTaskLink.Description key={2}>Omschrijving</TopTaskLink.Description>,
-    ],
+    label: 'Titel',
+    description: 'Omschrijving',
   },
 }
 
@@ -43,30 +41,27 @@ export const ThreeColumns: Story = {
   render: () => (
     <PageGrid>
       <GridCell gridColumns={4}>
-        <TopTaskLink href="/">
-          <TopTaskLink.Title>Staat van de Stad</TopTaskLink.Title>
-          <TopTaskLink.Description>
-            De Staat van de Stad Amsterdam biedt een overzicht van hoe de stad ervoor staat op tal van terreinen.
-          </TopTaskLink.Description>
-        </TopTaskLink>
+        <TopTaskLink
+          href="/"
+          label="Staat van de Stad"
+          description="De Staat van de Stad Amsterdam biedt een overzicht van hoe de stad ervoor staat op tal van terreinen."
+        />
       </GridCell>
       <GridCell gridColumns={4}>
-        <TopTaskLink href="/">
-          <TopTaskLink.Title>Metropoolregio Amsterdam</TopTaskLink.Title>
-          <TopTaskLink.Description>
-            Onderzoek en Statistiek verzamelt cijfers over de MRA en doet onderzoek naar onder meer de woningmarkt en
-            het toerisme in de regio.
-          </TopTaskLink.Description>
-        </TopTaskLink>
+        <TopTaskLink
+          href="/"
+          label="Metropoolregio Amsterdam"
+          description="Onderzoek en Statistiek verzamelt cijfers over de MRA en doet onderzoek naar onder meer de woningmarkt en
+          het toerisme in de regio."
+        />
       </GridCell>
       <GridCell gridColumns={4}>
-        <TopTaskLink href="/">
-          <TopTaskLink.Title>Armoede</TopTaskLink.Title>
-          <TopTaskLink.Description>
-            In Amsterdam leven meer mensen in armoede dan gemiddeld in Nederland. De afgelopen jaren daalde hun aantal
-            in Amsterdam wel geleidelijk.
-          </TopTaskLink.Description>
-        </TopTaskLink>
+        <TopTaskLink
+          href="/"
+          label="Armoede"
+          description="In Amsterdam leven meer mensen in armoede dan gemiddeld in Nederland. De afgelopen jaren daalde hun aantal
+          in Amsterdam wel geleidelijk."
+        />
       </GridCell>
     </PageGrid>
   ),
@@ -84,28 +79,16 @@ export const FourColumns: Story = {
   render: () => (
     <PageGrid>
       <GridCell gridColumns={3}>
-        <TopTaskLink href="/">
-          <TopTaskLink.Title>Stadsloket</TopTaskLink.Title>
-          <TopTaskLink.Description>Locaties en openingstijden</TopTaskLink.Description>
-        </TopTaskLink>
+        <TopTaskLink href="/" label="Stadsloket" description="Locaties en openingstijden" />
       </GridCell>
       <GridCell gridColumns={3}>
-        <TopTaskLink href="/">
-          <TopTaskLink.Title>P+R</TopTaskLink.Title>
-          <TopTaskLink.Description>Parkeren en reizen</TopTaskLink.Description>
-        </TopTaskLink>
+        <TopTaskLink href="/" label="P+R" description="Parkeren en reizen" />
       </GridCell>
       <GridCell gridColumns={3}>
-        <TopTaskLink href="/">
-          <TopTaskLink.Title>Documenten</TopTaskLink.Title>
-          <TopTaskLink.Description>Paspoort, ID-kaart en rijbewijs</TopTaskLink.Description>
-        </TopTaskLink>
+        <TopTaskLink href="/" label="Documenten" description="Paspoort, ID-kaart en rijbewijs" />
       </GridCell>
       <GridCell gridColumns={3}>
-        <TopTaskLink href="/">
-          <TopTaskLink.Title>Meldingen</TopTaskLink.Title>
-          <TopTaskLink.Description>Melding openbare ruimte en overlast</TopTaskLink.Description>
-        </TopTaskLink>
+        <TopTaskLink href="/" label="Meldingen" description="Melding openbare ruimte en overlast" />
       </GridCell>
     </PageGrid>
   ),

--- a/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.stories.tsx
+++ b/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.stories.tsx
@@ -21,16 +21,22 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
-  render: () => (
-    <PageGrid>
-      <GridCell gridColumns={4}>
-        <TopTaskLink href="/">
-          <TopTaskLink.Title>Titel</TopTaskLink.Title>
-          <TopTaskLink.Description>Omschrijving</TopTaskLink.Description>
-        </TopTaskLink>
-      </GridCell>
-    </PageGrid>
-  ),
+  decorators: [
+    (Story) => (
+      <PageGrid>
+        <GridCell gridColumns={4}>
+          <Story />
+        </GridCell>
+      </PageGrid>
+    ),
+  ],
+  args: {
+    href: '/',
+    children: [
+      <TopTaskLink.Title key={1}>Titel</TopTaskLink.Title>,
+      <TopTaskLink.Description key={2}>Omschrijving</TopTaskLink.Description>,
+    ],
+  },
 }
 
 export const ThreeColumns: Story = {
@@ -64,6 +70,14 @@ export const ThreeColumns: Story = {
       </GridCell>
     </PageGrid>
   ),
+  parameters: {
+    docs: {
+      source: { type: 'dynamic' },
+      canvas: {
+        sourceState: 'hidden',
+      },
+    },
+  },
 }
 
 export const FourColumns: Story = {
@@ -95,4 +109,12 @@ export const FourColumns: Story = {
       </GridCell>
     </PageGrid>
   ),
+  parameters: {
+    docs: {
+      source: { type: 'dynamic' },
+      canvas: {
+        sourceState: 'hidden',
+      },
+    },
+  },
 }

--- a/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.stories.tsx
+++ b/storybook/storybook-react/src/components/TopTaskLink/TopTaskLink.stories.tsx
@@ -1,0 +1,98 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright (c) 2023 Gemeente Amsterdam
+ */
+
+import { GridCell, PageGrid, TopTaskLink } from '@amsterdam/design-system-react/src'
+import { Meta, StoryObj } from '@storybook/react'
+
+import '@amsterdam/design-system-css/src/top-task-link/top-task-link.scss'
+
+const meta = {
+  title: 'Top task link',
+  component: TopTaskLink,
+  args: {
+    href: '/',
+  },
+} satisfies Meta<typeof TopTaskLink>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => (
+    <PageGrid>
+      <GridCell gridColumns={4}>
+        <TopTaskLink href="/">
+          <TopTaskLink.Title>Titel</TopTaskLink.Title>
+          <TopTaskLink.Description>Omschrijving</TopTaskLink.Description>
+        </TopTaskLink>
+      </GridCell>
+    </PageGrid>
+  ),
+}
+
+export const ThreeColumns: Story = {
+  render: () => (
+    <PageGrid>
+      <GridCell gridColumns={4}>
+        <TopTaskLink href="/">
+          <TopTaskLink.Title>Staat van de Stad</TopTaskLink.Title>
+          <TopTaskLink.Description>
+            De Staat van de Stad Amsterdam biedt een overzicht van hoe de stad ervoor staat op tal van terreinen.
+          </TopTaskLink.Description>
+        </TopTaskLink>
+      </GridCell>
+      <GridCell gridColumns={4}>
+        <TopTaskLink href="/">
+          <TopTaskLink.Title>Metropoolregio Amsterdam</TopTaskLink.Title>
+          <TopTaskLink.Description>
+            Onderzoek en Statistiek verzamelt cijfers over de MRA en doet onderzoek naar onder meer de woningmarkt en
+            het toerisme in de regio.
+          </TopTaskLink.Description>
+        </TopTaskLink>
+      </GridCell>
+      <GridCell gridColumns={4}>
+        <TopTaskLink href="/">
+          <TopTaskLink.Title>Armoede</TopTaskLink.Title>
+          <TopTaskLink.Description>
+            In Amsterdam leven meer mensen in armoede dan gemiddeld in Nederland. De afgelopen jaren daalde hun aantal
+            in Amsterdam wel geleidelijk.
+          </TopTaskLink.Description>
+        </TopTaskLink>
+      </GridCell>
+    </PageGrid>
+  ),
+}
+
+export const FourColumns: Story = {
+  render: () => (
+    <PageGrid>
+      <GridCell gridColumns={3}>
+        <TopTaskLink href="/">
+          <TopTaskLink.Title>Stadsloket</TopTaskLink.Title>
+          <TopTaskLink.Description>Locaties en openingstijden</TopTaskLink.Description>
+        </TopTaskLink>
+      </GridCell>
+      <GridCell gridColumns={3}>
+        <TopTaskLink href="/">
+          <TopTaskLink.Title>P+R</TopTaskLink.Title>
+          <TopTaskLink.Description>Parkeren en reizen</TopTaskLink.Description>
+        </TopTaskLink>
+      </GridCell>
+      <GridCell gridColumns={3}>
+        <TopTaskLink href="/">
+          <TopTaskLink.Title>Documenten</TopTaskLink.Title>
+          <TopTaskLink.Description>Paspoort, ID-kaart en rijbewijs</TopTaskLink.Description>
+        </TopTaskLink>
+      </GridCell>
+      <GridCell gridColumns={3}>
+        <TopTaskLink href="/">
+          <TopTaskLink.Title>Meldingen</TopTaskLink.Title>
+          <TopTaskLink.Description>Melding openbare ruimte en overlast</TopTaskLink.Description>
+        </TopTaskLink>
+      </GridCell>
+    </PageGrid>
+  ),
+}


### PR DESCRIPTION
To discuss:

- currently, when you select the toptask with a screenreader, it reads 'link title, link description', implying there are 2 links when there's only one. I think we should change the structure to match https://inclusive-components.design/cards/ -> we've changed it to two `span`s, which makes a screenreader read it as one. Also, we've added an `aria-label` with `${label}, ${description}`
- should you be able to add an icon in the mvp? -> not mvp
- do we want to cut off the title and description at 2 lines in the component? [Like so](https://gitlab.com/os-amsterdam/website-onderzoek-en-statistiek/-/blob/develop/website/components/Card/Card.style.js?ref_type=heads#L100-105) -> Vincent will check with Inge
