### PR TITLE
fix: Start-align text in Accordion Button

### DIFF
--- a/packages/css/src/components/accordion/accordion.scss
+++ b/packages/css/src/components/accordion/accordion.scss
@@ -33,6 +33,7 @@
   line-height: var(--ams-accordion-button-line-height);
   padding-block: var(--ams-accordion-button-padding-block);
   padding-inline: var(--ams-accordion-button-padding-inline);
+  text-align: start;
 
   &:focus {
     outline-offset: var(--ams-accordion-button-focus-outline-offset);


### PR DESCRIPTION
Text got centered because it is in a `<button>`.