### PR TITLE
feat!: Group design tokens for Grid Space

### DIFF
--- a/proprietary/tokens/src/brand/amsterdam/space.compact.tokens.json
+++ b/proprietary/tokens/src/brand/amsterdam/space.compact.tokens.json
@@ -1,14 +1,16 @@
 {
   "amsterdam": {
     "space": {
-      "xs": { "value": "clamp(0.25rem, calc(0.390625vw - 0.015625rem), 0.625rem)" },
-      "sm": { "value": "clamp(0.5rem, calc(0.78125vw - 0.03125rem), 1.25rem)" },
-      "md": {
-        "value": "clamp(1rem, calc(1.5625vw - 0.0625rem), 2.5rem)",
-        "comment": "Grows from 16px at 1088px wide to 40px at 2624px wide."
-      },
-      "lg": { "value": "clamp(1.5rem, calc(2.34375vw - 0.09375rem), 3.75rem)" },
-      "xl": { "value": "clamp(2rem, calc(3.125vw - 0.125rem), 5rem)" }
+      "grid": {
+        "xs": { "value": "clamp(0.25rem, calc(0.390625vw - 0.015625rem), 0.625rem)" },
+        "sm": { "value": "clamp(0.5rem, calc(0.78125vw - 0.03125rem), 1.25rem)" },
+        "md": {
+          "value": "clamp(1rem, calc(1.5625vw - 0.0625rem), 2.5rem)",
+          "comment": "Grows from 16px at 1088px wide to 40px at 2624px wide."
+        },
+        "lg": { "value": "clamp(1.5rem, calc(2.34375vw - 0.09375rem), 3.75rem)" },
+        "xl": { "value": "clamp(2rem, calc(3.125vw - 0.125rem), 5rem)" }
+      }
     }
   }
 }

