### PR TITLE
chore: Add example of wrapping button label

### DIFF
--- a/packages/css/src/components/button/README.md
+++ b/packages/css/src/components/button/README.md
@@ -6,7 +6,7 @@ Allows the user to perform actions and operate the user interface.
 
 ## Guidelines
 
-- A label text that describes the function of the button.
+- A short label text that describes the function of the button.
 - A clear contrasting colour scheme so that it is easy to recognize and quickly locate.
 - Use the correct type of button for the corresponding application.
   For example, a button within a form must always be of the type `submit`.

--- a/storybook/src/components/Button/Button.docs.mdx
+++ b/storybook/src/components/Button/Button.docs.mdx
@@ -41,9 +41,9 @@ Use tertiary buttons for unimportant calls to action – as many as necessary.
 
 ### Text wrapping
 
-The label can occasionally wrap over multiple lines, for various reasons.
-A shorter text might be unavailable.
-Two buttons could sit next to each other on a narrow screen.
-Or the user has configured a large font on their device.
+Keep in mind that the label may occasionally wrap over multiple lines:
+a shorter text might be unavailable,
+two buttons could sit next to each other on a narrow screen,
+or the user has configured a large font on their device.
 
 <Canvas of={ButtonStories.TextWrapping} />

--- a/storybook/src/components/Button/Button.docs.mdx
+++ b/storybook/src/components/Button/Button.docs.mdx
@@ -37,4 +37,13 @@ Use tertiary buttons for unimportant calls to action – as many as necessary.
 
 ### Button with an icon
 
-<Canvas of={ButtonStories.ButtonWithAnIcon} />
+<Canvas of={ButtonStories.WithIcon} />
+
+### Text wrapping
+
+The label can occasionally wrap over multiple lines, for various reasons.
+A shorter text might be unavailable.
+Two buttons could sit next to each other on a narrow screen.
+Or the user has configured a large font on their device.
+
+<Canvas of={ButtonStories.TextWrapping} />

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -46,7 +46,7 @@ export const Tertiary: Story = {
   },
 }
 
-export const ButtonWithAnIcon: Story = {
+export const WithIcon: Story = {
   args: {
     children: ['Button label', <Icon key="icon" svg={ShareIcon} size="level-5" />],
   },
@@ -55,4 +55,17 @@ export const ButtonWithAnIcon: Story = {
       table: { disable: true },
     },
   },
+}
+
+export const TextWrapping: Story = {
+  args: {
+    children: 'Vergunningsaanvraag verzenden',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: '16rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
 }


### PR DESCRIPTION
I added this story a couple of days ago while working on padding. It shows the effect of vertical padding and line height in action simultaneously (it seems like line height could be a bit smaller here), and it prepares a case against the potential claim that “button labels don’t wrap.”