### PR TITLE
feat!: Rename Breadcrumb Item to Link

### DIFF
--- a/packages/css/src/components/breadcrumb/breadcrumb.scss
+++ b/packages/css/src/components/breadcrumb/breadcrumb.scss
@@ -41,14 +41,14 @@
 }
 
 .ams-breadcrumb__link {
-  color: var(--ams-breadcrumb-item-link-color);
-  outline-offset: var(--ams-breadcrumb-item-link-outline-offset);
-  text-decoration-line: var(--ams-breadcrumb-item-link-text-decoration-line);
-  text-decoration-thickness: var(--ams-breadcrumb-item-link-text-decoration-thickness);
-  text-underline-offset: var(--ams-breadcrumb-item-link-text-underline-offset);
+  color: var(--ams-breadcrumb-link-color);
+  outline-offset: var(--ams-breadcrumb-link-outline-offset);
+  text-decoration-line: var(--ams-breadcrumb-link-text-decoration-line);
+  text-decoration-thickness: var(--ams-breadcrumb-link-text-decoration-thickness);
+  text-underline-offset: var(--ams-breadcrumb-link-text-underline-offset);
 
   &:hover {
-    color: var(--ams-breadcrumb-item-link-hover-color);
-    text-decoration-line: var(--ams-breadcrumb-item-link-hover-text-decoration-line);
+    color: var(--ams-breadcrumb-link-hover-color);
+    text-decoration-line: var(--ams-breadcrumb-link-hover-text-decoration-line);
   }
 }

