### PR TITLE
chore: Clarify spacious and compact values for Grid Space

### DIFF
--- a/storybook/src/docs/space.docs.mdx
+++ b/storybook/src/docs/space.docs.mdx
@@ -18,104 +18,17 @@ Five options are available, of which the middle one is the default.
 Multiplication factors for the smaller and larger lengths are ¼, ½, 1½, and 2.
 The tables below show the resulting pixel widths at some reference widths.
 
-320, 576, 832, 1088, 1344, 1600, 1856, 2112, 2368, 2624
-
 #### Spacious
 
 In Spacious Mode, the medium grid space grows from 16 to 56 pixels between window widths of 320 and 1600.
 
-<table>
-  <thead>
-    <tr>
-      <th style={{ textAlign: "right" }}></th>
-      <th style={{ textAlign: "center" }}>320</th>
-      <th style={{ textAlign: "center" }}>576</th>
-      <th style={{ textAlign: "center" }}>832</th>
-      <th style={{ textAlign: "center" }}>1088</th>
-      <th style={{ textAlign: "center" }}>1344</th>
-      <th style={{ textAlign: "center" }}>1600</th>
-      <th style={{ textAlign: "center" }}>2112</th>
-      <th style={{ textAlign: "center" }}>2624</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td style={{ textAlign: "right" }}>
-        <strong>Extra small</strong>
-      </td>
-      <td style={{ textAlign: "center" }}>4</td>
-      <td style={{ textAlign: "center" }}>6</td>
-      <td style={{ textAlign: "center" }}>8</td>
-      <td style={{ textAlign: "center" }}>10</td>
-      <td style={{ textAlign: "center" }}>12</td>
-      <td colSpan={3} style={{ textAlign: "center" }}>
-        14
-      </td>
-    </tr>
-    <tr>
-      <td style={{ textAlign: "right" }}>
-        <strong>Small</strong>
-      </td>
-      <td style={{ textAlign: "center" }}>8</td>
-      <td style={{ textAlign: "center" }}>12</td>
-      <td style={{ textAlign: "center" }}>16</td>
-      <td style={{ textAlign: "center" }}>20</td>
-      <td style={{ textAlign: "center" }}>24</td>
-      <td colSpan={3} style={{ textAlign: "center" }}>
-        28
-      </td>
-    </tr>
-    <tr>
-      <td style={{ textAlign: "right" }}>
-        <strong>Medium</strong>
-      </td>
-      <td style={{ textAlign: "center" }}>
-        <strong>16</strong>
-      </td>
-      <td style={{ textAlign: "center" }}>
-        <strong>24</strong>
-      </td>
-      <td style={{ textAlign: "center" }}>
-        <strong>32</strong>
-      </td>
-      <td style={{ textAlign: "center" }}>
-        <strong>40</strong>
-      </td>
-      <td style={{ textAlign: "center" }}>
-        <strong>48</strong>
-      </td>
-      <td colSpan={3} style={{ textAlign: "center" }}>
-        <strong>56</strong>
-      </td>
-    </tr>
-    <tr>
-      <td style={{ textAlign: "right" }}>
-        <strong>Large</strong>
-      </td>
-      <td style={{ textAlign: "center" }}>24</td>
-      <td style={{ textAlign: "center" }}>36</td>
-      <td style={{ textAlign: "center" }}>48</td>
-      <td style={{ textAlign: "center" }}>60</td>
-      <td style={{ textAlign: "center" }}>72</td>
-      <td colSpan={3} style={{ textAlign: "center" }}>
-        84
-      </td>
-    </tr>
-    <tr>
-      <td style={{ textAlign: "right" }}>
-        <strong>Extra large</strong>
-      </td>
-      <td style={{ textAlign: "center" }}>32</td>
-      <td style={{ textAlign: "center" }}>48</td>
-      <td style={{ textAlign: "center" }}>64</td>
-      <td style={{ textAlign: "center" }}>80</td>
-      <td style={{ textAlign: "center" }}>96</td>
-      <td colSpan={3} style={{ textAlign: "center" }}>
-        102
-      </td>
-    </tr>
-  </tbody>
-</table>
+|                 |  320   |  576   |  832   |  1088  |  1344  |  1600  |
+| --------------: | :----: | :----: | :----: | :----: | :----: | :----: |
+| **Extra small** |   4    |   6    |   8    |   10   |   12   |   14   |
+|       **Small** |   8    |   12   |   16   |   20   |   24   |   28   |
+|      **Medium** | **16** | **24** | **32** | **40** | **48** | **56** |
+|       **Large** |   24   |   36   |   48   |   60   |   72   |   84   |
+| **Extra large** |   32   |   48   |   64   |   80   |   96   |  102   |
 
 #### Compact
 

