### PR TITLE
chore: Correct indentation for values in design token files

### DIFF
--- a/proprietary/tokens/src/common/amsterdam/border.tokens.json
+++ b/proprietary/tokens/src/common/amsterdam/border.tokens.json
@@ -1,15 +1,9 @@
 {
   "amsterdam": {
     "border-width": {
-      "sm": {
-        "value": "1px"
-      },
-      "md": {
-        "value": "2px"
-      },
-      "lg": {
-        "value": "3px"
-      }
+      "sm": { "value": "1px" },
+      "md": { "value": "2px" },
+      "lg": { "value": "3px" }
     }
   }
 }

--- a/proprietary/tokens/src/common/amsterdam/spacing.tokens.json
+++ b/proprietary/tokens/src/common/amsterdam/spacing.tokens.json
@@ -2,18 +2,10 @@
   "amsterdam": {
     "spacing": {
       "inset": {
-        "sm": {
-          "value": "0.5rem"
-        },
-        "md": {
-          "value": "1rem"
-        },
-        "lg": {
-          "value": "1.5rem"
-        },
-        "xl": {
-          "value": "2.5rem"
-        }
+        "sm": { "value": "0.5rem" },
+        "md": { "value": "1rem" },
+        "lg": { "value": "1.5rem" },
+        "xl": { "value": "2.5rem" }
       }
     }
   }

--- a/proprietary/tokens/src/components/amsterdam/accordion.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/accordion.tokens.json
@@ -9,9 +9,7 @@
         "font-family": { "value": "{amsterdam.typography.font-family}" },
         "font-weight": { "value": "{amsterdam.typography.font-weight.bold}" },
         "hover": {
-          "box-shadow": {
-            "value": "inset 0 0 0 2px {amsterdam.color.neutral-grey3}"
-          }
+          "box-shadow": { "value": "inset 0 0 0 2px {amsterdam.color.neutral-grey3}" }
         },
         "spacious": {
           "font-size": { "value": "{amsterdam.typography.spacious.text-level.5.font-size}" },

--- a/proprietary/tokens/src/components/amsterdam/button.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/button.tokens.json
@@ -10,30 +10,20 @@
         "line-height": { "value": "{amsterdam.typography.compact.text-level.6.line-height}" }
       },
       "secondary": {
-        "box-shadow": {
-          "value": "inset 0 0 0 2px {amsterdam.color.primary-blue}"
-        },
+        "box-shadow": { "value": "inset 0 0 0 2px {amsterdam.color.primary-blue}" },
         "hover": {
-          "box-shadow": {
-            "value": "inset 0 0 0 3px {amsterdam.color.dark-blue}"
-          }
+          "box-shadow": { "value": "inset 0 0 0 3px {amsterdam.color.dark-blue}" }
         },
         "disabled": {
-          "box-shadow": {
-            "value": "inset 0 0 0 2px {amsterdam.color.neutral-grey2}"
-          }
+          "box-shadow": { "value": "inset 0 0 0 2px {amsterdam.color.neutral-grey2}" }
         },
         "focus": {
-          "box-shadow": {
-            "value": "inset 0 0 0 2px {amsterdam.color.primary-blue}"
-          }
+          "box-shadow": { "value": "inset 0 0 0 2px {amsterdam.color.primary-blue}" }
         }
       },
       "tertiary": {
         "hover": {
-          "box-shadow": {
-            "value": "inset 0 0 0 2px {amsterdam.color.neutral-grey3}"
-          }
+          "box-shadow": { "value": "inset 0 0 0 2px {amsterdam.color.neutral-grey3}" }
         }
       }
     }

