### PR TITLE
feat!: Merge tokens for start and end padding

### DIFF
--- a/packages/css/src/components/alert/alert.scss
+++ b/packages/css/src/components/alert/alert.scss
@@ -11,10 +11,8 @@
   flex-direction: row;
   gap: var(--amsterdam-alert-gap);
   justify-content: space-between;
-  padding-block-end: var(--amsterdam-alert-padding-block-end);
-  padding-block-start: var(--amsterdam-alert-padding-block-start);
-  padding-inline-end: var(--amsterdam-alert-padding-inline-end);
-  padding-inline-start: var(--amsterdam-alert-padding-inline-start);
+  padding-block: var(--amsterdam-alert-padding-block);
+  padding-inline: var(--amsterdam-alert-padding-inline);
 }
 
 .amsterdam-alert__content {

--- a/packages/css/src/components/button/button.scss
+++ b/packages/css/src/components/button/button.scss
@@ -16,10 +16,8 @@
   gap: var(--amsterdam-button-gap);
   line-height: var(--amsterdam-button-line-height);
   outline-offset: var(--amsterdam-button-outline-offset);
-  padding-block-end: var(--amsterdam-button-padding-block-end);
-  padding-block-start: var(--amsterdam-button-padding-block-start);
-  padding-inline-end: var(--amsterdam-button-padding-inline-end);
-  padding-inline-start: var(--amsterdam-button-padding-inline-start);
+  padding-block: var(--amsterdam-button-padding-block);
+  padding-inline: var(--amsterdam-button-padding-inline);
   touch-action: manipulation;
 
   &:disabled,

--- a/proprietary/tokens/src/components/amsterdam/alert.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/alert.tokens.json
@@ -4,10 +4,8 @@
       "border-width": { "value": "4px" },
       "border-style": { "value": "solid" },
       "gap": { "value": "1rem" },
-      "padding-block-start": { "value": "{amsterdam.space.inside.md}" },
-      "padding-block-end": { "value": "{amsterdam.space.inside.md}" },
-      "padding-inline-start": { "value": "{amsterdam.space.inside.lg}" },
-      "padding-inline-end": { "value": "{amsterdam.space.inside.lg}" },
+      "padding-block": { "value": "{amsterdam.space.inside.md}" },
+      "padding-inline": { "value": "{amsterdam.space.inside.lg}" },
       "error": {
         "border-color": { "value": "{amsterdam.color.primary-red}" }
       },

--- a/proprietary/tokens/src/components/amsterdam/button.tokens.json
+++ b/proprietary/tokens/src/components/amsterdam/button.tokens.json
@@ -6,10 +6,8 @@
       "font-size": { "value": "{amsterdam.typography.text-level.5.font-size}" },
       "line-height": { "value": "{amsterdam.typography.text-level.5.line-height}" },
       "gap": { "value": "1rem" },
-      "padding-block-start": { "value": "{amsterdam.space.inside.xs}" },
-      "padding-block-end": { "value": "{amsterdam.space.inside.xs}" },
-      "padding-inline-start": { "value": "{amsterdam.space.inside.md}" },
-      "padding-inline-end": { "value": "{amsterdam.space.inside.md}" },
+      "padding-block": { "value": "{amsterdam.space.inside.xs}" },
+      "padding-inline": { "value": "{amsterdam.space.inside.md}" },
       "outline-offset": { "value": "{amsterdam.focus.outline-offset}" },
       "busy": {
         "cursor": { "value": "{amsterdam.action.busy.cursor}" }


### PR DESCRIPTION
The amount of horizontal white space at the start and end of a button or alert will most probably be equal. We can reflect this in our tokens.

People that really want two different values can set e.g. `"padding-block": { "value": "2rem 1rem" }` because the CSS property is a shorthand.