### PR TITLE
feat!: Rename ‘header logo’ to ‘header logo link’ and add missing token for outline offset

### DIFF
--- a/packages/css/src/components/header/header.scss
+++ b/packages/css/src/components/header/header.scss
@@ -18,9 +18,9 @@
   }
 }
 
-.amsterdam-header__logo {
+.amsterdam-header__logo-link {
   flex: none;
-  outline-offset: var(--amsterdam-header-logo-outline-offset);
+  outline-offset: var(--amsterdam-header-logo-link-outline-offset);
 }
 
 .amsterdam-header__links {

--- a/packages/css/src/components/header/header.scss
+++ b/packages/css/src/components/header/header.scss
@@ -20,7 +20,7 @@
 
 .amsterdam-header__logo {
   flex: none;
-  outline-offset: var(--amsterdam-link-outline-offset);
+  outline-offset: var(--amsterdam-header-logo-outline-offset);
 }
 
 .amsterdam-header__links {

--- a/packages/react/src/Header/Header.tsx
+++ b/packages/react/src/Header/Header.tsx
@@ -37,7 +37,7 @@ export const Header = forwardRef(
     return (
       <>
         <header {...restProps} ref={ref} className={clsx('amsterdam-header', className)}>
-          <a href={logoLink} className="amsterdam-header__logo">
+          <a href={logoLink} className="amsterdam-header__logo-link">
             <VisuallyHidden>{logoLinkTitle}</VisuallyHidden>
             <Logo brand={logoBrand} />
           </a>

--- a/proprietary/tokens/src/components/amsterdam/header.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/header.tokens.json
@@ -4,6 +4,9 @@
       "column-gap": {
         "value": "{amsterdam.space.md}",
         "comment": "Must have the same value as `amsterdam.grid.column-gap`."
+      },
+      "logo": {
+        "outline-offset": { "value": "{amsterdam.focus.outline-offset}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/amsterdam/header.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/header.tokens.json
@@ -5,9 +5,9 @@
         "value": "{amsterdam.space.md}",
         "comment": "Must have the same value as `amsterdam.grid.column-gap`."
       },
+      "padding-block": { "value": "{amsterdam.space.inside.md}" },
       "logo-link": {
-        "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
-        "padding-block": { "value": "{amsterdam.space.inside.md}" }
+        "outline-offset": { "value": "{amsterdam.focus.outline-offset}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/amsterdam/header.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/header.tokens.json
@@ -5,7 +5,7 @@
         "value": "{amsterdam.space.md}",
         "comment": "Must have the same value as `amsterdam.grid.column-gap`."
       },
-      "logo": {
+      "logo-link": {
         "outline-offset": { "value": "{amsterdam.focus.outline-offset}" }
       }
     }


### PR DESCRIPTION
I came across this mistake, where `Header` uses a token of `Link`.