### PR TITLE
chore: Support autocomplete for Row and Column gap and alignment

### DIFF
--- a/packages/react/src/Column/Column.tsx
+++ b/packages/react/src/Column/Column.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 import { forwardRef } from 'react'
 import type { HTMLAttributes, PropsWithChildren } from 'react'
 
-export const columnGapSizes: Array<string> = ['none', 'extra-small', 'small', 'large', 'extra-large']
+export const columnGapSizes: Array<string> = ['none', 'extra-small', 'small', 'large', 'extra-large'] as const
 
 type ColumnTag = 'article' | 'div' | 'section'
 type ColumnGap = (typeof columnGapSizes)[number]

--- a/packages/react/src/Row/Row.tsx
+++ b/packages/react/src/Row/Row.tsx
@@ -8,7 +8,7 @@ import { forwardRef } from 'react'
 import type { HTMLAttributes, PropsWithChildren } from 'react'
 import type { CrossAlign, MainAlign } from '../common/layout'
 
-export const rowGapSizes: Array<string> = ['none', 'extra-small', 'small', 'large', 'extra-large']
+export const rowGapSizes: Array<string> = ['none', 'extra-small', 'small', 'large', 'extra-large'] as const
 
 type RowGap = (typeof rowGapSizes)[number]
 type RowTag = 'article' | 'div' | 'section'

--- a/packages/react/src/common/layout.ts
+++ b/packages/react/src/common/layout.ts
@@ -1,5 +1,5 @@
-export const crossAlignOptions: Array<string> = ['baseline', 'center', 'end', 'start']
+export const crossAlignOptions: Array<string> = ['baseline', 'center', 'end', 'start'] as const
 export type CrossAlign = (typeof crossAlignOptions)[number]
 
-export const mainAlignOptions: Array<string> = ['around', 'between', 'center', 'end', 'evenly']
+export const mainAlignOptions: Array<string> = ['around', 'between', 'center', 'end', 'evenly'] as const
 export type MainAlign = (typeof mainAlignOptions)[number]


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

To help developers select an allowed value of these props.

## Why

Makes them work faster and with less errors.

## How

Uses const assertions (`as const`) on the list of string options to force its type not to be string[] but the array of values itself.

> An array has a numeric index signature, as it’s indexed by numbers (0, 1, 2, …), so we use typeof animals[number] to get a union type of all items in our array: 'cat' | 'dog' | 'mouse'.
– https://steveholgado.com/typescript-types-from-arrays/

