### PR TITLE
fix: Include children in public prop types

### DIFF
--- a/packages/react/src/Accordion/Accordion.tsx
+++ b/packages/react/src/Accordion/Accordion.tsx
@@ -4,16 +4,8 @@
  */
 
 import clsx from 'clsx'
-import {
-  ForwardedRef,
-  forwardRef,
-  ForwardRefExoticComponent,
-  HTMLAttributes,
-  PropsWithChildren,
-  RefAttributes,
-  useImperativeHandle,
-  useRef,
-} from 'react'
+import { forwardRef, useImperativeHandle, useRef } from 'react'
+import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
 import AccordionContext from './AccordionContext'
 import { AccordionSection } from './AccordionSection'
 import useFocusWithArrows from './useFocusWithArrows'

--- a/packages/react/src/Accordion/AccordionSection.tsx
+++ b/packages/react/src/Accordion/AccordionSection.tsx
@@ -5,7 +5,8 @@
 
 import { ChevronDownIcon } from '@amsterdam/design-system-react-icons'
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren, useContext, useId, useState } from 'react'
+import { forwardRef, useContext, useId, useState } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import AccordionContext from './AccordionContext'
 import { getHeadingElement } from '../Heading/Heading'
 import { Icon } from '../Icon/Icon'

--- a/packages/react/src/Accordion/AccordionSection.tsx
+++ b/packages/react/src/Accordion/AccordionSection.tsx
@@ -10,14 +10,14 @@ import AccordionContext from './AccordionContext'
 import { getHeadingElement } from '../Heading/Heading'
 import { Icon } from '../Icon/Icon'
 
