### PR TITLE
feat: Allow small text for ordered lists

### DIFF
--- a/packages/css/src/components/ordered-list/ordered-list.scss
+++ b/packages/css/src/components/ordered-list/ordered-list.scss
@@ -38,13 +38,13 @@
   }
 }
 
+.ams-ordered-list--inverse-color:not(.ams-ordered-list--no-markers) {
+  color: var(--ams-ordered-list-inverse-color);
+}
+
 .ams-ordered-list--small:not(.ams-ordered-list--no-markers) {
   font-size: var(--ams-ordered-list-small-font-size);
   line-height: var(--ams-ordered-list-small-line-height);
-}
-
-.ams-ordered-list--inverse-color:not(.ams-ordered-list--no-markers) {
-  color: var(--ams-ordered-list-inverse-color);
 }
 
 /** A nested list has a different marker and less indentation for correct alignment. */

--- a/packages/css/src/components/ordered-list/ordered-list.scss
+++ b/packages/css/src/components/ordered-list/ordered-list.scss
@@ -26,9 +26,9 @@
 .ams-ordered-list:not(.ams-ordered-list--no-markers) {
   color: var(--ams-ordered-list-color);
   font-family: var(--ams-ordered-list-font-family);
-  font-size: var(--ams-ordered-list-font-size);
+  font-size: var(--ams-ordered-list-medium-font-size);
   font-weight: var(--ams-ordered-list-font-weight);
-  line-height: var(--ams-ordered-list-line-height);
+  line-height: var(--ams-ordered-list-medium-line-height);
   list-style-type: var(--ams-ordered-list-list-style-type);
 
   /** List items are responsible for indentation and marker positioning. */
@@ -36,6 +36,16 @@
     margin-inline-start: var(--ams-ordered-list-item-margin-inline-start);
     padding-inline-start: var(--ams-ordered-list-item-padding-inline-start);
   }
