### PR TITLE
chore: Correct token nesting for inverse color

### DIFF
--- a/proprietary/tokens/src/components/ams/blockquote.tokens.json
+++ b/proprietary/tokens/src/components/ams/blockquote.tokens.json
@@ -6,7 +6,11 @@
       "font-size": { "value": "{ams.text.level.3.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.bold}" },
       "line-height": { "value": "{ams.text.level.3.line-height}" },
-      "inverse-color": { "value": "{ams.color.primary-white}" }
+      "inverse": {
+        "color": {
+          "value": "{ams.color.primary-white}"
+        }
+      }
     }
   }
 }

--- a/proprietary/tokens/src/components/ams/description-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/description-list.tokens.json
@@ -6,18 +6,18 @@
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "gap": { "value": "{ams.space.stack.md}" },
+      "line-height": { "value": "{ams.text.level.5.line-height}" },
+      "details": {
+        "font-weight": { "value": "{ams.text.font-weight.bold}" },
+        "padding-inline-start": { "value": "{ams.space.inside.xl}" }
+      },
       "inverse": {
         "color": {
           "value": "{ams.color.primary-white}"
         }
       },
-      "line-height": { "value": "{ams.text.level.5.line-height}" },
       "row": {
         "gap": { "value": "{ams.space.stack.md}" }
-      },
-      "details": {
-        "font-weight": { "value": "{ams.text.font-weight.bold}" },
-        "padding-inline-start": { "value": "{ams.space.inside.xl}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/description-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/description-list.tokens.json
@@ -6,7 +6,11 @@
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "gap": { "value": "{ams.space.stack.md}" },
-      "inverse-color": { "value": "{ams.color.primary-white}" },
+      "inverse": {
+        "color": {
+          "value": "{ams.color.primary-white}"
+        }
+      },
       "line-height": { "value": "{ams.text.level.5.line-height}" },
       "row": {
         "gap": { "value": "{ams.space.stack.md}" }

--- a/proprietary/tokens/src/components/ams/heading.tokens.json
+++ b/proprietary/tokens/src/components/ams/heading.tokens.json
@@ -4,7 +4,11 @@
       "color": { "value": "{ams.color.primary-black}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-weight": { "value": "{ams.text.font-weight.bold}" },
-      "inverse-color": { "value": "{ams.color.primary-white}" },
+      "inverse": {
+        "color": {
+          "value": "{ams.color.primary-white}"
+        }
+      },
       "level": {
         "1": {
           "font-size": { "value": "{ams.text.level.1.font-size}" },

--- a/proprietary/tokens/src/components/ams/ordered-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/ordered-list.tokens.json
@@ -6,7 +6,11 @@
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "gap": { "value": "0.75rem" },
-      "inverse-color": { "value": "{ams.color.primary-white}" },
+      "inverse": {
+        "color": {
+          "value": "{ams.color.primary-white}"
+        }
+      },
       "line-height": { "value": "{ams.text.level.5.line-height}" },
       "list-style-type": { "value": "decimal" },
       "small": {

--- a/proprietary/tokens/src/components/ams/ordered-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/ordered-list.tokens.json
@@ -6,16 +6,12 @@
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "gap": { "value": "0.75rem" },
+      "line-height": { "value": "{ams.text.level.5.line-height}" },
+      "list-style-type": { "value": "decimal" },
       "inverse": {
         "color": {
           "value": "{ams.color.primary-white}"
         }
-      },
-      "line-height": { "value": "{ams.text.level.5.line-height}" },
-      "list-style-type": { "value": "decimal" },
-      "small": {
-        "font-size": { "value": "{ams.text.level.6.font-size}" },
-        "line-height": { "value": "{ams.text.level.6.line-height}" }
       },
       "item": {
         "margin-inline-start": {
@@ -39,6 +35,10 @@
             "comment": "The total level >=2 indentation for Amsterdam is 28 pixels, or 1.75rem."
           }
         }
+      },
+      "small": {
+        "font-size": { "value": "{ams.text.level.6.font-size}" },
+        "line-height": { "value": "{ams.text.level.6.line-height}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/page-heading.tokens.json
+++ b/proprietary/tokens/src/components/ams/page-heading.tokens.json
@@ -5,12 +5,12 @@
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.0.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.bold}" },
+      "line-height": { "value": "{ams.text.level.0.font-size}" },
       "inverse": {
         "color": {
           "value": "{ams.color.primary-white}"
         }
-      },
-      "line-height": { "value": "{ams.text.level.0.font-size}" }
+      }
     }
   }
 }

--- a/proprietary/tokens/src/components/ams/page-heading.tokens.json
+++ b/proprietary/tokens/src/components/ams/page-heading.tokens.json
@@ -5,7 +5,11 @@
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.0.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.bold}" },
-      "inverse-color": { "value": "{ams.color.primary-white}" },
+      "inverse": {
+        "color": {
+          "value": "{ams.color.primary-white}"
+        }
+      },
       "line-height": { "value": "{ams.text.level.0.font-size}" }
     }
   }