-export interface AccordionSectionProps extends HTMLAttributes<HTMLElement> {
+export interface AccordionSectionProps extends PropsWithChildren<HTMLAttributes<HTMLElement>> {
   label: string
   expanded?: boolean
 }
 
 export const AccordionSection = forwardRef(
   (
-    { label, expanded = false, children, className, ...otherProps }: PropsWithChildren<AccordionSectionProps>,
+    { label, expanded = false, children, className, ...otherProps }: AccordionSectionProps,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
     const { headingLevel, section } = useContext(AccordionContext)

--- a/packages/react/src/AspectRatio/AspectRatio.tsx
+++ b/packages/react/src/AspectRatio/AspectRatio.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 export type Ratio = 'x-tall' | 'tall' | 'square' | 'wide' | 'x-wide' | '2x-wide'
 

--- a/packages/react/src/Blockquote/Blockquote.tsx
+++ b/packages/react/src/Blockquote/Blockquote.tsx
@@ -6,7 +6,7 @@
 import clsx from 'clsx'
 import { BlockquoteHTMLAttributes, ForwardedRef, forwardRef, PropsWithChildren } from 'react'
 
-export interface BlockquoteProps extends BlockquoteHTMLAttributes<HTMLQuoteElement> {
+export interface BlockquoteProps extends PropsWithChildren<BlockquoteHTMLAttributes<HTMLQuoteElement>> {
   /**
    * De kleur van het citaat.
    * Gebruik deze property om het citaat in tegenovergestelde kleur te tonen.
@@ -15,10 +15,7 @@ export interface BlockquoteProps extends BlockquoteHTMLAttributes<HTMLQuoteEleme
 }
 
 export const Blockquote = forwardRef(
-  (
-    { children, className, inverseColor, ...restProps }: PropsWithChildren<BlockquoteProps>,
-    ref: ForwardedRef<HTMLQuoteElement>,
-  ) => (
+  ({ children, className, inverseColor, ...restProps }: BlockquoteProps, ref: ForwardedRef<HTMLQuoteElement>) => (
     <blockquote
       {...restProps}
       ref={ref}

--- a/packages/react/src/Blockquote/Blockquote.tsx
+++ b/packages/react/src/Blockquote/Blockquote.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { BlockquoteHTMLAttributes, ForwardedRef, forwardRef, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { BlockquoteHTMLAttributes, ForwardedRef, PropsWithChildren } from 'react'
 
 export interface BlockquoteProps extends PropsWithChildren<BlockquoteHTMLAttributes<HTMLQuoteElement>> {
   /**

--- a/packages/react/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/Breadcrumb/Breadcrumb.tsx
@@ -1,3 +1,8 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright (c) 2023 Gemeente Amsterdam
+ */
+
 import { forwardRef } from 'react'
 import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
 

--- a/packages/react/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/Breadcrumb/Breadcrumb.tsx
@@ -6,7 +6,7 @@
 import { forwardRef } from 'react'
 import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
 
-type BreadcrumbProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
+export type BreadcrumbProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
 
 interface BreadcrumbComponent extends ForwardRefExoticComponent<BreadcrumbProps & RefAttributes<HTMLElement>> {
   Item: typeof BreadcrumbItem

--- a/packages/react/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/Breadcrumb/Breadcrumb.tsx
@@ -1,11 +1,5 @@
-import {
-  ForwardedRef,
-  forwardRef,
-  ForwardRefExoticComponent,
-  HTMLAttributes,
-  PropsWithChildren,
-  RefAttributes,
-} from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
 
 type BreadcrumbProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
 

--- a/packages/react/src/Breadcrumb/index.ts
+++ b/packages/react/src/Breadcrumb/index.ts
@@ -1,2 +1,2 @@
 export { Breadcrumb } from './Breadcrumb'
-export type { BreadcrumbItemProps } from './Breadcrumb'
+export type { BreadcrumbProps, BreadcrumbItemProps } from './Breadcrumb'

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -6,7 +6,8 @@
 
 import { Button as CommunityButton } from '@utrecht/component-library-react'
 import clsx from 'clsx'
-import { ButtonHTMLAttributes, ForwardedRef, forwardRef, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ButtonHTMLAttributes, ForwardedRef, PropsWithChildren } from 'react'
 
 export interface ButtonProps extends PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>> {
   variant?: 'primary' | 'secondary' | 'tertiary'

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -8,7 +8,7 @@ import { Button as CommunityButton } from '@utrecht/component-library-react'
 import clsx from 'clsx'
 import { ButtonHTMLAttributes, ForwardedRef, forwardRef, PropsWithChildren } from 'react'
 
-export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>> {
   variant?: 'primary' | 'secondary' | 'tertiary'
 }
 
@@ -26,10 +26,7 @@ function getAppearance(variant: ButtonProps['variant']): CommunityButtonAppearan
 }
 
 export const Button = forwardRef(
-  (
-    { children, disabled, variant = 'primary', ...restProps }: PropsWithChildren<ButtonProps>,
-    ref: ForwardedRef<HTMLButtonElement>,
-  ) => {
+  ({ children, disabled, variant = 'primary', ...restProps }: ButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
     return (
       <CommunityButton
         {...restProps}

--- a/packages/react/src/Card/Card.tsx
+++ b/packages/react/src/Card/Card.tsx
@@ -4,10 +4,10 @@
  */
 
 import clsx from 'clsx'
-import {
+import { forwardRef } from 'react'
+import type {
   AnchorHTMLAttributes,
   ForwardedRef,
-  forwardRef,
   ForwardRefExoticComponent,
   HTMLAttributes,
   PropsWithChildren,

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -15,14 +15,14 @@ import {
   useRef,
 } from 'react'
 
-export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface CheckboxProps extends PropsWithChildren<InputHTMLAttributes<HTMLInputElement>> {
   invalid?: boolean
   indeterminate?: boolean
 }
 
 export const Checkbox = forwardRef(
   (
-    { children, className, invalid, indeterminate, ...restProps }: PropsWithChildren<CheckboxProps>,
+    { children, className, invalid, indeterminate, ...restProps }: CheckboxProps,
     ref: ForwardedRef<HTMLInputElement>,
   ) => {
     const id = useId()

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -4,16 +4,8 @@
  */
 
 import clsx from 'clsx'
-import {
-  ForwardedRef,
-  forwardRef,
-  InputHTMLAttributes,
-  PropsWithChildren,
-  useEffect,
-  useId,
-  useImperativeHandle,
-  useRef,
-} from 'react'
+import { forwardRef, useEffect, useId, useImperativeHandle, useRef } from 'react'
+import type { ForwardedRef, InputHTMLAttributes, PropsWithChildren } from 'react'
 
 export interface CheckboxProps extends PropsWithChildren<InputHTMLAttributes<HTMLInputElement>> {
   invalid?: boolean

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { DialogHTMLAttributes, ForwardedRef, forwardRef, PropsWithChildren, ReactNode } from 'react'
+import { forwardRef } from 'react'
+import type { DialogHTMLAttributes, ForwardedRef, PropsWithChildren, ReactNode } from 'react'
 import { IconButton } from '../IconButton'
 
 export interface DialogProps extends PropsWithChildren<DialogHTMLAttributes<HTMLDialogElement>> {

--- a/packages/react/src/Footer/Footer.tsx
+++ b/packages/react/src/Footer/Footer.tsx
@@ -4,14 +4,8 @@
  */
 
 import clsx from 'clsx'
-import {
-  ForwardedRef,
-  forwardRef,
-  ForwardRefExoticComponent,
-  HTMLAttributes,
-  PropsWithChildren,
-  RefAttributes,
-} from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
 import { Spotlight } from '../Spotlight/Spotlight'
 
 export const FooterTop = forwardRef(

--- a/packages/react/src/FormLabel/FormLabel.tsx
+++ b/packages/react/src/FormLabel/FormLabel.tsx
@@ -5,7 +5,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, LabelHTMLAttributes, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, LabelHTMLAttributes, PropsWithChildren } from 'react'
 
 export const FormLabel = forwardRef(
   (

--- a/packages/react/src/Grid/Grid.tsx
+++ b/packages/react/src/Grid/Grid.tsx
@@ -4,14 +4,8 @@
  */
 
 import clsx from 'clsx'
-import {
-  ForwardedRef,
-  forwardRef,
-  ForwardRefExoticComponent,
-  HTMLAttributes,
-  PropsWithChildren,
-  RefAttributes,
-} from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
 import { GridCell } from './GridCell'
 
 export type GridColumnNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12

--- a/packages/react/src/Grid/GridCell.tsx
+++ b/packages/react/src/Grid/GridCell.tsx
@@ -3,7 +3,8 @@
  * Copyright (c) 2023 Gemeente Amsterdam
  */
 import clsx from 'clsx'
-import { type ForwardedRef, forwardRef, type HTMLAttributes, type PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { GridColumnNumber, GridColumnNumbers } from './Grid'
 import { gridCellClasses } from './gridCellClasses'
 

--- a/packages/react/src/Header/Header.tsx
+++ b/packages/react/src/Header/Header.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes, ReactNode } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes, ReactNode } from 'react'
 import { Heading } from '../Heading'
 import { Logo } from '../Logo'
 import type { LogoBrand } from '../Logo'

--- a/packages/react/src/Heading/Heading.tsx
+++ b/packages/react/src/Heading/Heading.tsx
@@ -10,7 +10,7 @@ import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'rea
 export type HeadingLevel = 1 | 2 | 3 | 4
 type HeadingSize = 'level-1' | 'level-2' | 'level-3' | 'level-4' | 'level-5' | 'level-6'
 
-export interface HeadingProps extends HTMLAttributes<HTMLHeadingElement> {
+export interface HeadingProps extends PropsWithChildren<HTMLAttributes<HTMLHeadingElement>> {
   /**
    * Het hiërarchische niveau van de titel.
    */
@@ -42,7 +42,7 @@ export function getHeadingElement(level: HeadingLevel) {
 
 export const Heading = forwardRef(
   (
-    { children, className, inverseColor, level = 1, size, ...restProps }: PropsWithChildren<HeadingProps>,
+    { children, className, inverseColor, level = 1, size, ...restProps }: HeadingProps,
     ref: ForwardedRef<HTMLHeadingElement>,
   ) => {
     const HeadingX = getHeadingElement(level)

--- a/packages/react/src/Heading/Heading.tsx
+++ b/packages/react/src/Heading/Heading.tsx
@@ -5,7 +5,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 export type HeadingLevel = 1 | 2 | 3 | 4
 type HeadingSize = 'level-1' | 'level-2' | 'level-3' | 'level-4' | 'level-5' | 'level-6'

--- a/packages/react/src/Icon/Icon.tsx
+++ b/packages/react/src/Icon/Icon.tsx
@@ -6,7 +6,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes } from 'react'
 
 export interface IconProps extends HTMLAttributes<HTMLSpanElement> {
   size?: 'level-3' | 'level-4' | 'level-5' | 'level-6'

--- a/packages/react/src/IconButton/IconButton.tsx
+++ b/packages/react/src/IconButton/IconButton.tsx
@@ -5,7 +5,8 @@
 
 import { CloseIcon } from '@amsterdam/design-system-react-icons'
 import clsx from 'clsx'
-import { ButtonHTMLAttributes, ForwardedRef, forwardRef } from 'react'
+import { forwardRef } from 'react'
+import type { ButtonHTMLAttributes, ForwardedRef } from 'react'
 import { Icon } from '../Icon'
 import { VisuallyHidden } from '../VisuallyHidden'
 

--- a/packages/react/src/Image/Image.tsx
+++ b/packages/react/src/Image/Image.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { type ForwardedRef, forwardRef, type ImgHTMLAttributes } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, ImgHTMLAttributes } from 'react'
 
 export interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   cover?: Boolean

--- a/packages/react/src/Image/index.ts
+++ b/packages/react/src/Image/index.ts
@@ -1,1 +1,2 @@
-export { Image, type ImageProps } from './Image'
+export { Image } from './Image'
+export type { ImageProps } from './Image'

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -26,11 +26,11 @@ type ConditionalProps =
       icon?: Function
     }
 
-export type LinkProps = CommonProps & ConditionalProps
+export type LinkProps = PropsWithChildren<CommonProps & ConditionalProps>
 
 export const Link = forwardRef(
   (
-    { children, variant = 'standalone', icon, onBackground, className, ...otherProps }: PropsWithChildren<LinkProps>,
+    { children, variant = 'standalone', icon, onBackground, className, ...otherProps }: LinkProps,
     ref: ForwardedRef<HTMLAnchorElement>,
   ) => (
     <a

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -5,7 +5,8 @@
 
 import { ChevronRightIcon } from '@amsterdam/design-system-react-icons'
 import clsx from 'clsx'
-import { AnchorHTMLAttributes, ForwardedRef, forwardRef, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { AnchorHTMLAttributes, ForwardedRef, PropsWithChildren } from 'react'
 import { Icon } from '../Icon/Icon'
 
 type LinkOnBackground = 'default' | 'light' | 'dark'

--- a/packages/react/src/Logo/Logo.tsx
+++ b/packages/react/src/Logo/Logo.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, ForwardRefExoticComponent, RefAttributes, SVGProps } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, ForwardRefExoticComponent, RefAttributes, SVGProps } from 'react'
 import {
   LogoAmsterdam,
   LogoGgdAmsterdam,

--- a/packages/react/src/Logo/brand/LogoAmsterdam.tsx
+++ b/packages/react/src/Logo/brand/LogoAmsterdam.tsx
@@ -1,4 +1,5 @@
-import { ForwardedRef, forwardRef, type SVGProps } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, SVGProps } from 'react'
 
 const LogoAmsterdam = forwardRef((props: SVGProps<SVGSVGElement>, ref: ForwardedRef<SVGSVGElement>) => (
   <svg

--- a/packages/react/src/Logo/brand/LogoGgdAmsterdam.tsx
+++ b/packages/react/src/Logo/brand/LogoGgdAmsterdam.tsx
@@ -1,4 +1,5 @@
-import { ForwardedRef, forwardRef, type SVGProps } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, SVGProps } from 'react'
 
 const LogoGgdAmsterdam = forwardRef((props: SVGProps<SVGSVGElement>, ref: ForwardedRef<SVGSVGElement>) => (
   <svg

--- a/packages/react/src/Logo/brand/LogoStadsarchief.tsx
+++ b/packages/react/src/Logo/brand/LogoStadsarchief.tsx
@@ -1,4 +1,5 @@
-import { ForwardedRef, forwardRef, type SVGProps } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, SVGProps } from 'react'
 
 const LogoStadsarchief = forwardRef((props: SVGProps<SVGSVGElement>, ref: ForwardedRef<SVGSVGElement>) => (
   <svg

--- a/packages/react/src/Logo/brand/LogoStadsbankVanLening.tsx
+++ b/packages/react/src/Logo/brand/LogoStadsbankVanLening.tsx
@@ -1,4 +1,5 @@
-import { ForwardedRef, forwardRef, type SVGProps } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, SVGProps } from 'react'
 
 const LogoStadsbankVanLening = forwardRef((props: SVGProps<SVGSVGElement>, ref: ForwardedRef<SVGSVGElement>) => (
   <svg

--- a/packages/react/src/Logo/brand/LogoVgaVerzekeringen.tsx
+++ b/packages/react/src/Logo/brand/LogoVgaVerzekeringen.tsx
@@ -1,4 +1,5 @@
-import { ForwardedRef, forwardRef, type SVGProps } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, SVGProps } from 'react'
 
 const LogoVgaVerzekeringen = forwardRef((props: SVGProps<SVGSVGElement>, ref: ForwardedRef<SVGSVGElement>) => (
   <svg

--- a/packages/react/src/Mark/Mark.tsx
+++ b/packages/react/src/Mark/Mark.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 export interface MarkProps extends PropsWithChildren<HTMLAttributes<HTMLElement>> {}
 

--- a/packages/react/src/MegaMenu/MegaMenu.tsx
+++ b/packages/react/src/MegaMenu/MegaMenu.tsx
@@ -4,14 +4,8 @@
  */
 
 import clsx from 'clsx'
-import {
-  ForwardedRef,
-  forwardRef,
-  ForwardRefExoticComponent,
-  HTMLAttributes,
-  PropsWithChildren,
-  RefAttributes,
-} from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
 
 type MegaMenuProps = {} & PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 

--- a/packages/react/src/OrderedList/OrderedList.tsx
+++ b/packages/react/src/OrderedList/OrderedList.tsx
@@ -4,16 +4,15 @@
  */
 
 import clsx from 'clsx'
-import {
+import { forwardRef } from 'react'
+import type {
   ForwardedRef,
-  forwardRef,
   ForwardRefExoticComponent,
   LiHTMLAttributes,
   OlHTMLAttributes,
   PropsWithChildren,
   RefAttributes,
 } from 'react'
-
 export interface OrderedListProps extends PropsWithChildren<OlHTMLAttributes<HTMLOListElement>> {
   markers?: boolean
 }

--- a/packages/react/src/OrderedList/OrderedList.tsx
+++ b/packages/react/src/OrderedList/OrderedList.tsx
@@ -23,10 +23,7 @@ interface OrderedListComponent extends ForwardRefExoticComponent<OrderedListProp
 }
 
 export const OrderedList = forwardRef(
-  (
-    { children, markers = true, className, ...restProps }: PropsWithChildren<OrderedListProps>,
-    ref: ForwardedRef<HTMLOListElement>,
-  ) => {
+  ({ children, markers = true, className, ...restProps }: OrderedListProps, ref: ForwardedRef<HTMLOListElement>) => {
     return (
       <ol
         ref={ref}
@@ -41,13 +38,10 @@ export const OrderedList = forwardRef(
 
 OrderedList.displayName = 'OrderedList'
 
-export type OrderedListItemProps = LiHTMLAttributes<HTMLLIElement>
+export type OrderedListItemProps = PropsWithChildren<LiHTMLAttributes<HTMLLIElement>>
 
 export const OrderedListItem = forwardRef(
-  (
-    { children, className, ...restProps }: PropsWithChildren<OrderedListItemProps>,
-    ref: ForwardedRef<HTMLLIElement>,
-  ) => {
+  ({ children, className, ...restProps }: OrderedListItemProps, ref: ForwardedRef<HTMLLIElement>) => {
     return (
       <li ref={ref} className={clsx('amsterdam-ordered-list__item', className)} {...restProps}>
         {children}

--- a/packages/react/src/Overlap/Overlap.tsx
+++ b/packages/react/src/Overlap/Overlap.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { type ForwardedRef, forwardRef, type HTMLAttributes, type PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 export const Overlap = forwardRef(
   (

--- a/packages/react/src/PageHeading/PageHeading.tsx
+++ b/packages/react/src/PageHeading/PageHeading.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 export interface PageHeadingProps extends PropsWithChildren<HTMLAttributes<HTMLHeadingElement>> {
   /**

--- a/packages/react/src/PageHeading/PageHeading.tsx
+++ b/packages/react/src/PageHeading/PageHeading.tsx
@@ -6,7 +6,7 @@
 import clsx from 'clsx'
 import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
 
-export interface PageHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
+export interface PageHeadingProps extends PropsWithChildren<HTMLAttributes<HTMLHeadingElement>> {
   /**
    * De kleur van de titel
    * Gebruik deze property om de titel in tegenovergestelde kleur te tonen.
@@ -15,10 +15,7 @@ export interface PageHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
 }
 
 export const PageHeading = forwardRef(
-  (
-    { children, className, inverseColor, ...restProps }: PropsWithChildren<PageHeadingProps>,
-    ref: ForwardedRef<HTMLHeadingElement>,
-  ) => (
+  ({ children, className, inverseColor, ...restProps }: PageHeadingProps, ref: ForwardedRef<HTMLHeadingElement>) => (
     <h1
       {...restProps}
       ref={ref}

--- a/packages/react/src/PageMenu/PageMenu.tsx
+++ b/packages/react/src/PageMenu/PageMenu.tsx
@@ -4,11 +4,11 @@
  */
 
 import clsx from 'clsx'
-import {
+import { forwardRef } from 'react'
+import type {
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
   ForwardedRef,
-  forwardRef,
   ForwardRefExoticComponent,
   HTMLAttributes,
   PropsWithChildren,

--- a/packages/react/src/Pagination/Pagination.tsx
+++ b/packages/react/src/Pagination/Pagination.tsx
@@ -5,7 +5,8 @@
 
 import { ChevronLeftIcon, ChevronRightIcon } from '@amsterdam/design-system-react-icons'
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes, useMemo, useState } from 'react'
+import { forwardRef, useMemo, useState } from 'react'
+import type { ForwardedRef, HTMLAttributes } from 'react'
 import { Icon } from '../Icon/Icon'
 
 export interface PaginationProps extends HTMLAttributes<HTMLElement> {

--- a/packages/react/src/Paragraph/Paragraph.tsx
+++ b/packages/react/src/Paragraph/Paragraph.tsx
@@ -5,7 +5,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 export interface ParagraphProps extends PropsWithChildren<HTMLAttributes<HTMLParagraphElement>> {
   size?: 'small' | 'large'

--- a/packages/react/src/Paragraph/Paragraph.tsx
+++ b/packages/react/src/Paragraph/Paragraph.tsx
@@ -7,7 +7,7 @@
 import clsx from 'clsx'
 import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
 
-export interface ParagraphProps extends HTMLAttributes<HTMLParagraphElement> {
+export interface ParagraphProps extends PropsWithChildren<HTMLAttributes<HTMLParagraphElement>> {
   size?: 'small' | 'large'
   /**
    * De kleur van de paragraaf
@@ -18,7 +18,7 @@ export interface ParagraphProps extends HTMLAttributes<HTMLParagraphElement> {
 
 export const Paragraph = forwardRef(
   (
-    { children, className, inverseColor, size, ...otherProps }: PropsWithChildren<ParagraphProps>,
+    { children, className, inverseColor, size, ...otherProps }: ParagraphProps,
     ref: ForwardedRef<HTMLParagraphElement>,
   ) => (
     <p

--- a/packages/react/src/Screen/Screen.tsx
+++ b/packages/react/src/Screen/Screen.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 type ScreenMaxWidth = 'wide' | 'x-wide'
 

--- a/packages/react/src/SearchField/SearchField.tsx
+++ b/packages/react/src/SearchField/SearchField.tsx
@@ -4,14 +4,8 @@
  */
 
 import clsx from 'clsx'
-import {
-  ForwardedRef,
-  forwardRef,
-  ForwardRefExoticComponent,
-  HTMLAttributes,
-  PropsWithChildren,
-  RefAttributes,
-} from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
 import { SearchFieldButton } from './SearchFieldButton'
 import { SearchFieldInput } from './SearchFieldInput'
 

--- a/packages/react/src/SearchField/SearchFieldButton.tsx
+++ b/packages/react/src/SearchField/SearchFieldButton.tsx
@@ -5,7 +5,8 @@
 
 import { SearchIcon } from '@amsterdam/design-system-react-icons'
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes } from 'react'
 import { Icon } from '../Icon'
 import { VisuallyHidden } from '../VisuallyHidden'
 

--- a/packages/react/src/SearchField/SearchFieldInput.tsx
+++ b/packages/react/src/SearchField/SearchFieldInput.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, InputHTMLAttributes, useId } from 'react'
+import { forwardRef, useId } from 'react'
+import type { ForwardedRef, InputHTMLAttributes } from 'react'
 import { VisuallyHidden } from '../VisuallyHidden'
 
 interface SearchFieldInputProps extends InputHTMLAttributes<HTMLInputElement> {

--- a/packages/react/src/Switch/Switch.tsx
+++ b/packages/react/src/Switch/Switch.tsx
@@ -1,3 +1,8 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright (c) 2023 Gemeente Amsterdam
+ */
+
 import clsx from 'clsx'
 import { forwardRef, useId } from 'react'
 import type { ForwardedRef, InputHTMLAttributes, PropsWithChildren } from 'react'

--- a/packages/react/src/Switch/Switch.tsx
+++ b/packages/react/src/Switch/Switch.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, InputHTMLAttributes, PropsWithChildren, useId } from 'react'
+import { forwardRef, useId } from 'react'
+import type { ForwardedRef, InputHTMLAttributes, PropsWithChildren } from 'react'
 
 export const Switch = forwardRef(
   (

--- a/packages/react/src/Table/TableCaption.tsx
+++ b/packages/react/src/Table/TableCaption.tsx
@@ -5,7 +5,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 export interface TableCaptionProps extends PropsWithChildren<HTMLAttributes<HTMLTableCaptionElement>> {}
 

--- a/packages/react/src/TextInput/TextInput.tsx
+++ b/packages/react/src/TextInput/TextInput.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, InputHTMLAttributes } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, InputHTMLAttributes } from 'react'
 
 export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {}
 

--- a/packages/react/src/TopTaskLink/TopTaskLink.tsx
+++ b/packages/react/src/TopTaskLink/TopTaskLink.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { AnchorHTMLAttributes, ForwardedRef, forwardRef } from 'react'
+import { forwardRef } from 'react'
+import type { AnchorHTMLAttributes, ForwardedRef } from 'react'
 
 export interface TopTaskLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   label: string

--- a/packages/react/src/UnorderedList/UnorderedList.tsx
+++ b/packages/react/src/UnorderedList/UnorderedList.tsx
@@ -39,13 +39,10 @@ export const UnorderedList = forwardRef(
 
 UnorderedList.displayName = 'UnorderedList'
 
-export type UnorderedListItemProps = LiHTMLAttributes<HTMLLIElement>
+export type UnorderedListItemProps = PropsWithChildren<LiHTMLAttributes<HTMLLIElement>>
 
 export const UnorderedListItem = forwardRef(
-  (
-    { children, className, ...restProps }: PropsWithChildren<UnorderedListItemProps>,
-    ref: ForwardedRef<HTMLLIElement>,
-  ) => {
+  ({ children, className, ...restProps }: UnorderedListItemProps, ref: ForwardedRef<HTMLLIElement>) => {
     return (
       <li ref={ref} className={clsx('amsterdam-unordered-list__item', className)} {...restProps}>
         {children}

--- a/packages/react/src/UnorderedList/UnorderedList.tsx
+++ b/packages/react/src/UnorderedList/UnorderedList.tsx
@@ -4,9 +4,9 @@
  */
 
 import clsx from 'clsx'
-import {
+import { forwardRef } from 'react'
+import type {
   ForwardedRef,
-  forwardRef,
   ForwardRefExoticComponent,
   HTMLAttributes,
   LiHTMLAttributes,

--- a/packages/react/src/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/react/src/VisuallyHidden/VisuallyHidden.tsx
@@ -4,7 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 export const VisuallyHidden = forwardRef(
   (


### PR DESCRIPTION
As discovered in the [prototype for Signalen](https://github.com/Amsterdam/design-system-prototypes/pull/29/files#diff-23cf4a753c169ee8c2be4917bb7af0355d897f5db16c1f8c3c39075d10241bd7R6), we didn’t include the `children` prop in our exported `LinkProps`.

This has been resolved for all components.

Additionally, we’re now importing all types explicitly as types.