### PR TITLE
chore: Add example of a form page

### DIFF
--- a/storybook/src/pages/amsterdam/ArticlePage/ArticlePage.docs.mdx
+++ b/storybook/src/pages/amsterdam/ArticlePage/ArticlePage.docs.mdx
@@ -7,4 +7,4 @@ import * as ArticleStories from "./ArticlePage.stories.tsx";
 
 # Article Page
 
-This page type is mainly for news or related kinds of articles.
+This page type is for news or similar kinds of articles.

--- a/storybook/src/pages/amsterdam/FormPage/FormPage.docs.mdx
+++ b/storybook/src/pages/amsterdam/FormPage/FormPage.docs.mdx
@@ -1,0 +1,10 @@
+{/* @license CC0-1.0 */}
+
+import { Meta } from "@storybook/blocks";
+import * as FormStories from "./FormPage.stories.tsx";
+
+<Meta of={FormStories} />
+
+# Form Page
+
+This simple example presents various types of fields.

--- a/storybook/src/pages/amsterdam/FormPage/FormPage.stories.tsx
+++ b/storybook/src/pages/amsterdam/FormPage/FormPage.stories.tsx
@@ -1,0 +1,25 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { Meta, StoryObj } from '@storybook/react'
+import { FormPage } from './FormPage'
+
+const meta = {
+  title: 'Pages/Amsterdam.nl/Form Page',
+  component: FormPage,
+  argTypes: {
+    footer: {
+      table: { disable: true },
+    },
+  },
+  parameters: {
+    layout: 'fullscreen',
+    themes: { themeOverride: 'Spacious' },
+  },
+} satisfies Meta<typeof FormPage>
+
+export default meta
+
+export const Default: StoryObj = {}

