### PR TITLE
fix!: Remove unused grey-4 color token

### DIFF
--- a/proprietary/tokens/src/brand/amsterdam/color.tokens.json
+++ b/proprietary/tokens/src/brand/amsterdam/color.tokens.json
@@ -15,8 +15,7 @@
       "magenta": { "value": "#E50082" },
       "neutral-grey1": { "value": "#E8E8E8" },
       "neutral-grey2": { "value": "#BEBEBE" },
-      "neutral-grey3": { "value": "#767676" },
-      "neutral-grey4": { "value": "#323232" }
+      "neutral-grey3": { "value": "#767676" }
     }
   }
 }


### PR DESCRIPTION
This has been removed from Figma a couple of weeks ago. We don’t use it anywhere, and chances are slim that anyone else does.