--- a/storybook/src/docs/space.docs.mdx
+++ b/storybook/src/docs/space.docs.mdx
@@ -18,29 +18,169 @@ Five options are available, of which the middle one is the default.
 Multiplication factors for the smaller and larger lengths are ¼, ½, 1½, and 2.
 The tables below show the resulting pixel widths at some reference widths.
 
+320, 576, 832, 1088, 1344, 1600, 1856, 2112, 2368, 2624
+
 #### Spacious
 
 In Spacious Mode, the medium grid space grows from 16 to 56 pixels between window widths of 320 and 1600.
 
-|                 |  320   |  576   |  1088  |  1600  |
-| --------------: | :----: | :----: | :----: | :----: |
-| **Extra small** |   4    |   6    |   10   |   14   |
-|       **Small** |   8    |   12   |   20   |   28   |
-|      **Medium** | **16** | **24** | **40** | **56** |
-|       **Large** |   24   |   36   |   60   |   84   |
-| **Extra large** |   32   |   48   |   80   |  102   |
+<table>
+  <thead>
+    <tr>
+      <th style={{ textAlign: "right" }}></th>
+      <th style={{ textAlign: "center" }}>320</th>
+      <th style={{ textAlign: "center" }}>576</th>
+      <th style={{ textAlign: "center" }}>1088</th>
+      <th style={{ textAlign: "center" }}>1600</th>
+      <th style={{ textAlign: "center" }}>2112</th>
+      <th style={{ textAlign: "center" }}>2624</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={{ textAlign: "right" }}>
+        <strong>Extra small</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>4</td>
+      <td style={{ textAlign: "center" }}>6</td>
+      <td style={{ textAlign: "center" }}>10</td>
+      <td colSpan={3} style={{ textAlign: "center" }}>
+        14
+      </td>
+    </tr>
+    <tr>
+      <td style={{ textAlign: "right" }}>
+        <strong>Small</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>8</td>
+      <td style={{ textAlign: "center" }}>12</td>
+      <td style={{ textAlign: "center" }}>20</td>
+      <td colSpan={3} style={{ textAlign: "center" }}>
+        28
+      </td>
+    </tr>
+    <tr>
+      <td style={{ textAlign: "right" }}>
+        <strong>Medium</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>
+        <strong>16</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>
+        <strong>24</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>
+        <strong>40</strong>
+      </td>
+      <td colSpan={3} style={{ textAlign: "center" }}>
+        <strong>56</strong>
+      </td>
+    </tr>
+    <tr>
+      <td style={{ textAlign: "right" }}>
+        <strong>Large</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>24</td>
+      <td style={{ textAlign: "center" }}>36</td>
+      <td style={{ textAlign: "center" }}>60</td>
+      <td colSpan={3} style={{ textAlign: "center" }}>
+        84
+      </td>
+    </tr>
+    <tr>
+      <td style={{ textAlign: "right" }}>
+        <strong>Extra large</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>32</td>
+      <td style={{ textAlign: "center" }}>48</td>
+      <td style={{ textAlign: "center" }}>80</td>
+      <td colSpan={3} style={{ textAlign: "center" }}>
+        102
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 #### Compact
 
 In Compact Mode, the medium grid space grows from 16 to 40 pixels between window widths of 1088 and 2624.
 
