### PR TITLE
feat!: Change blue color names of Spotlight to match Badge API

### DIFF
--- a/packages/css/src/components/spotlight/spotlight.scss
+++ b/packages/css/src/components/spotlight/spotlight.scss
@@ -7,16 +7,16 @@
   background-color: var(--amsterdam-spotlight-blue-background-color);
 }
 
+.amsterdam-spotlight--dark-blue {
+  background-color: var(--amsterdam-spotlight-dark-blue-background-color);
+}
+
 .amsterdam-spotlight--dark-green {
   background-color: var(--amsterdam-spotlight-dark-green-background-color);
 }
 
 .amsterdam-spotlight--green {
   background-color: var(--amsterdam-spotlight-green-background-color);
-}
-
-.amsterdam-spotlight--light-blue {
-  background-color: var(--amsterdam-spotlight-light-blue-background-color);
 }
 
 .amsterdam-spotlight--magenta {

--- a/packages/react/src/Footer/FooterTop.tsx
+++ b/packages/react/src/Footer/FooterTop.tsx
@@ -12,7 +12,7 @@ export type FooterTopProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 
 export const FooterTop = forwardRef(
   ({ children, className, ...restProps }: FooterTopProps, ref: ForwardedRef<HTMLDivElement>) => (
-    <Spotlight {...restProps} color="blue" ref={ref} className={clsx('amsterdam-footer__top', className)}>
+    <Spotlight {...restProps} color="dark-blue" ref={ref} className={clsx('amsterdam-footer__top', className)}>
       {children}
     </Spotlight>
   ),

--- a/packages/react/src/Spotlight/Spotlight.test.tsx
+++ b/packages/react/src/Spotlight/Spotlight.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { createRef } from 'react'
-import { Spotlight } from './Spotlight'
+import { Spotlight, spotlightColors } from './Spotlight'
 import '@testing-library/jest-dom'
 
 describe('Spotlight', () => {
@@ -41,13 +41,15 @@ describe('Spotlight', () => {
     expect(ref.current).toBe(component)
   })
 
-  it('gets a color class if you set a color', () => {
-    const { container } = render(<Spotlight color="green" />)
+  spotlightColors.map((color) =>
+    it(`renders with ${color} color`, () => {
+      const { container } = render(<Spotlight color={color} />)
 
-    const component = container.querySelector(':only-child')
+      const component = container.querySelector(':only-child')
 
-    expect(component).toHaveClass('amsterdam-spotlight--green')
-  })
+      expect(component).toHaveClass(`amsterdam-spotlight--${color}`)
+    }),
+  )
 
   it('renders a custom tag', () => {
     render(<Spotlight as="article" />)

--- a/packages/react/src/Spotlight/Spotlight.tsx
+++ b/packages/react/src/Spotlight/Spotlight.tsx
@@ -6,13 +6,26 @@
 import clsx from 'clsx'
 import { forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
 
+export const spotlightColors = [
+  'blue',
+  'dark-blue',
+  'dark-green',
+  'green',
+  'magenta',
+  'orange',
+  'purple',
+  'yellow',
+] as const
+
+type SpotlightColor = (typeof spotlightColors)[number]
+
 export type SpotlightProps = {
   as?: 'article' | 'aside' | 'div' | 'footer' | 'section'
-  color?: 'blue' | 'dark-green' | 'green' | 'light-blue' | 'magenta' | 'orange' | 'purple' | 'yellow'
+  color?: SpotlightColor
 } & PropsWithChildren<HTMLAttributes<HTMLElement>>
 
 export const Spotlight = forwardRef<HTMLDivElement, SpotlightProps>(
-  ({ children, className, as: Tag = 'div', color = 'blue', ...restProps }: SpotlightProps, ref) => (
+  ({ children, className, as: Tag = 'div', color = 'dark-blue', ...restProps }: SpotlightProps, ref) => (
     <Tag {...restProps} ref={ref} className={clsx('amsterdam-spotlight', `amsterdam-spotlight--${color}`, className)}>
       {children}
     </Tag>

--- a/proprietary/tokens/src/components/amsterdam/spotlight.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/spotlight.tokens.json
@@ -2,6 +2,9 @@
   "amsterdam": {
     "spotlight": {
       "blue": {
+        "background-color": { "value": "{amsterdam.color.blue}" }
+      },
+      "dark-blue": {
         "background-color": { "value": "{amsterdam.color.primary-blue}" }
       },
       "dark-green": {
@@ -9,9 +12,6 @@
       },
       "green": {
         "background-color": { "value": "{amsterdam.color.green}" }
-      },
-      "light-blue": {
-        "background-color": { "value": "{amsterdam.color.blue}" }
       },
       "magenta": {
         "background-color": { "value": "{amsterdam.color.magenta}" }

--- a/storybook/storybook-react/src/Spotlight/Spotlight.docs.mdx
+++ b/storybook/storybook-react/src/Spotlight/Spotlight.docs.mdx
@@ -14,21 +14,17 @@ import README from "../../../../packages/css/src/components/spotlight/README.md?
 
 <Canvas of={SpotlightStories.Blue} />
 
+### Dark Blue
+
+<Canvas of={SpotlightStories.DarkBlue} />
+
 ### Dark Green
 
 <Canvas of={SpotlightStories.DarkGreen} />
 
-### Yellow
-
-<Canvas of={SpotlightStories.Yellow} />
-
 ### Green
 
 <Canvas of={SpotlightStories.Green} />
-
-### Light Blue
-
-<Canvas of={SpotlightStories.LightBlue} />
 
 ### Magenta
 
@@ -41,6 +37,10 @@ import README from "../../../../packages/css/src/components/spotlight/README.md?
 ### Purple
 
 <Canvas of={SpotlightStories.Purple} />
+
+### Yellow
+
+<Canvas of={SpotlightStories.Yellow} />
 
 ### Custom HTML Element
 

--- a/storybook/storybook-react/src/Spotlight/Spotlight.stories.tsx
+++ b/storybook/storybook-react/src/Spotlight/Spotlight.stories.tsx
@@ -22,16 +22,6 @@ const meta = {
     color: {
       control: {
         type: 'select',
-        labels: {
-          blue: 'Blue',
-          'dark-blue': 'Dark blue',
-          'dark-green': 'Dark green',
-          green: 'Green',
-          magenta: 'Magenta',
-          orange: 'Orange',
-          purple: 'Purple',
-          yellow: 'Yellow',
-        },
       },
       options: ['blue', 'dark-blue', 'dark-green', 'green', 'magenta', 'orange', 'purple', 'yellow'],
     },

--- a/storybook/storybook-react/src/Spotlight/Spotlight.stories.tsx
+++ b/storybook/storybook-react/src/Spotlight/Spotlight.stories.tsx
@@ -23,17 +23,17 @@ const meta = {
       control: {
         type: 'select',
         labels: {
-          blue: 'Blauw',
-          'dark-green': 'Donkergroen',
-          green: 'Groen',
-          'light-blue': 'Lichtblauw',
+          blue: 'Blue',
+          'dark-blue': 'Dark blue',
+          'dark-green': 'Dark green',
+          green: 'Green',
           magenta: 'Magenta',
-          orange: 'Oranje',
-          purple: 'Paars',
-          yellow: 'Geel',
+          orange: 'Orange',
+          purple: 'Purple',
+          yellow: 'Yellow',
         },
       },
-      options: ['blue', 'dark-green', 'green', 'light-blue', 'magenta', 'orange', 'purple', 'yellow'],
+      options: ['blue', 'dark-blue', 'dark-green', 'green', 'magenta', 'orange', 'purple', 'yellow'],
     },
     children: {
       control: {
@@ -58,39 +58,21 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
-export const Yellow: Story = {
-  args: {
-    color: 'yellow',
-  },
-}
-
-export const Orange: Story = {
-  args: {
-    color: 'orange',
-  },
-}
-
-export const Magenta: Story = {
-  args: {
-    color: 'magenta',
-  },
-}
-
-export const Purple: Story = {
-  args: {
-    color: 'purple',
-  },
-}
-
 export const Blue: Story = {
   args: {
     color: 'blue',
   },
 }
 
-export const LightBlue: Story = {
+export const DarkBlue: Story = {
   args: {
-    color: 'light-blue',
+    color: 'dark-blue',
+  },
+}
+
+export const DarkGreen: Story = {
+  args: {
+    color: 'dark-green',
   },
 }
 
@@ -100,9 +82,27 @@ export const Green: Story = {
   },
 }
 
-export const DarkGreen: Story = {
+export const Magenta: Story = {
   args: {
-    color: 'dark-green',
+    color: 'magenta',
+  },
+}
+
+export const Orange: Story = {
+  args: {
+    color: 'orange',
+  },
+}
+
+export const Purple: Story = {
+  args: {
+    color: 'purple',
+  },
+}
+
+export const Yellow: Story = {
+  args: {
+    color: 'yellow',
   },
 }
 


### PR DESCRIPTION
This renames `light-blue` to `blue` and `blue` to `dark-blue` and sorts all lists alphabetically.