### PR TITLE
feat!: Improve sizing behaviour of Dialog

### DIFF
--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -3,14 +3,19 @@
  * Copyright Gemeente Amsterdam
  */
 
+@mixin reset-dialog {
+  inset: 0;
+  padding-block: 0;
+  padding-inline: 0;
+}
+
 .ams-dialog {
   background-color: var(--ams-dialog-background-color);
   border: var(--ams-dialog-border);
-  inset: 0;
   max-inline-size: var(--ams-dialog-max-inline-size);
-  padding-block: 0;
-  padding-inline: 0;
   position: fixed;
+
+  @include reset-dialog;
 
   /* no token because dialog does not inherit from any element */
   &::backdrop {

--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -12,6 +12,7 @@
 .ams-dialog {
   background-color: var(--ams-dialog-background-color);
   border: var(--ams-dialog-border);
+  display: flex;
   inline-size: var(--ams-dialog-inline-size);
   max-block-size: var(--ams-dialog-max-block-size);
   max-inline-size: var(--ams-dialog-max-inline-size);
@@ -28,10 +29,6 @@
 .ams-dialog__form {
   display: grid;
   gap: var(--ams-dialog-form-gap);
-  grid-template-rows: auto 1fr auto;
-  max-block-size: var(--ams-dialog-form-max-block-size);
-
-  // TODO Decide on these widths
   padding-block: var(--ams-dialog-form-padding-block);
   padding-inline: var(--ams-dialog-form-padding-inline);
 }
@@ -39,7 +36,7 @@
 .ams-dialog__article {
   display: grid;
   gap: var(--ams-space-md); /* Until we have a consistent way of spacing text elements */
-  max-block-size: 100%; /* safari */
+  max-block-size: 100%; /* Safari */
   overflow-y: auto;
   overscroll-behavior-y: contain;
 }

--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -12,6 +12,8 @@
 .ams-dialog {
   background-color: var(--ams-dialog-background-color);
   border: var(--ams-dialog-border);
+  inline-size: var(--ams-dialog-inline-size);
+  max-block-size: var(--ams-dialog-max-block-size);
   max-inline-size: var(--ams-dialog-max-inline-size);
   position: fixed;
 

--- a/proprietary/tokens/src/components/ams/dialog.tokens.json
+++ b/proprietary/tokens/src/components/ams/dialog.tokens.json
@@ -3,7 +3,9 @@
     "dialog": {
       "background-color": { "value": "{ams.color.primary-white}" },
       "border": { "value": "0" },
-      "max-inline-size": { "value": "min(87.69vw, 45rem)" },
+      "inline-size": { "value": "calc(100vw - 2 * {ams.space.grid.md})" },
+      "max-block-size": { "value": "calc(100vh - 2 * {ams.space.grid.md})" },
+      "max-inline-size": { "value": "48rem" },
       "form": {
         "gap": { "value": "{ams.space.md}" },
         "padding-block": { "value": "{ams.space.grid.md}" },

--- a/proprietary/tokens/src/components/ams/dialog.tokens.json
+++ b/proprietary/tokens/src/components/ams/dialog.tokens.json
@@ -9,8 +9,7 @@
       "form": {
         "gap": { "value": "{ams.space.md}" },
         "padding-block": { "value": "{ams.space.grid.md}" },
-        "padding-inline": { "value": "{ams.space.grid.lg}" },
-        "max-block-size": { "value": "75vh" }
+        "padding-inline": { "value": "{ams.space.grid.lg}" }
       },
       "header": {
         "gap": { "value": "{ams.space.md}" }


### PR DESCRIPTION
Aligns the (maximum) block and inline sizes of a Dialog with our spacing system.

A Dialog now gets
- as large as necessary to fit its content,
- with a maximum that leaves a medium grid space of margin at all sides,
- and a horizontal maximum of 48 rems.

The inner layout has been improved as well: making the `<dialog>` a flex container automatically makes its child `<form>` size optimally. Setting heights for the grid rows of the form no longer seems necessary.

It is a breaking change because the `dialog-form-max-block-size` token gets removed.