### PR TITLE
fix: Improve subcomponent types

### DIFF
--- a/packages/react/src/Accordion/Accordion.tsx
+++ b/packages/react/src/Accordion/Accordion.tsx
@@ -5,9 +5,9 @@
 
 import clsx from 'clsx'
 import { forwardRef, useImperativeHandle, useRef } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import AccordionContext from './AccordionContext'
-import { AccordionSection } from './AccordionSection'
+import { AccordionSection as Section } from './AccordionSection'
 import { HeadingLevel } from '../Heading/Heading'
 import { useKeyboardFocus } from '../common/useKeyboardFocus'
 
@@ -16,11 +16,7 @@ export type AccordionProps = {
   section?: boolean
 } & PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 
-type AccordionComponent = {
-  Section: typeof AccordionSection
-} & ForwardRefExoticComponent<AccordionProps & RefAttributes<HTMLDivElement>>
-
-export const Accordion = forwardRef(
+const AccordionParent = forwardRef(
   ({ children, className, headingLevel, section = true }: AccordionProps, ref: ForwardedRef<HTMLDivElement>) => {
     const innerRef = useRef<HTMLDivElement>(null)
 
@@ -37,9 +33,8 @@ export const Accordion = forwardRef(
       </AccordionContext.Provider>
     )
   },
-) as AccordionComponent
+)
 
-Accordion.displayName = 'Accordion'
+AccordionParent.displayName = 'Accordion'
 
-Accordion.Section = AccordionSection
-Accordion.Section.displayName = 'Accordion.Section'
+export const Accordion = Object.assign(AccordionParent, { Section })

--- a/packages/react/src/Accordion/Accordion.tsx
+++ b/packages/react/src/Accordion/Accordion.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 import { forwardRef, useImperativeHandle, useRef } from 'react'
 import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import AccordionContext from './AccordionContext'
-import { AccordionSection as Section } from './AccordionSection'
+import { AccordionSection } from './AccordionSection'
 import { HeadingLevel } from '../Heading/Heading'
 import { useKeyboardFocus } from '../common/useKeyboardFocus'
 
@@ -16,7 +16,7 @@ export type AccordionProps = {
   section?: boolean
 } & PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 
