### PR TITLE
chore: Remove unnecessary 'autocapitalize' attribute

### DIFF
--- a/packages/css/src/components/password-input/README.md
+++ b/packages/css/src/components/password-input/README.md
@@ -10,7 +10,7 @@ Helps users enter a password.
   It ensures that the input is not readable by others who might be looking at the screen.
 - The characters entered are hidden, represented by squares.
 
-This component sets `autocapitalize="none"`, `autocorrect="off"` and `spellcheck="false"` to stop browsers automatically changing user input.
+This component sets `autocorrect="off"` and `spellcheck="false"` to stop browsers automatically changing user input.
 Passwords shouldn’t be checked for spelling or grammar.
 This may also prevent posting the password to third-party plugins.
 These props cannot be overridden.

--- a/packages/css/src/components/text-input/README.md
+++ b/packages/css/src/components/text-input/README.md
@@ -10,7 +10,7 @@ A form field in which a user can enter text.
 - Do not use a Text Input when users could provide more than 1 sentence of text.
 - The width of the Text Input should be appropriate for the information to be entered.
 - A Text Input must have a Label, and in most cases, this label should be visible.
-- Use `spellcheck="false"` for fields that may contain sensitive information, such as passwords and personal data.
+- Use `spellcheck="false"` for fields that may contain sensitive information, such as personal data.
   Some browser extensions for spell-checking send this information to external servers.
 - Apply automatic assistance where possible.
   For example, in logged-in systems, pre-filling known values can prevent errors and save time.

--- a/packages/react/src/PasswordInput/PasswordInput.test.tsx
+++ b/packages/react/src/PasswordInput/PasswordInput.test.tsx
@@ -31,12 +31,11 @@ describe('Password input', () => {
     expect(component).toHaveClass('ams-password-input extra')
   })
 
-  it('renders three attributes for privacy', () => {
+  it('renders two attributes for privacy', () => {
     const { container } = render(<PasswordInput />)
 
     const component = container.querySelector(':only-child')
 
-    expect(component).toHaveAttribute('autocapitalize', 'none')
     expect(component).toHaveAttribute('autocorrect', 'off')
     expect(component).toHaveAttribute('spellcheck', 'false')
   })

--- a/packages/react/src/PasswordInput/PasswordInput.tsx
+++ b/packages/react/src/PasswordInput/PasswordInput.tsx
@@ -20,7 +20,6 @@ export const PasswordInput = forwardRef(
     <input
       {...restProps}
       aria-invalid={invalid || undefined}
-      autoCapitalize="none"
       autoCorrect="off"
       className={clsx('ams-password-input', className)}
       dir={dir ?? 'auto'}

--- a/storybook/src/components/TextInput/TextInput.docs.mdx
+++ b/storybook/src/components/TextInput/TextInput.docs.mdx
@@ -26,7 +26,7 @@ On some devices, it may show an email-specific keyboard.
 Consider setting the following attributes:
 
 1. Set `autocomplete="email"` to help browsers autofill the user’s email address.
-2. Set `autocapitalize="none"`, `autocorrect="off"` and `spellcheck="false"` to stop browsers automatically changing user input.
+2. Set `autocorrect="off"` and `spellcheck="false"` to stop browsers automatically changing user input.
    Email addresses shouldn’t be checked for spelling or grammar.
    This may also prevent posting the email address to third-party plugins.
 
@@ -46,7 +46,7 @@ On some devices, it may show a URL-specific keyboard to aid in entering web addr
 Consider setting the following attributes:
 
 1. Set `autocomplete="url"` to help browsers autofill the user’s web address.
-2. Set `autocapitalize="none"`, `autocorrect="off"` and `spellcheck="false"` to stop browsers automatically changing user input.
+2. Set `autocorrect="off"` and `spellcheck="false"` to stop browsers automatically changing user input.
    Email addresses shouldn’t be checked for spelling or grammar.
    This may also prevent posting the web address to third-party plugins.
 


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It removes unnecessary `autocapitalize` attributes. We used to set it for the PasswordInput, and we mentioned it for `input` types `url` and `email`. However, [`autocapitalize` doesn't do anything for these inputs](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize#usage_notes). I tested this in Safari on iOS and Chrome, Edge and Samsung Internet on Android. 

## Why

The attribute is not necessary, and possibly confusing. 

## How

By removing the attribute for PasswordInput, and updating the docs for TextInput. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Provide links to any related issues or discussions.
- Add a link to the specific story in the feature branch deploy.
- Mention any areas where additional review or feedback is needed.