-|                 |   1088 |   1600 |   2112 |   2624 |
-| --------------: | -----: | -----: | -----: | -----: |
-| **Extra small** |      4 |      6 |      8 |     10 |
-|       **Small** |      8 |     12 |     16 |     20 |
-|      **Medium** | **16** | **24** | **32** | **40** |
-|       **Large** |     24 |     36 |     48 |     60 |
-| **Extra large** |     32 |     48 |     64 |     80 |
+<table>
+  <thead>
+    <tr>
+      <th style={{ textAlign: "right" }}></th>
+      <th style={{ textAlign: "center" }}>320</th>
+      <th style={{ textAlign: "center" }}>576</th>
+      <th style={{ textAlign: "center" }}>1088</th>
+      <th style={{ textAlign: "center" }}>1600</th>
+      <th style={{ textAlign: "center" }}>2112</th>
+      <th style={{ textAlign: "center" }}>2624</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style={{ textAlign: "right" }}>
+        <strong>Extra small</strong>
+      </td>
+      <td colspan={3} style={{ textAlign: "center" }}>
+        4
+      </td>
+      <td style={{ textAlign: "center" }}>6</td>
+      <td style={{ textAlign: "center" }}>8</td>
+      <td style={{ textAlign: "center" }}>10</td>
+    </tr>
+    <tr>
+      <td style={{ textAlign: "right" }}>
+        <strong>Small</strong>
+      </td>
+      <td colspan={3} style={{ textAlign: "center" }}>
+        8
+      </td>
+      <td style={{ textAlign: "center" }}>12</td>
+      <td style={{ textAlign: "center" }}>16</td>
+      <td style={{ textAlign: "center" }}>20</td>
+    </tr>
+    <tr>
+      <td style={{ textAlign: "right" }}>
+        <strong>Medium</strong>
+      </td>
+      <td colspan={3} style={{ textAlign: "center" }}>
+        <strong>16</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>
+        <strong>24</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>
+        <strong>32</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>
+        <strong>40</strong>
+      </td>
+    </tr>
+    <tr>
+      <td style={{ textAlign: "right" }}>
+        <strong>Large</strong>
+      </td>
+      <td colspan={3} style={{ textAlign: "center" }}>
+        24
+      </td>
+      <td style={{ textAlign: "center" }}>36</td>
+      <td style={{ textAlign: "center" }}>48</td>
+      <td style={{ textAlign: "center" }}>60</td>
+    </tr>
+    <tr>
+      <td style={{ textAlign: "right" }}>
+        <strong>Extra large</strong>
+      </td>
+      <td colspan={3} style={{ textAlign: "center" }}>
+        32
+      </td>
+      <td style={{ textAlign: "center" }}>48</td>
+      <td style={{ textAlign: "center" }}>64</td>
+      <td style={{ textAlign: "center" }}>80</td>
+    </tr>
+  </tbody>
+</table>
 
 ## Stack Space
 

--- a/storybook/src/docs/space.docs.mdx
+++ b/storybook/src/docs/space.docs.mdx
@@ -44,7 +44,9 @@ In Compact Mode, the medium grid space grows from 16 to 40 pixels between window
       <th style={{ textAlign: "center" }}>1088</th>
       <th style={{ textAlign: "center" }}>1344</th>
       <th style={{ textAlign: "center" }}>1600</th>
+      <th style={{ textAlign: "center" }}>1856</th>
       <th style={{ textAlign: "center" }}>2112</th>
+      <th style={{ textAlign: "center" }}>2368</th>
       <th style={{ textAlign: "center" }}>2624</th>
     </tr>
   </thead>
@@ -58,7 +60,9 @@ In Compact Mode, the medium grid space grows from 16 to 40 pixels between window
       </td>
       <td style={{ textAlign: "center" }}>5</td>
       <td style={{ textAlign: "center" }}>6</td>
+      <td style={{ textAlign: "center" }}>7</td>
       <td style={{ textAlign: "center" }}>8</td>
+      <td style={{ textAlign: "center" }}>9</td>
       <td style={{ textAlign: "center" }}>10</td>
     </tr>
     <tr>
@@ -70,7 +74,9 @@ In Compact Mode, the medium grid space grows from 16 to 40 pixels between window
       </td>
       <td style={{ textAlign: "center" }}>10</td>
       <td style={{ textAlign: "center" }}>12</td>
+      <td style={{ textAlign: "center" }}>14</td>
       <td style={{ textAlign: "center" }}>16</td>
+      <td style={{ textAlign: "center" }}>18</td>
       <td style={{ textAlign: "center" }}>20</td>
     </tr>
     <tr>
@@ -87,7 +93,13 @@ In Compact Mode, the medium grid space grows from 16 to 40 pixels between window
         <strong>24</strong>
       </td>
       <td style={{ textAlign: "center" }}>
+        <strong>28</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>
         <strong>32</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>
+        <strong>36</strong>
       </td>
       <td style={{ textAlign: "center" }}>
         <strong>40</strong>