--- a/proprietary/tokens/src/brand/amsterdam/space.tokens.json
+++ b/proprietary/tokens/src/brand/amsterdam/space.tokens.json
@@ -1,14 +1,16 @@
 {
   "amsterdam": {
     "space": {
-      "xs": { "value": "clamp(0.25rem, calc(0.78125vw + 0.09375rem), 0.875rem)" },
-      "sm": { "value": "clamp(0.5rem, calc(1.5625vw + 0.1875rem), 1.75rem)" },
-      "md": {
-        "value": "clamp(1rem, calc(3.125vw + 0.375rem), 3.5rem)",
-        "comment": "Grows from 16px at 320px wide to 56px at 1600px wide."
+      "grid": {
+        "xs": { "value": "clamp(0.25rem, calc(0.78125vw + 0.09375rem), 0.875rem)" },
+        "sm": { "value": "clamp(0.5rem, calc(1.5625vw + 0.1875rem), 1.75rem)" },
+        "md": {
+          "value": "clamp(1rem, calc(3.125vw + 0.375rem), 3.5rem)",
+          "comment": "Grows from 16px at 320px wide to 56px at 1600px wide."
+        },
+        "lg": { "value": "clamp(1.5rem, calc(4.6875vw + 0.5625rem), 5.25rem)" },
+        "xl": { "value": "clamp(2rem, calc(6.25vw + 0.75rem), 7rem)" }
       },
-      "lg": { "value": "clamp(1.5rem, calc(4.6875vw + 0.5625rem), 5.25rem)" },
-      "xl": { "value": "clamp(2rem, calc(6.25vw + 0.75rem), 7rem)" },
       "inside": {
         "xs": { "value": ".5rem" },
         "sm": { "value": ".75rem" },

--- a/proprietary/tokens/src/components/amsterdam/column.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/column.tokens.json
@@ -2,11 +2,11 @@
   "amsterdam": {
     "column": {
       "gap": {
-        "xs": { "value": "{amsterdam.space.xs}" },
-        "sm": { "value": "{amsterdam.space.sm}" },
-        "md": { "value": "{amsterdam.space.md}" },
-        "lg": { "value": "{amsterdam.space.lg}" },
-        "xl": { "value": "{amsterdam.space.xl}" }
+        "xs": { "value": "{amsterdam.space.grid.xs}" },
+        "sm": { "value": "{amsterdam.space.grid.sm}" },
+        "md": { "value": "{amsterdam.space.grid.md}" },
+        "lg": { "value": "{amsterdam.space.grid.lg}" },
+        "xl": { "value": "{amsterdam.space.grid.xl}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/amsterdam/gap.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/gap.tokens.json
@@ -1,11 +1,11 @@
 {
   "amsterdam": {
     "gap": {
-      "xs": { "value": "{amsterdam.space.xs}" },
-      "sm": { "value": "{amsterdam.space.sm}" },
-      "md": { "value": "{amsterdam.space.md}" },
-      "lg": { "value": "{amsterdam.space.lg}" },
-      "xl": { "value": "{amsterdam.space.xl}" }
+      "xs": { "value": "{amsterdam.space.grid.xs}" },
+      "sm": { "value": "{amsterdam.space.grid.sm}" },
+      "md": { "value": "{amsterdam.space.grid.md}" },
+      "lg": { "value": "{amsterdam.space.grid.lg}" },
+      "xl": { "value": "{amsterdam.space.grid.xl}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/amsterdam/grid.compact.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/grid.compact.tokens.json
@@ -1,7 +1,7 @@
 {
   "amsterdam": {
     "grid": {
-      "padding-inline": { "value": "{amsterdam.space.md}" }
+      "padding-inline": { "value": "{amsterdam.space.grid.md}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/amsterdam/grid.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/grid.tokens.json
@@ -2,17 +2,17 @@
   "amsterdam": {
     "grid": {
       "column-count": { "value": "4" },
-      "column-gap": { "value": "{amsterdam.space.md}" },
+      "column-gap": { "value": "{amsterdam.space.grid.md}" },
       "padding-block": {
-        "sm": { "value": "{amsterdam.space.sm}" },
-        "md": { "value": "{amsterdam.space.md}" },
-        "lg": { "value": "{amsterdam.space.lg}" }
+        "sm": { "value": "{amsterdam.space.grid.sm}" },
+        "md": { "value": "{amsterdam.space.grid.md}" },
+        "lg": { "value": "{amsterdam.space.grid.lg}" }
       },
-      "padding-inline": { "value": "{amsterdam.space.lg}" },
+      "padding-inline": { "value": "{amsterdam.space.grid.lg}" },
       "row-gap": {
-        "sm": { "value": "{amsterdam.space.sm}" },
-        "md": { "value": "{amsterdam.space.md}" },
-        "lg": { "value": "{amsterdam.space.lg}" }
+        "sm": { "value": "{amsterdam.space.grid.sm}" },
+        "md": { "value": "{amsterdam.space.grid.md}" },
+        "lg": { "value": "{amsterdam.space.grid.lg}" }
       },
       "medium": {
         "column-count": { "value": "8" }

--- a/proprietary/tokens/src/components/amsterdam/header.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/header.tokens.json
@@ -2,7 +2,7 @@
   "amsterdam": {
     "header": {
       "column-gap": {
-        "value": "{amsterdam.space.md}",
+        "value": "{amsterdam.space.grid.md}",
         "comment": "Must have the same value as `amsterdam.grid.column-gap`."
       },
       "padding-block": { "value": "{amsterdam.space.inside.md}" }

--- a/proprietary/tokens/src/components/amsterdam/margin.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/margin.tokens.json
@@ -1,11 +1,11 @@
 {
   "amsterdam": {
     "margin": {
-      "xs": { "value": "{amsterdam.space.xs}" },
-      "sm": { "value": "{amsterdam.space.sm}" },
-      "md": { "value": "{amsterdam.space.md}" },
-      "lg": { "value": "{amsterdam.space.lg}" },
-      "xl": { "value": "{amsterdam.space.xl}" }
+      "xs": { "value": "{amsterdam.space.grid.xs}" },
+      "sm": { "value": "{amsterdam.space.grid.sm}" },
+      "md": { "value": "{amsterdam.space.grid.md}" },
+      "lg": { "value": "{amsterdam.space.grid.lg}" },
+      "xl": { "value": "{amsterdam.space.grid.xl}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/amsterdam/mega-menu.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/mega-menu.tokens.json
@@ -3,13 +3,13 @@
     "mega-menu": {
       "list-category": {
         "column-gap": {
-          "value": "{amsterdam.space.md}",
+          "value": "{amsterdam.space.grid.md}",
           "comment": "Must have the same value as `amsterdam.grid.column-gap`."
         },
         "column-width": { "value": "20rem" },
         "padding-block-start": { "value": "1rem" },
         "padding-block-end": {
-          "value": "{amsterdam.space.md}",
+          "value": "{amsterdam.space.grid.md}",
           "comment": "Must have the same value as `amsterdam.grid.row-gap.md`."
         }
       }


### PR DESCRIPTION
The ‘Grid Space’ name and `amsterdam.space.grid` namespace seem fine, although it may be unfortunate to name it after one component that uses it, even if it is the main one. An alternative can be ‘Layout Space’ and `amsterdam.space.layout`, which match the name of the group of components Grid belongs to.