### PR TITLE
chore: Fix release pipeline

### DIFF
--- a/.github/workflows/feature-branch-cleanup.yml
+++ b/.github/workflows/feature-branch-cleanup.yml
@@ -4,6 +4,7 @@ name: Feature branch cleanup
 on:
   pull_request:
     types: [closed]
+    branches-ignore: [main]
 
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,14 +28,14 @@ jobs:
           ref: "main"
         # these if statements ensure that a publication only occurs when
         # a new release is created:
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == false }}
 
       - name: Set up Node.js version
         uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == false }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v3
@@ -43,13 +43,13 @@ jobs:
         with:
           version: 8
           run_install: false
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == false }}
 
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == false }}
 
       - name: Set up pnpm cache
         uses: actions/cache@v4
@@ -58,21 +58,21 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == false }}
 
       - name: Install dependencies
         run: pnpm install
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == false }}
 
       - name: Build
         run: pnpm run build
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == false }}
 
       - name: Publish
         run: pnpm -r publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == false }}
 
       # The logic below handles the Storybook deploy:
       - name: "Restore build artifact: Storybook"
@@ -81,7 +81,7 @@ jobs:
           workflow: "lint-test.yml"
           name: storybook
           path: dist/storybook
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == false }}
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
@@ -91,4 +91,4 @@ jobs:
           # feature branch directories are prefixed with demo-*
           # these are excluded from this action's default clean
           clean-exclude: demo-*
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == false }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,14 +28,14 @@ jobs:
           ref: "main"
         # these if statements ensure that a publication only occurs when
         # a new release is created:
-        if: ${{ steps.release.outputs.releases_created == false }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Set up Node.js version
         uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
-        if: ${{ steps.release.outputs.releases_created == false }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v3
@@ -43,13 +43,13 @@ jobs:
         with:
           version: 8
           run_install: false
-        if: ${{ steps.release.outputs.releases_created == false }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-        if: ${{ steps.release.outputs.releases_created == false }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Set up pnpm cache
         uses: actions/cache@v4
@@ -58,21 +58,21 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
-        if: ${{ steps.release.outputs.releases_created == false }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Install dependencies
         run: pnpm install
-        if: ${{ steps.release.outputs.releases_created == false }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Build
         run: pnpm run build
-        if: ${{ steps.release.outputs.releases_created == false }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Publish
         run: pnpm -r publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.releases_created == false }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       # The logic below handles the Storybook deploy:
       - name: "Restore build artifact: Storybook"
@@ -81,7 +81,7 @@ jobs:
           workflow: "lint-test.yml"
           name: storybook
           path: dist/storybook
-        if: ${{ steps.release.outputs.releases_created == false }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
@@ -91,4 +91,4 @@ jobs:
           # feature branch directories are prefixed with demo-*
           # these are excluded from this action's default clean
           clean-exclude: demo-*
-        if: ${{ steps.release.outputs.releases_created == false }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}

--- a/documentation/publishing.md
+++ b/documentation/publishing.md
@@ -52,3 +52,14 @@ This will cause a major version bump in both packages on release and add its des
     git merge --ff-only origin/main
     git push
    ```
+
+### Gotchas
+
+Release Please uses labels to determine the status of a release.
+A release PR gets the label `autorelease: pending` or `autorelease: triggered`.
+When running the action again, the PR with those labels gets released, and the labels should be removed.
+However, due to GitHub API failures, it's possible that the label was not removed correctly upon a previous release and Release Please thinks that the previous release is still pending.
+Release Please will not create a new release PR if it thinks there is a pending release.
+To fix this, check whether any closed PRs still have the `autorelease: pending` or `autorelease: triggered` labels, and remove them.
+
+[See the Release Please docs for more information](https://github.com/googleapis/release-please?tab=readme-ov-file#release-please-bot-does-not-create-a-release-pr-why).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "bootstrap-sha": "740ff24dd3b733fae86f97b0e2740eebb5ca2b25",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "group-pull-request-title-pattern": "chore(release): Publish new release(s)",
   "packages": {
     "packages/css": {},
     "packages/react": {},


### PR DESCRIPTION
- Removed `group-pull-request-title-pattern`, because this caused an error in the pipeline, which aborts the action
- Changed the condition for publication. [The condition in the docs](https://github.com/google-github-actions/release-please-action?tab=readme-ov-file#automating-publication-to-npm) doesn't work (anymore)
- Do not try to clean a feature branch deploy on closed PRs with `main` as the base, because `main` doesn't have feature branch deploys