### PR TITLE
feat: display component status badge (using Badges addon)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
       '@babel/core':
         specifier: 7.24.5
         version: 7.24.5
+      '@geometricpanda/storybook-addon-badges':
+        specifier: 2.0.2
+        version: 2.0.2(@storybook/blocks@8.0.10(@types/react@18.3.2)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/components@8.0.10(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@8.0.10)(@storybook/manager-api@8.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@8.0.10)(@storybook/theming@8.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/types@8.0.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mdx-js/react':
         specifier: 3.0.1
         version: 3.0.1(@types/react@18.3.2)(react@18.3.1)
@@ -1354,6 +1357,24 @@ packages:
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@geometricpanda/storybook-addon-badges@2.0.2':
+    resolution: {integrity: sha512-RlJvQcSSXwwrN+ABc+2s1UDatWSUsba9TPX/TyNVyobuZZPvu+Bx1d2HVDCIVtXwhlrSvgVB2yr+nVa18edOgw==}
+    peerDependencies:
+      '@storybook/blocks': ^7.0.0
+      '@storybook/components': ^7.0.0
+      '@storybook/core-events': ^7.0.0
+      '@storybook/manager-api': ^7.0.0
+      '@storybook/preview-api': ^7.0.0
+      '@storybook/theming': ^7.0.0
+      '@storybook/types': ^7.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -9162,6 +9183,19 @@ snapshots:
   '@fal-works/esbuild-plugin-global-externals@2.1.2': {}
 
   '@gar/promisify@1.1.3': {}
+
+  '@geometricpanda/storybook-addon-badges@2.0.2(@storybook/blocks@8.0.10(@types/react@18.3.2)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/components@8.0.10(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/core-events@8.0.10)(@storybook/manager-api@8.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/preview-api@8.0.10)(@storybook/theming@8.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@storybook/types@8.0.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@storybook/blocks': 8.0.10(@types/react@18.3.2)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/components': 8.0.10(@types/react@18.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/core-events': 8.0.10
+      '@storybook/manager-api': 8.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/preview-api': 8.0.10
+      '@storybook/theming': 8.0.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/types': 8.0.10
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@hapi/hoek@9.3.0': {}
 

--- a/storybook/config/main.ts
+++ b/storybook/config/main.ts
@@ -22,6 +22,7 @@ const config: StorybookConfig = {
         },
       },
     },
+    '@geometricpanda/storybook-addon-badges',
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -25,6 +25,7 @@
     "@amsterdam/design-system-react-icons": "workspace:*",
     "@amsterdam/design-system-tokens": "workspace:*",
     "@babel/core": "7.24.5",
+    "@geometricpanda/storybook-addon-badges": "2.0.2",
     "@mdx-js/react": "3.0.1",
     "@storybook/addon-a11y": "8.0.10",
     "@storybook/addon-actions": "8.0.10",

--- a/storybook/src/components/Header/Header.stories.tsx
+++ b/storybook/src/components/Header/Header.stories.tsx
@@ -5,11 +5,15 @@
 
 import { Header, PageMenu } from '@amsterdam/design-system-react/src'
 import { SearchIcon } from '@amsterdam/design-system-react-icons'
+import { BADGE } from '@geometricpanda/storybook-addon-badges'
 import { Meta, StoryObj } from '@storybook/react'
 
 const meta = {
   title: 'Components/Containers/Header',
   component: Header,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } satisfies Meta<typeof Header>
 
 export default meta

--- a/storybook/src/components/Icon/Icon.stories.tsx
+++ b/storybook/src/components/Icon/Icon.stories.tsx
@@ -5,6 +5,7 @@
 
 import { Heading, Icon } from '@amsterdam/design-system-react/src'
 import * as Icons from '@amsterdam/design-system-react-icons'
+import { BADGE } from '@geometricpanda/storybook-addon-badges'
 import { Meta, StoryObj } from '@storybook/react'
 
 const meta = {
@@ -18,6 +19,9 @@ const meta = {
       options: Object.keys(Icons),
       mapping: Icons,
     },
+  },
+  parameters: {
+    badges: [BADGE.BETA],
   },
 } satisfies Meta<typeof Icon>
 

--- a/storybook/src/docs/icon-gallery.docs.mdx
+++ b/storybook/src/docs/icon-gallery.docs.mdx
@@ -1,7 +1,10 @@
+import { BADGE } from "@geometricpanda/storybook-addon-badges";
 import { Meta } from "@storybook/blocks";
 import { AmsterdamIconGallery } from "./components/AmsterdamIconGallery";
 
-<Meta title="Docs/Assets/Icons" />
+{/* Below "parameters" prop does not seem to work. Not sure how to implement badges on our doc stories. Any ideas? */}
+
+<Meta title="Docs/Assets/Icons" parameters={{ badges: [BADGE.BETA] }} />
 
 # Icons
 


### PR DESCRIPTION
This is the second of two draft pull requests to add status badges to stories to inform the reader about the lifecycle status of the component.

This PR uses the [Badges addon](https://storybook.js.org/addons/@geometricpanda/storybook-addon-badges/).

GitHub: https://github.com/geometricpanda/storybook-addon-badges?tab=readme-ov-file

Tried to apply to Header, Icon and Icon Gallery. Does not seem to work in our Docs/Assets. If you know how to get it working there, please let me know or fix it yourself.