### PR TITLE
feat: Add and use tokens for inside spacing

### DIFF
--- a/packages/css/src/components/accordion/accordion.scss
+++ b/packages/css/src/components/accordion/accordion.scss
@@ -24,8 +24,8 @@
   font-weight: var(--amsterdam-accordion-button-font-weight);
   justify-content: space-between;
   line-height: var(--amsterdam-accordion-button-line-height);
-  padding-block: 0.75rem;
-  padding-inline: 1rem;
+  padding-block: var(--amsterdam-accordion-button-padding-block);
+  padding-inline: var(--amsterdam-accordion-button-padding-inline);
   width: 100%;
 
   &:focus {
@@ -54,8 +54,8 @@
 
 .amsterdam-accordion__panel {
   display: none;
-  padding-block: 1rem;
-  padding-inline: 1rem;
+  padding-block: var(--amsterdam-accordion-panel-padding-block);
+  padding-inline: var(--amsterdam-accordion-panel-padding-inline);
 }
 
 .amsterdam-accordion__panel--expanded {

--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -26,6 +26,8 @@
   gap: var(--amsterdam-dialog-form-gap);
   grid-template-rows: auto 1fr auto;
   max-block-size: var(--amsterdam-dialog-form-max-block-size);
+
+  // TODO Decide on these widths
   padding-block: var(--amsterdam-dialog-form-padding-block);
   padding-inline: var(--amsterdam-dialog-form-padding-inline);
 }

--- a/packages/css/src/components/header/header.scss
+++ b/packages/css/src/components/header/header.scss
@@ -9,7 +9,7 @@
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  padding-block: 1rem;
+  padding-block: var(--amsterdam-header-padding-block);
   row-gap: 1.5rem;
 
   @media screen and (min-width: $amsterdam-breakpoint-wide) {

--- a/packages/css/src/components/mega-menu/mega-menu.scss
+++ b/packages/css/src/components/mega-menu/mega-menu.scss
@@ -6,6 +6,8 @@
 .amsterdam-mega-menu__list-category {
   column-gap: var(--amsterdam-mega-menu-list-category-column-gap);
   column-width: var(--amsterdam-mega-menu-list-category-column-width);
+
+  // TODO Move to bottom margin of heading
   padding-block-start: var(--amsterdam-mega-menu-list-category-padding-block-start);
 
   &:not(:last-child) {

--- a/packages/css/src/components/pagination/pagination.scss
+++ b/packages/css/src/components/pagination/pagination.scss
@@ -38,7 +38,7 @@
   display: flex;
   gap: 0.5rem;
   outline-offset: var(--amsterdam-pagination-button-outline-offset);
-  padding-inline: 0.75rem;
+  padding-inline: var(--amsterdam-pagination-button-padding-inline);
   text-decoration-line: var(--amsterdam-pagination-button-text-decoration-line);
   text-decoration-thickness: var(--amsterdam-pagination-button-text-decoration-thickness);
   text-underline-offset: var(--amsterdam-pagination-button-text-underline-offset);

--- a/packages/css/src/components/search-field/search-field.scss
+++ b/packages/css/src/components/search-field/search-field.scss
@@ -23,8 +23,8 @@
   font-weight: var(--amsterdam-search-field-input-font-weight);
   line-height: var(--amsterdam-search-field-input-line-height);
   outline-offset: var(--amsterdam-search-field-input-outline-offset);
-  padding-block: 0.5rem;
-  padding-inline: 1rem;
+  padding-block: var(--amsterdam-search-field-input-padding-block);
+  padding-inline: var(--amsterdam-search-field-input-padding-inline);
   touch-action: manipulation;
   width: 100%;
 
@@ -58,8 +58,10 @@
   color: var(--amsterdam-search-field-button-color);
   cursor: pointer;
   outline-offset: var(--amsterdam-search-field-button-outline-offset);
-  padding-block: 0.5rem;
-  padding-inline: 0.5rem;
+
+  // TODO Check if these paddings are necessary
+  padding-block: var(--amsterdam-search-field-button-padding-block);
+  padding-inline: var(--amsterdam-search-field-button-padding-inline);
   touch-action: manipulation;
 
   &:hover {

--- a/packages/css/src/components/skip-link/skip-link.scss
+++ b/packages/css/src/components/skip-link/skip-link.scss
@@ -12,8 +12,8 @@
   font-weight: var(--amsterdam-skip-link-font-weight);
   line-height: var(--amsterdam-skip-link-line-height);
   outline-offset: var(--amsterdam-skip-link-outline-offset);
-  padding-block: 0.5rem;
-  padding-inline: 1rem;
+  padding-block: var(--amsterdam-skip-link-padding-block);
+  padding-inline: var(--amsterdam-skip-link-padding-inline);
   text-align: center;
   text-decoration: none;
 

--- a/packages/css/src/components/table/table.scss
+++ b/packages/css/src/components/table/table.scss
@@ -25,8 +25,8 @@
 .amsterdam-table__cell,
 .amsterdam-table__header-cell {
   border-bottom: var(--amsterdam-table-cell-border-bottom);
-  padding-block: 1rem;
-  padding-inline: 1rem;
+  padding-block: var(--amsterdam-table-cell-padding-block);
+  padding-inline: var(--amsterdam-table-cell-padding-inline);
   text-align: start;
   vertical-align: top;
 }

--- a/packages/css/src/components/text-input/text-input.scss
+++ b/packages/css/src/components/text-input/text-input.scss
@@ -18,8 +18,8 @@
   font-weight: var(--amsterdam-text-input-font-weight);
   line-height: var(--amsterdam-text-input-line-height);
   outline-offset: var(--amsterdam-text-input-outline-offset);
-  padding-block: 0.5rem;
-  padding-inline: 1rem;
+  padding-block: var(--amsterdam-text-input-padding-block);
+  padding-inline: var(--amsterdam-text-input-padding-inline);
   touch-action: manipulation;
   width: 100%;
 

--- a/proprietary/tokens/src/brand/amsterdam/space.compact.tokens.json
+++ b/proprietary/tokens/src/brand/amsterdam/space.compact.tokens.json
@@ -6,6 +6,13 @@
       "md": { "value": "clamp(1rem, calc(1.5625vw - 0.0625rem), 2.5rem)" },
       "lg": { "value": "clamp(1.5rem, calc(2.34375vw - 0.09375rem), 3.75rem)" },
       "xl": { "value": "clamp(2rem, calc(3.125vw - 0.125rem), 5rem)" }
+    },
+    "inside": {
+      "xs": { "value": ".25rem" },
+      "sm": { "value": ".5rem" },
+      "md": { "value": "1rem" },
+      "lg": { "value": "1.5rem" },
+      "xl": { "value": "2rem" }
     }
   }
 }

--- a/proprietary/tokens/src/brand/amsterdam/space.tokens.json
+++ b/proprietary/tokens/src/brand/amsterdam/space.tokens.json
@@ -5,7 +5,14 @@
       "sm": { "value": "clamp(0.5rem, calc(1.5625vw + 0.1875rem), 1.75rem)" },
       "md": { "value": "clamp(1rem, calc(3.125vw + 0.375rem), 3.5rem)" },
       "lg": { "value": "clamp(1.5rem, calc(4.6875vw + 0.5625rem), 5.25rem)" },
-      "xl": { "value": "clamp(2rem, calc(6.25vw + 0.75rem), 7rem)" }
+      "xl": { "value": "clamp(2rem, calc(6.25vw + 0.75rem), 7rem)" },
+      "inside": {
+        "xs": { "value": ".375rem" },
+        "sm": { "value": ".75rem" },
+        "md": { "value": "1.5rem" },
+        "lg": { "value": "2.25rem" },
+        "xl": { "value": "3rem" }
+      }
     }
   }
 }

