### PR TITLE
feat: Add Skip link component

### DIFF
--- a/packages/css/src/components/index.scss
+++ b/packages/css/src/components/index.scss
@@ -4,6 +4,7 @@
  */
 
 /* Append here */
+@import "./skip-link/skip-link";
 @import "./mark/mark";
 @import "./text-input/text-input";
 @import "./search-field/search-field";

--- a/packages/css/src/components/skip-link/README.md
+++ b/packages/css/src/components/skip-link/README.md
@@ -1,1 +1,30 @@
 # Skip Link
+
+Gebruik een Skip link om makkelijk met het toetsenbord naar de belangrijkste inhoud te navigeren.
+Met een Skip link kun je terugkerende navigatieblokken (zoals het hoofdmenu of het kruimelpad) overslaan.
+Een Skip link is verborgen totdat deze met het toetsenbord geactiveerd wordt.
+
+## Richtlijnen
+
+### Zo gebruiken
+
+- Plaats de Skip link als eerste element in `<body`, tenzij je een cookie-banner hebt.
+  Plaats de Skip link dan direct na de cookie-banner.
+- Gebruik de Skip link om naar de belangrijkste inhoud te navigeren.
+  Op een artikelpagina is dat bijvoorbeeld de titel van het artikel, op een zoekpagina is dat het zoekveld.
+- Voor complexe pagina's met meerdere secties kun je meer dan 1 Skip link gebruiken.
+  In de meeste gevallen is dit niet nodig.
+
+### Dit vermijden
+
+- Skip links zijn niet nodig op een simpele pagina waar alleen tekst staat en weinig navigatie.
+  Het doel van een Skip link is om terugkerende navigatieblokken over te slaan.
+  Als die blokken er niet zijn, is een Skip link niet nodig.
+- Plaats de Skip link niet in een `nav` regio, of in de Header.
+
+## Relevante WCAG eisen
+
+- Voor dit component gelden dezelfde WCAG eisen als voor [het link component](https://amsterdam.github.io/design-system/?path=/docs/react_navigation-link--docs).
+- [WCAG 2.4.1](https://www.w3.org/TR/WCAG22/#bypass-blocks): gebruik een Skip link op elke pagina die begint met een terugkerend navigatieblok.
+- [WCAG 3.2.3](https://www.w3.org/TR/WCAG22/#consistent-navigation): een Skip link staat op elke pagina op dezelfde plek.
+- [WCAG 3.2.4](https://www.w3.org/TR/WCAG22/#consistent-identification): een Skip link heeft dezelfde labels op alle pagina's. Bijvoorbeeld niet: "Navigatie overslaan" op een gedeelte van de site, en "Naar de inhoud" op andere pagina's.

--- a/packages/css/src/components/skip-link/README.md
+++ b/packages/css/src/components/skip-link/README.md
@@ -1,0 +1,1 @@
+# Skip Link

--- a/packages/css/src/components/skip-link/skip-link.scss
+++ b/packages/css/src/components/skip-link/skip-link.scss
@@ -15,6 +15,7 @@
   outline-offset: var(--amsterdam-skip-link-outline-offset);
   padding-block: 0.5rem;
   padding-inline: 1rem;
+  text-align: center;
   text-decoration: none;
   width: 100%;
 

--- a/packages/css/src/components/skip-link/skip-link.scss
+++ b/packages/css/src/components/skip-link/skip-link.scss
@@ -1,0 +1,28 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright (c) 2023 Gemeente Amsterdam
+ */
+
+.amsterdam-skip-link {
+  background-color: var(--amsterdam-skip-link-background-color);
+  color: var(--amsterdam-skip-link-color);
+  display: flex;
+  font-family: var(--amsterdam-skip-link-font-family);
+  font-size: var(--amsterdam-skip-link-font-size);
+  font-weight: var(--amsterdam-skip-link-font-weight);
+  justify-content: center;
+  line-height: var(--amsterdam-skip-link-line-height);
+  outline-offset: var(--amsterdam-skip-link-outline-offset);
+  padding-block: 0.5rem;
+  text-decoration: none;
+  width: 100%;
+
+  &:hover {
+    background-color: var(--amsterdam-skip-link-hover-background-color);
+  }
+
+  .amsterdam-theme--compact & {
+    font-size: var(--amsterdam-skip-link-compact-font-size);
+    line-height: var(--amsterdam-skip-link-compact-line-height);
+  }
+}

--- a/packages/css/src/components/skip-link/skip-link.scss
+++ b/packages/css/src/components/skip-link/skip-link.scss
@@ -14,6 +14,7 @@
   line-height: var(--amsterdam-skip-link-line-height);
   outline-offset: var(--amsterdam-skip-link-outline-offset);
   padding-block: 0.5rem;
+  padding-inline: 1rem;
   text-decoration: none;
   width: 100%;
 

--- a/packages/react/src/SkipLink/README.md
+++ b/packages/react/src/SkipLink/README.md
@@ -1,0 +1,3 @@
+# React Skip Link component
+
+[Skip Link documentation](../../../css/src/skip-link/README.md)

--- a/packages/react/src/SkipLink/SkipLink.test.tsx
+++ b/packages/react/src/SkipLink/SkipLink.test.tsx
@@ -1,42 +1,41 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { createRef } from 'react'
 import { SkipLink } from './SkipLink'
 import '@testing-library/jest-dom'
 
 describe('Skip link', () => {
   it('renders', () => {
-    const { container } = render(<SkipLink />)
+    render(<SkipLink href="/" />)
 
-    const component = container.querySelector(':only-child')
+    const component = screen.getByRole('link')
 
     expect(component).toBeInTheDocument()
     expect(component).toBeVisible()
   })
 
   it('renders a design system BEM class name', () => {
-    const { container } = render(<SkipLink />)
+    render(<SkipLink href="/" />)
 
-    const component = container.querySelector(':only-child')
+    const component = screen.getByRole('link')
 
     expect(component).toHaveClass('amsterdam-skip-link')
   })
 
   it('renders an additional class name', () => {
-    const { container } = render(<SkipLink className="extra" />)
+    render(<SkipLink href="/" className="extra" />)
 
-    const component = container.querySelector(':only-child')
+    const component = screen.getByRole('link')
 
     expect(component).toHaveClass('extra')
-
     expect(component).toHaveClass('amsterdam-skip-link')
   })
 
   it('supports ForwardRef in React', () => {
-    const ref = createRef<HTMLElement>()
+    const ref = createRef<HTMLAnchorElement>()
 
-    const { container } = render(<SkipLink ref={ref} />)
+    render(<SkipLink href="/" ref={ref} />)
 
-    const component = container.querySelector(':only-child')
+    const component = screen.getByRole('link')
 
     expect(ref.current).toBe(component)
   })

--- a/packages/react/src/SkipLink/SkipLink.test.tsx
+++ b/packages/react/src/SkipLink/SkipLink.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react'
+import { createRef } from 'react'
+import { SkipLink } from './SkipLink'
+import '@testing-library/jest-dom'
+
+describe('Skip link', () => {
+  it('renders', () => {
+    const { container } = render(<SkipLink />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toBeInTheDocument()
+    expect(component).toBeVisible()
+  })
+
+  it('renders a design system BEM class name', () => {
+    const { container } = render(<SkipLink />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('amsterdam-skip-link')
+  })
+
+  it('renders an additional class name', () => {
+    const { container } = render(<SkipLink className="extra" />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('extra')
+
+    expect(component).toHaveClass('amsterdam-skip-link')
+  })
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLElement>()
+
+    const { container } = render(<SkipLink ref={ref} />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(ref.current).toBe(component)
+  })
+})

--- a/packages/react/src/SkipLink/SkipLink.tsx
+++ b/packages/react/src/SkipLink/SkipLink.tsx
@@ -1,0 +1,19 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright (c) 2023 Gemeente Amsterdam
+ */
+
+import clsx from 'clsx'
+import { type AnchorHTMLAttributes, type ForwardedRef, forwardRef, type PropsWithChildren } from 'react'
+
+export interface SkipLinkProps extends PropsWithChildren<AnchorHTMLAttributes<HTMLAnchorElement>> {}
+
+export const SkipLink = forwardRef(
+  ({ children, className, ...restProps }: SkipLinkProps, ref: ForwardedRef<HTMLAnchorElement>) => (
+    <a {...restProps} ref={ref} className={clsx('amsterdam-skip-link', 'amsterdam-visually-hidden', className)}>
+      {children}
+    </a>
+  ),
+)
+
+SkipLink.displayName = 'SkipLink'

--- a/packages/react/src/SkipLink/index.ts
+++ b/packages/react/src/SkipLink/index.ts
@@ -1,0 +1,2 @@
+export { SkipLink } from './SkipLink'
+export type { SkipLinkProps } from './SkipLink'

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 /* Append here */
+export * from './SkipLink'
 export * from './Mark'
 export * from './TextInput'
 export * from './SearchField'

--- a/proprietary/tokens/src/components/amsterdam/skip-link.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/skip-link.tokens.json
@@ -1,0 +1,20 @@
+{
+  "amsterdam": {
+    "skip-link": {
+      "background-color": { "value": "{amsterdam.color.primary-blue}" },
+      "color": { "value": "{amsterdam.color.primary-white}" },
+      "font-family": { "value": "{amsterdam.typography.font-family}" },
+      "font-weight": { "value": "{amsterdam.typography.font-weight.normal}" },
+      "font-size": { "value": "{amsterdam.typography.spacious.text-level.6.font-size}" },
+      "line-height": { "value": "{amsterdam.typography.spacious.text-level.6.line-height}" },
+      "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
+      "compact": {
+        "font-size": { "value": "{amsterdam.typography.compact.text-level.6.font-size}" },
+        "line-height": { "value": "{amsterdam.typography.compact.text-level.6.line-height}" }
+      },
+      "hover": {
+        "background-color": { "value": "{amsterdam.color.dark-blue}" }
+      }
+    }
+  }
+}

--- a/storybook/storybook-react/src/SkipLink/SkipLink.docs.mdx
+++ b/storybook/storybook-react/src/SkipLink/SkipLink.docs.mdx
@@ -1,4 +1,4 @@
-import { Controls, Markdown, Meta, Primary } from "@storybook/blocks";
+import { Canvas, Controls, Markdown, Meta, Primary } from "@storybook/blocks";
 import * as SkipLinkStories from "./SkipLink.stories.tsx";
 import README from "../../../../packages/css/src/components/skip-link/README.md?raw";
 
@@ -9,3 +9,11 @@ import README from "../../../../packages/css/src/components/skip-link/README.md?
 <Primary />
 
 <Controls />
+
+## On Focus
+
+<Canvas of={SkipLinkStories.OnFocus} />
+
+## Multiple links
+
+<Canvas of={SkipLinkStories.MultipleLinks} />

--- a/storybook/storybook-react/src/SkipLink/SkipLink.docs.mdx
+++ b/storybook/storybook-react/src/SkipLink/SkipLink.docs.mdx
@@ -10,10 +10,15 @@ import README from "../../../../packages/css/src/components/skip-link/README.md?
 
 <Controls />
 
-## On Focus
+## Toon bij focus
+
+Een Skip link wordt pas getoond als deze focus krijgt.
 
 <Canvas of={SkipLinkStories.OnFocus} />
 
-## Multiple links
+## Meerdere links
+
+Als je een complexe pagina met meerdere secties hebt, kun je meer dan 1 Skip link gebruiken.
+In de meeste gevallen is dit niet nodig.
 
 <Canvas of={SkipLinkStories.MultipleLinks} />

--- a/storybook/storybook-react/src/SkipLink/SkipLink.docs.mdx
+++ b/storybook/storybook-react/src/SkipLink/SkipLink.docs.mdx
@@ -1,0 +1,11 @@
+import { Controls, Markdown, Meta, Primary } from "@storybook/blocks";
+import * as SkipLinkStories from "./SkipLink.stories.tsx";
+import README from "../../../../packages/css/src/components/skip-link/README.md?raw";
+
+<Meta of={SkipLinkStories} />
+
+<Markdown>{README}</Markdown>
+
+<Primary />
+
+<Controls />

--- a/storybook/storybook-react/src/SkipLink/SkipLink.stories.tsx
+++ b/storybook/storybook-react/src/SkipLink/SkipLink.stories.tsx
@@ -7,7 +7,7 @@ import { Grid, Paragraph, Screen, SkipLink } from '@amsterdam/design-system-reac
 import { Meta, StoryObj } from '@storybook/react'
 
 const meta = {
-  title: 'Skip Link',
+  title: 'Navigation/Skip Link',
   component: SkipLink,
   args: {
     children: 'Direct naar inhoud',

--- a/storybook/storybook-react/src/SkipLink/SkipLink.stories.tsx
+++ b/storybook/storybook-react/src/SkipLink/SkipLink.stories.tsx
@@ -1,0 +1,22 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright (c) 2023 Gemeente Amsterdam
+ */
+
+import { SkipLink } from '@amsterdam/design-system-react'
+import { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Skip Link',
+  component: SkipLink,
+  args: {
+    children: 'Direct naar inhoud',
+    href: '#',
+  },
+} satisfies Meta<typeof SkipLink>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/storybook/storybook-react/src/SkipLink/SkipLink.stories.tsx
+++ b/storybook/storybook-react/src/SkipLink/SkipLink.stories.tsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 Gemeente Amsterdam
  */
 
-import { SkipLink } from '@amsterdam/design-system-react'
+import { Grid, Screen, SkipLink } from '@amsterdam/design-system-react'
 import { Meta, StoryObj } from '@storybook/react'
 
 const meta = {
@@ -13,10 +13,51 @@ const meta = {
     children: 'Direct naar inhoud',
     href: '#',
   },
+  argTypes: {
+    style: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Screen>
+        <Grid>
+          <Grid.Cell span="all">
+            <Story />
+          </Grid.Cell>
+        </Grid>
+      </Screen>
+    ),
+  ],
 } satisfies Meta<typeof SkipLink>
 
 export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {
+    style: {
+      clip: 'auto',
+      clipPath: 'none',
+      height: 'auto',
+      overflow: 'auto',
+      position: 'static',
+      whiteSpace: 'normal',
+      width: 'auto',
+    },
+  },
+}
+
+export const OnFocus: Story = {}
+
+export const MultipleLinks: Story = {
+  render: () => (
+    <>
+      <SkipLink href="#">Direct naar inhoud</SkipLink>
+      <SkipLink href="#">Direct naar footer</SkipLink>
+    </>
+  ),
+}

--- a/storybook/storybook-react/src/SkipLink/SkipLink.stories.tsx
+++ b/storybook/storybook-react/src/SkipLink/SkipLink.stories.tsx
@@ -3,7 +3,7 @@
  * Copyright (c) 2023 Gemeente Amsterdam
  */
 
-import { Grid, Screen, SkipLink } from '@amsterdam/design-system-react'
+import { Grid, Paragraph, Screen, SkipLink } from '@amsterdam/design-system-react'
 import { Meta, StoryObj } from '@storybook/react'
 
 const meta = {
@@ -51,13 +51,27 @@ export const Default: Story = {
   },
 }
 
-export const OnFocus: Story = {}
+export const OnFocus: Story = {
+  decorators: [
+    (Story) => (
+      <>
+        <Paragraph size="small" style={{ marginBottom: '2rem' }}>
+          Klik op deze tekst en druk vervolgens op tab om de Skip link te tonen.
+        </Paragraph>
+        <Story />
+      </>
+    ),
+  ],
+}
 
 export const MultipleLinks: Story = {
   render: () => (
     <>
+      <Paragraph size="small" style={{ marginBottom: '2rem' }}>
+        Klik op deze tekst en druk vervolgens twee keer op tab om de Skip links te tonen.
+      </Paragraph>
       <SkipLink href="#">Direct naar inhoud</SkipLink>
-      <SkipLink href="#">Direct naar footer</SkipLink>
+      <SkipLink href="#">Direct naar contactgegevens</SkipLink>
     </>
   ),
 }


### PR DESCRIPTION
I've used the `visually-hidden` class as a css util here. The `:not(:active, :focus)` part doesn't work if you use the `VisuallyHidden` component. Maybe we should think about properly turning this into a css util?