--- a/proprietary/tokens/src/components/ams/paragraph.tokens.json
+++ b/proprietary/tokens/src/components/ams/paragraph.tokens.json
@@ -11,13 +11,13 @@
           "value": "{ams.color.primary-white}"
         }
       },
-      "small": {
-        "font-size": { "value": "{ams.text.level.6.font-size}" },
-        "line-height": { "value": "{ams.text.level.6.line-height}" }
-      },
       "large": {
         "font-size": { "value": "{ams.text.level.4.font-size}" },
         "line-height": { "value": "{ams.text.level.4.line-height}" }
+      },
+      "small": {
+        "font-size": { "value": "{ams.text.level.6.font-size}" },
+        "line-height": { "value": "{ams.text.level.6.line-height}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/paragraph.tokens.json
+++ b/proprietary/tokens/src/components/ams/paragraph.tokens.json
@@ -6,7 +6,11 @@
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "line-height": { "value": "{ams.text.level.5.line-height}" },
-      "inverse-color": { "value": "{ams.color.primary-white}" },
+      "inverse": {
+        "color": {
+          "value": "{ams.color.primary-white}"
+        }
+      },
       "small": {
         "font-size": { "value": "{ams.text.level.6.font-size}" },
         "line-height": { "value": "{ams.text.level.6.line-height}" }

--- a/proprietary/tokens/src/components/ams/unordered-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/unordered-list.tokens.json
@@ -6,13 +6,13 @@
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "gap": { "value": "0.75rem" },
+      "line-height": { "value": "{ams.text.level.5.line-height}" },
+      "list-style-type": { "value": "'\\2022'" },
       "inverse": {
         "color": {
           "value": "{ams.color.primary-white}"
         }
       },
-      "line-height": { "value": "{ams.text.level.5.line-height}" },
-      "list-style-type": { "value": "'\\2022'" },
       "item": {
         "margin-inline-start": {
           "value": "1.625rem",
@@ -22,6 +22,10 @@
           "value": "0.875rem",
           "comment": "The total level 1 indentation for Amsterdam is 40 pixels, or 2.5rem."
         }
+      },
+      "small": {
+        "font-size": { "value": "{ams.text.level.6.font-size}" },
+        "line-height": { "value": "{ams.text.level.6.line-height}" }
       },
       "unordered-list": {
         "list-style-type": { "value": "'\\2013'" },
@@ -35,10 +39,6 @@
             "comment": "The total level >=2 indentation for Amsterdam is 28 pixels, or 1.75rem."
           }
         }
-      },
-      "small": {
-        "font-size": { "value": "{ams.text.level.6.font-size}" },
-        "line-height": { "value": "{ams.text.level.6.line-height}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/unordered-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/unordered-list.tokens.json
@@ -6,7 +6,11 @@
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "gap": { "value": "0.75rem" },
-      "inverse-color": { "value": "{ams.color.primary-white}" },
+      "inverse": {
+        "color": {
+          "value": "{ams.color.primary-white}"
+        }
+      },
       "line-height": { "value": "{ams.text.level.5.line-height}" },
       "list-style-type": { "value": "'\\2022'" },
       "item": {


### PR DESCRIPTION
This doesn’t affect the actual token names, but having `inverse-color` as a level violates the rule that the name of the leaf must be a CSS property.