### PR TITLE
Add PageMenu Component

### DIFF
--- a/packages/css/src/index.scss
+++ b/packages/css/src/index.scss
@@ -4,6 +4,7 @@
  */
 
 /* Append here */
+@import "./page-menu/page-menu";
 @import "./accordion/accordion";
 @import "./breadcrumb/breadcrumb";
 @import "./button/button";

--- a/packages/css/src/page-menu/README.md
+++ b/packages/css/src/page-menu/README.md
@@ -1,0 +1,1 @@
+# Page menu

--- a/packages/css/src/page-menu/README.md
+++ b/packages/css/src/page-menu/README.md
@@ -1,1 +1,15 @@
-# Page menu
+# Page Menu
+
+Het Page Menu wordt alleen gebruikt in het Header en Footer component en is uitsluitend bedoeld voor horizontale navigatie. Het uiterlijk van de links en buttons zijn gelijk getrokken en kunnen beide gebruikt worden. Een link voor navigatie acties en een button voor het afvuren van een javascript event voor bijvoorbeeld het openen van het hoofdmenu of het tonen van een modal.
+
+## Richtlijnen
+
+- Als hoofdnavigatie in de header heeft het Page Menu maximaal 5 items inclusief Zoeken en Menu, staan op 1 regel en is rechts uitgelijnd. Houd minimaal 1 kolom afstand tussen de sitetitel en het eerste menu-item.
+- Als footer menu in het Page Menu links uitgelijnd.
+- Submenu's zijn niet toegestaan.
+  - Gebruik het standaard Menu-item als er meer informatie in het hoofdmenu nodig is. Dit item toont een schermbreed uitklapmenu (overlay) met koppelingen. De indeling van de koppelingen is vrij.
+  - Bij gebruik van het Menu-item zijn de overige items (bijvoorbeeld Zoeken, Contact) in de koptekst functioneel. Deze items kunnen herhaald worden binnen het uitgeklapte Menu-item.
+
+## Relevante WCAG eisen
+
+- [Consistent Navigation (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/consistent-navigation.html)

--- a/packages/css/src/page-menu/page-menu.scss
+++ b/packages/css/src/page-menu/page-menu.scss
@@ -9,7 +9,6 @@
   box-sizing: border-box;
   margin-block: 0;
   padding-inline: 0;
-  -webkit-text-size-adjust: 100%;
 }
 
 @mixin reset-item {
@@ -24,6 +23,7 @@
   flex-direction: row;
   flex-wrap: wrap;
   list-style: none;
+  row-gap: var(--amsterdam-page-menu-list-row-gap);
 
   @include reset-list;
 }
@@ -62,8 +62,8 @@
   @include reset-item;
 }
 
-.amsterdam-page-menu__link a:hover,
-.amsterdam-page-menu__button button:hover {
+.amsterdam-page-menu__link:hover,
+.amsterdam-page-menu__button:hover {
   color: var(--amsterdam-page-menu-item-hover-color);
 }
 

--- a/packages/css/src/page-menu/page-menu.scss
+++ b/packages/css/src/page-menu/page-menu.scss
@@ -16,6 +16,13 @@
   -webkit-text-size-adjust: 100%;
 }
 
+@mixin reset-button {
+  background-color: transparent;
+  border: 0;
+  margin-block: 0;
+  padding-inline: 0;
+}
+
 .amsterdam-page-menu {
   align-items: center;
   column-gap: var(--amsterdam-page-menu-column-gap);
@@ -52,14 +59,11 @@
 }
 
 .amsterdam-page-menu__button {
-  background-color: transparent;
-  border: 0;
   cursor: pointer;
-  margin-block: 0;
-  padding-inline: 0;
 
-  @include page-menu-item;
   @include reset-item;
+  @include reset-button;
+  @include page-menu-item;
 }
 
 .amsterdam-page-menu__link:hover,

--- a/packages/css/src/page-menu/page-menu.scss
+++ b/packages/css/src/page-menu/page-menu.scss
@@ -16,14 +16,14 @@
   -webkit-text-size-adjust: 100%;
 }
 
