### PR TITLE
This breaks the (old) CRA builds

### DIFF
--- a/proprietary/tokens/src/components/amsterdam/grid.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/grid.tokens.json
@@ -6,21 +6,21 @@
       },
       "density-low": {
         "gap": {
-          "value": "clamp(1rem, 3.125vw + 0.375rem, 3.5rem)",
+          "value": "clamp(1rem, calc(3.125vw + 0.375rem), 3.5rem)",
           "comment": "Grows from 16px at 320px wide to 56px at 1600px wide."
         },
         "padding-inline": {
-          "value": "clamp(1.5rem, 4.6875vw + 0.5625rem, 5.25rem)",
+          "value": "clamp(1.5rem, calc(4.6875vw + 0.5625rem), 5.25rem)",
           "comment": "Equals 1.5 times the gap."
         }
       },
       "density-high": {
         "gap": {
-          "value": "clamp(1rem, 1.5625vw - 0.0625rem, 2.5rem)",
+          "value": "clamp(1rem, calc(1.5625vw - 0.0625rem), 2.5rem)",
           "comment": "Grows from 16px at 1088px wide to 40px at 2624px wide."
         },
         "padding-inline": {
-          "value": "clamp(1rem, 1.5625vw - 0.0625rem, 2.5rem)",
+          "value": "clamp(1rem, calc(1.5625vw - 0.0625rem), 2.5rem)",
           "comment": "Equals the gap."
         }
       },


### PR DESCRIPTION
Hee Chan reported that this grid CSS breaks the CRA build. This was previously the case in typography.

Since the old CRA (v4) uses a buggy safe css parser, it does not accept "unsafe" calculations. It needs to be used with `calc()`. Same issue with the Typography. 