### PR TITLE
feat: Allow ‘Grid Cell’ to render a custom HTML element

### DIFF
--- a/packages/react/src/Grid/GridCell.test.tsx
+++ b/packages/react/src/Grid/GridCell.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { createRef } from 'react'
 import { Grid } from './Grid'
 import '@testing-library/jest-dom'
@@ -82,9 +82,15 @@ describe('Grid.Cell', () => {
     )
   })
 
-  it('renders the correct class name for the "all" value of span', () => {
+  it('renders the correct class name for the “all” value of span', () => {
     const { container } = render(<Grid.Cell span="all" />)
     const component = container.querySelector(':only-child')
     expect(component).toHaveClass('amsterdam-grid__cell--span-all')
+  })
+
+  it('renders a custom tag', () => {
+    render(<Grid.Cell as="article" />)
+    const cell = screen.getByRole('article')
+    expect(cell).toBeInTheDocument()
   })
 })

--- a/packages/react/src/Grid/GridCell.tsx
+++ b/packages/react/src/Grid/GridCell.tsx
@@ -20,14 +20,19 @@ type GridCellSpanAndStartProps = {
   start?: GridColumnNumber | GridColumnNumbers
 }
 
-export type GridCellProps = (GridCellSpanAllProp | GridCellSpanAndStartProps) &
+export type GridCellProps = {
+  as?: 'article' | 'div' | 'section'
+} & (GridCellSpanAllProp | GridCellSpanAndStartProps) &
   PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 
 export const GridCell = forwardRef(
-  ({ children, className, span, start, ...restProps }: GridCellProps, ref: ForwardedRef<HTMLDivElement>) => (
-    <div {...restProps} ref={ref} className={clsx('amsterdam-grid__cell', gridCellClasses(span, start), className)}>
+  (
+    { as: Tag = 'div', children, className, span, start, ...restProps }: GridCellProps,
+    ref: ForwardedRef<HTMLDivElement>,
+  ) => (
+    <Tag {...restProps} ref={ref} className={clsx('amsterdam-grid__cell', gridCellClasses(span, start), className)}>
       {children}
-    </div>
+    </Tag>
   ),
 )
 

--- a/packages/react/src/Spotlight/Spotlight.test.tsx
+++ b/packages/react/src/Spotlight/Spotlight.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { createRef } from 'react'
 import { Spotlight } from './Spotlight'
 import '@testing-library/jest-dom'
@@ -47,5 +47,11 @@ describe('Spotlight', () => {
     const component = container.querySelector(':only-child')
 
     expect(component).toHaveClass('amsterdam-spotlight--green')
+  })
+
+  it('renders a custom tag', () => {
+    render(<Spotlight as="article" />)
+    const cell = screen.getByRole('article')
+    expect(cell).toBeInTheDocument()
   })
 })

--- a/packages/react/src/Spotlight/Spotlight.tsx
+++ b/packages/react/src/Spotlight/Spotlight.tsx
@@ -12,19 +12,11 @@ export interface SpotlightProps extends PropsWithChildren<HTMLAttributes<HTMLEle
 }
 
 export const Spotlight = forwardRef<HTMLDivElement, SpotlightProps>(
-  ({ children, className, as = 'div', color = 'blue', ...restProps }: SpotlightProps, ref) => {
-    const Component = as
-
-    return (
-      <Component
-        {...restProps}
-        ref={ref}
-        className={clsx('amsterdam-spotlight', `amsterdam-spotlight--${color}`, className)}
-      >
-        {children}
-      </Component>
-    )
-  },
+  ({ children, className, as: Tag = 'div', color = 'blue', ...restProps }: SpotlightProps, ref) => (
+    <Tag {...restProps} ref={ref} className={clsx('amsterdam-spotlight', `amsterdam-spotlight--${color}`, className)}>
+      {children}
+    </Tag>
+  ),
 )
 
 Spotlight.displayName = 'Spotlight'

