### PR TITLE
chore: Simplify linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,7 +55,12 @@
       "plugins": ["@typescript-eslint", "import", "jest"]
     },
     {
-      "extends": ["plugin:react/recommended", "eslint-config-prettier", "./.eslintrc.ts.json"],
+      "extends": [
+        "plugin:react/recommended",
+        "eslint-config-prettier",
+        "./.eslintrc.ts.json",
+        "./.eslintrc.react.json"
+      ],
       "files": ["*.ts", "*.tsx"],
       "parser": "@typescript-eslint/parser",
       "parserOptions": {

--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -1,8 +1,0 @@
-{
-  "env": {
-    "jest/globals": true
-  },
-  "rules": {
-    "react/react-in-jsx-scope": "off"
-  }
-}


### PR DESCRIPTION
/packages/react had its own eslint config, which isn't necessary.