### PR TITLE
fix: Convert main Storybook config files to ESM

### DIFF
--- a/storybook/storybook-docs/config/main.js
+++ b/storybook/storybook-docs/config/main.js
@@ -1,10 +1,10 @@
 import remarkGfm from 'remark-gfm'
 
+// eslint-disable-next-line no-undef
 const { STORYBOOK_BUILD_PATH } = process.env
 const REPO_NAME = 'design-system'
 
-/* eslint-env node */
-module.exports = {
+const config = {
   core: {
     disableTelemetry: true,
   },
@@ -58,3 +58,5 @@ module.exports = {
     }
   },
 }
+
+export default config

--- a/storybook/storybook-react/config/main.ts
+++ b/storybook/storybook-react/config/main.ts
@@ -1,7 +1,7 @@
+import type { StorybookConfig } from '@storybook/react-vite'
 import remarkGfm from 'remark-gfm'
 
-/* eslint-env node */
-module.exports = {
+const config: StorybookConfig = {
   core: {
     disableTelemetry: true,
   },
@@ -34,3 +34,5 @@ module.exports = {
     autodocs: true,
   },
 }
+
+export default config


### PR DESCRIPTION
Our CJS config files caused a warning, this should fix that