### PR TITLE
feat: Decrease text size in Compact Mode

### DIFF
--- a/proprietary/tokens/src/brand/ams/text.compact.tokens.json
+++ b/proprietary/tokens/src/brand/ams/text.compact.tokens.json
@@ -3,25 +3,25 @@
     "text": {
       "level": {
         "0": {
-          "font-size": { "value": "clamp(1.891rem, calc(1.506rem + 1.927vw), 3.433rem)" }
+          "font-size": { "value": "clamp(1.5768rem, 1.4299rem + 0.7346vw, 2.1645rem)" }
         },
         "1": {
-          "font-size": { "value": "clamp(1.621rem, calc(1.34rem + 1.408vw), 2.747rem)" }
+          "font-size": { "value": "clamp(1.4016rem, 1.2883rem + 0.5665vw, 1.8547rem)" }
         },
         "2": {
-          "font-size": { "value": "clamp(1.389rem, calc(1.187rem + 1.01vw), 2.197rem)" }
+          "font-size": { "value": "clamp(1.2458rem, 1.16rem + 0.4293vw, 1.5893rem)" }
         },
         "3": {
-          "font-size": { "value": "clamp(1.191rem, calc(1.049rem + 0.709vw), 1.758rem)" }
+          "font-size": { "value": "clamp(1.1074rem, 1.0438rem + 0.3181vw, 1.3619rem)" }
         },
         "4": {
-          "font-size": { "value": "clamp(1.021rem, calc(0.925rem + 0.481vw), 1.406rem)" }
+          "font-size": { "value": "clamp(0.9844rem, 0.9387rem + 0.2283vw, 1.167rem)" }
         },
         "5": {
-          "font-size": { "value": "clamp(0.875rem, calc(0.813rem + 0.313vw), 1.125rem)" }
+          "font-size": { "value": "clamp(0.875rem, 0.8438rem + 0.1563vw, 1rem)" }
         },
         "6": {
-          "font-size": { "value": "clamp(0.75rem, calc(0.713rem + 0.188vw), 0.9rem)" }
+          "font-size": { "value": "clamp(0.7778rem, 0.758rem + 0.0989vw, 0.8569rem)" }
         }
       }
     }

--- a/storybook/src/docs/typography.docs.mdx
+++ b/storybook/src/docs/typography.docs.mdx
@@ -72,14 +72,14 @@ And the minimum:
 
 For applications, such large text is not necessary, even counterproductive.
 Hence, there’s a compact theme for typography.
-In this theme, a paragraph is 14 pixels at the minimum window width and 18 pixels at the maximum.
+In this theme, a paragraph is 14 pixels at the minimum window width and 16 pixels at the maximum.
 Text is a quarter smaller and grows slightly more slowly.
 
 The maximum text sizes for all levels in the compact theme:
 
 <Typeset
   fontFamily="Amsterdam Sans, Arial, sans-serif"
-  fontSizes={[54.9, 43.9, 35.2, 28.1, 22.5, 18, 14.4]}
+  fontSizes={[34.6, 29.6, 25.4, 21.8, 18.7, 16, 13.7]}
   fontWeight={400}
   sampleText="Jouw typograaf biedt mij zulke exquise schreven"
 />
@@ -88,7 +88,7 @@ And the minimum:
 
 <Typeset
   fontFamily="Amsterdam Sans, Arial, sans-serif"
-  fontSizes={[30.3, 25.9, 22.2, 19.1, 16.3, 14, 12]}
+  fontSizes={[25.2, 22.4, 19.9, 17.7, 15.8, 14, 12.4]}
   fontWeight={400}
   sampleText="Jouw typograaf biedt mij zulke exquise schreven"
 />


### PR DESCRIPTION
The default text size (paragraphs on wide screens) is now 16 pixels instead of 18. This seems to be enough for applications. There is not much growing left now (from 14 to 16), we’ll have to evaluate that.

A next PR introduces compact spacing tokens. A second will include Amopis pages in Storybook. These three form an iteration to assess the values and change them where necessary. Thanks to the token layer, these changes aren’t breaking.