-.amsterdam-page-menu__list {
+.amsterdam-page-menu {
   align-items: center;
-  column-gap: var(--amsterdam-page-menu-list-column-gap);
+  column-gap: var(--amsterdam-page-menu-column-gap);
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   list-style: none;
-  row-gap: var(--amsterdam-page-menu-list-row-gap);
+  row-gap: var(--amsterdam-page-menu-row-gap);
 
   @include reset-list;
 }

--- a/packages/css/src/page-menu/page-menu.scss
+++ b/packages/css/src/page-menu/page-menu.scss
@@ -1,0 +1,8 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright (c) 2023 Gemeente Amsterdam
+ */
+
+.amsterdam-page-menu {
+  /* Add styles here */
+}

--- a/packages/css/src/page-menu/page-menu.scss
+++ b/packages/css/src/page-menu/page-menu.scss
@@ -3,6 +3,56 @@
  * Copyright (c) 2023 Gemeente Amsterdam
  */
 
-.amsterdam-page-menu {
-  /* Add styles here */
+@import "../../utils/breakpoint";
+
+@mixin reset {
+  border: 0;
+  box-sizing: border-box;
+  margin-block: 0;
+  padding-inline: 0;
+  -webkit-text-size-adjust: 100%;
+}
+
+.amsterdam-page-menu__list {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: var(--amsterdam-page-menu-gap);
+  list-style: none;
+
+  @include reset;
+}
+
+.amsterdam-page-menu__link a,
+.amsterdam-page-menu__button button {
+  align-items: center;
+  background: none;
+  color: var(--amsterdam-page-menu-item-color);
+  cursor: pointer;
+  display: inline-flex;
+  flex-direction: row;
+  font-family: var(--amsterdam-page-menu-font-family);
+  font-size: var(--amsterdam-page-menu-item-narrow-font-size);
+  gap: var(--amsterdam-page-menu-item-gap);
+  line-height: var(--amsterdam-page-menu-item-line-height);
+  text-align: center;
+  text-decoration: var(--amsterdam-page-menu-item-text-decoration);
+  touch-action: manipulation;
+
+  @media screen and (width > $amsterdam-breakpoint) {
+    font-size: var(--amsterdam-page-menu-item-wide-font-size);
+  }
+
+  @include reset;
+}
+
+.amsterdam-page-menu__link a:hover,
+.amsterdam-page-menu__button button:hover {
+  color: var(--amsterdam-page-menu-item-hover-color);
+}
+
+.amsterdam-page-menu__link svg,
+.amsterdam-page-menu__button svg {
+  color: currentColor;
 }

--- a/packages/css/src/page-menu/page-menu.scss
+++ b/packages/css/src/page-menu/page-menu.scss
@@ -5,35 +5,36 @@
 
 @import "../../utils/breakpoint";
 
-@mixin reset {
-  border: 0;
+@mixin reset-list {
   box-sizing: border-box;
   margin-block: 0;
   padding-inline: 0;
   -webkit-text-size-adjust: 100%;
 }
 
+@mixin reset-item {
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+}
+
 .amsterdam-page-menu__list {
   align-items: center;
+  column-gap: var(--amsterdam-page-menu-list-column-gap);
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  gap: var(--amsterdam-page-menu-gap);
   list-style: none;
 
-  @include reset;
+  @include reset-list;
 }
 
-.amsterdam-page-menu__link a,
-.amsterdam-page-menu__button button {
-  align-items: center;
-  background: none;
+@mixin page-menu-item {
   color: var(--amsterdam-page-menu-item-color);
-  cursor: pointer;
   display: inline-flex;
   flex-direction: row;
-  font-family: var(--amsterdam-page-menu-font-family);
+  font-family: var(--amsterdam-page-menu-item-font-family);
   font-size: var(--amsterdam-page-menu-item-narrow-font-size);
+  font-weight: var(--amsterdam-page-menu-item-narrow-font-weight);
   gap: var(--amsterdam-page-menu-item-gap);
   line-height: var(--amsterdam-page-menu-item-line-height);
   text-align: center;
@@ -43,8 +44,22 @@
   @media screen and (width > $amsterdam-breakpoint) {
     font-size: var(--amsterdam-page-menu-item-wide-font-size);
   }
+}
 
-  @include reset;
+.amsterdam-page-menu__link {
+  @include page-menu-item;
+  @include reset-item;
+}
+
+.amsterdam-page-menu__button {
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+  margin-block: 0;
+  padding-inline: 0;
+
+  @include page-menu-item;
+  @include reset-item;
 }
 
 .amsterdam-page-menu__link a:hover,

--- a/packages/react/src/PageMenu/PageMenu.test.tsx
+++ b/packages/react/src/PageMenu/PageMenu.test.tsx
@@ -3,19 +3,16 @@ import { render } from '@testing-library/react'
 import { createRef } from 'react'
 import { PageMenu } from './PageMenu'
 import '@testing-library/jest-dom'
-import { Icon } from '../Icon'
 
 describe('page menu', () => {
   it('renders a page menu with children', () => {
     const { container } = render(
       <PageMenu>
         <PageMenu.Link href="#">English</PageMenu.Link>
-        <PageMenu.Link href="#">
-          Inloggen Mijn Amsterdam <Icon svg={Login} size="level-7" />
+        <PageMenu.Link href="#" icon={Login}>
+          Inloggen Mijn Amsterdam
         </PageMenu.Link>
-        <PageMenu.Button>
-          Alle onderwerpen <Icon svg={Menu} size="level-7" />
-        </PageMenu.Button>
+        <PageMenu.Button icon={Menu}>Alle onderwerpen</PageMenu.Button>
       </PageMenu>,
     )
 
@@ -27,6 +24,14 @@ describe('page menu', () => {
     expect(component).toBeVisible()
     expect(children.length).toBe(3)
     expect(icons.length).toBe(2)
+  })
+
+  it('renders a design system BEM class name', () => {
+    const { container } = render(<PageMenu />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('amsterdam-page-menu')
   })
 
   it('is able to pass a React ref', () => {

--- a/packages/react/src/PageMenu/PageMenu.test.tsx
+++ b/packages/react/src/PageMenu/PageMenu.test.tsx
@@ -47,4 +47,14 @@ describe('page menu', () => {
 
     expect(ref.current).toBe(component)
   })
+
+  it('can have a additional class name', () => {
+    const { container } = render(<PageMenu className="intro" />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('intro')
+
+    expect(component).toHaveClass('amsterdam-page-menu')
+  })
 })

--- a/packages/react/src/PageMenu/PageMenu.test.tsx
+++ b/packages/react/src/PageMenu/PageMenu.test.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react'
+import { createRef } from 'react'
+import { PageMenu } from './PageMenu'
+import '@testing-library/jest-dom'
+
+describe('Page menu', () => {
+  it('renders', () => {
+    const { container } = render(<PageMenu />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toBeInTheDocument()
+    expect(component).toBeVisible()
+  })
+
+  it('renders a design system BEM class name', () => {
+    const { container } = render(<PageMenu />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('amsterdam-page-menu')
+  })
+
+  it('can have a custom class name', () => {
+    const { container } = render(<PageMenu className="extra" />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('extra')
+  })
+
+  it('can have a additional class name', () => {
+    const { container } = render(<PageMenu className="extra" />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('extra')
+
+    expect(component).toHaveClass('amsterdam-page-menu')
+  })
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLElement>()
+
+    const { container } = render(<PageMenu ref={ref} />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(ref.current).toBe(component)
+  })
+})

--- a/packages/react/src/PageMenu/PageMenu.test.tsx
+++ b/packages/react/src/PageMenu/PageMenu.test.tsx
@@ -1,48 +1,42 @@
+import { Login, Menu } from '@amsterdam/design-system-react-icons'
 import { render } from '@testing-library/react'
 import { createRef } from 'react'
 import { PageMenu } from './PageMenu'
 import '@testing-library/jest-dom'
+import { Icon } from '../Icon'
 
-describe('Page menu', () => {
-  it('renders', () => {
-    const { container } = render(<PageMenu />)
+describe('page menu', () => {
+  it('renders a page menu with children', () => {
+    const { container } = render(
+      <PageMenu>
+        <PageMenu.Link href="#">English</PageMenu.Link>
+        <PageMenu.Link href="#">
+          Inloggen Mijn Amsterdam <Icon svg={Login} size="level-7" />
+        </PageMenu.Link>
+        <PageMenu.Button>
+          Alle onderwerpen <Icon svg={Menu} size="level-7" />
+        </PageMenu.Button>
+      </PageMenu>,
+    )
 
     const component = container.querySelector(':only-child')
+    const children = container.querySelectorAll('li')
+    const icons = container.querySelectorAll('svg')
 
     expect(component).toBeInTheDocument()
     expect(component).toBeVisible()
+    expect(children.length).toBe(3)
+    expect(icons.length).toBe(2)
   })
 
-  it('renders a design system BEM class name', () => {
-    const { container } = render(<PageMenu />)
-
-    const component = container.querySelector(':only-child')
-
-    expect(component).toHaveClass('amsterdam-page-menu')
-  })
-
-  it('can have a custom class name', () => {
-    const { container } = render(<PageMenu className="extra" />)
-
-    const component = container.querySelector(':only-child')
-
-    expect(component).toHaveClass('extra')
-  })
-
-  it('can have a additional class name', () => {
-    const { container } = render(<PageMenu className="extra" />)
-
-    const component = container.querySelector(':only-child')
-
-    expect(component).toHaveClass('extra')
-
-    expect(component).toHaveClass('amsterdam-page-menu')
-  })
-
-  it('supports ForwardRef in React', () => {
+  it('is able to pass a React ref', () => {
     const ref = createRef<HTMLElement>()
 
-    const { container } = render(<PageMenu ref={ref} />)
+    const { container } = render(
+      <PageMenu ref={ref}>
+        <PageMenu.Link href="#">English</PageMenu.Link>
+      </PageMenu>,
+    )
 
     const component = container.querySelector(':only-child')
 

--- a/packages/react/src/PageMenu/PageMenu.tsx
+++ b/packages/react/src/PageMenu/PageMenu.tsx
@@ -3,20 +3,20 @@
  * Copyright (c) 2023 Gemeente Amsterdam
  */
 
-import React, {
+import {
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
   ForwardedRef,
   forwardRef,
+  ForwardRefExoticComponent,
   HTMLAttributes,
   PropsWithChildren,
+  RefAttributes,
 } from 'react'
 import { Icon } from '../Icon'
 
 interface PageMenuComponent
-  extends React.ForwardRefExoticComponent<
-    PropsWithChildren<HTMLAttributes<HTMLElement>> & React.RefAttributes<HTMLElement>
-  > {
+  extends ForwardRefExoticComponent<PropsWithChildren<HTMLAttributes<HTMLElement>> & RefAttributes<HTMLElement>> {
   Link: typeof PageMenuLink
   Button: typeof PageMenuButton
 }
@@ -42,8 +42,8 @@ export interface PageMenuButtonProps extends PropsWithChildren<ButtonHTMLAttribu
 const PageMenuLink = forwardRef(
   ({ children, icon, ...restProps }: PageMenuLinkProps, ref: ForwardedRef<HTMLAnchorElement>) => {
     return (
-      <li className="amsterdam-page-menu__link">
-        <a {...restProps} ref={ref}>
+      <li className="amsterdam-page-menu__item">
+        <a {...restProps} ref={ref} className="amsterdam-page-menu__link">
           {children}
           {icon && <Icon svg={icon} size="level-7" />}
         </a>
@@ -55,8 +55,8 @@ const PageMenuLink = forwardRef(
 const PageMenuButton = forwardRef(
   ({ children, icon, ...restProps }: PageMenuButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
     return (
-      <li className="amsterdam-page-menu__button">
-        <button {...restProps} type="button" ref={ref}>
+      <li className="amsterdam-page-menu__item">
+        <button {...restProps} type="button" ref={ref} className="amsterdam-page-menu__button">
           {children}
           {icon && <Icon svg={icon} size="level-7" />}
         </button>

--- a/packages/react/src/PageMenu/PageMenu.tsx
+++ b/packages/react/src/PageMenu/PageMenu.tsx
@@ -3,17 +3,50 @@
  * Copyright (c) 2023 Gemeente Amsterdam
  */
 
-import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
+import React, { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
 
-export interface PageMenuProps extends PropsWithChildren<HTMLAttributes<HTMLElement>> {}
+interface PageMenuComponent
+  extends React.ForwardRefExoticComponent<
+    PropsWithChildren<HTMLAttributes<HTMLElement>> & React.RefAttributes<HTMLElement>
+  > {
+  Link: typeof PageMenuLink
+  Button: typeof PageMenuButton
+}
 
 export const PageMenu = forwardRef(
-  ({ children, className, ...restProps }: PageMenuProps, ref: ForwardedRef<HTMLElement>) => (
-    <span {...restProps} ref={ref} className={clsx('amsterdam-page-menu', className)}>
-      {children}
-    </span>
-  ),
+  ({ children, ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>, ref: ForwardedRef<HTMLElement>) => {
+    return (
+      <nav {...restProps} className="amsterdam-page-menu" ref={ref}>
+        <ul className="amsterdam-page-menu__list">{children}</ul>
+      </nav>
+    )
+  },
+) as PageMenuComponent
+
+export interface PageMenuLinkProps extends PropsWithChildren<HTMLAttributes<HTMLLIElement>> {
+  href?: string
+}
+
+const PageMenuLink = forwardRef(
+  ({ children, href, ...restProps }: PageMenuLinkProps, ref: ForwardedRef<HTMLLIElement>) => {
+    return (
+      <li {...restProps} className="amsterdam-page-menu__link" ref={ref}>
+        <a href={href}>{children}</a>
+      </li>
+    )
+  },
 )
 
+const PageMenuButton = forwardRef(({ children, ...restProps }: PageMenuLinkProps, ref: ForwardedRef<HTMLLIElement>) => {
+  return (
+    <li {...restProps} className="amsterdam-page-menu__button" ref={ref}>
+      <button>{children}</button>
+    </li>
+  )
+})
+
 PageMenu.displayName = 'PageMenu'
+PageMenuLink.displayName = 'PageMenuLink'
+PageMenuButton.displayName = 'PageMenuButton'
+PageMenu.Link = PageMenuLink
+PageMenu.Button = PageMenuButton

--- a/packages/react/src/PageMenu/PageMenu.tsx
+++ b/packages/react/src/PageMenu/PageMenu.tsx
@@ -3,7 +3,15 @@
  * Copyright (c) 2023 Gemeente Amsterdam
  */
 
-import React, { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
+import React, {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  ForwardedRef,
+  forwardRef,
+  HTMLAttributes,
+  PropsWithChildren,
+} from 'react'
+import { Icon } from '../Icon'
 
 interface PageMenuComponent
   extends React.ForwardRefExoticComponent<
@@ -23,27 +31,39 @@ export const PageMenu = forwardRef(
   },
 ) as PageMenuComponent
 
-export interface PageMenuLinkProps extends PropsWithChildren<HTMLAttributes<HTMLLIElement>> {
-  href?: string
+export interface PageMenuLinkProps extends PropsWithChildren<AnchorHTMLAttributes<HTMLAnchorElement>> {
+  icon?: Function
+}
+
+export interface PageMenuButtonProps extends PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>> {
+  icon?: Function
 }
 
 const PageMenuLink = forwardRef(
-  ({ children, href, ...restProps }: PageMenuLinkProps, ref: ForwardedRef<HTMLLIElement>) => {
+  ({ children, icon, ...restProps }: PageMenuLinkProps, ref: ForwardedRef<HTMLAnchorElement>) => {
     return (
-      <li {...restProps} className="amsterdam-page-menu__link" ref={ref}>
-        <a href={href}>{children}</a>
+      <li className="amsterdam-page-menu__link">
+        <a {...restProps} ref={ref}>
+          {children}
+          {icon && <Icon svg={icon} size="level-7" />}
+        </a>
       </li>
     )
   },
 )
 
-const PageMenuButton = forwardRef(({ children, ...restProps }: PageMenuLinkProps, ref: ForwardedRef<HTMLLIElement>) => {
-  return (
-    <li {...restProps} className="amsterdam-page-menu__button" ref={ref}>
-      <button>{children}</button>
-    </li>
-  )
-})
+const PageMenuButton = forwardRef(
+  ({ children, icon, ...restProps }: PageMenuButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
+    return (
+      <li className="amsterdam-page-menu__button">
+        <button {...restProps} type="button" ref={ref}>
+          {children}
+          {icon && <Icon svg={icon} size="level-7" />}
+        </button>
+      </li>
+    )
+  },
+)
 
 PageMenu.displayName = 'PageMenu'
 PageMenuLink.displayName = 'PageMenuLink'

--- a/packages/react/src/PageMenu/PageMenu.tsx
+++ b/packages/react/src/PageMenu/PageMenu.tsx
@@ -1,0 +1,19 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright (c) 2023 Gemeente Amsterdam
+ */
+
+import clsx from 'clsx'
+import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
+
+export interface PageMenuProps extends PropsWithChildren<HTMLAttributes<HTMLElement>> {}
+
+export const PageMenu = forwardRef(
+  ({ children, className, ...restProps }: PageMenuProps, ref: ForwardedRef<HTMLElement>) => (
+    <span {...restProps} ref={ref} className={clsx('amsterdam-page-menu', className)}>
+      {children}
+    </span>
+  ),
+)
+
+PageMenu.displayName = 'PageMenu'

--- a/packages/react/src/PageMenu/PageMenu.tsx
+++ b/packages/react/src/PageMenu/PageMenu.tsx
@@ -16,7 +16,7 @@ import {
 } from 'react'
 import { Icon } from '../Icon'
 
-type PageMenuProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
+type PageMenuProps = PropsWithChildren<HTMLAttributes<HTMLUListElement>>
 
 interface PageMenuComponent extends ForwardRefExoticComponent<PageMenuProps & RefAttributes<HTMLElement>> {
   Link: typeof PageMenuLink
@@ -24,11 +24,11 @@ interface PageMenuComponent extends ForwardRefExoticComponent<PageMenuProps & Re
 }
 
 export const PageMenu = forwardRef(
-  ({ children, className, ...restProps }: PageMenuProps, ref: ForwardedRef<HTMLElement>) => {
+  ({ children, className, ...restProps }: PageMenuProps, ref: ForwardedRef<HTMLUListElement>) => {
     return (
-      <nav {...restProps} className={clsx('amsterdam-page-menu', className)} ref={ref}>
-        <ul className="amsterdam-page-menu__list">{children}</ul>
-      </nav>
+      <ul {...restProps} className={clsx('amsterdam-page-menu', className)} ref={ref}>
+        {children}
+      </ul>
     )
   },
 ) as PageMenuComponent

--- a/packages/react/src/PageMenu/PageMenu.tsx
+++ b/packages/react/src/PageMenu/PageMenu.tsx
@@ -3,6 +3,7 @@
  * Copyright (c) 2023 Gemeente Amsterdam
  */
 
+import clsx from 'clsx'
 import {
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
@@ -15,16 +16,17 @@ import {
 } from 'react'
 import { Icon } from '../Icon'
 
-interface PageMenuComponent
-  extends ForwardRefExoticComponent<PropsWithChildren<HTMLAttributes<HTMLElement>> & RefAttributes<HTMLElement>> {
+type PageMenuProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
+
+interface PageMenuComponent extends ForwardRefExoticComponent<PageMenuProps & RefAttributes<HTMLElement>> {
   Link: typeof PageMenuLink
   Button: typeof PageMenuButton
 }
 
 export const PageMenu = forwardRef(
-  ({ children, ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>, ref: ForwardedRef<HTMLElement>) => {
+  ({ children, className, ...restProps }: PageMenuProps, ref: ForwardedRef<HTMLElement>) => {
     return (
-      <nav {...restProps} className="amsterdam-page-menu" ref={ref}>
+      <nav {...restProps} className={clsx('amsterdam-page-menu', className)} ref={ref}>
         <ul className="amsterdam-page-menu__list">{children}</ul>
       </nav>
     )

--- a/packages/react/src/PageMenu/README.md
+++ b/packages/react/src/PageMenu/README.md
@@ -1,3 +1,3 @@
-# React Page menu component
+# Page Menu
 
 [Page menu documentation](../../../css/src/page-menu/README.md)

--- a/packages/react/src/PageMenu/README.md
+++ b/packages/react/src/PageMenu/README.md
@@ -1,0 +1,3 @@
+# React Page menu component
+
+[Page menu documentation](../../../css/src/page-menu/README.md)

--- a/packages/react/src/PageMenu/index.ts
+++ b/packages/react/src/PageMenu/index.ts
@@ -1,2 +1,2 @@
 export { PageMenu } from './PageMenu'
-export type { PageMenuProps } from './PageMenu'
+export type { PageMenuLinkProps } from './PageMenu'

--- a/packages/react/src/PageMenu/index.ts
+++ b/packages/react/src/PageMenu/index.ts
@@ -1,0 +1,2 @@
+export { PageMenu } from './PageMenu'
+export type { PageMenuProps } from './PageMenu'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 /* Append here */
+import '../../css/src/page-menu/page-menu.scss'
 import '../../css/src/blockquote/blockquote.scss'
 import '../../css/src/checkbox/checkbox.scss'
 import '../../css/src/page-heading/page-heading.scss'

--- a/packages/react/src/unstyled/index.ts
+++ b/packages/react/src/unstyled/index.ts
@@ -4,6 +4,7 @@
  */
 
 /* Append here */
+export * from '../PageMenu'
 export * from '../Blockquote'
 export * from '../Checkbox'
 export * from '../PageHeading'

--- a/proprietary/tokens/src/components/amsterdam/page-menu.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/page-menu.tokens.json
@@ -1,15 +1,13 @@
 {
   "amsterdam": {
     "page-menu": {
-      "list": {
-        "column-gap": { "value": "2.5rem" },
-        "row-gap": { "value": "0.5rem" }
-      },
+      "column-gap": { "value": "2.5rem" },
+      "row-gap": { "value": "0.5rem" },
       "item": {
         "color": { "value": "{amsterdam.color.primary-black}" },
-        "gap": { "value": "0.5rem" },
         "font-family": { "value": "{amsterdam.typography.font-family}" },
         "font-weight": { "value": "{amsterdam.typography.font-weight.normal}" },
+        "gap": { "value": "0.5rem" },
         "line-height": { "value": "{amsterdam.typography.text-level.7.line-height}" },
         "text-decoration": { "value": "none" },
         "narrow": {
@@ -19,8 +17,7 @@
           "font-size": { "value": "{amsterdam.typography.text-level.7.wide.font-size}" }
         },
         "hover": {
-          "color": { "value": "{amsterdam.color.dark-blue}" },
-          "font-weight": { "value": "{amsterdam.typography.font-weight.bold}" }
+          "color": { "value": "{amsterdam.color.dark-blue}" }
         }
       }
     }

--- a/proprietary/tokens/src/components/amsterdam/page-menu.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/page-menu.tokens.json
@@ -1,5 +1,25 @@
 {
   "amsterdam": {
-    "page-menu": {}
+    "page-menu": {
+      "font-family": { "value": "{amsterdam.typography.font-family}" },
+      "font-weight": { "value": "{amsterdam.typography.font-weight.normal}" },
+      "gap": { "value": "2.5rem" },
+      "item": {
+        "color": { "value": "{amsterdam.color.primary-black}" },
+        "gap": { "value": "0.5rem" },
+        "line-height": { "value": "{amsterdam.typography.text-level.7.line-height}" },
+        "text-decoration": { "value": "none" },
+        "narrow": {
+          "font-size": { "value": "{amsterdam.typography.text-level.7.narrow.font-size}" }
+        },
+        "wide": {
+          "font-size": { "value": "{amsterdam.typography.text-level.7.wide.font-size}" }
+        },
+        "hover": {
+          "color": { "value": "{amsterdam.color.dark-blue}" },
+          "font-weight": { "value": "{amsterdam.typography.font-weight.bold}" }
+        }
+      }
+    }
   }
 }

--- a/proprietary/tokens/src/components/amsterdam/page-menu.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/page-menu.tokens.json
@@ -1,12 +1,14 @@
 {
   "amsterdam": {
     "page-menu": {
-      "font-family": { "value": "{amsterdam.typography.font-family}" },
-      "font-weight": { "value": "{amsterdam.typography.font-weight.normal}" },
-      "gap": { "value": "2.5rem" },
+      "list": {
+        "column-gap": { "value": "2.5rem" }
+      },
       "item": {
         "color": { "value": "{amsterdam.color.primary-black}" },
         "gap": { "value": "0.5rem" },
+        "font-family": { "value": "{amsterdam.typography.font-family}" },
+        "font-weight": { "value": "{amsterdam.typography.font-weight.normal}" },
         "line-height": { "value": "{amsterdam.typography.text-level.7.line-height}" },
         "text-decoration": { "value": "none" },
         "narrow": {

--- a/proprietary/tokens/src/components/amsterdam/page-menu.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/page-menu.tokens.json
@@ -1,0 +1,5 @@
+{
+  "amsterdam": {
+    "page-menu": {}
+  }
+}

--- a/proprietary/tokens/src/components/amsterdam/page-menu.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/page-menu.tokens.json
@@ -2,7 +2,8 @@
   "amsterdam": {
     "page-menu": {
       "list": {
-        "column-gap": { "value": "2.5rem" }
+        "column-gap": { "value": "2.5rem" },
+        "row-gap": { "value": "0.5rem" }
       },
       "item": {
         "color": { "value": "{amsterdam.color.primary-black}" },

--- a/storybook/storybook-react/src/components/PageMenu/PageMenu.docs.mdx
+++ b/storybook/storybook-react/src/components/PageMenu/PageMenu.docs.mdx
@@ -1,0 +1,11 @@
+import { Controls, Markdown, Meta, Primary } from "@storybook/blocks";
+import * as PageMenuStories from "./PageMenu.stories.tsx";
+import README from "../../../../../packages/css/src/page-menu/README.md?raw";
+
+<Meta of={PageMenuStories} />
+
+<Markdown>{README}</Markdown>
+
+<Primary />
+
+<Controls />

--- a/storybook/storybook-react/src/components/PageMenu/PageMenu.stories.tsx
+++ b/storybook/storybook-react/src/components/PageMenu/PageMenu.stories.tsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 Gemeente Amsterdam
  */
 
-import { Icon, PageMenu } from '@amsterdam/design-system-react'
+import { PageMenu } from '@amsterdam/design-system-react'
 import { Login, Menu } from '@amsterdam/design-system-react-icons'
 import { Meta, StoryObj } from '@storybook/react'
 
@@ -23,12 +23,10 @@ export const Default: Story = {
   render: () => (
     <PageMenu>
       <PageMenu.Link href="#">English</PageMenu.Link>
-      <PageMenu.Link href="#">
-        Inloggen Mijn Amsterdam <Icon svg={Login} size="level-7" />
+      <PageMenu.Link href="#" icon={Login}>
+        Inloggen Mijn Amsterdam
       </PageMenu.Link>
-      <PageMenu.Button>
-        Alle onderwerpen <Icon svg={Menu} size="level-7" />
-      </PageMenu.Button>
+      <PageMenu.Button icon={Menu}>Alle onderwerpen</PageMenu.Button>
     </PageMenu>
   ),
 }

--- a/storybook/storybook-react/src/components/PageMenu/PageMenu.stories.tsx
+++ b/storybook/storybook-react/src/components/PageMenu/PageMenu.stories.tsx
@@ -1,0 +1,21 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright (c) 2023 Gemeente Amsterdam
+ */
+
+import { PageMenu } from '@amsterdam/design-system-react'
+import { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Page menu',
+  component: PageMenu,
+  args: {
+    children: 'Nieuw component',
+  },
+} satisfies Meta<typeof PageMenu>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/storybook/storybook-react/src/components/PageMenu/PageMenu.stories.tsx
+++ b/storybook/storybook-react/src/components/PageMenu/PageMenu.stories.tsx
@@ -26,4 +26,9 @@ export const Default: Story = {
       <PageMenu.Button icon={Menu}>Alle onderwerpen</PageMenu.Button>
     </PageMenu>
   ),
+  parameters: {
+    docs: {
+      source: { type: 'dynamic' },
+    },
+  },
 }

--- a/storybook/storybook-react/src/components/PageMenu/PageMenu.stories.tsx
+++ b/storybook/storybook-react/src/components/PageMenu/PageMenu.stories.tsx
@@ -3,7 +3,8 @@
  * Copyright (c) 2023 Gemeente Amsterdam
  */
 
-import { PageMenu } from '@amsterdam/design-system-react'
+import { Icon, PageMenu } from '@amsterdam/design-system-react'
+import { Login, Menu } from '@amsterdam/design-system-react-icons'
 import { Meta, StoryObj } from '@storybook/react'
 
 const meta = {
@@ -18,4 +19,16 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  render: () => (
+    <PageMenu>
+      <PageMenu.Link href="#">English</PageMenu.Link>
+      <PageMenu.Link href="#">
+        Inloggen Mijn Amsterdam <Icon svg={Login} size="level-7" />
+      </PageMenu.Link>
+      <PageMenu.Button>
+        Alle onderwerpen <Icon svg={Menu} size="level-7" />
+      </PageMenu.Button>
+    </PageMenu>
+  ),
+}

--- a/storybook/storybook-react/src/components/PageMenu/PageMenu.stories.tsx
+++ b/storybook/storybook-react/src/components/PageMenu/PageMenu.stories.tsx
@@ -10,9 +10,6 @@ import { Meta, StoryObj } from '@storybook/react'
 const meta = {
   title: 'Page menu',
   component: PageMenu,
-  args: {
-    children: 'Nieuw component',
-  },
 } satisfies Meta<typeof PageMenu>
 
 export default meta


### PR DESCRIPTION
In order te re-use the horizontal menu in both the Header and Footer paterns we could use something like this. I've kept the amount of props like text labels or icons to a minimum.