### PR TITLE
feat: Add background colour and full-height prop to Screen

### DIFF
--- a/packages/css/src/components/screen/screen.scss
+++ b/packages/css/src/components/screen/screen.scss
@@ -8,9 +8,10 @@
 }
 
 .ams-screen {
-  @include reset;
-
+  background-color: var(--ams-screen-background-color);
   margin-inline: auto;
+
+  @include reset;
 }
 
 .ams-screen--wide {

--- a/packages/css/src/components/screen/screen.scss
+++ b/packages/css/src/components/screen/screen.scss
@@ -14,6 +14,10 @@
   @include reset;
 }
 
+.ams-screen--full-height {
+  min-height: 100vh;
+}
+
 .ams-screen--wide {
   max-width: var(--ams-screen-wide-max-width);
 }

--- a/packages/react/src/Screen/Screen.tsx
+++ b/packages/react/src/Screen/Screen.tsx
@@ -10,12 +10,22 @@ import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 type ScreenMaxWidth = 'wide' | 'x-wide'
 
 export type ScreenProps = {
+  /** Whether the screen should stretch to the full height of the viewport. */
+  fullHeight?: boolean
+  /** The maximum width of the screen. */
   maxWidth?: ScreenMaxWidth
 } & PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 
 export const Screen = forwardRef(
-  ({ children, className, maxWidth = 'wide', ...restProps }: ScreenProps, ref: ForwardedRef<HTMLDivElement>) => (
-    <div {...restProps} ref={ref} className={clsx('ams-screen', `ams-screen--${maxWidth}`, className)}>
+  (
+    { children, className, fullHeight, maxWidth = 'wide', ...restProps }: ScreenProps,
+    ref: ForwardedRef<HTMLDivElement>,
+  ) => (
+    <div
+      {...restProps}
+      ref={ref}
+      className={clsx('ams-screen', fullHeight && 'ams-screen--full-height', `ams-screen--${maxWidth}`, className)}
+    >
       {children}
     </div>
   ),

--- a/proprietary/tokens/src/components/ams/screen.tokens.json
+++ b/proprietary/tokens/src/components/ams/screen.tokens.json
@@ -1,6 +1,7 @@
 {
   "ams": {
     "screen": {
+      "background-color": { "value": "{ams.color.primary.white}" },
       "wide": {
         "max-width": { "value": "100rem" }
       },

--- a/proprietary/tokens/src/components/ams/screen.tokens.json
+++ b/proprietary/tokens/src/components/ams/screen.tokens.json
@@ -1,7 +1,7 @@
 {
   "ams": {
     "screen": {
-      "background-color": { "value": "{ams.color.primary.white}" },
+      "background-color": { "value": "{ams.color.primary-white}" },
       "wide": {
         "max-width": { "value": "100rem" }
       },


### PR DESCRIPTION
The initial value for `background-color` is `transparent`. I can imagine either dark mode or an OS or browser theme setting a background colour, but I’d rather be sure it’s white. We can adapt for dark mode later.

Another reason to define it explicitly is that even though a white background may come by default sometimes, it is an explicit part of our design that other components rely on.

We need the `100vh` height for applications, e.g. to accommodate the side menu. We also need it to ensure the white background spans from top to bottom.
