### PR TITLE
fix: Fix small space token lengths

### DIFF
--- a/proprietary/tokens/src/brand/amsterdam/space.tokens.json
+++ b/proprietary/tokens/src/brand/amsterdam/space.tokens.json
@@ -12,15 +12,15 @@
         "xl": { "value": "clamp(2rem, calc(6.25vw + 0.75rem), 7rem)" }
       },
       "inside": {
-        "xs": { "value": ".25rem" },
-        "sm": { "value": ".5rem" },
+        "xs": { "value": ".5rem" },
+        "sm": { "value": ".75rem" },
         "md": { "value": "1rem" },
         "lg": { "value": "1.5rem" },
         "xl": { "value": "2rem" }
       },
       "stack": {
-        "xs": { "value": ".25rem" },
-        "sm": { "value": ".5rem" },
+        "xs": { "value": ".5rem" },
+        "sm": { "value": ".75rem" },
         "md": { "value": "1rem" },
         "lg": { "value": "1.5rem" },
         "xl": { "value": "2rem" }


### PR DESCRIPTION
I guess mishandling a merge conflict resulted in these incorrect values.