### PR TITLE
chore: Document that the header and footer are required

### DIFF
--- a/packages/css/src/components/footer/README.md
+++ b/packages/css/src/components/footer/README.md
@@ -2,13 +2,16 @@
 
 # Footer
 
-The footer is the closing section on every web page.
-Its content provides service information.
-A part is prescribed, and a part is filled based on the website’s objectives.
+Provides service information at the bottom of every page.
 
 ## Guidelines
 
-- The footer is mandatory, and there is one on every page.
+The Footer must be used on all websites and applications for the City of Amsterdam.
+It includes the logo of the City or the organization, the site title (except for the general website), and a menu with links to commonly used pages.
+The Footer is important because it conveys our corporate identity and is the first thing people see.
+Using it consistently helps users recognize and trust the website.
+It is the same on every page of the application.
+
 - The first column focuses on contact information.
   The information is as specific as possible and tailored to the respective website or page (e.g., including a chat option if available).
 - The second column contains links to relevant (online) sites or sources.

--- a/packages/css/src/components/footer/README.md
+++ b/packages/css/src/components/footer/README.md
@@ -6,15 +6,16 @@ Provides service information at the bottom of every page.
 
 ## Guidelines
 
-The Footer must be used on all websites and applications for the City of Amsterdam.
-It includes the logo of the City or the organization, the site title (except for the general website), and a menu with links to commonly used pages.
-The Footer is important because it conveys our corporate identity and is the first thing people see.
-Using it consistently helps users recognize and trust the website.
+The Footer must be used on all websites for the City of Amsterdam.
+For applications, only its menu at the bottom can be sufficient.
 It is the same on every page of the application.
+
+The large blue area offers space for various practical links:
 
 - The first column focuses on contact information.
   The information is as specific as possible and tailored to the respective website or page (e.g., including a chat option if available).
 - The second column contains links to relevant (online) sites or sources.
 - The third column refers to newsletters, social media, etc.
-- The last part of the footer is intended for links to privacy policies, cookie statements, explanations about the website, etc.
-  It is not intended for links to contact information, for example.
+
+At the very bottom is a [Page Menu](?path=/docs/components-navigation-page-menu--docs) intended for links to privacy policies, cookie statements, explanations about the website, etc.
+Contact information should not go here.

--- a/packages/css/src/components/footer/README.md
+++ b/packages/css/src/components/footer/README.md
@@ -6,16 +6,17 @@ Provides service information at the bottom of every page.
 
 ## Guidelines
 
-The Footer must be used on all websites for the City of Amsterdam.
-For applications, only its menu at the bottom can be sufficient.
-It is the same on every page of the application.
+The Footer consists of a dark blue [Spotlight](/docs/components-containers-spotlight--docs) and a [Page Menu](?path=/docs/components-navigation-page-menu--docs).
+It must be used on all websites for the City of Amsterdam.
+For applications, only the Page Menu can be sufficient.
+The Footer is the same on every page of the application.
 
-The large blue area offers space for various practical links:
+The Spotlight offers space for various practical links:
 
 - The first column focuses on contact information.
   The information is as specific as possible and tailored to the respective website or page (e.g., including a chat option if available).
 - The second column contains links to relevant (online) sites or sources.
 - The third column refers to newsletters, social media, etc.
 
-At the very bottom is a [Page Menu](?path=/docs/components-navigation-page-menu--docs) intended for links to privacy policies, cookie statements, explanations about the website, etc.
-Contact information should not go here.
+The menu at the very bottom is intended for links to privacy policies, cookie statements, information about the website itself, etc.
+Contact details should not go here.

--- a/packages/css/src/components/header/README.md
+++ b/packages/css/src/components/header/README.md
@@ -2,13 +2,18 @@
 
 # Header
 
-Arranges the City’s logo, the name of the application, and a page menu.
+Displays the City’s logo and a navigation menu at the top of every page.
+Includes the name of the application if it is not the general website.
 
 ## Guidelines
 
-- Use the Header when the site is hosted on amsterdam.nl or one of its subdomains.
-- The page menu can contain a maximum of 5 items, including menu and search.
-- When you have a long subsite title, use no or as few page menu items as possible.
+The Header must be used on all websites and applications for the City of Amsterdam.
+It includes the logo of the City or the organization, the site title (except for the general website), and a menu with links to commonly used pages.
+The Header is important because it conveys our corporate identity and is the first thing people see.
+Using it consistently helps users recognize and trust the website.
+It is the same on every page of the application.
+
+The Page Menu should contain no more than 5 items, including ‘Search’ and ‘Menu’.
 
 ## References
 

--- a/packages/css/src/components/header/README.md
+++ b/packages/css/src/components/header/README.md
@@ -14,7 +14,7 @@ The Header is important because it conveys our corporate identity and is the fir
 Using it consistently helps users recognize and trust the website.
 It is the same on every page of the application.
 
-The amount of links in the Page Menu should be limited to a handful.
+The page menu can contain a maximum of 5 items.
 The last two will often be ‘Search’ and ‘Menu’.
 Labels should be short to ensure the menu fits on one line, even on medium-wide screens.
 An icon can be added to the end of a link to make its function easier to find.

--- a/packages/css/src/components/header/README.md
+++ b/packages/css/src/components/header/README.md
@@ -9,11 +9,15 @@ Includes the name of the application if it is not the general website.
 
 The Header must be used on all websites and applications for the City of Amsterdam.
 It includes the logo of the City or the organization, the site title (except for the general website), and a menu with links to commonly used pages.
+
 The Header is important because it conveys our corporate identity and is the first thing people see.
 Using it consistently helps users recognize and trust the website.
 It is the same on every page of the application.
 
-The Page Menu should contain no more than 5 items, including ‘Search’ and ‘Menu’.
+The amount of links in the Page Menu should be limited to a handful.
+The last two will often be ‘Search’ and ‘Menu’.
+Labels should be short to ensure the menu fits on one line, even on medium-wide screens.
+An icon can be added to the end of a link to make its function easier to find.
 
 ## References
 

--- a/packages/css/src/components/header/README.md
+++ b/packages/css/src/components/header/README.md
@@ -2,7 +2,7 @@
 
 # Header
 
-Displays the City’s logo at the top of every page, and optionally a secondary navigation menu.
+Displays the City’s logo at the top of every page, and optionally a navigation menu.
 Includes the name of the application if it is not the general website.
 
 ## Guidelines

--- a/packages/css/src/components/header/README.md
+++ b/packages/css/src/components/header/README.md
@@ -2,7 +2,7 @@
 
 # Header
 
-Displays the City’s logo and a navigation menu at the top of every page.
+Displays the City’s logo at the top of every page, and optionally a secondary navigation menu.
 Includes the name of the application if it is not the general website.
 
 ## Guidelines


### PR DESCRIPTION
This follows up input from our design department that we hsould mark the Header and Footer as required for every page and every application because it plays such a big role in making all our websites recognizable as being from the City, which generates trust to use them.