### PR TITLE
fix: Sync release please version numbers to released versions

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "packages/css": "0.5.0",
   "packages/react": "0.5.0",
-  "proprietary/assets": "0.1.6",
-  "proprietary/react-icons": "0.1.11",
+  "proprietary/assets": "0.1.7",
+  "proprietary/react-icons": "0.1.12",
   "proprietary/tokens": "0.5.0"
 }


### PR DESCRIPTION
We released new versions of `assets` and `react-icons` which we didn't specify in the release please manifest.
This PR fixes that