### PR TITLE
Set screen language to Dutch

### DIFF
--- a/packages/react/src/Screen/Screen.tsx
+++ b/packages/react/src/Screen/Screen.tsx
@@ -14,7 +14,12 @@ export interface ScreenProps extends PropsWithChildren<HTMLAttributes<HTMLDivEle
 
 export const Screen = forwardRef(
   ({ children, className, maxWidth = 'wide', ...restProps }: ScreenProps, ref: ForwardedRef<HTMLDivElement>) => (
-    <div {...restProps} ref={ref} className={clsx('amsterdam-screen', `amsterdam-screen--${maxWidth}`, className)}>
+    <div
+      {...restProps}
+      ref={ref}
+      className={clsx('amsterdam-screen', `amsterdam-screen--${maxWidth}`, className)}
+      lang="nl"
+    >
       {children}
     </div>
   ),


### PR DESCRIPTION
> The default value of `lang` is unknown, therefore it is recommended to always specify this attribute with the appropriate value. ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang))

Adding this to the `Screen` component is appropriate as it’s the outermost component we have control over and it applies to the entire tree (“If these attributes are omitted from an element, then the language of this element is the same as the language of its parent element, if any” – [Spec](https://html.spec.whatwg.org/multipage/dom.html#attr-lang))

Support for more languages through a prop with a number of options may follow – see https://amsterdam.nl/stijlweb/heldere-taal/engels-talen/.