### PR TITLE
feat: Icon only button

### DIFF
--- a/packages/react/src/Button/Button.test.tsx
+++ b/packages/react/src/Button/Button.test.tsx
@@ -5,7 +5,7 @@ import { Button } from './Button'
 
 describe('Button', () => {
   it('renders an element with role button', () => {
-    render(<Button>Click me!</Button>)
+    render(<Button label="Click me!" />)
 
     const button = screen.getByRole('button', {
       name: 'Click me!',
@@ -16,7 +16,7 @@ describe('Button', () => {
   })
 
   it('renders an additional class name', () => {
-    render(<Button className="extra">Click me!</Button>)
+    render(<Button label="Click me!" className="extra" />)
 
     const button = screen.getByRole('button', {
       name: 'Click me!',
@@ -26,7 +26,7 @@ describe('Button', () => {
   })
 
   it('renders a default button with variant primary', () => {
-    render(<Button>primary</Button>)
+    render(<Button label="primary" />)
 
     const button = screen.getByRole('button', {
       name: 'primary',
@@ -40,9 +40,9 @@ describe('Button', () => {
   it('renders a button with a specified variant', () => {
     render(
       <>
-        <Button variant="primary">primary</Button>
-        <Button variant="secondary">secondary</Button>
-        <Button variant="tertiary">tertiary</Button>
+        <Button variant="primary" label="primary" />
+        <Button variant="secondary" label="secondary" />
+        <Button variant="tertiary" label="tertiary" />
       </>,
     )
 
@@ -69,15 +69,9 @@ describe('Button', () => {
   it('renders a disabled button with a specified variant', () => {
     render(
       <>
-        <Button disabled variant="primary">
-          primary
-        </Button>
-        <Button disabled variant="secondary">
-          secondary
-        </Button>
-        <Button disabled variant="tertiary">
-          tertiary
-        </Button>
+        <Button disabled variant="primary" label="primary" />
+        <Button disabled variant="secondary" label="secondary" />
+        <Button disabled variant="tertiary" label="tertiary" />
       </>,
     )
 
@@ -104,7 +98,7 @@ describe('Button', () => {
   it('is able to pass a React ref', () => {
     const ref = createRef<HTMLButtonElement>()
 
-    const { container } = render(<Button ref={ref} />)
+    const { container } = render(<Button label="Click me!" ref={ref} />)
 
     const button = container.querySelector(':only-child')
 

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -5,16 +5,31 @@
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type { ButtonHTMLAttributes, ForwardedRef, PropsWithChildren } from 'react'
+import type { ButtonHTMLAttributes, ForwardedRef } from 'react'
+import { Icon } from '../Icon'
 
 export type ButtonProps = {
   /** The level of prominence. Use a primary button only once per page or section. */
   variant?: 'primary' | 'secondary' | 'tertiary'
-} & PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>
+  label: string
+  hideLabel?: boolean
+  iconStart?: Function
+  iconEnd?: Function
+} & ButtonHTMLAttributes<HTMLButtonElement>
 
 export const Button = forwardRef(
   (
-    { children, className, type, disabled, variant = 'primary', ...restProps }: ButtonProps,
+    {
+      className,
+      type,
+      disabled,
+      variant = 'primary',
+      label,
+      hideLabel = false,
+      iconStart,
+      iconEnd,
+      ...restProps
+    }: ButtonProps,
     ref: ForwardedRef<HTMLButtonElement>,
   ) => {
     return (
@@ -25,7 +40,9 @@ export const Button = forwardRef(
         className={clsx('ams-button', `ams-button--${variant}`, className)}
         type={type || 'button'}
       >
-        {children}
+        {iconStart && <Icon svg={iconStart} size="level-5" />}
+        {hideLabel ? <span className="ams-visually-hidden">{label}</span> : label}
+        {iconEnd && <Icon svg={iconEnd} size="level-5" />}
       </button>
     )
   },

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -5,21 +5,22 @@
 
 import clsx from 'clsx'
 import { forwardRef } from 'react'
-import type { ButtonHTMLAttributes, ForwardedRef } from 'react'
+import type { ButtonHTMLAttributes, ForwardedRef, PropsWithChildren } from 'react'
 import { Icon } from '../Icon'
 
 export type ButtonProps = {
   /** The level of prominence. Use a primary button only once per page or section. */
   variant?: 'primary' | 'secondary' | 'tertiary'
-  label: string
+  label?: string
   hideLabel?: boolean
   iconStart?: Function
   iconEnd?: Function
-} & ButtonHTMLAttributes<HTMLButtonElement>
+} & PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>
 
 export const Button = forwardRef(
   (
     {
+      children,
       className,
       type,
       disabled,
@@ -42,6 +43,7 @@ export const Button = forwardRef(
       >
         {iconStart && <Icon svg={iconStart} size="level-5" />}
         {hideLabel ? <span className="ams-visually-hidden">{label}</span> : label}
+        {children}
         {iconEnd && <Icon svg={iconEnd} size="level-5" />}
       </button>
     )

--- a/storybook/src/components/Button/Button.docs.mdx
+++ b/storybook/src/components/Button/Button.docs.mdx
@@ -37,9 +37,17 @@ Use tertiary buttons for unimportant calls to action – as many as necessary.
 
 <Canvas of={ButtonStories.Tertiary} />
 
-### Button with an icon
+### Button with a start icon
 
-<Canvas of={ButtonStories.WithIcon} />
+<Canvas of={ButtonStories.StartIcon} />
+
+### Button with a end icon
+
+<Canvas of={ButtonStories.EndIcon} />
+
+### Button with an icon only
+
+<Canvas of={ButtonStories.OnlyIcon} />
 
 ### Text wrapping
 

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -16,10 +16,6 @@ const meta = {
     disabled: false,
   },
   argTypes: {
-    children: {
-      description: 'The text for the label and/or an icon.',
-      table: { disable: false },
-    },
     disabled: {
       description: 'Prevents interaction. Avoid if possible.',
     },

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -3,7 +3,6 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { Icon } from '@amsterdam/design-system-react'
 import { Button } from '@amsterdam/design-system-react/src'
 import { ShareIcon } from '@amsterdam/design-system-react-icons'
 import { Meta, StoryObj } from '@storybook/react'
@@ -12,7 +11,7 @@ const meta = {
   title: 'Components/Buttons/Button',
   component: Button,
   args: {
-    children: 'Button label',
+    label: 'Button label',
     variant: 'primary',
     disabled: false,
   },
@@ -45,20 +44,29 @@ export const Tertiary: Story = {
   },
 }
 
-export const WithIcon: Story = {
+export const StartIcon: Story = {
   args: {
-    children: ['Button label', <Icon key="icon" svg={ShareIcon} size="level-5" />],
+    iconStart: ShareIcon,
   },
-  argTypes: {
-    children: {
-      table: { disable: true },
-    },
+}
+
+export const EndIcon: Story = {
+  args: {
+    iconEnd: ShareIcon,
+  },
+}
+
+export const OnlyIcon: Story = {
+  args: {
+    variant: 'tertiary',
+    hideLabel: true,
+    iconStart: ShareIcon,
   },
 }
 
 export const TextWrapping: Story = {
   args: {
-    children: 'Vergunningsaanvraag verzenden',
+    label: 'Vergunningsaanvraag verzenden',
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/Dialog/Dialog.stories.tsx
+++ b/storybook/src/components/Dialog/Dialog.stories.tsx
@@ -18,10 +18,8 @@ const meta = {
   args: {
     actions: (
       <>
-        <Button type="submit">Doorgaan</Button>
-        <Button onClick={closeDialog} variant="tertiary">
-          Stoppen
-        </Button>
+        <Button type="submit" label="Doorgaan" />
+        <Button onClick={closeDialog} variant="tertiary" label="Stoppen" />
       </>
     ),
     children: (
@@ -72,7 +70,7 @@ export const Default: Story = {
 
 export const WithScrollbar: Story = {
   args: {
-    actions: <Button onClick={closeDialog}>Sluiten</Button>,
+    actions: <Button onClick={closeDialog} label="Sluiten" />,
     children: [
       <Heading level={2} size="level-5" key={1}>
         Algemeen
@@ -130,9 +128,10 @@ export const TriggerButton: Story = {
   decorators: [
     (Story) => (
       <article>
-        <Button onClick={() => (document.querySelector('#openDialog') as HTMLDialogElement)?.showModal()}>
-          Open Dialog
-        </Button>
+        <Button
+          onClick={() => (document.querySelector('#openDialog') as HTMLDialogElement)?.showModal()}
+          label="Open Dialog"
+        />
         <Story />
       </article>
     ),
@@ -143,10 +142,8 @@ export const VerticalButtons: Story = {
   args: {
     actions: (
       <>
-        <Button type="submit">Lange teksten op deze knoppen</Button>
-        <Button onClick={closeDialog} variant="tertiary">
-          Om verticaal stapelen te demonstreren
-        </Button>
+        <Button type="submit" label="Lange teksten op deze knoppen" />
+        <Button onClick={closeDialog} variant="tertiary" label="Om verticaal stapelen te demonstreren" />
       </>
     ),
     open: true,


### PR DESCRIPTION
To prevent confusing between button and icon button I've aligned the button to figma. There are booleans for label, icon start or end.

## What

Removed children from button, added label and icons. A combination of two icons is possible but this could be a condition I can build, you just need to choose between start or end.

## Why

This prevents users adding anything, like a wrong sized icon or even another button, as a child to the button.


## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [X] Add or update unit tests
- [ ] Add or update documentation
- [X] Add or update stories
- [X] Add or update exports in index.\* files
- [X] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- I would love to add an optional counter, this would solve the filter button problem.
- We're missing an active state