-const AccordionParent = forwardRef(
+const AccordionRoot = forwardRef(
   ({ children, className, headingLevel, section = true }: AccordionProps, ref: ForwardedRef<HTMLDivElement>) => {
     const innerRef = useRef<HTMLDivElement>(null)
 
@@ -35,6 +35,6 @@ const AccordionParent = forwardRef(
   },
 )
 
-AccordionParent.displayName = 'Accordion'
+AccordionRoot.displayName = 'Accordion'
 
-export const Accordion = Object.assign(AccordionParent, { Section })
+export const Accordion = Object.assign(AccordionRoot, { Section: AccordionSection })

--- a/packages/react/src/Accordion/AccordionSection.tsx
+++ b/packages/react/src/Accordion/AccordionSection.tsx
@@ -66,4 +66,4 @@ export const AccordionSection = forwardRef(
   },
 )
 
-AccordionSection.displayName = 'AccordionSection'
+AccordionSection.displayName = 'Accordion.Section'

--- a/packages/react/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/Breadcrumb/Breadcrumb.tsx
@@ -5,24 +5,19 @@
 
 import { clsx } from 'clsx'
 import { forwardRef } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { BreadcrumbItem } from './BreadcrumbItem'
 
 export type BreadcrumbProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
 
-type BreadcrumbComponent = {
-  Item: typeof BreadcrumbItem
-} & ForwardRefExoticComponent<BreadcrumbProps & RefAttributes<HTMLElement>>
-
-export const Breadcrumb = forwardRef(
+export const BreadcrumbRoot = forwardRef(
   ({ children, className, ...restProps }: BreadcrumbProps, ref: ForwardedRef<HTMLElement>) => (
     <nav {...restProps} className={clsx('ams-breadcrumb', className)} ref={ref}>
       <ol className="ams-breadcrumb__list">{children}</ol>
     </nav>
   ),
-) as BreadcrumbComponent
+)
 
-Breadcrumb.displayName = 'Breadcrumb'
+BreadcrumbRoot.displayName = 'Breadcrumb'
 
-Breadcrumb.Item = BreadcrumbItem
-Breadcrumb.Item.displayName = 'Breadcrumb.Item'
+export const Breadcrumb = Object.assign(BreadcrumbRoot, { Item: BreadcrumbItem })

--- a/packages/react/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/Breadcrumb/Breadcrumb.tsx
@@ -10,7 +10,7 @@ import { BreadcrumbItem } from './BreadcrumbItem'
 
 export type BreadcrumbProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
 
-export const BreadcrumbRoot = forwardRef(
+const BreadcrumbRoot = forwardRef(
   ({ children, className, ...restProps }: BreadcrumbProps, ref: ForwardedRef<HTMLElement>) => (
     <nav {...restProps} className={clsx('ams-breadcrumb', className)} ref={ref}>
       <ol className="ams-breadcrumb__list">{children}</ol>

--- a/packages/react/src/Breadcrumb/BreadcrumbItem.tsx
+++ b/packages/react/src/Breadcrumb/BreadcrumbItem.tsx
@@ -21,4 +21,4 @@ export const BreadcrumbItem = forwardRef(
   ),
 )
 
-BreadcrumbItem.displayName = 'BreadcrumbItem'
+BreadcrumbItem.displayName = 'Breadcrumb.Item'

--- a/packages/react/src/Card/Card.tsx
+++ b/packages/react/src/Card/Card.tsx
@@ -5,25 +5,20 @@
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { CardHeadingGroup } from './CardHeadingGroup'
 import { CardLink } from './CardLink'
 
 export type CardProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
 
-type CardComponent = {
-  HeadingGroup: typeof CardHeadingGroup
-  Link: typeof CardLink
-} & ForwardRefExoticComponent<CardProps & RefAttributes<HTMLElement>>
+export const CardRoot = forwardRef(
+  ({ children, className, ...restProps }: CardProps, ref: ForwardedRef<HTMLElement>) => (
+    <article {...restProps} ref={ref} className={clsx('ams-card', className)}>
+      {children}
+    </article>
+  ),
+)
 
-export const Card = forwardRef(({ children, className, ...restProps }: CardProps, ref: ForwardedRef<HTMLElement>) => (
-  <article {...restProps} ref={ref} className={clsx('ams-card', className)}>
-    {children}
-  </article>
-)) as CardComponent
+CardRoot.displayName = 'Card'
 
-Card.HeadingGroup = CardHeadingGroup
-Card.Link = CardLink
-Card.displayName = 'Card'
-Card.HeadingGroup.displayName = 'Card.HeadingGroup'
-Card.Link.displayName = 'Card.Link'
+export const Card = Object.assign(CardRoot, { HeadingGroup: CardHeadingGroup, Link: CardLink })

--- a/packages/react/src/Card/Card.tsx
+++ b/packages/react/src/Card/Card.tsx
@@ -11,13 +11,11 @@ import { CardLink } from './CardLink'
 
 export type CardProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
 
-export const CardRoot = forwardRef(
-  ({ children, className, ...restProps }: CardProps, ref: ForwardedRef<HTMLElement>) => (
-    <article {...restProps} ref={ref} className={clsx('ams-card', className)}>
-      {children}
-    </article>
-  ),
-)
+const CardRoot = forwardRef(({ children, className, ...restProps }: CardProps, ref: ForwardedRef<HTMLElement>) => (
+  <article {...restProps} ref={ref} className={clsx('ams-card', className)}>
+    {children}
+  </article>
+))
 
 CardRoot.displayName = 'Card'
 

--- a/packages/react/src/Card/CardHeadingGroup.tsx
+++ b/packages/react/src/Card/CardHeadingGroup.tsx
@@ -21,4 +21,4 @@ export const CardHeadingGroup = forwardRef(
   ),
 )
 
-CardHeadingGroup.displayName = 'CardHeadingGroup'
+CardHeadingGroup.displayName = 'Card.HeadingGroup'

--- a/packages/react/src/Card/CardLink.tsx
+++ b/packages/react/src/Card/CardLink.tsx
@@ -17,4 +17,4 @@ export const CardLink = forwardRef(
   ),
 )
 
-CardLink.displayName = 'CardLink'
+CardLink.displayName = 'Card.Link'

--- a/packages/react/src/Footer/Footer.tsx
+++ b/packages/react/src/Footer/Footer.tsx
@@ -11,13 +11,11 @@ import { FooterTop } from './FooterTop'
 
 export type FooterProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
 
-export const FooterRoot = forwardRef(
-  ({ children, className, ...restProps }: FooterProps, ref: ForwardedRef<HTMLElement>) => (
-    <footer {...restProps} ref={ref} className={clsx('ams-footer', className)}>
-      {children}
-    </footer>
-  ),
-)
+const FooterRoot = forwardRef(({ children, className, ...restProps }: FooterProps, ref: ForwardedRef<HTMLElement>) => (
+  <footer {...restProps} ref={ref} className={clsx('ams-footer', className)}>
+    {children}
+  </footer>
+))
 
 FooterRoot.displayName = 'Footer'
 

--- a/packages/react/src/Footer/Footer.tsx
+++ b/packages/react/src/Footer/Footer.tsx
@@ -5,28 +5,20 @@
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { FooterBottom } from './FooterBottom'
 import { FooterTop } from './FooterTop'
 
 export type FooterProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
 
-type FooterComponent = {
-  Top: typeof FooterTop
-  Bottom: typeof FooterBottom
-} & ForwardRefExoticComponent<FooterProps & RefAttributes<HTMLElement>>
-
-export const Footer = forwardRef(
+export const FooterRoot = forwardRef(
   ({ children, className, ...restProps }: FooterProps, ref: ForwardedRef<HTMLElement>) => (
     <footer {...restProps} ref={ref} className={clsx('ams-footer', className)}>
       {children}
     </footer>
   ),
-) as FooterComponent
+)
 
-Footer.Top = FooterTop
-Footer.Bottom = FooterBottom
+FooterRoot.displayName = 'Footer'
 
-Footer.displayName = 'Footer'
-Footer.Top.displayName = 'Footer.Top'
-Footer.Bottom.displayName = 'Footer.Bottom'
+export const Footer = Object.assign(FooterRoot, { Bottom: FooterBottom, Top: FooterTop })

--- a/packages/react/src/Footer/FooterBottom.tsx
+++ b/packages/react/src/Footer/FooterBottom.tsx
@@ -17,4 +17,4 @@ export const FooterBottom = forwardRef(
   ),
 )
 