+}
+
+.ams-ordered-list--small {
+  font-size: var(--ams-ordered-list-small-font-size);
+  line-height: var(--ams-ordered-list-small-line-height);
+}
+
+.ams-ordered-list--large {
+  font-size: var(--ams-ordered-list-large-font-size);
+  line-height: var(--ams-ordered-list-large-line-height);
 }
 
 .ams-ordered-list--inverse-color:not(.ams-ordered-list--no-markers) {

--- a/packages/css/src/components/ordered-list/ordered-list.scss
+++ b/packages/css/src/components/ordered-list/ordered-list.scss
@@ -26,9 +26,9 @@
 .ams-ordered-list:not(.ams-ordered-list--no-markers) {
   color: var(--ams-ordered-list-color);
   font-family: var(--ams-ordered-list-font-family);
-  font-size: var(--ams-ordered-list-medium-font-size);
+  font-size: var(--ams-ordered-list-font-size);
   font-weight: var(--ams-ordered-list-font-weight);
-  line-height: var(--ams-ordered-list-medium-line-height);
+  line-height: var(--ams-ordered-list-line-height);
   list-style-type: var(--ams-ordered-list-list-style-type);
 
   /** List items are responsible for indentation and marker positioning. */
@@ -41,11 +41,6 @@
 .ams-ordered-list--small:not(.ams-ordered-list--no-markers) {
   font-size: var(--ams-ordered-list-small-font-size);
   line-height: var(--ams-ordered-list-small-line-height);
-}
-
-.ams-ordered-list--large:not(.ams-ordered-list--no-markers) {
-  font-size: var(--ams-ordered-list-large-font-size);
-  line-height: var(--ams-ordered-list-large-line-height);
 }
 
 .ams-ordered-list--inverse-color:not(.ams-ordered-list--no-markers) {

--- a/packages/css/src/components/ordered-list/ordered-list.scss
+++ b/packages/css/src/components/ordered-list/ordered-list.scss
@@ -38,12 +38,12 @@
   }
 }
 
-.ams-ordered-list--small {
+.ams-ordered-list--small:not(.ams-ordered-list--no-markers) {
   font-size: var(--ams-ordered-list-small-font-size);
   line-height: var(--ams-ordered-list-small-line-height);
 }
 
-.ams-ordered-list--large {
+.ams-ordered-list--large:not(.ams-ordered-list--no-markers) {
   font-size: var(--ams-ordered-list-large-font-size);
   line-height: var(--ams-ordered-list-large-line-height);
 }

--- a/packages/react/src/OrderedList/OrderedList.test.tsx
+++ b/packages/react/src/OrderedList/OrderedList.test.tsx
@@ -69,14 +69,6 @@ describe('Ordered list', () => {
     expect(component).toHaveClass('ams-ordered-list--small')
   })
 
-  it('renders the large size class', () => {
-    render(<OrderedList size="large" />)
-
-    const component = screen.getByRole('list')
-
-    expect(component).toHaveClass('ams-ordered-list--large')
-  })
-
   it('supports ForwardRef in React', () => {
     const ref = createRef<HTMLOListElement>()
 

--- a/packages/react/src/OrderedList/OrderedList.test.tsx
+++ b/packages/react/src/OrderedList/OrderedList.test.tsx
@@ -61,6 +61,22 @@ describe('Ordered list', () => {
     expect(items.length).toBe(3)
   })
 
+  it('renders the small size class', () => {
+    render(<OrderedList size="small" />)
+
+    const component = screen.getByRole('list')
+
+    expect(component).toHaveClass('ams-ordered-list--small')
+  })
+
+  it('renders the large size class', () => {
+    render(<OrderedList size="large" />)
+
+    const component = screen.getByRole('list')
+
+    expect(component).toHaveClass('ams-ordered-list--large')
+  })
+
   it('supports ForwardRef in React', () => {
     const ref = createRef<HTMLOListElement>()
 

--- a/packages/react/src/OrderedList/OrderedList.tsx
+++ b/packages/react/src/OrderedList/OrderedList.tsx
@@ -9,16 +9,17 @@ import type { ForwardedRef, OlHTMLAttributes, PropsWithChildren } from 'react'
 import { OrderedListItem } from './OrderedListItem'
 
 export type OrderedListProps = {
-  markers?: boolean
   /** Changes the text color for readability on a dark background. */
   inverseColor?: boolean
+  /** Whether the list items show a marker. */
+  markers?: boolean
   /** The size of the ordered list */
   size?: 'small'
 } & PropsWithChildren<OlHTMLAttributes<HTMLOListElement>>
 
 const OrderedListRoot = forwardRef(
   (
-    { children, className, inverseColor, size, markers = true, ...restProps }: OrderedListProps,
+    { children, className, inverseColor, markers = true, size, ...restProps }: OrderedListProps,
     ref: ForwardedRef<HTMLOListElement>,
   ) => (
     <ol

--- a/packages/react/src/OrderedList/OrderedList.tsx
+++ b/packages/react/src/OrderedList/OrderedList.tsx
@@ -12,11 +12,13 @@ export type OrderedListProps = {
   markers?: boolean
   /** Changes the text color for readability on a dark background. */
   inverseColor?: boolean
+  /** The size of the ordered list */
+  size?: 'small' | 'large'
 } & PropsWithChildren<OlHTMLAttributes<HTMLOListElement>>
 
 const OrderedListRoot = forwardRef(
   (
-    { children, className, inverseColor, markers = true, ...restProps }: OrderedListProps,
+    { children, className, inverseColor, size, markers = true, ...restProps }: OrderedListProps,
     ref: ForwardedRef<HTMLOListElement>,
   ) => (
     <ol
@@ -25,6 +27,7 @@ const OrderedListRoot = forwardRef(
         'ams-ordered-list',
         inverseColor && 'ams-ordered-list--inverse-color',
         !markers && 'ams-ordered-list--no-markers',
+        size && `ams-ordered-list--${size}`,
         className,
       )}
       {...restProps}

--- a/packages/react/src/OrderedList/OrderedList.tsx
+++ b/packages/react/src/OrderedList/OrderedList.tsx
@@ -13,7 +13,7 @@ export type OrderedListProps = {
   /** Changes the text color for readability on a dark background. */
   inverseColor?: boolean
   /** The size of the ordered list */
-  size?: 'small' | 'large'
+  size?: 'small'
 } & PropsWithChildren<OlHTMLAttributes<HTMLOListElement>>
 
 const OrderedListRoot = forwardRef(

--- a/packages/react/src/UnorderedList/UnorderedList.tsx
+++ b/packages/react/src/UnorderedList/UnorderedList.tsx
@@ -11,6 +11,7 @@ import { UnorderedListItem } from './UnorderedListItem'
 export type UnorderedListProps = {
   /** Changes the text color for readability on a dark background. */
   inverseColor?: boolean
+  /** Whether the list items show a marker. */
   markers?: boolean
   /** The size of the unordered list. */
   size?: 'small'

--- a/proprietary/tokens/src/components/ams/ordered-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/ordered-list.tokens.json
@@ -3,12 +3,22 @@
     "ordered-list": {
       "color": { "value": "{ams.color.primary-black}" },
       "font-family": { "value": "{ams.text.font-family}" },
-      "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "gap": { "value": "0.75rem" },
       "inverse-color": { "value": "{ams.color.primary-white}" },
-      "line-height": { "value": "{ams.text.level.5.line-height}" },
       "list-style-type": { "value": "decimal" },
+      "small": {
+        "font-size": { "value": "{ams.text.level.6.font-size}" },
+        "line-height": { "value": "{ams.text.level.6.line-height}" }
+      },
+      "medium": {
+        "font-size": { "value": "{ams.text.level.5.font-size}" },
+        "line-height": { "value": "{ams.text.level.5.line-height}" }
+      },
+      "large": {
+        "font-size": { "value": "{ams.text.level.4.font-size}" },
+        "line-height": { "value": "{ams.text.level.4.line-height}" }
+      },
       "item": {
         "margin-inline-start": {
           "value": "2.25rem",

--- a/proprietary/tokens/src/components/ams/ordered-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/ordered-list.tokens.json
@@ -3,21 +3,15 @@
     "ordered-list": {
       "color": { "value": "{ams.color.primary-black}" },
       "font-family": { "value": "{ams.text.font-family}" },
+      "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "gap": { "value": "0.75rem" },
       "inverse-color": { "value": "{ams.color.primary-white}" },
+      "line-height": { "value": "{ams.text.level.5.line-height}" },
       "list-style-type": { "value": "decimal" },
       "small": {
         "font-size": { "value": "{ams.text.level.6.font-size}" },
         "line-height": { "value": "{ams.text.level.6.line-height}" }
-      },
-      "medium": {
-        "font-size": { "value": "{ams.text.level.5.font-size}" },
-        "line-height": { "value": "{ams.text.level.5.line-height}" }
-      },
-      "large": {
-        "font-size": { "value": "{ams.text.level.4.font-size}" },
-        "line-height": { "value": "{ams.text.level.4.line-height}" }
       },
       "item": {
         "margin-inline-start": {

--- a/storybook/src/components/OrderedList/OrderedList.docs.mdx
+++ b/storybook/src/components/OrderedList/OrderedList.docs.mdx
@@ -23,12 +23,6 @@ Use a list with a smaller font size in form descriptions and captions and the li
 
 <Canvas of={OrderedListStories.Small} />
 
-## Large
-
-Use this size only for the introductory text of a page.
-
-<Canvas of={OrderedListStories.Large} />
-
 ### Two Levels
 
 A list may have one nested level.

--- a/storybook/src/components/OrderedList/OrderedList.docs.mdx
+++ b/storybook/src/components/OrderedList/OrderedList.docs.mdx
@@ -17,6 +17,18 @@ Extra white space between items enhances the distinction, mainly when they consi
 
 <Controls />
 
+## Small
+
+Use a list with a smaller font size in form descriptions and captions and the like.
+
+<Canvas of={OrderedListStories.Small} />
+
+## Large
+
+Use this size only for the introductory text of a page.
+
+<Canvas of={OrderedListStories.Large} />
+
 ### Two Levels
 
 A list may have one nested level.

--- a/storybook/src/components/OrderedList/OrderedList.stories.tsx
+++ b/storybook/src/components/OrderedList/OrderedList.stories.tsx
@@ -28,7 +28,7 @@ const meta = {
     size: {
       control: {
         type: 'radio',
-        labels: { small: 'small', undefined: 'medium', large: 'large' },
+        labels: { small: 'small', undefined: 'medium' },
       },
       options: ['small', undefined, 'large'],
     },
@@ -45,12 +45,6 @@ export const Default: Story = {}
 export const Small: Story = {
   args: {
     size: 'small',
-  },
-}
-
-export const Large: Story = {
-  args: {
-    size: 'large',
   },
 }
 

--- a/storybook/src/components/OrderedList/OrderedList.stories.tsx
+++ b/storybook/src/components/OrderedList/OrderedList.stories.tsx
@@ -35,6 +35,18 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
+export const Small: Story = {
+  args: {
+    size: 'small',
+  },
+}
+
+export const Large: Story = {
+  args: {
+    size: 'large',
+  },
+}
+
 export const TwoLevels: Story = {
   render: (args) => (
     <OrderedList {...args}>

--- a/storybook/src/components/OrderedList/OrderedList.stories.tsx
+++ b/storybook/src/components/OrderedList/OrderedList.stories.tsx
@@ -25,6 +25,13 @@ const meta = {
   argTypes: {
     reversed: { control: 'boolean' },
     start: { control: 'number' },
+    size: {
+      control: {
+        type: 'radio',
+        labels: { small: 'small', undefined: 'medium', large: 'large' },
+      },
+      options: ['small', undefined, 'large'],
+    },
   },
   decorators: [inverseColorDecorator],
 } satisfies Meta<typeof OrderedList>


### PR DESCRIPTION
I've opted to use the same sizes as the paragraph because they can be used together.