@@ -102,7 +114,9 @@ In Compact Mode, the medium grid space grows from 16 to 40 pixels between window
       </td>
       <td style={{ textAlign: "center" }}>30</td>
       <td style={{ textAlign: "center" }}>36</td>
+      <td style={{ textAlign: "center" }}>42</td>
       <td style={{ textAlign: "center" }}>48</td>
+      <td style={{ textAlign: "center" }}>54</td>
       <td style={{ textAlign: "center" }}>60</td>
     </tr>
     <tr>
@@ -114,7 +128,9 @@ In Compact Mode, the medium grid space grows from 16 to 40 pixels between window
       </td>
       <td style={{ textAlign: "center" }}>40</td>
       <td style={{ textAlign: "center" }}>48</td>
+      <td style={{ textAlign: "center" }}>56</td>
       <td style={{ textAlign: "center" }}>64</td>
+      <td style={{ textAlign: "center" }}>72</td>
       <td style={{ textAlign: "center" }}>80</td>
     </tr>
   </tbody>

--- a/storybook/src/docs/space.docs.mdx
+++ b/storybook/src/docs/space.docs.mdx
@@ -30,7 +30,9 @@ In Spacious Mode, the medium grid space grows from 16 to 56 pixels between windo
       <th style={{ textAlign: "right" }}></th>
       <th style={{ textAlign: "center" }}>320</th>
       <th style={{ textAlign: "center" }}>576</th>
+      <th style={{ textAlign: "center" }}>832</th>
       <th style={{ textAlign: "center" }}>1088</th>
+      <th style={{ textAlign: "center" }}>1344</th>
       <th style={{ textAlign: "center" }}>1600</th>
       <th style={{ textAlign: "center" }}>2112</th>
       <th style={{ textAlign: "center" }}>2624</th>
@@ -43,7 +45,9 @@ In Spacious Mode, the medium grid space grows from 16 to 56 pixels between windo
       </td>
       <td style={{ textAlign: "center" }}>4</td>
       <td style={{ textAlign: "center" }}>6</td>
+      <td style={{ textAlign: "center" }}>8</td>
       <td style={{ textAlign: "center" }}>10</td>
+      <td style={{ textAlign: "center" }}>12</td>
       <td colSpan={3} style={{ textAlign: "center" }}>
         14
       </td>
@@ -54,7 +58,9 @@ In Spacious Mode, the medium grid space grows from 16 to 56 pixels between windo
       </td>
       <td style={{ textAlign: "center" }}>8</td>
       <td style={{ textAlign: "center" }}>12</td>
+      <td style={{ textAlign: "center" }}>16</td>
       <td style={{ textAlign: "center" }}>20</td>
+      <td style={{ textAlign: "center" }}>24</td>
       <td colSpan={3} style={{ textAlign: "center" }}>
         28
       </td>
@@ -70,7 +76,13 @@ In Spacious Mode, the medium grid space grows from 16 to 56 pixels between windo
         <strong>24</strong>
       </td>
       <td style={{ textAlign: "center" }}>
+        <strong>32</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>
         <strong>40</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>
+        <strong>48</strong>
       </td>
       <td colSpan={3} style={{ textAlign: "center" }}>
         <strong>56</strong>
@@ -82,7 +94,9 @@ In Spacious Mode, the medium grid space grows from 16 to 56 pixels between windo
       </td>
       <td style={{ textAlign: "center" }}>24</td>
       <td style={{ textAlign: "center" }}>36</td>
+      <td style={{ textAlign: "center" }}>48</td>
       <td style={{ textAlign: "center" }}>60</td>
+      <td style={{ textAlign: "center" }}>72</td>
       <td colSpan={3} style={{ textAlign: "center" }}>
         84
       </td>
@@ -93,7 +107,9 @@ In Spacious Mode, the medium grid space grows from 16 to 56 pixels between windo
       </td>
       <td style={{ textAlign: "center" }}>32</td>
       <td style={{ textAlign: "center" }}>48</td>
+      <td style={{ textAlign: "center" }}>64</td>
       <td style={{ textAlign: "center" }}>80</td>
+      <td style={{ textAlign: "center" }}>96</td>
       <td colSpan={3} style={{ textAlign: "center" }}>
         102
       </td>
