### PR TITLE
fix: Remove margin Safari sets on buttons

### DIFF
--- a/packages/css/src/components/accordion/accordion.scss
+++ b/packages/css/src/components/accordion/accordion.scss
@@ -19,9 +19,16 @@
   margin-inline: 0;
 }
 
+@mixin reset-button {
+  border: 0;
+  margin-block: 0; // [1]
+  margin-inline: 0; // [1]
+
+  // [1] Remove the margin in older Safari.
+}
+
 .ams-accordion__button {
   background-color: transparent;
-  border: 0;
   color: var(--ams-accordion-button-color);
   cursor: pointer;
   display: flex;
@@ -34,6 +41,8 @@
   padding-block: var(--ams-accordion-button-padding-block);
   padding-inline: var(--ams-accordion-button-padding-inline);
   text-align: start;
+
+  @include reset-button;
 
   &:focus {
     outline-offset: var(--ams-accordion-button-focus-outline-offset);

--- a/packages/css/src/components/button/button.scss
+++ b/packages/css/src/components/button/button.scss
@@ -7,6 +7,10 @@
 
 @mixin reset-button {
   border: 0;
+  margin-block: 0; // [1]
+  margin-inline: 0; // [1]
+
+  // [1] Remove the margin in older Safari.
 }
 
 .ams-button {

--- a/packages/css/src/components/header/header.scss
+++ b/packages/css/src/components/header/header.scss
@@ -79,6 +79,7 @@
   font-weight: var(--ams-page-menu-item-font-weight);
   line-height: var(--ams-page-menu-item-line-height);
   margin-block: 0;
+  margin-inline: 0;
   padding-inline: 0 1.875rem;
   text-align: center;
   touch-action: manipulation;

--- a/packages/css/src/components/icon-button/icon-button.scss
+++ b/packages/css/src/components/icon-button/icon-button.scss
@@ -5,8 +5,12 @@
 
 @mixin reset {
   border: 0;
+  margin-block: 0; // [1]
+  margin-inline: 0; // [1]
   padding-block: 0;
   padding-inline: 0;
+
+  // [1] Remove the margin in older Safari.
 }
 
 .ams-icon-button {

--- a/packages/css/src/components/search-field/search-field.scss
+++ b/packages/css/src/components/search-field/search-field.scss
@@ -71,10 +71,10 @@
 
 @mixin reset-button {
   border: 0;
+  margin-block: 0; // [1]
+  margin-inline: 0; // [1]
 
-  // Reset margins added by Safari on iOS
-  margin-block: 0;
-  margin-inline: 0;
+  // [1] Remove the margin in older Safari.
 }
 
 .ams-search-field__button {

--- a/packages/css/src/components/tabs/tabs.scss
+++ b/packages/css/src/components/tabs/tabs.scss
@@ -8,6 +8,10 @@
 @mixin reset-button {
   background-color: transparent;
   border: 0;
+  margin-block: 0; // [1]
+  margin-inline: 0; // [1]
+
+  // [1] Remove the margin in older Safari.
 }
 
 .ams-tabs {


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It removes the margin older Safari sets on buttons

## Why

To have consistent styling between older Safari and other browsers

## How

By setting `margin-block` and `margin-inline` to 0

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Provide links to any related issues or discussions.
- Add a link to the specific story in the feature branch deploy.
- Mention any areas where additional review or feedback is needed.
