### PR TITLE
chore: Remove unused date-fns package

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,8 +34,7 @@
   "dependencies": {
     "@amsterdam/design-system-react-icons": "workspace:*",
     "@utrecht/component-library-react": "2.0.0",
-    "clsx": "2.0.0",
-    "date-fns": "2.30.0"
+    "clsx": "2.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
@@ -51,7 +50,6 @@
     "@testing-library/jest-dom": "6.1.5",
     "@testing-library/react": "14.1.2",
     "@testing-library/user-event": "14.5.1",
-    "@types/date-fns": "2.6.0",
     "@types/jest": "29.5.11",
     "@types/lodash": "4.14.202",
     "@types/react": "18.2.45",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,13 +126,10 @@ importers:
         version: link:../../proprietary/react-icons
       '@utrecht/component-library-react':
         specifier: 2.0.0
-        version: 2.0.0(date-fns@2.30.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.0.0(react-dom@18.2.0)(react@18.2.0)
       clsx:
         specifier: 2.0.0
         version: 2.0.0
-      date-fns:
-        specifier: 2.30.0
-        version: 2.30.0
     devDependencies:
       '@babel/core':
         specifier: 7.23.6
@@ -173,9 +170,6 @@ importers:
       '@testing-library/user-event':
         specifier: 14.5.1
         version: 14.5.1(@testing-library/dom@9.3.3)
-      '@types/date-fns':
-        specifier: 2.6.0
-        version: 2.6.0
       '@types/jest':
         specifier: 29.5.11
         version: 29.5.11
@@ -473,9 +467,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: 4.2.1
         version: 4.2.1(vite@5.0.10)
-      date-fns:
-        specifier: 2.30.0
-        version: 2.30.0
       http-server:
         specifier: 14.1.1
         version: 14.1.1
@@ -1925,6 +1916,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.0
+    dev: true
 
   /@babel/template@7.22.15:
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
@@ -5618,12 +5610,6 @@ packages:
       '@types/node': 20.10.5
     dev: true
 
-  /@types/date-fns@2.6.0:
-    resolution: {integrity: sha512-9DSw2ZRzV0Tmpa6PHHJbMcZn79HHus+BBBohcOaDzkK/G3zMjDUDYjJIWBFLbkh+1+/IOS0A59BpQfdr37hASg==}
-    dependencies:
-      date-fns: 2.30.0
-    dev: true
-
   /@types/debug@4.1.9:
     resolution: {integrity: sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==}
     dependencies:
@@ -6136,7 +6122,7 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
-  /@utrecht/component-library-react@2.0.0(date-fns@2.30.0)(react-dom@18.2.0)(react@18.2.0):
+  /@utrecht/component-library-react@2.0.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-WiZXgMhoDVRUZdPf9aVWBO1FIBVrY+qCNBHhX31lbUHZL83fMmcke4BFneu8Uk5ZB/ckDG+lFdbA23YuC9h0OA==}
     peerDependencies:
       date-fns: ^2.30.0
@@ -6153,7 +6139,6 @@ packages:
         optional: true
     dependencies:
       clsx: 1.2.1
-      date-fns: 2.30.0
       lodash.chunk: 4.2.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -7967,12 +7952,6 @@ packages:
       whatwg-mimetype: 3.0.0
       whatwg-url: 11.0.0
     dev: true
-
-  /date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
-    dependencies:
-      '@babel/runtime': 7.23.6
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -15201,6 +15180,7 @@ packages:
 
   /regenerator-runtime@0.14.0:
     resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
+    dev: true
 
   /regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}

--- a/storybook/storybook-react/package.json
+++ b/storybook/storybook-react/package.json
@@ -47,7 +47,6 @@
     "@storybook/theming": "7.6.5",
     "@types/react": "18.2.45",
     "@vitejs/plugin-react": "4.2.1",
-    "date-fns": "2.30.0",
     "http-server": "14.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
We’re not using this.

@hcvdhaar Did I forget why we added this in the first place?