### PR TITLE
fix: Close Dialog without submit

### DIFF
--- a/packages/css/src/components/dialog/README.md
+++ b/packages/css/src/components/dialog/README.md
@@ -25,6 +25,11 @@ Also, this approach keeps the order of buttons consistent on both narrow and wid
 | Shift + Tab | Moves focus to the previous focusable element inside the dialog. |
 | Escape      | Closes the dialog.                                               |
 
+## Closing Dialog without submit
+
+You can close a Dialog without submitting by using `<button type="button" onClick={closeDialog}>`.
+This uses the `closeDialog` function from the React package.
+
 ## References
 
 - [HTMLDialogElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement)

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -26,7 +26,7 @@ export const Dialog = forwardRef(
     ref: ForwardedRef<HTMLDialogElement>,
   ) => (
     <dialog {...restProps} ref={ref} className={clsx('ams-dialog', className)}>
-      <form method="dialog" className="ams-dialog__form">
+      <form className="ams-dialog__form" method="dialog">
         <header className="ams-dialog__header">
           <Heading size="level-4">{heading}</Heading>
           <IconButton label={closeButtonLabel} size="level-4" type="button" onClick={closeDialog} />

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -29,7 +29,7 @@ export const Dialog = forwardRef(
       <form className="ams-dialog__form" method="dialog">
         <header className="ams-dialog__header">
           <Heading size="level-4">{heading}</Heading>
-          <IconButton label={closeButtonLabel} size="level-4" type="button" onClick={closeDialog} />
+          <IconButton label={closeButtonLabel} onClick={closeDialog} size="level-4" type="button" />
         </header>
         <article className="ams-dialog__article">{children}</article>
         {actions && <footer className="ams-dialog__footer">{actions}</footer>}

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -20,6 +20,8 @@ export type DialogProps = {
 
 export const closeDialog = (event: MouseEvent<HTMLButtonElement>) => event.currentTarget.closest('dialog')?.close()
 
+export const openDialog = (id: string) => (document.querySelector(id) as HTMLDialogElement)?.showModal()
+
 export const Dialog = forwardRef(
   (
     { actions, children, className, closeButtonLabel = 'Sluiten', heading, ...restProps }: DialogProps,

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -4,7 +4,7 @@
  */
 
 import clsx from 'clsx'
-import { forwardRef } from 'react'
+import { forwardRef, MouseEvent } from 'react'
 import type { DialogHTMLAttributes, ForwardedRef, PropsWithChildren, ReactNode } from 'react'
 import { Heading } from '../Heading'
 import { IconButton } from '../IconButton'
@@ -18,6 +18,8 @@ export type DialogProps = {
   heading: string
 } & PropsWithChildren<DialogHTMLAttributes<HTMLDialogElement>>
 
+export const closeDialog = (event: MouseEvent<HTMLButtonElement>) => event.currentTarget.closest('dialog')?.close()
+
 export const Dialog = forwardRef(
   (
     { actions, children, className, closeButtonLabel = 'Sluiten', heading, ...restProps }: DialogProps,
@@ -27,7 +29,7 @@ export const Dialog = forwardRef(
       <form method="dialog" className="ams-dialog__form">
         <header className="ams-dialog__header">
           <Heading size="level-4">{heading}</Heading>
-          <IconButton formNoValidate label={closeButtonLabel} size="level-4" />
+          <IconButton label={closeButtonLabel} size="level-4" type="button" onClick={closeDialog} />
         </header>
         <article className="ams-dialog__article">{children}</article>
         {actions && <footer className="ams-dialog__footer">{actions}</footer>}

--- a/packages/react/src/Dialog/index.ts
+++ b/packages/react/src/Dialog/index.ts
@@ -1,2 +1,2 @@
-export { closeDialog, Dialog } from './Dialog'
+export { closeDialog, Dialog, openDialog } from './Dialog'
 export type { DialogProps } from './Dialog'

--- a/packages/react/src/Dialog/index.ts
+++ b/packages/react/src/Dialog/index.ts
@@ -1,2 +1,2 @@
-export { Dialog } from './Dialog'
+export { Dialog, closeDialog } from './Dialog'
 export type { DialogProps } from './Dialog'

--- a/packages/react/src/Dialog/index.ts
+++ b/packages/react/src/Dialog/index.ts
@@ -1,2 +1,2 @@
-export { Dialog, closeDialog } from './Dialog'
+export { closeDialog, Dialog } from './Dialog'
 export type { DialogProps } from './Dialog'

--- a/storybook/src/components/Dialog/Dialog.docs.mdx
+++ b/storybook/src/components/Dialog/Dialog.docs.mdx
@@ -24,13 +24,13 @@ Click or tap the button to open a dialog.
 
 <Canvas of={DialogStories.TriggerButton} />
 
-Some basic example code to open and close a dialog:
+You can open the dialog using this code:
 
 ```ts
 const openDialog = () => (document.querySelector("#openDialog") as HTMLDialogElement)?.showModal();
-
-const closeDialog = (e: MouseEvent<HTMLButtonElement>) => e.currentTarget.closest("dialog")?.close();
 ```
+
+To close it, use the the `closeDialog` function from the React package.
 
 ## Vertically Stacked Buttons
 

--- a/storybook/src/components/Dialog/Dialog.docs.mdx
+++ b/storybook/src/components/Dialog/Dialog.docs.mdx
@@ -24,13 +24,10 @@ Click or tap the button to open a dialog.
 
 <Canvas of={DialogStories.TriggerButton} />
 
-You can open the dialog using this code:
+To open the dialog, use the `openDialog` function from the React package.
+Pass the Dialog’s `id` to the function to select it.
 
-```ts
-const openDialog = () => (document.querySelector("#openDialog") as HTMLDialogElement)?.showModal();
-```
-
-To close it, use the the `closeDialog` function from the React package.
+To close the Dialog, use the `closeDialog` function.
 
 ## Vertically Stacked Buttons
 

--- a/storybook/src/components/Dialog/Dialog.stories.tsx
+++ b/storybook/src/components/Dialog/Dialog.stories.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Button, closeDialog, Heading, Paragraph } from '@amsterdam/design-system-react'
-import { Dialog } from '@amsterdam/design-system-react/src'
+import { Dialog, openDialog } from '@amsterdam/design-system-react/src'
 import { Meta, StoryObj } from '@storybook/react'
 
 const meta = {
@@ -125,9 +125,7 @@ export const TriggerButton: Story = {
   decorators: [
     (Story) => (
       <article>
-        <Button onClick={() => (document.querySelector('#openDialog') as HTMLDialogElement)?.showModal()}>
-          Open Dialog
-        </Button>
+        <Button onClick={() => openDialog('#openDialog')}>Open Dialog</Button>
         <Story />
       </article>
     ),

--- a/storybook/src/components/Dialog/Dialog.stories.tsx
+++ b/storybook/src/components/Dialog/Dialog.stories.tsx
@@ -3,14 +3,9 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { Button, Heading, Paragraph } from '@amsterdam/design-system-react'
+import { Button, closeDialog, Heading, Paragraph } from '@amsterdam/design-system-react'
 import { Dialog } from '@amsterdam/design-system-react/src'
 import { Meta, StoryObj } from '@storybook/react'
-import { MouseEvent } from 'react'
-
-const closeDialog = (event: MouseEvent<HTMLButtonElement>) => {
-  return event.currentTarget.closest('dialog')?.close()
-}
 
 const meta = {
   title: 'Components/Containers/Dialog',


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

This changes the Dialog close button from `type="submit"` to `type="button"`, and uses JS to close the Dialog.

## Why

We received [an issue noting that using the Dialog close button triggers a submit event](https://github.com/Amsterdam/design-system/issues/1546), which it shouldn't.

## How

By changing the Dialog close button from `type="submit"` to `type="button"`, and using and exporting a JS function to close the nearest modal.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- JSDom doesn't fully support `dialog`, so this functionality isn't tested.