### PR TITLE
chore: Use `Tag` for dynamic component name for consistency

### DIFF
--- a/packages/react/src/Alert/Alert.tsx
+++ b/packages/react/src/Alert/Alert.tsx
@@ -50,11 +50,10 @@ export const Alert = forwardRef(
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
     const alertSize = title ? 'level-4' : 'level-5'
-
-    const Element = title ? 'section' : 'div'
+    const Tag = title ? 'section' : 'div'
 
     return (
-      <Element
+      <Tag
         {...restProps}
         ref={ref}
         className={clsx('amsterdam-alert', severity && `amsterdam-alert--${severity}`, className)}
@@ -71,7 +70,7 @@ export const Alert = forwardRef(
           {children}
         </div>
         {closeable && <IconButton label="Sluiten" size={alertSize} onClick={onClose} />}
-      </Element>
+      </Tag>
     )
   },
 )


### PR DESCRIPTION
We use `Tag` for the same construct in Grid Cell, Column, and Spotlight.