--- a/proprietary/tokens/src/components/amsterdam/accordion.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/accordion.tokens.json
@@ -7,12 +7,18 @@
         "font-size": { "value": "{amsterdam.typography.text-level.5.font-size}" },
         "font-weight": { "value": "{amsterdam.typography.font-weight.bold}" },
         "line-height": { "value": "{amsterdam.typography.text-level.5.line-height}" },
+        "padding-block": { "value": "{amsterdam.space.inside.sm}" },
+        "padding-inline": { "value": "{amsterdam.space.inside.md}" },
         "focus": {
           "outline-offset": { "value": "{amsterdam.focus.outline-offset}" }
         },
         "hover": {
           "box-shadow": { "value": "inset 0 0 0 2px {amsterdam.color.neutral-grey3}" }
         }
+      },
+      "panel": {
+        "padding-block": { "value": "{amsterdam.space.inside.sm}" },
+        "padding-inline": { "value": "{amsterdam.space.inside.md}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/amsterdam/badge.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/badge.tokens.json
@@ -5,7 +5,7 @@
       "font-size": { "value": "{amsterdam.typography.text-level.5.font-size}" },
       "font-weight": { "value": "{amsterdam.typography.font-weight.bold}" },
       "line-height": { "value": "{amsterdam.typography.text-level.5.line-height}" },
-      "padding-inline": { "value": "0.5rem" },
+      "padding-inline": { "value": "{amsterdam.space.inside.sm}" },
       "blue": {
         "background-color": { "value": "{amsterdam.color.blue}" },
         "color": { "value": "{amsterdam.color.primary-black}" }

--- a/proprietary/tokens/src/components/amsterdam/button.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/button.tokens.json
@@ -6,10 +6,10 @@
       "font-size": { "value": "{amsterdam.typography.text-level.5.font-size}" },
       "line-height": { "value": "{amsterdam.typography.text-level.5.line-height}" },
       "gap": { "value": "1rem" },
-      "padding-inline-start": { "value": "1rem" },
-      "padding-inline-end": { "value": "1rem" },
-      "padding-block-start": { "value": "0.5rem" },
-      "padding-block-end": { "value": "0.5rem" },
+      "padding-inline-start": { "value": "{amsterdam.space.inside.lg}" },
+      "padding-inline-end": { "value": "{amsterdam.space.inside.lg}" },
+      "padding-block-start": { "value": "{amsterdam.space.inside.xs}" },
+      "padding-block-end": { "value": "{amsterdam.space.inside.xs}" },
       "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
       "busy": {
         "cursor": { "value": "{amsterdam.action.busy.cursor}" }

--- a/proprietary/tokens/src/components/amsterdam/header.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/header.tokens.json
@@ -1,7 +1,8 @@
 {
   "amsterdam": {
     "header": {
-      "column-gap": { "value": "{amsterdam.grid.gap}" }
+      "column-gap": { "value": "{amsterdam.grid.gap}" },
+      "padding-block": { "value": "{amsterdam.space.inside.md}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/amsterdam/pagination.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/pagination.tokens.json
@@ -8,6 +8,8 @@
       "line-height": { "value": "{amsterdam.typography.text-level.5.line-height}" },
       "button": {
         "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
+        "padding-block": { "value": "{amsterdam.space.inside.xs}" },
+        "padding-inline": { "value": "{amsterdam.space.inside.xs}" },
         "text-decoration-line": { "value": "{amsterdam.link-appearance.subtle.text-decoration-line}" },
         "text-decoration-thickness": { "value": "{amsterdam.link-appearance.text-decoration-thickness}" },
         "text-underline-offset": { "value": "{amsterdam.link-appearance.text-underline-offset}" },

--- a/proprietary/tokens/src/components/amsterdam/search-field.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/search-field.tokens.json
@@ -7,7 +7,9 @@
         "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
         "hover": {
           "background-color": { "value": "{amsterdam.color.dark-blue}" }
-        }
+        },
+        "padding-block": { "value": "{amsterdam.space.inside.xs}" },
+        "padding-inline": { "value": "{amsterdam.space.inside.xs}" }
       },
       "input": {
         "box-shadow": {
@@ -19,6 +21,8 @@
         "font-weight": { "value": "{amsterdam.typography.font-weight.normal}" },
         "line-height": { "value": "{amsterdam.typography.text-level.6.line-height}" },
         "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
+        "padding-block": { "value": "{amsterdam.space.inside.xs}" },
+        "padding-inline": { "value": "{amsterdam.space.inside.sm}" },
         "cancel-button": {
           "background-image": {
             "value": "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><path fill='%23004699' fill-rule='evenodd' d='M29.333 5.47 26.53 2.668 16 13.187 5.47 2.666 2.668 5.47 13.187 16 2.666 26.53l2.804 2.803L16 18.813l10.53 10.52 2.803-2.804L18.813 16z'/></svg>\")"

--- a/proprietary/tokens/src/components/amsterdam/skip-link.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/skip-link.tokens.json
@@ -8,6 +8,8 @@
       "font-size": { "value": "{amsterdam.typography.text-level.6.font-size}" },
       "line-height": { "value": "{amsterdam.typography.text-level.6.line-height}" },
       "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
+      "padding-block": { "value": "{amsterdam.space.inside.xs}" },
+      "padding-inline": { "value": "{amsterdam.space.inside.md}" },
       "hover": {
         "background-color": { "value": "{amsterdam.color.dark-blue}" }
       }

--- a/proprietary/tokens/src/components/amsterdam/table.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/table.tokens.json
@@ -10,7 +10,9 @@
         "font-weight": { "value": "{amsterdam.typography.font-weight.bold}" }
       },
       "cell": {
-        "border-bottom": { "value": "1px solid {amsterdam.color.neutral-grey1}" }
+        "border-bottom": { "value": "1px solid {amsterdam.color.neutral-grey1}" },
+        "padding-block": { "value": "{amsterdam.space.inside.sm}" },
+        "padding-inline": { "value": "{amsterdam.space.inside.sm}" }
       },
       "header-cell": {
         "font-weight": { "value": "{amsterdam.typography.font-weight.bold}" }

--- a/proprietary/tokens/src/components/amsterdam/text-input.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/text-input.tokens.json
@@ -8,6 +8,8 @@
       "font-weight": { "value": "{amsterdam.typography.font-weight.normal}" },
       "line-height": { "value": "{amsterdam.typography.text-level.6.line-height}" },
       "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
+      "padding-block": { "value": "{amsterdam.space.inside.xs}" },
+      "padding-inline": { "value": "{amsterdam.space.inside.sm}" },
       "disabled": {
         "background-color": { "value": "{amsterdam.color.primary-white}" },
         "box-shadow": { "value": "inset 0 0 0 1px {amsterdam.color.neutral-grey2}" },

--- a/storybook/storybook-docs/src/space.stories.mdx
+++ b/storybook/storybook-docs/src/space.stories.mdx
@@ -18,23 +18,25 @@ The tables below show the resulting pixels widths at some reference widths.
 
 In spacious mode, the medium white space grows from 16 to 56 pixels between window widths of 320 and 1600.
 
-| Window width | Extra small | Small | Medium | Large | Extra large |
-| :----------: | :---------: | :---: | :----: | :---: | :---------: |
-|     320      |      4      |   8   | **16** |  24   |     32      |
-|     576      |      6      |  12   | **24** |  36   |     48      |
-|     1088     |     10      |  20   | **40** |  60   |     80      |
-|     1600     |     14      |  28   | **56** |  84   |     102     |
+|                 |  320   |  576   |  1088  |  1600  |
+| --------------: | :----: | :----: | :----: | :----: |
+| **Extra small** |   4    |   6    |   10   |   14   |
+|       **Small** |   8    |   12   |   20   |   28   |
+|      **Medium** | **16** | **24** | **40** | **56** |
+|       **Large** |   24   |   36   |   60   |   84   |
+| **Extra large** |   32   |   48   |   80   |  102   |
 
 #### Compact
 
 In compact mode, the medium white space grows from 16 to 40 pixels between window widths of 1088 and 2624.
 
-| Window width | Extra small | Small | Medium | Large | Extra large |
-| :----------: | :---------: | :---: | :----: | :---: | :---------: |
-|     1088     |      4      |   8   | **16** |  24   |     32      |
-|     1600     |      6      |  12   | **24** |  36   |     48      |
-|     2112     |      8      |  16   | **32** |  48   |     64      |
-|     2624     |     10      |  20   | **40** |  60   |     80      |
+|                 |   1088 |   1600 |   2112 |   2624 |
+| --------------: | -----: | -----: | -----: | -----: |
+| **Extra small** |      4 |      6 |      8 |     10 |
+|       **Small** |      8 |     12 |     16 |     20 |
+|      **Medium** | **16** | **24** | **32** | **40** |
+|       **Large** |     24 |     36 |     48 |     60 |
+| **Extra large** |     32 |     48 |     64 |     80 |
 
 ## About the units we use
 


### PR DESCRIPTION
This introduces tokens for inside space. No breaking changes, only additions.

They have fixed sizes; making them fluid doesn’t seem necessary. A large difference between the min and max values makes for too much space on wide screens and too little on narrow ones.

Five options again. The default in the spacious theme is 1.5rem – 1rem seemed logical but appeared to be too small in practice.

Applied them to all existing components, which changes some sizing which has to be fed back to the designers for review and application in Figma. Most notably, the button has become a bit wider and slightly less tall, making it look much more button-y, in my opinion.

Note: #1089 and #1091 should be merged first.