--- a/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
+++ b/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
@@ -62,8 +62,7 @@ export const FormPage = () => {
                     <Label htmlFor="familyName">Achternaam</Label>
                     <TextInput autoComplete="family-name" id="familyName" name="familyName" />
                   </Field>
-                  <Field>
-                    <Label htmlFor="city">Woonplaats</Label>
+                  <FieldSet legend="Woonplaats">
                     <Radio name="city" value="amsterdam">
                       Amsterdam
                     </Radio>
@@ -73,7 +72,7 @@ export const FormPage = () => {
                     <Radio name="city" value="anders">
                       Anders
                     </Radio>
-                  </Field>
+                  </FieldSet>
                   <Field>
                     <Label htmlFor="email">E-mail</Label>
                     <TextInput autoComplete="email" id="email" name="email" />

--- a/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
+++ b/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
@@ -1,0 +1,112 @@
+import {
+  Alert,
+  Breadcrumb,
+  Button,
+  Column,
+  Field,
+  FieldSet,
+  FormFieldCharacterCounter,
+  Grid,
+  Heading,
+  Label,
+  Paragraph,
+  Radio,
+  Row,
+  Screen,
+  Select,
+  SkipLink,
+  TextArea,
+  TextInput,
+} from '@amsterdam/design-system-react'
+import { useState } from 'react'
+import { AppHeader } from '../common/AppHeader'
+
+export const FormPage = () => {
+  const [textareaLength, setTextareaLength] = useState(0)
+
+  return (
+    <>
+      <SkipLink href="#main">Direct naar inhoud</SkipLink>
+      <Screen maxWidth="wide">
+        <AppHeader />
+        <Grid paddingTop="small" paddingBottom="medium">
+          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 8 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+            <Breadcrumb>
+              <Breadcrumb.Link>Home</Breadcrumb.Link>
+            </Breadcrumb>
+            <form className="ams-gap--md" id="main" onSubmit={(e) => e.preventDefault()}>
+              <Heading>Contact</Heading>
+              <Field>
+                <Label htmlFor="body">Wat wilt u aan de gemeente vragen?</Label>
+                <Paragraph id="bodyDescription" size="small">
+                  Een duidelijke beschrijving van uw vraag helpt ons bij het behandelen.
+                </Paragraph>
+                <TextArea
+                  aria-describedby="bodyDescription"
+                  id="body"
+                  onChange={(e) => setTextareaLength(e.target.value.length)}
+                  rows={4}
+                />
+                <FormFieldCharacterCounter length={textareaLength} maxLength={1000} />
+              </Field>
+              <FieldSet aria-describedby="contactDetailsDescription" legend="Wat zijn uw gegevens?">
+                <Column gap="small">
+                  <Paragraph id="contactDetailsDescription">
+                    Wij hebben uw gegevens nodig om contact met u te kunnen opnemen.
+                  </Paragraph>
+                  <Field>
+                    <Label htmlFor="initials">Voorletters</Label>
+                    <TextInput id="initials" name="initials" />
+                  </Field>
+                  <Field>
+                    <Label htmlFor="familyName">Achternaam</Label>
+                    <TextInput autoComplete="family-name" id="familyName" name="familyName" />
+                  </Field>
+                  <Field>
+                    <Label htmlFor="city">Woonplaats</Label>
+                    <Radio name="city" value="amsterdam">
+                      Amsterdam
+                    </Radio>
+                    <Radio name="city" value="weesp">
+                      Weesp
+                    </Radio>
+                    <Radio name="city" value="anders">
+                      Anders
+                    </Radio>
+                  </Field>
+                  <Field>
+                    <Label htmlFor="email">E-mail</Label>
+                    <TextInput autoComplete="email" id="email" name="email" />
+                  </Field>
+                  <Row>
+                    <Field>
+                      <Label htmlFor="countryCode">Landnummer</Label>
+                      <Select name="countryCode">
+                        <option value="+31">Nederland +31</option>
+                        <option value="+32">België +32</option>
+                        <option value="+33">Frankrijk +33</option>
+                      </Select>
+                    </Field>
+                    <Field>
+                      <Label htmlFor="phone">Telefoonnummer</Label>
+                      <TextInput autoComplete="phone" id="phone" name="phone" />
+                    </Field>
+                  </Row>
+                </Column>
+              </FieldSet>
+              <Alert severity="info">
+                <Paragraph>
+                  We bewaren uw contactgegevens voor het afhandelen van uw vraag of klacht en het verbeteren van onze
+                  dienstverlening.
+                </Paragraph>
+              </Alert>
+              <Row>
+                <Button type="submit">Versturen</Button>
+              </Row>
+            </form>
+          </Grid.Cell>
+        </Grid>
+      </Screen>
+    </>
+  )
+}

--- a/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
+++ b/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
@@ -34,8 +34,8 @@ export const FormPage = () => {
             <Breadcrumb>
               <Breadcrumb.Link>Home</Breadcrumb.Link>
             </Breadcrumb>
+            <Heading className="ams-mb--md">Contact</Heading>
             <form className="ams-gap--md" id="main" onSubmit={(e) => e.preventDefault()}>
-              <Heading>Contact</Heading>
               <Field>
                 <Label htmlFor="body">Wat wilt u aan de gemeente vragen?</Label>
                 <Paragraph id="bodyDescription" size="small">

--- a/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
+++ b/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
@@ -80,7 +80,7 @@ export const FormPage = () => {
                   <Row wrap>
                     <Field>
                       <Label htmlFor="countryCode">Landnummer</Label>
-                      <Select name="countryCode">
+                      <Select id="countryCode" name="countryCode">
                         <option value="+31">Nederland +31</option>
                         <option value="+32">België +32</option>
                         <option value="+33">Frankrijk +33</option>
@@ -88,7 +88,7 @@ export const FormPage = () => {
                     </Field>
                     <Field>
                       <Label htmlFor="phone">Telefoonnummer</Label>
-                      <TextInput autoComplete="phone" id="phone" name="phone" />
+                      <TextInput autoComplete="tel" id="phone" name="phone" />
                     </Field>
                   </Row>
                 </Column>

--- a/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
+++ b/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
@@ -99,9 +99,9 @@ export const FormPage = () => {
                   dienstverlening.
                 </Paragraph>
               </Alert>
-              <Row>
+              <div>
                 <Button type="submit">Versturen</Button>
-              </Row>
+              </div>
             </form>
           </Grid.Cell>
         </Grid>

--- a/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
+++ b/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
@@ -81,9 +81,9 @@ export const FormPage = () => {
                     <Field>
                       <Label htmlFor="countryCode">Landnummer</Label>
                       <Select id="countryCode" name="countryCode">
-                        <option value="+31">Nederland +31</option>
-                        <option value="+32">België +32</option>
-                        <option value="+33">Frankrijk +33</option>
+                        <Select.Option value="+31">Nederland +31</Select.Option>
+                        <Select.Option value="+32">België +32</Select.Option>
+                        <Select.Option value="+33">Frankrijk +33</Select.Option>
                       </Select>
                     </Field>
                     <Field>

--- a/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
+++ b/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
@@ -77,7 +77,7 @@ export const FormPage = () => {
                     <Label htmlFor="email">E-mail</Label>
                     <TextInput autoComplete="email" id="email" name="email" />
                   </Field>
-                  <Row>
+                  <Row wrap>
                     <Field>
                       <Label htmlFor="countryCode">Landnummer</Label>
                       <Select name="countryCode">


### PR DESCRIPTION
Copied from the Signalen prototype, and:

- added a text area
- translated field names from Dutch to English
- added autocomplete values