--- a/packages/react/src/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/react/src/Breadcrumb/Breadcrumb.test.tsx
@@ -24,18 +24,18 @@ describe('Breadcrumb', () => {
   })
 
   it('renders Breadcrumb component with children', () => {
-    const breadcrumbItems = [
-      { label: 'Item 1', href: '/item-1' },
-      { label: 'Item 2', href: '/item-2' },
-      { label: 'Item 3', href: '/item-3' },
+    const breadcrumbLinks = [
+      { label: 'Link 1', href: '/link-1' },
+      { label: 'Link 2', href: '/link-2' },
+      { label: 'Link 3', href: '/link-3' },
     ]
 
     const { container } = render(
       <Breadcrumb>
-        {breadcrumbItems.map((item, index) => (
-          <Breadcrumb.Item key={index} href={item.href}>
-            {item.label}
-          </Breadcrumb.Item>
+        {breadcrumbLinks.map((link, index) => (
+          <Breadcrumb.Link key={index} href={link.href}>
+            {link.label}
+          </Breadcrumb.Link>
         ))}
       </Breadcrumb>,
     )
@@ -52,7 +52,7 @@ describe('Breadcrumb', () => {
 
     const { container } = render(
       <Breadcrumb ref={ref}>
-        <Breadcrumb.Item href="/item-1">Valid Item</Breadcrumb.Item>
+        <Breadcrumb.Link href="/link-1">Valid Link</Breadcrumb.Link>
       </Breadcrumb>,
     )
 

--- a/packages/react/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/Breadcrumb/Breadcrumb.tsx
@@ -6,7 +6,7 @@
 import { clsx } from 'clsx'
 import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
-import { BreadcrumbItem } from './BreadcrumbItem'
+import { BreadcrumbLink } from './BreadcrumbLink'
 
 export type BreadcrumbProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
 
@@ -20,4 +20,4 @@ const BreadcrumbRoot = forwardRef(
 
 BreadcrumbRoot.displayName = 'Breadcrumb'
 
-export const Breadcrumb = Object.assign(BreadcrumbRoot, { Item: BreadcrumbItem })
+export const Breadcrumb = Object.assign(BreadcrumbRoot, { Link: BreadcrumbLink })

--- a/packages/react/src/Breadcrumb/BreadcrumbLink.test.tsx
+++ b/packages/react/src/Breadcrumb/BreadcrumbLink.test.tsx
@@ -1,18 +1,18 @@
 import { render, screen } from '@testing-library/react'
 import { createRef } from 'react'
-import { BreadcrumbItem } from './BreadcrumbItem'
+import { BreadcrumbLink } from './BreadcrumbLink'
 import '@testing-library/jest-dom'
 
-describe('Breadcrumb item', () => {
+describe('Breadcrumb link', () => {
   it('renders', () => {
-    render(<BreadcrumbItem href="/" />)
+    render(<BreadcrumbLink href="/" />)
     const component = screen.getByRole('listitem')
     expect(component).toBeInTheDocument()
     expect(component).toBeVisible()
   })
 
   it('renders a design system BEM class name', () => {
-    render(<BreadcrumbItem href="/" />)
+    render(<BreadcrumbLink href="/" />)
     const item = screen.getByRole('listitem')
     expect(item).toHaveClass('ams-breadcrumb__item')
 
@@ -21,20 +21,20 @@ describe('Breadcrumb item', () => {
   })
 
   it('renders an additional class name', () => {
-    render(<BreadcrumbItem href="/" className="extra" />)
+    render(<BreadcrumbLink href="/" className="extra" />)
     const component = screen.getByRole('listitem')
     expect(component).toHaveClass('ams-breadcrumb__item extra')
   })
 
   it('renders the href attribute', () => {
-    render(<BreadcrumbItem href="/" />)
+    render(<BreadcrumbLink href="/" />)
     const component = screen.getByRole('link')
     expect(component).toHaveAttribute('href', '/')
   })
 
   it('supports ForwardRef in React', () => {
     const ref = createRef<HTMLLIElement>()
-    render(<BreadcrumbItem href="/" ref={ref} />)
+    render(<BreadcrumbLink href="/" ref={ref} />)
     const component = screen.getByRole('listitem')
     expect(ref.current).toBe(component)
   })

--- a/packages/react/src/Breadcrumb/BreadcrumbLink.test.tsx
+++ b/packages/react/src/Breadcrumb/BreadcrumbLink.test.tsx
@@ -6,13 +6,16 @@ import '@testing-library/jest-dom'
 describe('Breadcrumb link', () => {
   it('renders', () => {
     render(<BreadcrumbLink href="/" />)
+
     const component = screen.getByRole('listitem')
+
     expect(component).toBeInTheDocument()
     expect(component).toBeVisible()
   })
 
   it('renders a design system BEM class name', () => {
     render(<BreadcrumbLink href="/" />)
+
     const item = screen.getByRole('listitem')
     expect(item).toHaveClass('ams-breadcrumb__item')
 
@@ -22,8 +25,10 @@ describe('Breadcrumb link', () => {
 
   it('renders an additional class name', () => {
     render(<BreadcrumbLink href="/" className="extra" />)
-    const component = screen.getByRole('listitem')
-    expect(component).toHaveClass('ams-breadcrumb__item extra')
+
+    const component = screen.getByRole('link')
+
+    expect(component).toHaveClass('ams-breadcrumb__link extra')
   })
 
   it('renders the href attribute', () => {
@@ -33,9 +38,11 @@ describe('Breadcrumb link', () => {
   })
 
   it('supports ForwardRef in React', () => {
-    const ref = createRef<HTMLLIElement>()
+    const ref = createRef<HTMLAnchorElement>()
     render(<BreadcrumbLink href="/" ref={ref} />)
-    const component = screen.getByRole('listitem')
+
+    const component = screen.getByRole('link')
+
     expect(ref.current).toBe(component)
   })
 })

--- a/packages/react/src/Breadcrumb/BreadcrumbLink.tsx
+++ b/packages/react/src/Breadcrumb/BreadcrumbLink.tsx
@@ -5,16 +5,14 @@
 
 import { clsx } from 'clsx'
 import { forwardRef } from 'react'
-import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
+import type { AnchorHTMLAttributes, ForwardedRef } from 'react'
 
-export type BreadcrumbLinkProps = {
-  href: string
-} & PropsWithChildren<HTMLAttributes<HTMLLIElement>>
+export type BreadcrumbLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
 
 export const BreadcrumbLink = forwardRef(
-  ({ children, className, href, ...restProps }: BreadcrumbLinkProps, ref: ForwardedRef<HTMLLIElement>) => (
-    <li {...restProps} className={clsx('ams-breadcrumb__item', className)} ref={ref}>
-      <a className="ams-breadcrumb__link" href={href}>
+  ({ children, className, href, ...restProps }: BreadcrumbLinkProps, ref: ForwardedRef<HTMLAnchorElement>) => (
+    <li className="ams-breadcrumb__item">
+      <a {...restProps} className={clsx('ams-breadcrumb__link', className)} href={href} ref={ref}>
         {children}
       </a>
     </li>

--- a/packages/react/src/Breadcrumb/BreadcrumbLink.tsx
+++ b/packages/react/src/Breadcrumb/BreadcrumbLink.tsx
@@ -10,9 +10,9 @@ import type { AnchorHTMLAttributes, ForwardedRef } from 'react'
 export type BreadcrumbLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>
 
 export const BreadcrumbLink = forwardRef(
-  ({ children, className, href, ...restProps }: BreadcrumbLinkProps, ref: ForwardedRef<HTMLAnchorElement>) => (
+  ({ children, className, ...restProps }: BreadcrumbLinkProps, ref: ForwardedRef<HTMLAnchorElement>) => (
     <li className="ams-breadcrumb__item">
-      <a {...restProps} className={clsx('ams-breadcrumb__link', className)} href={href} ref={ref}>
+      <a {...restProps} className={clsx('ams-breadcrumb__link', className)} ref={ref}>
         {children}
       </a>
     </li>

--- a/packages/react/src/Breadcrumb/BreadcrumbLink.tsx
+++ b/packages/react/src/Breadcrumb/BreadcrumbLink.tsx
@@ -7,12 +7,12 @@ import { clsx } from 'clsx'
 import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
-export type BreadcrumbItemProps = {
+export type BreadcrumbLinkProps = {
   href: string
 } & PropsWithChildren<HTMLAttributes<HTMLLIElement>>
 
-export const BreadcrumbItem = forwardRef(
-  ({ children, className, href, ...restProps }: BreadcrumbItemProps, ref: ForwardedRef<HTMLLIElement>) => (
+export const BreadcrumbLink = forwardRef(
+  ({ children, className, href, ...restProps }: BreadcrumbLinkProps, ref: ForwardedRef<HTMLLIElement>) => (
     <li {...restProps} className={clsx('ams-breadcrumb__item', className)} ref={ref}>
       <a className="ams-breadcrumb__link" href={href}>
         {children}
@@ -21,4 +21,4 @@ export const BreadcrumbItem = forwardRef(
   ),
 )
 
-BreadcrumbItem.displayName = 'Breadcrumb.Item'
+BreadcrumbLink.displayName = 'Breadcrumb.Link'

--- a/packages/react/src/Breadcrumb/index.ts
+++ b/packages/react/src/Breadcrumb/index.ts
@@ -1,3 +1,3 @@
 export { Breadcrumb } from './Breadcrumb'
 export type { BreadcrumbProps } from './Breadcrumb'
-export type { BreadcrumbItemProps } from './BreadcrumbItem'
+export type { BreadcrumbLinkProps } from './BreadcrumbLink'

--- a/proprietary/tokens/src/components/ams/breadcrumb.tokens.json
+++ b/proprietary/tokens/src/components/ams/breadcrumb.tokens.json
@@ -10,7 +10,7 @@
           "value": "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><path fill='%23000000' fill-rule='evenodd' d='m9.757 32-2.9-2.91L19.937 16 6.857 2.91 9.757 0l16 16z'/></svg>\")"
         }
       },
-      "item-link": {
+      "link": {
         "color": { "value": "{ams.link-appearance.color}" },
         "outline-offset": { "value": "{ams.focus.outline-offset}" },
         "text-decoration-line": { "value": "{ams.link-appearance.subtle.text-decoration-line}" },

--- a/storybook/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/storybook/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -18,15 +18,15 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     children: [
-      <Breadcrumb.Item href="#" key={1}>
+      <Breadcrumb.Link href="#" key={1}>
         Home
-      </Breadcrumb.Item>,
-      <Breadcrumb.Item href="#" key={2}>
+      </Breadcrumb.Link>,
+      <Breadcrumb.Link href="#" key={2}>
         Nieuws
-      </Breadcrumb.Item>,
-      <Breadcrumb.Item href="#" key={3}>
+      </Breadcrumb.Link>,
+      <Breadcrumb.Link href="#" key={3}>
         Kennisgevingen en bekendmakingen
-      </Breadcrumb.Item>,
+      </Breadcrumb.Link>,
     ],
   },
 }


### PR DESCRIPTION
A breadcrumb is a list of links. The ‘item’ level in between is implicit; the link is what matters. This change reflects that. Now the `href` prop is on a link, not an item.

Changes:

- The `Breadcrumb.Item` component has been renamed to `Breadcrumb.Link`
- Rest props and class names get applied to the `a` element instead of the `li`
- The `-item` fragment of the design tokens has been removed