### PR TITLE
chore: Update release please bootstrap SHA

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "plugins": ["node-workspace"],
-  "bootstrap-sha": "3bc9765e9de9553db5b643d2ed79735837d4d7b6",
+  "bootstrap-sha": "740ff24dd3b733fae86f97b0e2740eebb5ca2b25",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "group-pull-request-title-pattern": "chore(release): Publish new release(s)",


### PR DESCRIPTION
The last release wasn't completely handled by Release Please, so it doesn't quite know when to stop looking for commit messages to add to the changelogs. This PR sets the bootstrap SHA to the latest released commit to fix that.

After a release has been completely handled by Release Please, we can remove this line from the config. 