### PR TITLE
Remove padding from links and some other improvements

### DIFF
--- a/packages/css/src/breadcrumb/breadcrumb.scss
+++ b/packages/css/src/breadcrumb/breadcrumb.scss
@@ -24,9 +24,9 @@
 .amsterdam-breadcrumb__list {
   break-after: avoid;
   break-inside: avoid;
-  column-gap: 0.5rem;
   display: flex;
   flex-wrap: wrap;
+  gap: 0.5rem;
   list-style: none;
 
   @include reset;
@@ -51,7 +51,6 @@
   color: var(--amsterdam-breadcrumb-color);
   cursor: pointer;
   outline-offset: var(--amsterdam-breadcrumb-item-link-outline-offset);
-  padding-block: 0.75rem;
   text-decoration: none;
 
   &::first-letter {

--- a/packages/css/src/checkbox/checkbox.scss
+++ b/packages/css/src/checkbox/checkbox.scss
@@ -48,7 +48,6 @@
   font-weight: 400;
   gap: 0.5rem;
   line-height: var(--amsterdam-checkbox-line-height);
-  padding-block: 0.5rem;
 
   &:hover {
     color: var(--amsterdam-checkbox-hover-color);

--- a/packages/css/src/link/link.scss
+++ b/packages/css/src/link/link.scss
@@ -19,9 +19,9 @@
 }
 
 .amsterdam-link--standalone {
+  display: inline-block;
   font-size: var(--amsterdam-link-standalone-narrow-font-size);
-  line-height: var(--amsterdam-link-standalon-line-height);
-  padding-block: 0.5rem;
+  line-height: var(--amsterdam-link-standalone-line-height);
   text-decoration-thickness: var(--amsterdam-link-standalone-text-decoration-thickness);
   text-underline-offset: var(--amsterdam-link-standalone-text-underline-offset);
 
@@ -62,9 +62,6 @@
   font-size: var(--amsterdam-link-in-list-narrow-font-size);
   gap: var(--amsterdam-link-in-list-gap);
   line-height: var(--amsterdam-link-in-list-line-height);
-
-  // this padding differs from our spacing scheme, in order to meet WCAG 2.5.5 without having too much space between in list links
-  padding-block: 0.575rem;
   text-decoration: var(--amsterdam-link-in-list-text-decoration);
 
   &:hover,


### PR DESCRIPTION
A couple of changes in this PR:

- I've remove the padding from standalone and in list links, checkboxes and breadcrumbs. [The new WCAG states that hit areas only have to be 24x24px](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html), so the padding isn't necessary.
- I've fixed a typo in a token reference
- I've changed the display for standalone link to `inline-block`, so the hit area is the same as the line-height.