### PR TITLE
feat!: Allow additional background colours for Badge and remove dark blue option

### DIFF
--- a/packages/css/src/components/badge/badge.scss
+++ b/packages/css/src/components/badge/badge.scss
@@ -12,14 +12,14 @@
   padding-inline: var(--ams-badge-padding-inline);
 }
 
+.ams-badge--black {
+  background-color: var(--ams-badge-black-background-color);
+  color: var(--ams-badge-black-color);
+}
+
 .ams-badge--blue {
   background-color: var(--ams-badge-blue-background-color);
   color: var(--ams-badge-blue-color);
-}
-
-.ams-badge--dark-blue {
-  background-color: var(--ams-badge-dark-blue-background-color);
-  color: var(--ams-badge-dark-blue-color);
 }
 
 .ams-badge--dark-green {
@@ -30,6 +30,26 @@
 .ams-badge--green {
   background-color: var(--ams-badge-green-background-color);
   color: var(--ams-badge-green-color);
+}
+
+.ams-badge--grey-1 {
+  background-color: var(--ams-badge-grey-1-background-color);
+  color: var(--ams-badge-grey-1-color);
+}
+
+.ams-badge--grey-2 {
+  background-color: var(--ams-badge-grey-2-background-color);
+  color: var(--ams-badge-grey-2-color);
+}
+
+.ams-badge--grey-3 {
+  background-color: var(--ams-badge-grey-3-background-color);
+  color: var(--ams-badge-grey-3-color);
+}
+
+.ams-badge--light-blue {
+  background-color: var(--ams-badge-light-blue-background-color);
+  color: var(--ams-badge-light-blue-color);
 }
 
 .ams-badge--magenta {
@@ -47,36 +67,17 @@
   color: var(--ams-badge-purple-color);
 }
 
-.ams-badge--yellow {
-  background-color: var(--ams-badge-yellow-background-color);
-  color: var(--ams-badge-yellow-color);
-}
-
 .ams-badge--red {
   background-color: var(--ams-badge-red-background-color);
   color: var(--ams-badge-red-color);
 }
-.ams-badge--light-blue {
-  background-color: var(--ams-badge-light-blue-background-color);
-  color: var(--ams-badge-light-blue-color);
-}
+
 .ams-badge--white {
   background-color: var(--ams-badge-white-background-color);
   color: var(--ams-badge-white-color);
 }
-.ams-badge--black {
-  background-color: var(--ams-badge-black-background-color);
-  color: var(--ams-badge-black-color);
-}
-.ams-badge--grey-1 {
-  background-color: var(--ams-badge-grey-1-background-color);
-  color: var(--ams-badge-grey-1-color);
-}
-.ams-badge--grey-2 {
-  background-color: var(--ams-badge-grey-2-background-color);
-  color: var(--ams-badge-grey-2-color);
-}
-.ams-badge--grey-3 {
-  background-color: var(--ams-badge-grey-3-background-color);
-  color: var(--ams-badge-grey-3-color);
+
+.ams-badge--yellow {
+  background-color: var(--ams-badge-yellow-background-color);
+  color: var(--ams-badge-yellow-color);
 }

--- a/packages/css/src/components/badge/badge.scss
+++ b/packages/css/src/components/badge/badge.scss
@@ -51,3 +51,32 @@
   background-color: var(--ams-badge-yellow-background-color);
   color: var(--ams-badge-yellow-color);
 }
+
+.ams-badge--red {
+  background-color: var(--ams-badge-red-background-color);
+  color: var(--ams-badge-red-color);
+}
+.ams-badge--light-blue {
+  background-color: var(--ams-badge-light-blue-background-color);
+  color: var(--ams-badge-light-blue-color);
+}
+.ams-badge--white {
+  background-color: var(--ams-badge-white-background-color);
+  color: var(--ams-badge-white-color);
+}
+.ams-badge--black {
+  background-color: var(--ams-badge-black-background-color);
+  color: var(--ams-badge-black-color);
+}
+.ams-badge--grey-1 {
+  background-color: var(--ams-badge-grey-1-background-color);
+  color: var(--ams-badge-grey-1-color);
+}
+.ams-badge--grey-2 {
+  background-color: var(--ams-badge-grey-2-background-color);
+  color: var(--ams-badge-grey-2-color);
+}
+.ams-badge--grey-3 {
+  background-color: var(--ams-badge-grey-3-background-color);
+  color: var(--ams-badge-grey-3-color);
+}

--- a/packages/react/src/Badge/Badge.tsx
+++ b/packages/react/src/Badge/Badge.tsx
@@ -8,13 +8,19 @@ import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes } from 'react'
 
 export const badgeColors = [
+  'black',
   'blue',
-  'dark-blue',
   'dark-green',
   'green',
+  'grey-1',
+  'grey-2',
+  'grey-3',
+  'light-blue',
   'magenta',
   'orange',
   'purple',
+  'red',
+  'white',
   'yellow',
 ] as const
 

--- a/proprietary/tokens/src/components/ams/badge.tokens.json
+++ b/proprietary/tokens/src/components/ams/badge.tokens.json
@@ -6,11 +6,11 @@
       "font-weight": { "value": "{ams.text.font-weight.bold}" },
       "line-height": { "value": "{ams.text.level.5.line-height}" },
       "padding-inline": { "value": "{ams.space.inside.xs}" },
-      "blue": {
-        "background-color": { "value": "{ams.color.blue}" },
-        "color": { "value": "{ams.color.primary-black}" }
+      "black": {
+        "background-color": { "value": "{ams.color.primary-black}" },
+        "color": { "value": "{ams.color.primary-white}" }
       },
-      "dark-blue": {
+      "blue": {
         "background-color": { "value": "{ams.color.primary-blue}" },
         "color": { "value": "{ams.color.primary-white}" }
       },
@@ -20,6 +20,22 @@
       },
       "green": {
         "background-color": { "value": "{ams.color.green}" },
+        "color": { "value": "{ams.color.primary-black}" }
+      },
+      "grey-1": {
+        "background-color": { "value": "{ams.color.neutral-grey1}" },
+        "color": { "value": "{ams.color.primary-black}" }
+      },
+      "grey-2": {
+        "background-color": { "value": "{ams.color.neutral-grey2}" },
+        "color": { "value": "{ams.color.primary-black}" }
+      },
+      "grey-3": {
+        "background-color": { "value": "{ams.color.neutral-grey3}" },
+        "color": { "value": "{ams.color.primary-white}" }
+      },
+      "light-blue": {
+        "background-color": { "value": "{ams.color.blue}" },
         "color": { "value": "{ams.color.primary-black}" }
       },
       "magenta": {
@@ -33,6 +49,14 @@
       "purple": {
         "background-color": { "value": "{ams.color.purple}" },
         "color": { "value": "{ams.color.primary-white}" }
+      },
+      "red": {
+        "background-color": { "value": "{ams.color.primary-red}" },
+        "color": { "value": "{ams.color.primary-white}" }
+      },
+      "white": {
+        "background-color": { "value": "{ams.color.primary-white}" },
+        "color": { "value": "{ams.color.primary-black}" }
       },
       "yellow": {
         "background-color": { "value": "{ams.color.yellow}" },


### PR DESCRIPTION
Processed all badge colors from the Figma file, and remove dark-blue which is only used for the hover color of primary blue. This is why we need a semantic color layer.