### PR TITLE
chore: Change dependabot check frequency to restart it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
     commit-message:


### PR DESCRIPTION
Dependabot currently isn't working correctly in our repo. This has happened before, changing the check interval was enough then to fix it. Hopefully this will start dependabot up again. 