### PR TITLE
fix: Apply regular font size to lists of links

### DIFF
--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -49,7 +49,7 @@ export const Link = forwardRef(
         className,
       )}
     >
-      {variant === 'inList' && <Icon svg={icon ?? ChevronRightIcon} size="level-7" />}
+      {variant === 'inList' && <Icon svg={icon ?? ChevronRightIcon} size="level-6" />}
       {children}
     </a>
   ),

--- a/proprietary/tokens/src/components/amsterdam/link.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/link.tokens.json
@@ -44,12 +44,12 @@
           "text-decoration-line": { "value": "{amsterdam.link-appearance.subtle.hover.text-decoration-line}" }
         },
         "spacious": {
-          "font-size": { "value": "{amsterdam.typography.spacious.text-level.7.font-size}" },
-          "line-height": { "value": "{amsterdam.typography.spacious.text-level.7.line-height}" }
+          "font-size": { "value": "{amsterdam.typography.spacious.text-level.6.font-size}" },
+          "line-height": { "value": "{amsterdam.typography.spacious.text-level.6.line-height}" }
         },
         "compact": {
-          "font-size": { "value": "{amsterdam.typography.compact.text-level.7.font-size}" },
-          "line-height": { "value": "{amsterdam.typography.compact.text-level.7.line-height}" }
+          "font-size": { "value": "{amsterdam.typography.compact.text-level.6.font-size}" },
+          "line-height": { "value": "{amsterdam.typography.compact.text-level.6.line-height}" }
         }
       },
       "standalone": {

--- a/storybook/storybook-docs/src/typography.stories.mdx
+++ b/storybook/storybook-docs/src/typography.stories.mdx
@@ -13,15 +13,15 @@ Elk typografisch element zit op 1 zo’n niveau: titel, paragraaf, link, citaat,
 Ze zijn genummerd van 0 tot en met 6 – zo komen ze voor de diverse titels mooi overeen.
 Voorbeelden:
 
-| Niveau | Componenten                                          |
-| -----: | :--------------------------------------------------- |
-|      0 | Page heading                                         |
-|      1 | Heading 1                                            |
-|      2 | Heading 2                                            |
-|      3 | Heading 3, Blockquote                                |
-|      4 | Heading 4, Large Paragraph                           |
-|      5 | Paragraph, Button, Link behalve InList               |
-|      6 | Small Paragraph, InList Link, Form Label, Breadcrumb |
+| Niveau | Componenten                            |
+| -----: | :------------------------------------- |
+|      0 | Page heading                           |
+|      1 | Heading 1                              |
+|      2 | Heading 2                              |
+|      3 | Heading 3, Blockquote                  |
+|      4 | Heading 4, Large Paragraph             |
+|      5 | Paragraph, List, Link, Button          |
+|      6 | Small Paragraph, Page Menu, Breadcrumb |
 
 ### Responsive
 


### PR DESCRIPTION
Neither Inge nor I knew why links in lists had a smaller font size. We agree that all three paragraph sizes must be available for link lists as well. For now, setting the regular font size (level 6) to links is enough.