### PR TITLE
feat: Set explicit white background on text fields

### DIFF
--- a/packages/css/src/components/search-field/search-field.scss
+++ b/packages/css/src/components/search-field/search-field.scss
@@ -17,6 +17,7 @@
 }
 
 .ams-search-field__input {
+  background-color: var(--ams-search-field-input-background-color);
   box-shadow: var(--ams-search-field-input-box-shadow);
   color: var(--ams-search-field-input-color);
   font-family: var(--ams-search-field-input-font-family);

--- a/packages/css/src/components/text-area/text-area.scss
+++ b/packages/css/src/components/text-area/text-area.scss
@@ -11,6 +11,7 @@
 }
 
 .ams-text-area {
+  background-color: var(--ams-text-area-background-color);
   border: 0;
   box-shadow: var(--ams-text-area-box-shadow);
   color: var(--ams-text-area-color);

--- a/packages/css/src/components/text-input/text-input.scss
+++ b/packages/css/src/components/text-input/text-input.scss
@@ -11,6 +11,7 @@
 }
 
 .ams-text-input {
+  background-color: var(--ams-text-input-background-color);
   border: 0;
   box-shadow: var(--ams-text-input-box-shadow);
   color: var(--ams-text-input-color);

--- a/proprietary/tokens/src/components/ams/search-field.tokens.json
+++ b/proprietary/tokens/src/components/ams/search-field.tokens.json
@@ -12,6 +12,7 @@
         "padding-inline": { "value": "{ams.space.inside.xs}" }
       },
       "input": {
+        "background-color": { "value": "{ams.color.primary-white}" },
         "box-shadow": {
           "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-black}"
         },

--- a/proprietary/tokens/src/components/ams/text-area.tokens.json
+++ b/proprietary/tokens/src/components/ams/text-area.tokens.json
@@ -1,6 +1,7 @@
 {
   "ams": {
     "text-area": {
+      "background-color": { "value": "{ams.color.primary-white}" },
       "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-black}" },
       "color": { "value": "{ams.color.primary-black}" },
       "font-family": { "value": "{ams.text.font-family}" },

--- a/proprietary/tokens/src/components/ams/text-input.tokens.json
+++ b/proprietary/tokens/src/components/ams/text-input.tokens.json
@@ -1,6 +1,7 @@
 {
   "ams": {
     "text-input": {
+      "background-color": { "value": "{ams.color.primary-white}" },
       "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-black}" },
       "color": { "value": "{ams.color.primary-black}" },
       "font-family": { "value": "{ams.text.font-family}" },


### PR DESCRIPTION
While reviewing #1152, I noticed that `DateInput` sets an explicit background colour. This is because some mobile browsers set a grey background.

I think our other form fields should set their white background explicitly as well—at least to allow consumers to set a different colour and to prepare for dark mode later.