### PR TITLE
Wrap calculations in clamp css values in calc()

### DIFF
--- a/proprietary/tokens/src/brand/amsterdam/typography.tokens.json
+++ b/proprietary/tokens/src/brand/amsterdam/typography.tokens.json
@@ -9,73 +9,79 @@
       "text-level": {
         "0": {
           "narrow": {
-            "font-size": { "value": "clamp(2rem, 2rem + (2 * (100vw - 20rem)) / 33.3125, 4rem)" }
+            "font-size": { "value": "clamp(2rem, 2rem + calc(2 * (100vw - 20rem)) / 33.3125, 4rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(4rem, 4rem + (1 * (100vw - 53.375rem)) / 36.625, 5rem)" }
+            "font-size": { "value": "clamp(4rem, 4rem + calc(1 * (100vw - 53.375rem)) / 36.625, 5rem)" }
           },
           "line-height": { "value": "1.1" }
         },
         "1": {
           "narrow": {
-            "font-size": { "value": "clamp(2rem, 2rem + (1 * (100vw - 20rem)) / 33.3125, 3rem)" }
+            "font-size": { "value": "clamp(2rem, 2rem + calc(1 * (100vw - 20rem)) / 33.3125, 3rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(3rem, 3rem + (0.5 * (100vw - 53.375rem)) / 36.625, 3.5rem)" }
+            "font-size": { "value": "clamp(3rem, 3rem + calc(0.5 * (100vw - 53.375rem)) / 36.625, 3.5rem)" }
           },
           "line-height": { "value": "1.2" }
         },
         "2": {
           "narrow": {
-            "font-size": { "value": "clamp(1.75rem, 1.75rem + (0.5 * (100vw - 20rem)) / 33.3125, 2.25rem)" }
+            "font-size": { "value": "clamp(1.75rem, 1.75rem + calc(0.5 * (100vw - 20rem)) / 33.3125, 2.25rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(2.25rem, 2.25rem + (0.25 * (100vw - 53.375rem)) / 36.625, 2.5rem)" }
+            "font-size": { "value": "clamp(2.25rem, 2.25rem + calc(0.25 * (100vw - 53.375rem)) / 36.625, 2.5rem)" }
           },
           "line-height": { "value": "1.3" }
         },
         "3": {
           "narrow": {
-            "font-size": { "value": "clamp(1.5rem, 1.5rem + (0.3125 * (100vw - 20rem)) / 33.3125, 1.8125rem)" }
+            "font-size": { "value": "clamp(1.5rem, 1.5rem + calc(0.3125 * (100vw - 20rem)) / 33.3125, 1.8125rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(1.8125rem, 1.8125rem + (0.1875 * (100vw - 53.375rem)) / 36.625, 2rem)" }
+            "font-size": { "value": "clamp(1.8125rem, 1.8125rem + calc(0.1875 * (100vw - 53.375rem)) / 36.625, 2rem)" }
           },
           "line-height": { "value": "1.4" }
         },
         "4": {
           "narrow": {
-            "font-size": { "value": "clamp(1.25rem, 1.25rem + (0.1875 * (100vw - 20rem)) / 33.3125, 1.4375rem)" }
+            "font-size": { "value": "clamp(1.25rem, 1.25rem + calc(0.1875 * (100vw - 20rem)) / 33.3125, 1.4375rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(1.4375rem, 1.4375rem + (0.125 * (100vw - 53.375rem)) / 36.625, 1.5625rem)" }
+            "font-size": {
+              "value": "clamp(1.4375rem, 1.4375rem + calc(0.125 * (100vw - 53.375rem)) / 36.625, 1.5625rem)"
+            }
           },
           "line-height": { "value": "1.4" }
         },
         "5": {
           "narrow": {
-            "font-size": { "value": "clamp(1.375rem, 1.375rem + (0.25 * (100vw - 20rem)) / 33.3125, 1.625rem)" }
+            "font-size": { "value": "clamp(1.375rem, 1.375rem + calc(0.25 * (100vw - 20rem)) / 33.3125, 1.625rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(1.625rem, 1.625rem + (0.125 * (100vw - 53.375rem)) / 36.625, 1.75rem)" }
+            "font-size": { "value": "clamp(1.625rem, 1.625rem + calc(0.125 * (100vw - 53.375rem)) / 36.625, 1.75rem)" }
           },
           "line-height": { "value": "1.5" }
         },
         "6": {
           "narrow": {
-            "font-size": { "value": "clamp(1.125rem, 1.125rem + (0.1875 * (100vw - 20rem)) / 33.3125, 1.3125rem)" }
+            "font-size": { "value": "clamp(1.125rem, 1.125rem + calc(0.1875 * (100vw - 20rem)) / 33.3125, 1.3125rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(1.3125rem, 1.3125rem + (0.0625 * (100vw - 53.375rem)) / 36.625, 1.375rem)" }
+            "font-size": {
+              "value": "clamp(1.3125rem, 1.3125rem + calc(0.0625 * (100vw - 53.375rem)) / 36.625, 1.375rem)"
+            }
           },
           "line-height": { "value": "1.6" }
         },
         "7": {
           "narrow": {
-            "font-size": { "value": "clamp(1rem, 1rem + (0.0625 * (100vw - 20rem)) / 33.3125, 1.0625rem)" }
+            "font-size": { "value": "clamp(1rem, 1rem + calc(0.0625 * (100vw - 20rem)) / 33.3125, 1.0625rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(1.0625rem, 1.0625rem + (0.0625 * (100vw - 53.375rem)) / 36.625, 1.125rem)" }
+            "font-size": {
+              "value": "clamp(1.0625rem, 1.0625rem + calc(0.0625 * (100vw - 53.375rem)) / 36.625, 1.125rem)"
+            }
           },
           "line-height": { "value": "1.6" }
         }

--- a/proprietary/tokens/src/brand/amsterdam/typography.tokens.json
+++ b/proprietary/tokens/src/brand/amsterdam/typography.tokens.json
@@ -9,78 +9,84 @@
       "text-level": {
         "0": {
           "narrow": {
-            "font-size": { "value": "clamp(2rem, 2rem + calc(2 * (100vw - 20rem)) / 33.3125, 4rem)" }
+            "font-size": { "value": "clamp(2rem, calc(2rem + (2 * (100vw - 20rem)) / 33.3125), 4rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(4rem, 4rem + calc(1 * (100vw - 53.375rem)) / 36.625, 5rem)" }
+            "font-size": { "value": "clamp(4rem, calc(4rem + (1 * (100vw - 53.375rem)) / 36.625), 5rem)" }
           },
           "line-height": { "value": "1.1" }
         },
         "1": {
           "narrow": {
-            "font-size": { "value": "clamp(2rem, 2rem + calc(1 * (100vw - 20rem)) / 33.3125, 3rem)" }
+            "font-size": { "value": "clamp(2rem, calc(2rem + (1 * (100vw - 20rem)) / 33.3125), 3rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(3rem, 3rem + calc(0.5 * (100vw - 53.375rem)) / 36.625, 3.5rem)" }
+            "font-size": { "value": "clamp(3rem, calc(3rem + (0.5 * (100vw - 53.375rem)) / 36.625), 3.5rem)" }
           },
           "line-height": { "value": "1.2" }
         },
         "2": {
           "narrow": {
-            "font-size": { "value": "clamp(1.75rem, 1.75rem + calc(0.5 * (100vw - 20rem)) / 33.3125, 2.25rem)" }
+            "font-size": { "value": "clamp(1.75rem, calc(1.75rem + (0.5 * (100vw - 20rem)) / 33.3125), 2.25rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(2.25rem, 2.25rem + calc(0.25 * (100vw - 53.375rem)) / 36.625, 2.5rem)" }
+            "font-size": { "value": "clamp(2.25rem, calc(2.25rem + (0.25 * (100vw - 53.375rem)) / 36.625), 2.5rem)" }
           },
           "line-height": { "value": "1.3" }
         },
         "3": {
           "narrow": {
-            "font-size": { "value": "clamp(1.5rem, 1.5rem + calc(0.3125 * (100vw - 20rem)) / 33.3125, 1.8125rem)" }
+            "font-size": { "value": "clamp(1.5rem, calc(1.5rem + (0.3125 * (100vw - 20rem)) / 33.3125), 1.8125rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(1.8125rem, 1.8125rem + calc(0.1875 * (100vw - 53.375rem)) / 36.625, 2rem)" }
+            "font-size": {
+              "value": "clamp(1.8125rem, calc(1.8125rem + (0.1875 * (100vw - 53.375rem)) / 36.625), 2rem)"
+            }
           },
           "line-height": { "value": "1.4" }
         },
         "4": {
           "narrow": {
-            "font-size": { "value": "clamp(1.25rem, 1.25rem + calc(0.1875 * (100vw - 20rem)) / 33.3125, 1.4375rem)" }
+            "font-size": { "value": "clamp(1.25rem, calc(1.25rem + (0.1875 * (100vw - 20rem)) / 33.3125), 1.4375rem)" }
           },
           "wide": {
             "font-size": {
-              "value": "clamp(1.4375rem, 1.4375rem + calc(0.125 * (100vw - 53.375rem)) / 36.625, 1.5625rem)"
+              "value": "clamp(1.4375rem, calc(1.4375rem + (0.125 * (100vw - 53.375rem)) / 36.625), 1.5625rem)"
             }
           },
           "line-height": { "value": "1.4" }
         },
         "5": {
           "narrow": {
-            "font-size": { "value": "clamp(1.375rem, 1.375rem + calc(0.25 * (100vw - 20rem)) / 33.3125, 1.625rem)" }
+            "font-size": { "value": "clamp(1.375rem, calc(1.375rem + (0.25 * (100vw - 20rem)) / 33.3125), 1.625rem)" }
           },
           "wide": {
-            "font-size": { "value": "clamp(1.625rem, 1.625rem + calc(0.125 * (100vw - 53.375rem)) / 36.625, 1.75rem)" }
+            "font-size": {
+              "value": "clamp(1.625rem, calc(1.625rem + (0.125 * (100vw - 53.375rem)) / 36.625), 1.75rem)"
+            }
           },
           "line-height": { "value": "1.5" }
         },
         "6": {
           "narrow": {
-            "font-size": { "value": "clamp(1.125rem, 1.125rem + calc(0.1875 * (100vw - 20rem)) / 33.3125, 1.3125rem)" }
+            "font-size": {
+              "value": "clamp(1.125rem, calc(1.125rem + (0.1875 * (100vw - 20rem)) / 33.3125), 1.3125rem)"
+            }
           },
           "wide": {
             "font-size": {
-              "value": "clamp(1.3125rem, 1.3125rem + calc(0.0625 * (100vw - 53.375rem)) / 36.625, 1.375rem)"
+              "value": "clamp(1.3125rem, calc(1.3125rem + (0.0625 * (100vw - 53.375rem)) / 36.625), 1.375rem)"
             }
           },
           "line-height": { "value": "1.6" }
         },
         "7": {
           "narrow": {
-            "font-size": { "value": "clamp(1rem, 1rem + calc(0.0625 * (100vw - 20rem)) / 33.3125, 1.0625rem)" }
+            "font-size": { "value": "clamp(1rem, calc(1rem + (0.0625 * (100vw - 20rem)) / 33.3125), 1.0625rem)" }
           },
           "wide": {
             "font-size": {
-              "value": "clamp(1.0625rem, 1.0625rem + calc(0.0625 * (100vw - 53.375rem)) / 36.625, 1.125rem)"
+              "value": "clamp(1.0625rem, calc(1.0625rem + (0.0625 * (100vw - 53.375rem)) / 36.625), 1.125rem)"
             }
           },
           "line-height": { "value": "1.6" }


### PR DESCRIPTION
Projects using  postcss-safe-parser  (like CRA 4) are getting a build error on the :root variables that use a calc function without `calc()`. 