### PR TITLE
Simplify viewports in Storybook

### DIFF
--- a/storybook/storybook-react/config/viewports.ts
+++ b/storybook/storybook-react/config/viewports.ts
@@ -1,75 +1,27 @@
 import { ViewportMap } from './types'
 
 export const viewports: ViewportMap = {
-  phoneSm: {
-    name: 'Small phone',
+  phone: {
+    name: 'Phone',
     styles: {
-      height: '812px',
-      width: '375px',
+      height: '680px',
+      width: '320px',
     },
     type: 'mobile',
   },
-  phoneMd: {
-    name: 'Medium phone',
-    styles: {
-      height: '844px',
-      width: '390px',
-    },
-    type: 'mobile',
-  },
-  phoneLg: {
-    name: 'Large phone',
-    styles: {
-      height: '926px',
-      width: '428px',
-    },
-    type: 'mobile',
-  },
-  tabletSm: {
-    name: 'Small tablet',
-    styles: {
-      height: '768px',
-      width: '1024px',
-    },
-    type: 'tablet',
-  },
-  tabletMd: {
-    name: 'Medium tablet',
-    styles: {
-      height: '800px',
-      width: '1280px',
-    },
-    type: 'tablet',
-  },
-  tabletLg: {
-    name: 'Large tablet',
-    styles: {
-      height: '1024px',
-      width: '1366px',
-    },
-    type: 'tablet',
-  },
-  desktopSm: {
-    name: 'Small desktop',
-    styles: {
-      height: '900px',
-      width: '1440px',
-    },
-    type: 'desktop',
-  },
-  desktopMd: {
-    name: 'Medium desktop',
+  tablet: {
+    name: 'Tablet',
     styles: {
       height: '1080px',
-      width: '1920px',
+      width: '832px',
     },
-    type: 'desktop',
+    type: 'tablet',
   },
-  desktopLg: {
-    name: 'Large desktop',
+  desktop: {
+    name: 'Desktop',
     styles: {
-      height: '1440px',
-      width: '2560px',
+      height: '1080px',
+      width: '1600px',
     },
     type: 'desktop',
   },


### PR DESCRIPTION
We’re simplifying the list of viewports in Storybook with which people can get an indication of how a component will work on a phone, tablet or desktop computer.

Our responsive framework is ready to serve any screen resolution, but we’re not going to design every component or screen in every one of them. Our designers are used to making high-fidelity designs in Figma and need some control over the width of the frames they create and the measurements of our layout and typography at these widths.

We have decided to go with 320, 832 and 1600 as reference widths for design. It seems logical to match that list in Storybook. I tried to find logical heights to match.