--- a/proprietary/tokens/src/components/amsterdam/checkbox.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/checkbox.tokens.json
@@ -1,105 +1,65 @@
 {
   "amsterdam": {
     "checkbox": {
-      "color": {
-        "value": "{amsterdam.color.primary-black}"
-      },
+      "color": { "value": "{amsterdam.color.primary-black}" },
       "checkmark": {
-        "border-color": {
-          "value": "{amsterdam.color.primary-blue}"
-        },
+        "border-color": { "value": "{amsterdam.color.primary-blue}" },
         "checked": {
-          "background-color": {
-            "value": "{amsterdam.color.primary-blue}"
-          },
+          "background-color": { "value": "{amsterdam.color.primary-blue}" },
           "hover": {
-            "background-color": {
-              "value": "{amsterdam.color.dark-blue}"
-            }
+            "background-color": { "value": "{amsterdam.color.dark-blue}" }
           }
         },
         "disabled": {
-          "border-color": {
-            "value": "{amsterdam.color.neutral-grey3}"
-          },
+          "border-color": { "value": "{amsterdam.color.neutral-grey3}" },
           "checked": {
-            "background-color": {
-              "value": "{amsterdam.color.neutral-grey3}"
-            },
+            "background-color": { "value": "{amsterdam.color.neutral-grey3}" },
             "hover": {
-              "background-color": {
-                "value": "{amsterdam.color.neutral-grey3}"
-              }
+              "background-color": { "value": "{amsterdam.color.neutral-grey3}" }
             }
           },
           "indeterminate": {
-            "background-color": {
-              "value": "{amsterdam.color.neutral-grey3}"
-            },
+            "background-color": { "value": "{amsterdam.color.neutral-grey3}" },
             "hover": {
-              "background-color": {
-                "value": "{amsterdam.color.neutral-grey3}"
-              }
+              "background-color": { "value": "{amsterdam.color.neutral-grey3}" }
             }
           }
         },
         "hover": {
-          "border-color": {
-            "value": "{amsterdam.color.dark-blue}"
-          }
+          "border-color": { "value": "{amsterdam.color.dark-blue}" }
         },
         "invalid": {
-          "border-color": {
-            "value": "{amsterdam.color.primary-red}"
-          },
+          "border-color": { "value": "{amsterdam.color.primary-red}" },
           "checked": {
-            "background-color": {
-              "value": "{amsterdam.color.primary-red}"
-            },
+            "background-color": { "value": "{amsterdam.color.primary-red}" },
             "hover": {
-              "background-color": {
-                "value": "{amsterdam.color.primary-red}"
-              }
+              "background-color": { "value": "{amsterdam.color.primary-red}" }
             }
           },
           "hover": {
-            "border-color": {
-              "value": "{amsterdam.color.primary-red}"
-            }
+            "border-color": { "value": "{amsterdam.color.primary-red}" }
           },
           "indeterminate": {
-            "background-color": {
-              "value": "{amsterdam.color.primary-red}"
-            },
+            "background-color": { "value": "{amsterdam.color.primary-red}" },
             "hover": {
-              "background-color": {
-                "value": "{amsterdam.color.primary-red}"
-              }
+              "background-color": { "value": "{amsterdam.color.primary-red}" }
             }
           }
         },
         "indeterminate": {
-          "background-color": {
-            "value": "{amsterdam.color.primary-blue}"
-          },
+          "background-color": { "value": "{amsterdam.color.primary-blue}" },
           "hover": {
-            "background-color": {
-              "value": "{amsterdam.color.dark-blue}"
-            }
+            "background-color": { "value": "{amsterdam.color.dark-blue}" }
           }
         }
       },
       "disabled": {
-        "color": {
-          "value": "{amsterdam.color.neutral-grey3}"
-        }
+        "color": { "value": "{amsterdam.color.neutral-grey3}" }
       },
       "font-family": { "value": "{amsterdam.typography.font-family}" },
       "font-weight": { "value": "{amsterdam.typography.font-weight.normal}" },
       "hover": {
-        "color": {
-          "value": "{amsterdam.color.dark-blue}"
-        }
+        "color": { "value": "{amsterdam.color.dark-blue}" }
       },
       "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
       "spacious": {

--- a/proprietary/tokens/src/components/amsterdam/grid.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/grid.tokens.json
@@ -1,9 +1,7 @@
 {
   "amsterdam": {
     "grid": {
-      "column-count": {
-        "value": "4"
-      },
+      "column-count": { "value": "4" },
       "spacious": {
         "gap": {
           "value": "clamp(1rem, calc(3.125vw + 0.375rem), 3.5rem)",
@@ -25,14 +23,10 @@
         }
       },
       "medium": {
-        "column-count": {
-          "value": "8"
-        }
+        "column-count": { "value": "8" }
       },
       "wide": {
-        "column-count": {
-          "value": "12"
-        }
+        "column-count": { "value": "12" }
       }
     }
   }

--- a/proprietary/tokens/src/components/amsterdam/heading.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/heading.tokens.json
@@ -25,36 +25,20 @@
       },
       "compact": {
         "level-1": {
-          "line-height": {
-            "value": "{amsterdam.typography.compact.text-level.1.line-height}"
-          },
-          "font-size": {
-            "value": "{amsterdam.typography.compact.text-level.1.font-size}"
-          }
+          "line-height": { "value": "{amsterdam.typography.compact.text-level.1.line-height}" },
+          "font-size": { "value": "{amsterdam.typography.compact.text-level.1.font-size}" }
         },
         "level-2": {
-          "line-height": {
-            "value": "{amsterdam.typography.compact.text-level.2.line-height}"
-          },
-          "font-size": {
-            "value": "{amsterdam.typography.compact.text-level.2.font-size}"
-          }
+          "line-height": { "value": "{amsterdam.typography.compact.text-level.2.line-height}" },
+          "font-size": { "value": "{amsterdam.typography.compact.text-level.2.font-size}" }
         },
         "level-3": {
-          "line-height": {
-            "value": "{amsterdam.typography.compact.text-level.3.line-height}"
-          },
-          "font-size": {
-            "value": "{amsterdam.typography.compact.text-level.3.font-size}"
-          }
+          "line-height": { "value": "{amsterdam.typography.compact.text-level.3.line-height}" },
+          "font-size": { "value": "{amsterdam.typography.compact.text-level.3.font-size}" }
         },
         "level-4": {
-          "line-height": {
-            "value": "{amsterdam.typography.compact.text-level.4.line-height}"
-          },
-          "font-size": {
-            "value": "{amsterdam.typography.compact.text-level.4.font-size}"
-          }
+          "line-height": { "value": "{amsterdam.typography.compact.text-level.4.line-height}" },
+          "font-size": { "value": "{amsterdam.typography.compact.text-level.4.font-size}" }
         }
       }
     }

--- a/proprietary/tokens/src/components/amsterdam/highlight.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/highlight.tokens.json
@@ -2,44 +2,28 @@
   "amsterdam": {
     "highlight": {
       "blue": {
-        "background-color": {
-          "value": "{amsterdam.color.primary-blue}"
-        }
+        "background-color": { "value": "{amsterdam.color.primary-blue}" }
       },
       "dark-green": {
-        "background-color": {
-          "value": "{amsterdam.color.dark-green}"
-        }
+        "background-color": { "value": "{amsterdam.color.dark-green}" }
       },
       "green": {
-        "background-color": {
-          "value": "{amsterdam.color.green}"
-        }
+        "background-color": { "value": "{amsterdam.color.green}" }
       },
       "light-blue": {
-        "background-color": {
-          "value": "{amsterdam.color.blue}"
-        }
+        "background-color": { "value": "{amsterdam.color.blue}" }
       },
       "magenta": {
-        "background-color": {
-          "value": "{amsterdam.color.magenta}"
-        }
+        "background-color": { "value": "{amsterdam.color.magenta}" }
       },
       "orange": {
-        "background-color": {
-          "value": "{amsterdam.color.orange}"
-        }
+        "background-color": { "value": "{amsterdam.color.orange}" }
       },
       "purple": {
-        "background-color": {
-          "value": "{amsterdam.color.purple}"
-        }
+        "background-color": { "value": "{amsterdam.color.purple}" }
       },
       "yellow": {
-        "background-color": {
-          "value": "{amsterdam.color.yellow}"
-        }
+        "background-color": { "value": "{amsterdam.color.yellow}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/amsterdam/link.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/link.tokens.json
@@ -2,12 +2,8 @@
   "amsterdam": {
     "link": {
       "color": { "value": "{amsterdam.link-appearance.color}" },
-      "font-family": {
-        "value": "{amsterdam.typography.font-family}"
-      },
-      "font-weight": {
-        "value": "{amsterdam.typography.font-weight.normal}"
-      },
+      "font-family": { "value": "{amsterdam.typography.font-family}" },
+      "font-weight": { "value": "{amsterdam.typography.font-weight.normal}" },
       "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
       "hover": {
         "color": { "value": "{amsterdam.link-appearance.hover.color}" }
@@ -16,15 +12,9 @@
         "text-decoration-line": { "value": "{amsterdam.link-appearance.regular.text-decoration-line}" },
         "text-decoration-thickness": { "value": "{amsterdam.link-appearance.text-decoration-thickness}" },
         "text-underline-offset": { "value": "{amsterdam.link-appearance.text-underline-offset}" },
-        "font-family": {
-          "value": "inherit"
-        },
-        "font-size": {
-          "value": "inherit"
-        },
-        "line-height": {
-          "value": "inherit"
-        },
+        "font-family": { "value": "inherit" },
+        "font-size": { "value": "inherit" },
+        "line-height": { "value": "inherit" },
         "hover": {
           "text-decoration-thickness": {
             "value": "{amsterdam.link-appearance.regular.hover.text-decoration-thickness}"

--- a/proprietary/tokens/src/components/amsterdam/page-heading.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/page-heading.tokens.json
@@ -6,20 +6,12 @@
       "font-weight": { "value": "{amsterdam.typography.font-weight.bold}" },
       "inverse-color": { "value": "{amsterdam.color.primary-white}" },
       "spacious": {
-        "font-size": {
-          "value": "{amsterdam.typography.spacious.text-level.0.font-size}"
-        },
-        "line-height": {
-          "value": "{amsterdam.typography.spacious.text-level.0.font-size}"
-        }
+        "font-size": { "value": "{amsterdam.typography.spacious.text-level.0.font-size}" },
+        "line-height": { "value": "{amsterdam.typography.spacious.text-level.0.font-size}" }
       },
       "compact": {
-        "font-size": {
-          "value": "{amsterdam.typography.compact.text-level.0.font-size}"
-        },
-        "line-height": {
-          "value": "{amsterdam.typography.compact.text-level.0.font-size}"
-        }
+        "font-size": { "value": "{amsterdam.typography.compact.text-level.0.font-size}" },
+        "line-height": { "value": "{amsterdam.typography.compact.text-level.0.font-size}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/amsterdam/switch.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/switch.tokens.json
@@ -1,43 +1,23 @@
 {
   "amsterdam": {
     "switch": {
-      "font-family": {
-        "value": "{amsterdam.typography.font-family}"
-      },
-      "background-color": {
-        "value": "{amsterdam.color.neutral-grey3}"
-      },
-      "width": {
-        "value": "3.5rem"
-      },
+      "font-family": { "value": "{amsterdam.typography.font-family}" },
+      "background-color": { "value": "{amsterdam.color.neutral-grey3}" },
+      "width": { "value": "3.5rem" },
       "thumb": {
-        "background-color": {
-          "value": "{amsterdam.color.primary-white}"
-        },
-        "width": {
-          "value": "1.75rem"
-        },
-        "height": {
-          "value": "1.75rem"
-        },
+        "background-color": { "value": "{amsterdam.color.primary-white}" },
+        "width": { "value": "1.75rem" },
+        "height": { "value": "1.75rem" },
         "hover": {
-          "color": {
-            "value": "{amsterdam.color.dark-blue}"
-          }
+          "color": { "value": "{amsterdam.color.dark-blue}" }
         }
       },
       "checked": {
-        "background-color": {
-          "value": "{amsterdam.color.primary-blue}"
-        }
+        "background-color": { "value": "{amsterdam.color.primary-blue}" }
       },
-      "outline-offset": {
-        "value": "{amsterdam.focus.outline-offset}"
-      },
+      "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
       "disabled": {
-        "background-color": {
-          "value": "{amsterdam.color.neutral-grey2}"
-        }
+        "background-color": { "value": "{amsterdam.color.neutral-grey2}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/utrecht/button.tokens.json
+++ b/proprietary/tokens/src/components/utrecht/button.tokens.json
@@ -1,32 +1,18 @@
 {
   "utrecht": {
     "button": {
-      "background-color": {
-        "value": "{amsterdam.color.primary-blue}"
-      },
+      "background-color": { "value": "{amsterdam.color.primary-blue}" },
       "border-color": {},
       "border-radius": {},
       "border-width": {},
-      "color": {
-        "value": "{amsterdam.color.primary-white}"
-      },
-      "font-family": {
-        "value": "{amsterdam.typography.font-family}"
-      },
+      "color": { "value": "{amsterdam.color.primary-white}" },
+      "font-family": { "value": "{amsterdam.typography.font-family}" },
       "font-size": {},
       "line-height": {},
-      "padding-inline-start": {
-        "value": "{amsterdam.spacing.inset.md}"
-      },
-      "padding-inline-end": {
-        "value": "{amsterdam.spacing.inset.md}"
-      },
-      "padding-block-start": {
-        "value": "{amsterdam.spacing.inset.sm}"
-      },
-      "padding-block-end": {
-        "value": "{amsterdam.spacing.inset.sm}"
-      },
+      "padding-inline-start": { "value": "{amsterdam.spacing.inset.md}" },
+      "padding-inline-end": { "value": "{amsterdam.spacing.inset.md}" },
+      "padding-block-start": { "value": "{amsterdam.spacing.inset.sm}" },
+      "padding-block-end": { "value": "{amsterdam.spacing.inset.sm}" },
       "margin-inline-start": {},
       "margin-inline-end": {},
       "margin-block-start": {},
@@ -35,12 +21,8 @@
         "gap": {}
       },
       "disabled": {
-        "background-color": {
-          "value": "{amsterdam.color.neutral-grey2}"
-        },
-        "color": {
-          "value": "{amsterdam.color.primary-white}"
-        },
+        "background-color": { "value": "{amsterdam.color.neutral-grey2}" },
+        "color": { "value": "{amsterdam.color.primary-white}" },
         "border-color": {}
       },
       "hover": {
@@ -50,25 +32,17 @@
         "scale": {}
       },
       "primary-action": {
-        "background-color": {
-          "value": "{amsterdam.color.primary-blue}"
-        },
+        "background-color": { "value": "{amsterdam.color.primary-blue}" },
         "border-color": {},
         "border-width": {},
-        "color": {
-          "value": "{amsterdam.color.primary-white}"
-        },
+        "color": { "value": "{amsterdam.color.primary-white}" },
         "disabled": {
-          "background-color": {
-            "value": "{amsterdam.color.neutral-grey2}"
-          },
+          "background-color": { "value": "{amsterdam.color.neutral-grey2}" },
           "color": {},
           "border-color": {}
         },
         "hover": {
-          "background-color": {
-            "value": "{amsterdam.color.dark-blue}"
-          },
+          "background-color": { "value": "{amsterdam.color.dark-blue}" },
           "border-color": {},
           "color": {}
         },
@@ -130,28 +104,18 @@
         }
       },
       "secondary-action": {
-        "background-color": {
-          "value": "{amsterdam.color.primary-white}"
-        },
-        "color": {
-          "value": "{amsterdam.color.primary-blue}"
-        },
+        "background-color": { "value": "{amsterdam.color.primary-white}" },
+        "color": { "value": "{amsterdam.color.primary-blue}" },
         "border-color": {},
         "border-width": {},
         "hover": {
           "background-color": {},
-          "color": {
-            "value": "{amsterdam.color.dark-blue}"
-          },
+          "color": { "value": "{amsterdam.color.dark-blue}" },
           "border-color": {}
         },
         "disabled": {
-          "background-color": {
-            "value": "{amsterdam.color.primary-white}"
-          },
-          "color": {
-            "value": "{amsterdam.color.neutral-grey2}"
-          },
+          "background-color": { "value": "{amsterdam.color.primary-white}" },
+          "color": { "value": "{amsterdam.color.neutral-grey2}" },
           "border-color": {}
         },
         "danger": {
@@ -207,36 +171,24 @@
         }
       },
       "subtle": {
-        "background-color": {
-          "value": "transparent"
-        },
+        "background-color": { "value": "transparent" },
         "border-color": {},
         "border-width": {},
-        "color": {
-          "value": "{amsterdam.color.primary-blue}"
-        },
+        "color": { "value": "{amsterdam.color.primary-blue}" },
         "font-weight": {},
         "hover": {
           "background-color": {},
-          "color": {
-            "value": "{amsterdam.color.dark-blue}"
-          },
+          "color": { "value": "{amsterdam.color.dark-blue}" },
           "border-color": {}
         },
         "focus": {
           "background-color": {},
-          "color": {
-            "value": "{amsterdam.color.dark-blue}"
-          },
+          "color": { "value": "{amsterdam.color.dark-blue}" },
           "border-color": {}
         },
         "disabled": {
-          "background-color": {
-            "value": "transparent"
-          },
-          "color": {
-            "value": "{amsterdam.color.neutral-grey2}"
-          }
+          "background-color": { "value": "transparent" },
+          "color": { "value": "{amsterdam.color.neutral-grey2}" }
         },
         "danger": {
           "color": {},


### PR DESCRIPTION
This just moves `value` inline if possible, no value changes.