--- a/storybook/storybook-react/src/Grid/Grid.docs.mdx
+++ b/storybook/storybook-react/src/Grid/Grid.docs.mdx
@@ -90,6 +90,14 @@ Een voorbeeld met `start={2}`:
 
 <Canvas of={GridStories.StartPosition} />
 
+### Een ander HTML-element gebruiken
+
+Een cel wordt standaard als `<div>` in je HTML opgenomen.
+Heb je hier een ander element nodig, dan kan dat via de `as` prop.
+Zo kun je je opmaak semantischer maken.
+
+<Canvas of={GridStories.CustomTagName} />
+
 ## Richtlijnen
 
 Zorg ervoor dat het aantal kolommen dat je aan een cel toekent past bij het aantal kolommen van het grid voor de betreffende vensterbreedte.

--- a/storybook/storybook-react/src/Grid/Grid.stories.tsx
+++ b/storybook/storybook-react/src/Grid/Grid.stories.tsx
@@ -33,6 +33,10 @@ const gridArgTypes = {
 }
 
 const gridCellArgTypes = {
+  as: {
+    control: { type: 'inline-radio' },
+    options: ['article', 'div', 'section'],
+  },
   span: {
     control: { type: 'number', min: 1, max: 12 },
   },
@@ -154,4 +158,18 @@ export const StartPosition: GridCellStory = {
     span: 3,
     start: 2,
   },
+}
+
+export const CustomTagName: GridCellStory = {
+  ...GridCellStoryTemplate,
+  args: {
+    as: 'section',
+  },
+  render: ({ as }: StoryProps) => (
+    <Grid>
+      <Grid.Cell as={as} span="all">
+        <p className="amsterdam-docs-pink-box amsterdam-docs-paragraph">Deze cel gebruikt het HTML-element `{as}`.</p>
+      </Grid.Cell>
+    </Grid>
+  ),
 }

--- a/storybook/storybook-react/src/Spotlight/Spotlight.docs.mdx
+++ b/storybook/storybook-react/src/Spotlight/Spotlight.docs.mdx
@@ -41,3 +41,11 @@ import README from "../../../../packages/css/src/components/spotlight/README.md?
 ### Paars
 
 <Canvas of={SpotlightStories.Purple} />
+
+### Een ander HTML-element gebruiken
+
+Een spotlight wordt standaard als `<div>` in je HTML opgenomen.
+Heb je hier een ander element nodig, dan kan dat via de `as` prop.
+Zo kun je je opmaak semantischer maken.
+
+<Canvas of={SpotlightStories.CustomTagName} />

--- a/storybook/storybook-react/src/Spotlight/Spotlight.stories.tsx
+++ b/storybook/storybook-react/src/Spotlight/Spotlight.stories.tsx
@@ -11,6 +11,10 @@ const meta = {
   title: 'Containers/Spotlight',
   component: Spotlight,
   argTypes: {
+    as: {
+      control: { type: 'inline-radio' },
+      options: ['article', 'aside', 'div', 'footer', 'section'],
+    },
     color: {
       options: ['blue', 'dark-green', 'green', 'light-blue', 'magenta', 'orange', 'purple', 'yellow'],
       control: {
@@ -33,8 +37,8 @@ const meta = {
       },
     },
   },
-  render: ({ color }) => (
-    <Spotlight color={color}>
+  render: ({ as, color }) => (
+    <Spotlight as={as} color={color}>
       <Grid paddingVertical="medium">
         <Grid.Cell span="all">
           <Blockquote inverseColor={!color || !['green', 'yellow'].includes(color)}>{exampleQuote()}</Blockquote>
@@ -95,5 +99,11 @@ export const Green: Story = {
 export const DarkGreen: Story = {
   args: {
     color: 'dark-green',
+  },
+}
+
+export const CustomTagName: Story = {
+  args: {
+    as: 'section',
   },
 }


### PR DESCRIPTION
And update the approach on ‘Spotlight’.