@@ -111,7 +127,9 @@ In Compact Mode, the medium grid space grows from 16 to 40 pixels between window
       <th style={{ textAlign: "right" }}></th>
       <th style={{ textAlign: "center" }}>320</th>
       <th style={{ textAlign: "center" }}>576</th>
+      <th style={{ textAlign: "center" }}>832</th>
       <th style={{ textAlign: "center" }}>1088</th>
+      <th style={{ textAlign: "center" }}>1344</th>
       <th style={{ textAlign: "center" }}>1600</th>
       <th style={{ textAlign: "center" }}>2112</th>
       <th style={{ textAlign: "center" }}>2624</th>
@@ -122,9 +140,10 @@ In Compact Mode, the medium grid space grows from 16 to 40 pixels between window
       <td style={{ textAlign: "right" }}>
         <strong>Extra small</strong>
       </td>
-      <td colspan={3} style={{ textAlign: "center" }}>
+      <td colspan={4} style={{ textAlign: "center" }}>
         4
       </td>
+      <td style={{ textAlign: "center" }}>5</td>
       <td style={{ textAlign: "center" }}>6</td>
       <td style={{ textAlign: "center" }}>8</td>
       <td style={{ textAlign: "center" }}>10</td>
@@ -133,9 +152,10 @@ In Compact Mode, the medium grid space grows from 16 to 40 pixels between window
       <td style={{ textAlign: "right" }}>
         <strong>Small</strong>
       </td>
-      <td colspan={3} style={{ textAlign: "center" }}>
+      <td colspan={4} style={{ textAlign: "center" }}>
         8
       </td>
+      <td style={{ textAlign: "center" }}>10</td>
       <td style={{ textAlign: "center" }}>12</td>
       <td style={{ textAlign: "center" }}>16</td>
       <td style={{ textAlign: "center" }}>20</td>
@@ -144,8 +164,11 @@ In Compact Mode, the medium grid space grows from 16 to 40 pixels between window
       <td style={{ textAlign: "right" }}>
         <strong>Medium</strong>
       </td>
-      <td colspan={3} style={{ textAlign: "center" }}>
+      <td colspan={4} style={{ textAlign: "center" }}>
         <strong>16</strong>
+      </td>
+      <td style={{ textAlign: "center" }}>
+        <strong>20</strong>
       </td>
       <td style={{ textAlign: "center" }}>
         <strong>24</strong>
@@ -161,9 +184,10 @@ In Compact Mode, the medium grid space grows from 16 to 40 pixels between window
       <td style={{ textAlign: "right" }}>
         <strong>Large</strong>
       </td>
-      <td colspan={3} style={{ textAlign: "center" }}>
+      <td colspan={4} style={{ textAlign: "center" }}>
         24
       </td>
+      <td style={{ textAlign: "center" }}>30</td>
       <td style={{ textAlign: "center" }}>36</td>
       <td style={{ textAlign: "center" }}>48</td>
       <td style={{ textAlign: "center" }}>60</td>
@@ -172,9 +196,10 @@ In Compact Mode, the medium grid space grows from 16 to 40 pixels between window
       <td style={{ textAlign: "right" }}>
         <strong>Extra large</strong>
       </td>
-      <td colspan={3} style={{ textAlign: "center" }}>
+      <td colspan={4} style={{ textAlign: "center" }}>
         32
       </td>
+      <td style={{ textAlign: "center" }}>40</td>
       <td style={{ textAlign: "center" }}>48</td>
       <td style={{ textAlign: "center" }}>64</td>
       <td style={{ textAlign: "center" }}>80</td>


### PR DESCRIPTION
I received feedback that the difference in the columns for the tables listing the values for Grid Space on various screen widths were confusing, and I agreed.

In a couple of iterations, I decided to use a step of 256 pixels for every column; some were 512 before. Compact Mode starts at 1088 and you can’t get down to 320 with steps of 512. And both tables’ columns needed to align.

The first cells in the table for compact mode have been merged to highlight that their values are the same. This required using an HTML table instead of Markdown.

I experimented with hiding the obscure columns of 2368 and 2624, but this is how the tokens work; I decided to remain complete.

Links to the pages: [current](https://designsystem.amsterdam/?path=/docs/docs-design-guidelines-space--docs), [updated](http://designsystem.amsterdam/demo-clarify-grid-breakpoints/?path=/docs/docs-design-guidelines-space--docs).