### PR TITLE
chore: Document that Gap is not to be used on Grid

### DIFF
--- a/packages/css/src/components/gap/README.md
+++ b/packages/css/src/components/gap/README.md
@@ -19,7 +19,9 @@ The five sizes of [Component Space](/docs/brand-design-tokens-space--docs) are a
 ## Guidelines
 
 - Use this utility class to vertically separate the children of a parent element from each other.
-- It can be used on any element and sets the `gap` CSS property.
+- Do not use it on the Grid component.
+  Grid is responsible for its own gaps.
+- It can be used on any other element and sets the `gap` CSS property.
   It also makes the element a grid container; the gap would be ignored otherwise.
   These declarations are marked with the `!important` flag to ensure they override any other gaps and display modes.
 - To add a gap between 2 siblings, the first one can be given a [Margin Bottom](/docs/utilities-css-margin--docs) instead.

--- a/packages/css/src/components/grid/README.md
+++ b/packages/css/src/components/grid/README.md
@@ -17,6 +17,8 @@ Multiple instances of the grid component are possible on a page, but the columns
 Within the grid, you create cells containing the desired content.
 A cell often spans multiple columns of the grid.
 
+The Gap utility classes must not be used on the Grid component.
+
 ## Design
 
 The [design choices](/docs/brand-design-tokens-grid--docs) are described in the general documentation.


### PR DESCRIPTION
## What

It adds a guideline on both documentation pages not to use a Grid utility class on the Grid component.

## Why

Because we see this usage in the wild when it is not inteded.
