### PR TITLE
chore: Require explicit and inline type imports

### DIFF
--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -3,6 +3,9 @@
     "jest/globals": true
   },
   "rules": {
+    "@typescript-eslint/consistent-type-exports": "error",
+    "@typescript-eslint/consistent-type-imports": "error",
+    "import/consistent-type-specifier-style": ["error", "prefer-inline"],
     "react/react-in-jsx-scope": "off"
   }
 }

--- a/storybook/storybook-react/.eslintrc.json
+++ b/storybook/storybook-react/.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "rules": {
+    "@typescript-eslint/consistent-type-exports": "error",
+    "@typescript-eslint/consistent-type-imports": "error",
+    "import/consistent-type-specifier-style": ["error", "prefer-inline"],
     "react/prop-types": "off",
     "react/react-in-jsx-scope": "off"
   }


### PR DESCRIPTION
We want to export and import types explicitly.

We can use [inline type modifiers](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names) to combine type and component imports in one statement.

Let’s use ESLint to do this for us.