### PR TITLE
chore: Add Volta tooling versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "npm": "^8",
     "pnpm": "^8"
   },
+  "volta": {
+    "node": "20.11.1",
+    "npm": "10.5.0"
+  },
   "workspaces": [
     "./packages/*",
     "./proprietary/*",


### PR DESCRIPTION
This allows [Volta](https://volta.sh) users to automatically use the appropriate versions of node and npm.