### PR TITLE
fix: Fix SearchField styling on Safari on iOS

### DIFF
--- a/packages/css/src/components/search-field/search-field.scss
+++ b/packages/css/src/components/search-field/search-field.scss
@@ -11,7 +11,11 @@
 }
 
 @mixin reset-input {
+  // Reset native appearance, this causes issues on iOS and Android devices
+  -webkit-appearance: none;
+  appearance: none;
   border: 0;
+  border-radius: 0; // Reset rounded borders on iOS devices
   box-sizing: border-box;
   margin-block: 0;
 }
@@ -57,6 +61,10 @@
 
 @mixin reset-button {
   border: 0;
+
+  // Reset margins added by Safari on iOS
+  margin-block: 0;
+  margin-inline: 0;
 }
 
 .ams-search-field__button {


### PR DESCRIPTION
Safari on iOS has some perculiarities when it comes to inputs, this PR fixes those for Search Field