### PR TITLE
chore: Update path to breakpoint stylesheet in Storybook docs

### DIFF
--- a/storybook/storybook-docs/src/breakpoint.stories.mdx
+++ b/storybook/storybook-docs/src/breakpoint.stories.mdx
@@ -20,4 +20,4 @@ Bijvoorbeeld:
 }
 ```
 
-Binnen deze repository kun je het breakpoint als Sass-variabele importeren. Je vindt deze variabele in [packages/css/utils/breakpoint.scss](https://github.com/Amsterdam/design-system/blob/main/packages/css/utils/breakpoint.scss).
+Binnen deze repository kun je het breakpoint als Sass-variabele importeren. Je vindt deze variabele in [packages/css/src/common/breakpoint.scss](https://github.com/Amsterdam/design-system/blob/main/packages/css/src/common/breakpoint.scss).


### PR DESCRIPTION
We forgot this one.