-FooterBottom.displayName = 'FooterBottom'
+FooterBottom.displayName = 'Footer.Bottom'

--- a/packages/react/src/Footer/FooterTop.tsx
+++ b/packages/react/src/Footer/FooterTop.tsx
@@ -18,4 +18,4 @@ export const FooterTop = forwardRef(
   ),
 )
 
-FooterTop.displayName = 'FooterTop'
+FooterTop.displayName = 'Footer.Top'

--- a/packages/react/src/Grid/Grid.tsx
+++ b/packages/react/src/Grid/Grid.tsx
@@ -61,7 +61,7 @@ const paddingClasses = (
   return classes
 }
 
-export const GridRoot = forwardRef(
+const GridRoot = forwardRef(
   (
     { children, className, gapVertical, paddingBottom, paddingTop, paddingVertical, ...restProps }: GridProps,
     ref: ForwardedRef<HTMLDivElement>,

--- a/packages/react/src/Grid/Grid.tsx
+++ b/packages/react/src/Grid/Grid.tsx
@@ -5,7 +5,7 @@
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { GridCell } from './GridCell'
 
 export type GridColumnNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
@@ -61,11 +61,7 @@ const paddingClasses = (
   return classes
 }
 
-type GridComponent = {
-  Cell: typeof GridCell
-} & ForwardRefExoticComponent<GridProps & RefAttributes<HTMLDivElement>>
-
-export const Grid = forwardRef(
+export const GridRoot = forwardRef(
   (
     { children, className, gapVertical, paddingBottom, paddingTop, paddingVertical, ...restProps }: GridProps,
     ref: ForwardedRef<HTMLDivElement>,
@@ -83,7 +79,8 @@ export const Grid = forwardRef(
       {children}
     </div>
   ),
-) as GridComponent
+)
 
-Grid.Cell = GridCell
-Grid.displayName = 'Grid'
+GridRoot.displayName = 'Grid'
+
+export const Grid = Object.assign(GridRoot, { Cell: GridCell })

--- a/packages/react/src/LinkList/LinkList.tsx
+++ b/packages/react/src/LinkList/LinkList.tsx
@@ -5,17 +5,13 @@
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { LinkListLink } from './LinkListLink'
 
 export type LinkListProps = PropsWithChildren<HTMLAttributes<HTMLUListElement>>
 
-type LinkListComponent = {
-  Link: typeof LinkListLink
-} & ForwardRefExoticComponent<LinkListProps & RefAttributes<HTMLUListElement>>
-
 /** A collection of related links. */
-export const LinkList = forwardRef(
+const LinkListRoot = forwardRef(
   ({ children, className, ...restProps }: LinkListProps, ref: ForwardedRef<HTMLUListElement>) => {
     return (
       <ul ref={ref} className={clsx('ams-link-list', className)} {...restProps}>
@@ -23,7 +19,8 @@ export const LinkList = forwardRef(
       </ul>
     )
   },
-) as LinkListComponent
+)
 
-LinkList.Link = LinkListLink
-LinkList.displayName = 'LinkList'
+LinkListRoot.displayName = 'LinkList'
+
+export const LinkList = Object.assign(LinkListRoot, { Link: LinkListLink })

--- a/packages/react/src/LinkList/LinkListLink.tsx
+++ b/packages/react/src/LinkList/LinkListLink.tsx
@@ -6,13 +6,7 @@
 import { ChevronRightIcon } from '@amsterdam/design-system-react-icons'
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type {
-  AnchorHTMLAttributes,
-  ForwardedRef,
-  ForwardRefExoticComponent,
-  PropsWithChildren,
-  RefAttributes,
-} from 'react'
+import type { AnchorHTMLAttributes, ForwardedRef, PropsWithChildren } from 'react'
 import { Icon } from '../Icon'
 
 type BackgroundName = 'default' | 'light' | 'dark'
@@ -33,8 +27,6 @@ export type LinkListLinkProps = {
    */
   size?: 'small' | 'large'
 } & PropsWithChildren<AnchorHTMLAttributes<HTMLAnchorElement>>
-
-type LinkListLinkComponent = ForwardRefExoticComponent<LinkListLinkProps & RefAttributes<HTMLAnchorElement>>
 
 const iconSizeMap = {
   small: 'level-6',
@@ -67,6 +59,6 @@ export const LinkListLink = forwardRef(
       </li>
     )
   },
-) as LinkListLinkComponent
+)
 
 LinkListLink.displayName = 'LinkList.Link'

--- a/packages/react/src/MegaMenu/MegaMenu.tsx
+++ b/packages/react/src/MegaMenu/MegaMenu.tsx
@@ -5,22 +5,19 @@
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { MegaMenuListCategory } from './MegaMenuListCategory'
 
 export type MegaMenuProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 
-type MegaMenuComponent = {
-  ListCategory: typeof MegaMenuListCategory
-} & ForwardRefExoticComponent<MegaMenuProps & RefAttributes<HTMLDivElement>>
-
-export const MegaMenu = forwardRef(
+const MegaMenuRoot = forwardRef(
   ({ children, className, ...restProps }: MegaMenuProps, ref: ForwardedRef<HTMLDivElement>) => (
     <div {...restProps} ref={ref} className={clsx('ams-mega-menu', className)}>
       {children}
     </div>
   ),
-) as MegaMenuComponent
+)
 
-MegaMenu.displayName = 'MegaMenu'
-MegaMenu.ListCategory = MegaMenuListCategory
+MegaMenuRoot.displayName = 'MegaMenu'
+
+export const MegaMenu = Object.assign(MegaMenuRoot, { ListCategory: MegaMenuListCategory })

--- a/packages/react/src/OrderedList/OrderedList.tsx
+++ b/packages/react/src/OrderedList/OrderedList.tsx
@@ -5,7 +5,7 @@
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, OlHTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, OlHTMLAttributes, PropsWithChildren } from 'react'
 import { OrderedListItem } from './OrderedListItem'
 
 export type OrderedListProps = {
@@ -13,11 +13,7 @@ export type OrderedListProps = {
   inverseColor?: boolean
 } & PropsWithChildren<OlHTMLAttributes<HTMLOListElement>>
 
-type OrderedListComponent = {
-  Item: typeof OrderedListItem
-} & ForwardRefExoticComponent<OrderedListProps & RefAttributes<HTMLOListElement>>
-
-export const OrderedList = forwardRef(
+export const OrderedListRoot = forwardRef(
   (
     { children, className, inverseColor, markers = true, ...restProps }: OrderedListProps,
     ref: ForwardedRef<HTMLOListElement>,
@@ -35,7 +31,8 @@ export const OrderedList = forwardRef(
       {children}
     </ol>
   ),
-) as OrderedListComponent
+)
 
-OrderedList.displayName = 'OrderedList'
-OrderedList.Item = OrderedListItem
+OrderedListRoot.displayName = 'OrderedList'
+
+export const OrderedList = Object.assign(OrderedListRoot, { Item: OrderedListItem })

--- a/packages/react/src/OrderedList/OrderedList.tsx
+++ b/packages/react/src/OrderedList/OrderedList.tsx
@@ -13,7 +13,7 @@ export type OrderedListProps = {
   inverseColor?: boolean
 } & PropsWithChildren<OlHTMLAttributes<HTMLOListElement>>
 
-export const OrderedListRoot = forwardRef(
+const OrderedListRoot = forwardRef(
   (
     { children, className, inverseColor, markers = true, ...restProps }: OrderedListProps,
     ref: ForwardedRef<HTMLOListElement>,

--- a/packages/react/src/OrderedList/OrderedListItem.tsx
+++ b/packages/react/src/OrderedList/OrderedListItem.tsx
@@ -17,4 +17,4 @@ export const OrderedListItem = forwardRef(
   ),
 )
 
-OrderedListItem.displayName = 'OrderedListItem'
+OrderedListItem.displayName = 'OrderedList.Item'

--- a/packages/react/src/PageMenu/PageMenu.tsx
+++ b/packages/react/src/PageMenu/PageMenu.tsx
@@ -16,7 +16,7 @@ export type PageMenuProps = {
   alignEnd?: boolean
 } & PropsWithChildren<HTMLAttributes<HTMLUListElement>>
 
-export const PageMenuRoot = forwardRef(
+const PageMenuRoot = forwardRef(
   ({ alignEnd, children, className, ...restProps }: PageMenuProps, ref: ForwardedRef<HTMLUListElement>) => (
     <ul {...restProps} className={clsx('ams-page-menu', alignEnd && `ams-page-menu--align-end`, className)} ref={ref}>
       {children}

--- a/packages/react/src/PageMenu/PageMenu.tsx
+++ b/packages/react/src/PageMenu/PageMenu.tsx
@@ -5,7 +5,7 @@
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { PageMenuLink } from './PageMenuLink'
 
 export type PageMenuProps = {
@@ -16,18 +16,14 @@ export type PageMenuProps = {
   alignEnd?: boolean
 } & PropsWithChildren<HTMLAttributes<HTMLUListElement>>
 
-type PageMenuComponent = {
-  Link: typeof PageMenuLink
-} & ForwardRefExoticComponent<PageMenuProps & RefAttributes<HTMLUListElement>>
-
-export const PageMenu = forwardRef(
+export const PageMenuRoot = forwardRef(
   ({ alignEnd, children, className, ...restProps }: PageMenuProps, ref: ForwardedRef<HTMLUListElement>) => (
     <ul {...restProps} className={clsx('ams-page-menu', alignEnd && `ams-page-menu--align-end`, className)} ref={ref}>
       {children}
     </ul>
   ),
-) as PageMenuComponent
+)
 
-PageMenu.displayName = 'PageMenu'
-PageMenu.Link = PageMenuLink
-PageMenu.Link.displayName = 'PageMenu.Link'
+PageMenuRoot.displayName = 'PageMenu'
+
+export const OrderedList = Object.assign(PageMenuRoot, { Link: PageMenuLink })

--- a/packages/react/src/PageMenu/PageMenu.tsx
+++ b/packages/react/src/PageMenu/PageMenu.tsx
@@ -26,4 +26,4 @@ const PageMenuRoot = forwardRef(
 
 PageMenuRoot.displayName = 'PageMenu'
 
-export const OrderedList = Object.assign(PageMenuRoot, { Link: PageMenuLink })
+export const PageMenu = Object.assign(PageMenuRoot, { Link: PageMenuLink })

--- a/packages/react/src/PageMenu/PageMenuLink.tsx
+++ b/packages/react/src/PageMenu/PageMenuLink.tsx
@@ -23,4 +23,4 @@ export const PageMenuLink = forwardRef(
   ),
 )
 
-PageMenuLink.displayName = 'PageMenuLink'
+PageMenuLink.displayName = 'PageMenu.Link'

--- a/packages/react/src/SearchField/SearchField.tsx
+++ b/packages/react/src/SearchField/SearchField.tsx
@@ -5,18 +5,13 @@
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { SearchFieldButton } from './SearchFieldButton'
 import { SearchFieldInput } from './SearchFieldInput'
 
 export type SearchFieldProps = PropsWithChildren<HTMLAttributes<HTMLFormElement>>
 
-type SearchFieldComponent = {
-  Input: typeof SearchFieldInput
-  Button: typeof SearchFieldButton
-} & ForwardRefExoticComponent<SearchFieldProps & RefAttributes<HTMLFormElement>>
-
-export const SearchField = forwardRef(
+const SearchFieldRoot = forwardRef(
   ({ children, className, ...restProps }: SearchFieldProps, ref: ForwardedRef<HTMLFormElement>) => {
     return (
       <form role="search" {...restProps} ref={ref} className={clsx('ams-search-field', className)}>
@@ -24,10 +19,8 @@ export const SearchField = forwardRef(
       </form>
     )
   },
-) as SearchFieldComponent
+)
 
-SearchField.Input = SearchFieldInput
-SearchField.Button = SearchFieldButton
-SearchField.displayName = 'SearchField'
-SearchField.Input.displayName = 'SearchField.Input'
-SearchField.Button.displayName = 'SearchField.Button'
+SearchFieldRoot.displayName = 'SearchField'
+
+export const SearchField = Object.assign(SearchFieldRoot, { Button: SearchFieldButton, Input: SearchFieldInput })

--- a/packages/react/src/SearchField/SearchFieldButton.tsx
+++ b/packages/react/src/SearchField/SearchFieldButton.tsx
@@ -23,4 +23,4 @@ export const SearchFieldButton = forwardRef(
   ),
 )
 
-SearchFieldButton.displayName = 'SearchFieldButton'
+SearchFieldButton.displayName = 'SearchField.Button'

--- a/packages/react/src/SearchField/SearchFieldInput.tsx
+++ b/packages/react/src/SearchField/SearchFieldInput.tsx
@@ -36,4 +36,4 @@ export const SearchFieldInput = forwardRef(
   },
 )
 
-SearchFieldInput.displayName = 'SearchFieldInput'
+SearchFieldInput.displayName = 'SearchField.Input'

--- a/packages/react/src/Table/Table.tsx
+++ b/packages/react/src/Table/Table.tsx
@@ -5,13 +5,7 @@
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type {
-  ForwardedRef,
-  ForwardRefExoticComponent,
-  PropsWithChildren,
-  RefAttributes,
-  TableHTMLAttributes,
-} from 'react'
+import type { ForwardedRef, PropsWithChildren, TableHTMLAttributes } from 'react'
 import { TableBody } from './TableBody'
 import { TableCaption } from './TableCaption'
 import { TableCell } from './TableCell'
@@ -22,17 +16,7 @@ import { TableRow } from './TableRow'
 
 export type TableProps = PropsWithChildren<TableHTMLAttributes<HTMLTableElement>>
 
-type TableComponent = {
-  Body: typeof TableBody
-  Caption: typeof TableCaption
-  Cell: typeof TableCell
-  Footer: typeof TableFooter
-  Header: typeof TableHeader
-  HeaderCell: typeof TableHeaderCell
-  Row: typeof TableRow
-} & ForwardRefExoticComponent<TableProps & RefAttributes<HTMLTableElement>>
-
-export const Table = forwardRef(
+const TableRoot = forwardRef(
   ({ children, className, ...restProps }: TableProps, ref: ForwardedRef<HTMLTableElement>) => (
     <div className="ams-table">
       <table {...restProps} ref={ref} className={clsx('ams-table__table', className)}>
@@ -40,21 +24,16 @@ export const Table = forwardRef(
       </table>
     </div>
   ),
-) as TableComponent
+)
 
-Table.Body = TableBody
-Table.Caption = TableCaption
-Table.Cell = TableCell
-Table.Footer = TableFooter
-Table.Header = TableHeader
-Table.HeaderCell = TableHeaderCell
-Table.Row = TableRow
+TableRoot.displayName = 'Table'
 
-Table.displayName = 'Table'
-Table.Body.displayName = 'Table.Body'
-Table.Caption.displayName = 'Table.Caption'
-Table.Cell.displayName = 'Table.Cell'
-Table.Footer.displayName = 'Table.Footer'
-Table.Header.displayName = 'Table.Header'
-Table.HeaderCell.displayName = 'Table.HeaderCell'
-Table.Row.displayName = 'Table.Row'
+export const Table = Object.assign(TableRoot, {
+  Body: TableBody,
+  Caption: TableCaption,
+  Cell: TableCell,
+  Footer: TableFooter,
+  Header: TableHeader,
+  HeaderCell: TableHeaderCell,
+  Row: TableRow,
+})

--- a/packages/react/src/Table/TableBody.tsx
+++ b/packages/react/src/Table/TableBody.tsx
@@ -17,4 +17,4 @@ export const TableBody = forwardRef(
   ),
 )
 
-TableBody.displayName = 'TableBody'
+TableBody.displayName = 'Table.Body'

--- a/packages/react/src/Table/TableCaption.tsx
+++ b/packages/react/src/Table/TableCaption.tsx
@@ -18,4 +18,4 @@ export const TableCaption = forwardRef(
   ),
 )
 
-TableCaption.displayName = 'TableCaption'
+TableCaption.displayName = 'Table.Caption'

--- a/packages/react/src/Table/TableCell.tsx
+++ b/packages/react/src/Table/TableCell.tsx
@@ -17,4 +17,4 @@ export const TableCell = forwardRef(
   ),
 )
 
-TableCell.displayName = 'TableCell'
+TableCell.displayName = 'Table.Cell'

--- a/packages/react/src/Table/TableFooter.tsx
+++ b/packages/react/src/Table/TableFooter.tsx
@@ -17,4 +17,4 @@ export const TableFooter = forwardRef(
   ),
 )
 
-TableFooter.displayName = 'TableFooter'
+TableFooter.displayName = 'Table.Footer'

--- a/packages/react/src/Table/TableHeader.tsx
+++ b/packages/react/src/Table/TableHeader.tsx
@@ -17,4 +17,4 @@ export const TableHeader = forwardRef(
   ),
 )
 
-TableHeader.displayName = 'TableHeader'
+TableHeader.displayName = 'Table.Header'

--- a/packages/react/src/Table/TableHeaderCell.tsx
+++ b/packages/react/src/Table/TableHeaderCell.tsx
@@ -17,4 +17,4 @@ export const TableHeaderCell = forwardRef(
   ),
 )
 
-TableHeaderCell.displayName = 'TableHeaderCell'
+TableHeaderCell.displayName = 'Table.HeaderCell'

--- a/packages/react/src/Table/TableRow.tsx
+++ b/packages/react/src/Table/TableRow.tsx
@@ -17,4 +17,4 @@ export const TableRow = forwardRef(
   ),
 )
 
-TableRow.displayName = 'TableRow'
+TableRow.displayName = 'Table.Row'

--- a/packages/react/src/Tabs/Tabs.tsx
+++ b/packages/react/src/Tabs/Tabs.tsx
@@ -5,7 +5,7 @@
 
 import clsx from 'clsx'
 import { forwardRef, useId, useImperativeHandle, useRef, useState } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { TabsButton } from './TabsButton'
 import { TabsContext } from './TabsContext'
 import { TabsList } from './TabsList'
@@ -14,44 +14,36 @@ import { useKeyboardFocus } from '../common/useKeyboardFocus'
 
 export type TabsProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 
-type TabsComponent = {
-  /** Always use a TabList to hold the Tab Buttons */
-  List: typeof TabsList
-  /** Use a TabButton for each tab */
-  Button: typeof TabsButton
-  /** A TabsPanel will only return its contents when the corresponding TabsButton is activated */
-  Panel: typeof TabsPanel
-} & ForwardRefExoticComponent<TabsProps & RefAttributes<HTMLDivElement>>
+const TabsRoot = forwardRef(({ children, className, ...restProps }: TabsProps, ref: ForwardedRef<HTMLDivElement>) => {
+  const tabsId = useId()
+  const [activeTab, setActiveTab] = useState(0)
+  const innerRef = useRef<HTMLDivElement>(null)
 
-export const Tabs = forwardRef(
-  ({ children, className, ...restProps }: TabsProps, ref: ForwardedRef<HTMLDivElement>) => {
-    const tabsId = useId()
-    const [activeTab, setActiveTab] = useState(0)
-    const innerRef = useRef<HTMLDivElement>(null)
+  const updateTab = (tab: number) => {
+    setActiveTab(tab)
+  }
 
-    const updateTab = (tab: number) => {
-      setActiveTab(tab)
-    }
+  // use a passed ref if it's there, otherwise use innerRef
+  useImperativeHandle(ref, () => innerRef.current as HTMLDivElement)
 
-    // use a passed ref if it's there, otherwise use innerRef
-    useImperativeHandle(ref, () => innerRef.current as HTMLDivElement)
+  const { keyDown } = useKeyboardFocus(innerRef, {
+    rotating: true,
+    horizontally: true,
+  })
 
-    const { keyDown } = useKeyboardFocus(innerRef, {
-      rotating: true,
-      horizontally: true,
-    })
+  return (
+    <TabsContext.Provider value={{ activeTab, updateTab, tabsId }}>
+      <div {...restProps} role="tabs" ref={innerRef} onKeyDown={keyDown} className={clsx('ams-tabs', className)}>
+        {children}
+      </div>
+    </TabsContext.Provider>
+  )
+})
 
-    return (
-      <TabsContext.Provider value={{ activeTab, updateTab, tabsId }}>
-        <div {...restProps} role="tabs" ref={innerRef} onKeyDown={keyDown} className={clsx('ams-tabs', className)}>
-          {children}
-        </div>
-      </TabsContext.Provider>
-    )
-  },
-) as TabsComponent
+TabsRoot.displayName = 'Tabs'
 
-Tabs.List = TabsList
-Tabs.Button = TabsButton
-Tabs.Panel = TabsPanel
-Tabs.displayName = 'Tabs'
+export const Tabs = Object.assign(TabsRoot, {
+  Button: TabsButton,
+  List: TabsList,
+  Panel: TabsPanel,
+})

--- a/packages/react/src/UnorderedList/UnorderedList.tsx
+++ b/packages/react/src/UnorderedList/UnorderedList.tsx
@@ -5,7 +5,7 @@
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { UnorderedListItem } from './UnorderedListItem'
 
 export type UnorderedListProps = {
@@ -13,11 +13,7 @@ export type UnorderedListProps = {
   markers?: boolean
 } & PropsWithChildren<HTMLAttributes<HTMLUListElement>>
 
-type UnorderedListComponent = {
-  Item: typeof UnorderedListItem
-} & ForwardRefExoticComponent<UnorderedListProps & RefAttributes<HTMLUListElement>>
-
-export const UnorderedList = forwardRef(
+const UnorderedListRoot = forwardRef(
   (
     { children, className, inverseColor, markers = true, ...restProps }: UnorderedListProps,
     ref: ForwardedRef<HTMLUListElement>,
@@ -37,7 +33,8 @@ export const UnorderedList = forwardRef(
       </ul>
     )
   },
-) as UnorderedListComponent
+)
 
-UnorderedList.displayName = 'UnorderedList'
-UnorderedList.Item = UnorderedListItem
+UnorderedListRoot.displayName = 'UnorderedList'
+
+export const UnorderedList = Object.assign(UnorderedListRoot, { Item: UnorderedListItem })

--- a/packages/react/src/UnorderedList/UnorderedListItem.tsx
+++ b/packages/react/src/UnorderedList/UnorderedListItem.tsx
@@ -17,4 +17,4 @@ export const UnorderedListItem = forwardRef(
   ),
 )
 
-UnorderedListItem.displayName = 'UnorderedListItem'
+UnorderedListItem.displayName = 'UnorderedList.Item'

--- a/storybook/src/docs/components/ColorPalette.tsx
+++ b/storybook/src/docs/components/ColorPalette.tsx
@@ -10,20 +10,20 @@ const ColorPaletteRoot = forwardRef(({ children, ...restProps }: DivProps, ref: 
   </div>
 ))
 
-ColorPaletteRoot.displayName = 'ColourPalette'
+ColorPaletteRoot.displayName = 'ColorPalette'
 
 const ColorPaletteSection = ({ children }: DivProps) => (
   <div className="ams-storybook-color-palette__section">{children}</div>
 )
 
-ColorPaletteSection.displayName = 'ColourPalette.Section'
+ColorPaletteSection.displayName = 'ColorPalette.Section'
 
-type ColourPaletteTileProps = {
+type ColorPaletteTileProps = {
   color: string
   name: string
 }
 
-const ColorPaletteTile = ({ name, color }: ColourPaletteTileProps) => (
+const ColorPaletteTile = ({ name, color }: ColorPaletteTileProps) => (
   <div className="ams-storybook-color-palette__tile">
     <div className="ams-storybook-color-palette__example" style={{ backgroundColor: color }} />
     <dl className="sb-unstyled ams-storybook-color-palette__description">
@@ -33,6 +33,6 @@ const ColorPaletteTile = ({ name, color }: ColourPaletteTileProps) => (
   </div>
 )
 
-ColorPaletteTile.displayName = 'ColourPalette.Tile'
+ColorPaletteTile.displayName = 'ColorPalette.Tile'
 
 export const ColorPalette = Object.assign(ColorPaletteRoot, { Section: ColorPaletteSection, Tile: ColorPaletteTile })

--- a/storybook/src/docs/components/ColorPalette.tsx
+++ b/storybook/src/docs/components/ColorPalette.tsx
@@ -1,30 +1,29 @@
 import './color-palette.css'
 import { forwardRef } from 'react'
-import type { ForwardedRef, ForwardRefExoticComponent, HTMLAttributes, PropsWithChildren, RefAttributes } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 export type DivProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 
-type ColorPaletteComponent = {
-  Section: typeof ColorPaletteSection
-  Tile: typeof ColorPaletteTile
-} & ForwardRefExoticComponent<DivProps & RefAttributes<HTMLDivElement>>
-
-export const ColorPalette = forwardRef(({ children, ...restProps }: DivProps, ref: ForwardedRef<HTMLDivElement>) => (
+const ColorPaletteRoot = forwardRef(({ children, ...restProps }: DivProps, ref: ForwardedRef<HTMLDivElement>) => (
   <div {...restProps} ref={ref} className="ams-storybook-color-palette">
     {children}
   </div>
-)) as ColorPaletteComponent
+))
 
-export const ColorPaletteSection = ({ children }: DivProps) => (
+ColorPaletteRoot.displayName = 'ColourPalette'
+
+const ColorPaletteSection = ({ children }: DivProps) => (
   <div className="ams-storybook-color-palette__section">{children}</div>
 )
+
+ColorPaletteSection.displayName = 'ColourPalette.Section'
 
 type ColourPaletteTileProps = {
   color: string
   name: string
 }
 
-export const ColorPaletteTile = ({ name, color }: ColourPaletteTileProps) => (
+const ColorPaletteTile = ({ name, color }: ColourPaletteTileProps) => (
   <div className="ams-storybook-color-palette__tile">
     <div className="ams-storybook-color-palette__example" style={{ backgroundColor: color }} />
     <dl className="sb-unstyled ams-storybook-color-palette__description">
@@ -34,8 +33,6 @@ export const ColorPaletteTile = ({ name, color }: ColourPaletteTileProps) => (
   </div>
 )
 
-ColorPalette.Section = ColorPaletteSection
-ColorPalette.Tile = ColorPaletteTile
-ColorPalette.displayName = 'ColourPalette'
-ColorPaletteSection.displayName = 'ColourPalette.Section'
 ColorPaletteTile.displayName = 'ColourPalette.Tile'
+
+export const ColorPalette = Object.assign(ColorPaletteRoot, { Section: ColorPaletteSection, Tile: ColorPaletteTile })


### PR DESCRIPTION
[Jira ticket](https://gemeente-amsterdam.atlassian.net/browse/DES-591)

I've worked out an example on how we can improve the subcomponent types.
Instead of rendering Accordion as a type, Accordion is now simply defined as an object.

This changes the typing devs get to see, in VSCode on Win at least:

Old situation: `const Accordion: AccordionComponent`
New situation: 
```
const Accordion: React.ForwardRefExoticComponent<{
	headingLevel: HeadingLevel;
	section?: boolean | undefined;
} & HTMLAttributes<HTMLDivElement> & {
	children?: React.ReactNode;
} & React.RefAttributes<HTMLDivElement>> & {
	...;
}
```

Exporting types in a way that includes the subcomponent doesn't really seem possible.

Defining subcomponents as an object seems to be a common way of doing this:
- [SO thread 1](https://stackoverflow.com/questions/63453536/jsx-dot-notation-with-forwardref-typescript)
- [SO thread 2](https://stackoverflow.com/questions/61767987/sub-component-with-forwardref)
- [SO thread 3](https://stackoverflow.com/questions/70202711/how-to-attach-a-compound-component-when-using-react-forward-ref-property-does-n)