### PR TITLE
chore: Fix documentated values for Compact typography

### DIFF
--- a/storybook/src/docs/typography.docs.mdx
+++ b/storybook/src/docs/typography.docs.mdx
@@ -77,7 +77,7 @@ Typography is not fluid in this theme.
 Text Level 5 is 16 pixels on both narrow and wide windows.
 
 Larger text levels grow with a factor of 9 ÷ 8 ≈ 1.125.
-Smaller text levels grow with a factor of 11 ÷ 10 = 11.
+Smaller text levels grow with a factor of 11 ÷ 10 = 1.1.
 
 The maximum text sizes for all levels in the compact theme:
 

--- a/storybook/src/docs/typography.docs.mdx
+++ b/storybook/src/docs/typography.docs.mdx
@@ -77,7 +77,7 @@ Typography is not fluid in this theme.
 Text Level 5 is 16 pixels on both narrow and wide windows.
 
 Larger text levels grow with a factor of 9 ÷ 8 ≈ 1.125.
-Smaller text levels grow with a factor of 16 ÷ 15 = 1.067.
+Smaller text levels grow with a factor of 11 ÷ 10 = 11.
 
 The maximum text sizes for all levels in the compact theme:
 

--- a/storybook/src/docs/typography.docs.mdx
+++ b/storybook/src/docs/typography.docs.mdx
@@ -92,7 +92,7 @@ And the minimum:
 
 <Typeset
   fontFamily="Amsterdam Sans, Arial, sans-serif"
-  fontSizes={[22.1, 20.7, 19.4, 18.2, 17.1, 16, 15]}
+  fontSizes={[25.8, 23.4, 21.3, 19.4, 17.6, 16, 14.6]}
   fontWeight={400}
   sampleText="Jouw typograaf biedt mij zulke exquise schreven"
 />
@@ -117,8 +117,8 @@ The text sizes at those points are as follows, rounded to 1 decimal place:
 
 | Device Class | Design Width |    0 |    1 |    2 |    3 |    4 |   5 |    6 |
 | :----------- | ------------ | ---: | ---: | ---: | ---: | ---: | --: | ---: |
-| Phone        | 320          | 22.1 | 20.7 | 19.4 | 18.2 | 17.1 |  16 |   15 |
-| Tablet       | 832          | 24.8 | 22.7 | 20.8 |   19 | 17.4 |  16 | 14.7 |
+| Phone        | 320          | 25.8 | 23.4 | 21.3 | 19.4 | 17.6 |  16 | 14.6 |
+| Tablet       | 832          |   27 | 24.3 | 21.9 | 19.7 | 17.8 |  16 | 14.4 |
 | Desktop      | 1600         | 28.8 | 25.6 | 22.8 | 20.3 |   18 |  16 | 14.2 |
 
 ## Emphasis


### PR DESCRIPTION
I still made a copy paste error in #1389, apparently.