### PR TITLE
chore: Improve headings and guidelines throughout documentation

### DIFF
--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -16,7 +16,10 @@ The docs display:
 3. The controls for the component, which displays all args for the component.
 4. A canvas for every other story, each with an introduction.
 
-We write our documentation in English, the stories are Dutch.
+We write our documentation in English, the stories are in Dutch.
+
+All headings use sentence case.
+Component names are in title case – starting each word with a capital letter – to make people recognise them as such.
 
 ## Best practices for controls
 

--- a/packages/css/src/components/avatar/README.md
+++ b/packages/css/src/components/avatar/README.md
@@ -9,7 +9,7 @@ A circular badge representing a person.
 The avatar contains 1 or 2 initial letters from the person's full name, a picture, or a generic icon.
 The default background colour is dark blue.
 
-## Usage
+## Guidelines
 
-Display an avatar for the person currently using the application,
-or to associate a person with a content item.
+- Display an avatar for the person currently using the application,
+  or to associate a person with a content item.

--- a/packages/css/src/components/breadcrumb/README.md
+++ b/packages/css/src/components/breadcrumb/README.md
@@ -7,17 +7,11 @@ Users can use it to navigate.
 
 ## Guidelines
 
-### Use like this
-
-Only use the breadcrumb trail if it adds something functional for the user and the structure is ‘static’.
-
-### Avoid this
-
-Do not display the breadcrumb trail on a form page.
-It distracts the user from their task, or one can accidentally interpret it as a Progress Indicator.
-
-It is a secondary navigation pattern.
-It can’t replace the main navigation.
+- Only use the breadcrumb trail if it adds something functional for the user and the structure is ‘static’.
+- Do not display the breadcrumb trail on a form page.
+  It distracts the user from their task, or one can accidentally interpret it as a Progress Indicator.
+- This is a secondary navigation pattern.
+  It can’t replace the main navigation.
 
 ### Using links with routing libraries
 

--- a/packages/css/src/components/button/README.md
+++ b/packages/css/src/components/button/README.md
@@ -11,6 +11,8 @@ Allows the user to perform actions and operate the user interface.
 - Use the correct type of button for the corresponding application.
   For example, a button within a form must always be of the type `submit`.
 - Make sure one can operate a button through a keyboard.
+- Primary, secondary and tertiary buttons can be used side by side.
+  Skipping levels is allowed.
 
 ## Relevant WCAG requirements
 

--- a/packages/css/src/components/field/README.md
+++ b/packages/css/src/components/field/README.md
@@ -6,4 +6,4 @@ Wraps a single input and its related elements. May indicate that the input has a
 
 ## Guidelines
 
-Only use Field to wrap a single input. Use [Field Set](/docs/components-forms-field-set--docs) to wrap multiple inputs.
+- Only use Field to wrap a single input. Use [Field Set](/docs/components-forms-field-set--docs) to wrap multiple inputs.

--- a/packages/css/src/components/footer/README.md
+++ b/packages/css/src/components/footer/README.md
@@ -6,10 +6,10 @@ Provides service information at the bottom of every page.
 
 ## Guidelines
 
-The Footer consists of a dark blue [Spotlight](/docs/components-containers-spotlight--docs) and a [Page Menu](/docs/components-navigation-page-menu--docs).
-It must be used on all websites for the City of Amsterdam.
-For applications, only the Page Menu can be sufficient.
-The Footer is the same on every page of the application.
+- The Footer consists of a dark blue [Spotlight](/docs/components-containers-spotlight--docs) and a [Page Menu](/docs/components-navigation-page-menu--docs).
+  It must be used on all websites for the City of Amsterdam.
+- For applications, only the Page Menu can be sufficient.
+- The Footer is the same on every page of the application.
 
 The Spotlight offers space for various practical links:
 

--- a/packages/css/src/components/grid/README.md
+++ b/packages/css/src/components/grid/README.md
@@ -4,20 +4,17 @@
 
 Divides the screen into columns to align the elements of a page.
 
-## Usage
+## Guidelines
 
-Every page should use the grid as the foundation for its layout.
-It is placed directly within the [Screen](/docs/components-layout-screen--docs).
-
-A [Footer](/docs/components-containers-footer--docs) and a [Spotlight](/docs/components-containers-spotlight--docs) are slightly wider than the grid.
-You close one instance of the grid before these components.
-Inside and optionally after them, you start a new one.
-Multiple instances of the grid component are possible on a page, but the columns of all grids must align precisely.
-
-Within the grid, you create cells containing the desired content.
-A cell often spans multiple columns of the grid.
-
-The Gap utility classes must not be used on the Grid component.
+- Every page should use the grid as the foundation for its layout.
+  It is placed directly within the [Screen](/docs/components-layout-screen--docs).
+- A [Footer](/docs/components-containers-footer--docs) and a [Spotlight](/docs/components-containers-spotlight--docs) are slightly wider than the grid.
+  You close one instance of the grid before these components.
+  Inside and optionally after them, you start a new one.
+  Multiple instances of the grid component are possible on a page, but the columns of all grids must align precisely.
+- Within the grid, you create cells containing the desired content.
+  A cell often spans multiple columns of the grid.
+- The Gap utility classes must not be used on the Grid component.
 
 ## Design
 

--- a/packages/css/src/components/header/README.md
+++ b/packages/css/src/components/header/README.md
@@ -7,17 +7,15 @@ Includes the name of the application if it is not the general website.
 
 ## Guidelines
 
-The Header must be used on all websites and applications for the City of Amsterdam.
-It includes the logo of the City or the organization, the site title (except for the general website), and a menu with links to commonly used pages.
-
-The Header is important because it conveys our corporate identity and is the first thing people see.
-Using it consistently helps users recognize and trust the website.
-It is the same on every page of the application.
-
-The page menu can contain a maximum of 5 items.
-The last two will often be ‘Search’ and ‘Menu’.
-Labels should be short to ensure the menu fits on one line, even on medium-wide screens.
-An icon can be added to the end of a link to make its function easier to find.
+- The Header must be used on all websites and applications for the City of Amsterdam.
+- It includes the logo of the City or the organization, the site title (except for the general website), and a menu with links to commonly used pages.
+- The Header is important because it conveys our corporate identity and is the first thing people see.
+  Using it consistently helps users recognize and trust the website.
+- It is the same on every page of the application.
+- The page menu can contain a maximum of 5 items.
+  The last two will often be ‘Search’ and ‘Menu’.
+- Labels should be short to ensure the menu fits on one line, even on medium-wide screens.
+- An icon can be added to the end of a link to make its function easier to find.
 
 ## References
 

--- a/packages/css/src/components/label/README.md
+++ b/packages/css/src/components/label/README.md
@@ -6,4 +6,4 @@ Describes a form control.
 
 ## Guidelines
 
-Always associate a form element (such as an `input` or `textarea`) with a label.
+- Always associate a form element (such as an `input` or `textarea`) with a label.

--- a/packages/css/src/components/link-list/README.md
+++ b/packages/css/src/components/link-list/README.md
@@ -13,6 +13,5 @@ Therefore, it is blue and clickable.
 
 ## Guidelines
 
-Use a Link List to present multiple links within a theme.
-
-For additional guidelines, refer to the [Link](/docs/components-navigation-link--docs) component.
+- Use a Link List to present multiple links within a theme.
+- For additional guidelines, refer to the [Link](/docs/components-navigation-link--docs) component.

--- a/packages/css/src/components/mark/README.md
+++ b/packages/css/src/components/mark/README.md
@@ -7,13 +7,8 @@ Provides strong emphasis on the text and draws attention to it.
 
 ## Guidelines
 
-### How to Use
-
-- Use a maximum of 1 mark per page.
+- Use a maximum of 1 Mark per page.
 - Limit the marked text to 1 sentence.
-
-### Avoid This
-
 - Do not use it in titles and subtitles.
   Use a significant and engaging title if the entire paragraph is important.
 - Do not mark an entire paragraph.

--- a/packages/css/src/components/ordered-list/README.md
+++ b/packages/css/src/components/ordered-list/README.md
@@ -7,3 +7,8 @@ This list can have 2 levels.
 The first level has numbers as list markers.
 The second level uses letters in alphabetical order.
 List items indent their text by a fixed distance.
+
+## Design
+
+The list uses ascending numbers as markers, providing enough space for numbers up to 99.
+Extra white space between items enhances the distinction, mainly when they consist of multiple lines of text.

--- a/packages/css/src/components/screen/README.md
+++ b/packages/css/src/components/screen/README.md
@@ -4,15 +4,15 @@
 
 Manages the maximum width and alignment of the entire website or application.
 
-## Usage
+## Guidelines
 
-This should be the outermost component of your website or application.
-Within it, combine components such as
-[Grid](/docs/components-layout-grid--docs),
-[Header](/docs/components-containers-header--docs),
-[Footer](/docs/components-containers-footer--docs),
-[Spotlight](/docs/components-containers-spotlight--docs),
-and Figure.
+- This should be the outermost component of your website or application.
+- Within it, combine components such as
+  [Grid](/docs/components-layout-grid--docs),
+  [Header](/docs/components-containers-header--docs),
+  [Footer](/docs/components-containers-footer--docs),
+  [Spotlight](/docs/components-containers-spotlight--docs),
+  and Figure.
 
 ## Design
 

--- a/packages/css/src/components/skip-link/README.md
+++ b/packages/css/src/components/skip-link/README.md
@@ -11,8 +11,6 @@ When the link is shown, it pushes the entire page down.
 
 ## Guidelines
 
-### How to Use
-
 - Place the Skip Link as the first element in `<body>` unless you have a cookie banner.
   In that case, place the Skip Link immediately after the cookie banner.
 - Use the Skip Link to navigate to the main content.
@@ -20,9 +18,6 @@ When the link is shown, it pushes the entire page down.
 - Set `id="example-id"` on the container of that element and then use `href="#example-id"` on the Skip Link.
 - You can use more than one Skip Link for complex pages with multiple sections.
   In most cases, this is not necessary.
-
-### Avoid
-
 - Skip Links are unnecessary on a simple page with only text and minimal navigation.
   The purpose of a Skip Link is to bypass recurring navigation blocks.
   If those blocks are not present, a Skip Link is not needed.

--- a/packages/css/src/components/spotlight/README.md
+++ b/packages/css/src/components/spotlight/README.md
@@ -6,7 +6,7 @@ Emphasizes a section on a page through a distinctive background colour.
 
 ## Guidelines
 
-Refer to [this overview on Stijlweb](https://amsterdam.nl/stijlweb/basiselementen/kleuren/#PagCls_15671872) to determine whether you can use black or white text on the background colour of your choice.
+- Refer to [this overview on Stijlweb](https://amsterdam.nl/stijlweb/basiselementen/kleuren/#PagCls_15671872) to determine whether you can use black or white text on the background colour of your choice.
 
 ## Relevant WCAG requirements
 

--- a/packages/css/src/components/tabs/README.md
+++ b/packages/css/src/components/tabs/README.md
@@ -4,11 +4,13 @@
 
 Tabs are used to bundle related content in a compact overview within a page. Each tab has a short name, and these names indicate the relationship between the information displayed in each tab.
 
-## How to use
+## Guidelines
 
 - The content of each tab is viewable independently, not in the context of one another.
 - The content within each tab should have a similar structure.
 - Use when there is limited visual space and content needs to be divided into sections.
+- Each tab consists of a button and a panel.
+  A `tab` prop with a corresponding value connects them.
 
 You can navigate tabs with your keyboard:
 

--- a/packages/css/src/components/unordered-list/README.md
+++ b/packages/css/src/components/unordered-list/README.md
@@ -7,3 +7,9 @@ This list can have 2 levels.
 The first level consists of squares.
 The second level consists of en dashes (–).
 Text in the list items is indented by a fixed distance.
+
+## Design
+
+Items of an unordered list have square markers.
+There is extra white space between the items.
+This provides better distinction between the items, especially when they consist of multiple lines of text.

--- a/storybook/src/components/Accordion/Accordion.docs.mdx
+++ b/storybook/src/components/Accordion/Accordion.docs.mdx
@@ -23,15 +23,15 @@ If you want the contents of an accordion section to appear initially, pass the `
 
 <Canvas of={AccordionStories.ExpandedByDefault} />
 
-## Too many landmarks
+### Improve semantics
 
-By default, an accordion section uses the HTML tag `section` to render the content.
-Having many accordion sections on your page (more than 6) can lead to too many landmark regions, confusing screen reader users.
+By default, an Accordion Section renders a `section` element in HTML.
+Having many accordion sections on your page can lead to too many landmark regions, confusing screen reader users.
 In that case, use `sectionAs="div"`.
 
-<Canvas of={AccordionStories.TooManyLandmarks} />
+<Canvas of={AccordionStories.ImproveSemantics} />
 
-## Technical considerations
+### Technical considerations
 
 ### The `Accordion` parent component
 

--- a/storybook/src/components/Accordion/Accordion.docs.mdx
+++ b/storybook/src/components/Accordion/Accordion.docs.mdx
@@ -26,7 +26,7 @@ If you want the contents of an accordion section to appear initially, pass the `
 ### Improve semantics
 
 By default, an Accordion Section renders a `section` element in HTML.
-Having many accordion sections on your page can lead to too many landmark regions, confusing screen reader users.
+Having many Accordion Sections on your page can lead to too many landmark regions, confusing screen reader users.
 In that case, use `sectionAs="div"`.
 
 <Canvas of={AccordionStories.ImproveSemantics} />

--- a/storybook/src/components/Accordion/Accordion.docs.mdx
+++ b/storybook/src/components/Accordion/Accordion.docs.mdx
@@ -23,13 +23,13 @@ If you want the contents of an accordion section to appear initially, pass the `
 
 <Canvas of={AccordionStories.ExpandedByDefault} />
 
-### Improve semantics
+### Limit the amount of accessibility landmarks
 
-By default, an Accordion Section renders a `section` element in HTML.
-Having many Accordion Sections on your page can lead to too many landmark regions, confusing screen reader users.
-In that case, use `sectionAs="div"`.
+An Accordion Section renders a `section` element in HTML by default.
+Each of them introduces a landmark region, but having many of them on a page can confuse screen reader users.
+Consider using general `div` elements instead through `sectionAs="div"`.
 
-<Canvas of={AccordionStories.ImproveSemantics} />
+<Canvas of={AccordionStories.ReduceLandmarks} />
 
 ### Technical considerations
 

--- a/storybook/src/components/Accordion/Accordion.docs.mdx
+++ b/storybook/src/components/Accordion/Accordion.docs.mdx
@@ -27,7 +27,7 @@ If you want the contents of an accordion section to appear initially, pass the `
 
 An Accordion Section renders a `section` element in HTML by default.
 Each of them introduces a landmark region, but having many of them on a page can confuse screen reader users.
-Consider using general `div` elements instead through `sectionAs="div"`.
+Let Accordions with 6 Sections or more render generic `div` elements through `sectionAs="div"`.
 
 <Canvas of={AccordionStories.ReduceLandmarks} />
 

--- a/storybook/src/components/Accordion/Accordion.stories.tsx
+++ b/storybook/src/components/Accordion/Accordion.stories.tsx
@@ -59,7 +59,7 @@ export const ExpandedByDefault: Story = {
   },
 }
 
-export const ImproveSemantics: Story = {
+export const ReduceLandmarks: Story = {
   args: {
     sectionAs: 'div',
     children: [

--- a/storybook/src/components/Accordion/Accordion.stories.tsx
+++ b/storybook/src/components/Accordion/Accordion.stories.tsx
@@ -59,7 +59,7 @@ export const ExpandedByDefault: Story = {
   },
 }
 
-export const TooManyLandmarks: Story = {
+export const ImproveSemantics: Story = {
   args: {
     sectionAs: 'div',
     children: [

--- a/storybook/src/components/Alert/Alert.docs.mdx
+++ b/storybook/src/components/Alert/Alert.docs.mdx
@@ -8,17 +8,16 @@ import README from "../../../../packages/css/src/components/alert/README.md?raw"
 
 <Markdown>{README}</Markdown>
 
-## Examples
-
-The default Alert is a warning.
-
 <Primary />
 
 <Controls />
 
+## Examples
+
 ### Warning
 
 Display a warning when user action is required.
+This is the default severity.
 
 <Canvas of={AlertStories.Warning} />
 
@@ -41,19 +40,19 @@ An informative message can emphasize matters that are useful to follow.
 
 <Canvas of={AlertStories.Info} />
 
-### With Inline Link
+### With inline link
 
 Include an inline link in the text to guide the user.
 
 <Canvas of={AlertStories.WithInlineLink} />
 
-### With List
+### With list
 
 For clarification, formatted text can be included in the alert.
 
 <Canvas of={AlertStories.WithList} />
 
-### Without Heading
+### Without heading
 
 Sometimes, a heading is unnecessary.
 The icon automatically becomes slightly smaller.

--- a/storybook/src/components/AspectRatio/AspectRatio.docs.mdx
+++ b/storybook/src/components/AspectRatio/AspectRatio.docs.mdx
@@ -12,29 +12,31 @@ import README from "../../../../packages/css/src/components/aspect-ratio/README.
 
 <Controls />
 
-## Double extra wide
+## Examples
+
+### Double extra wide
 
 We only use this aspect ratio for a ‘hero’ image across the entire website width.
 
 <Canvas of={AspectRatioStories.DoubleExtraWide} />
 
-## Extra wide
+### Extra wide
 
 <Canvas of={AspectRatioStories.ExtraWide} />
 
-## Wide
+### Wide
 
 <Canvas of={AspectRatioStories.Wide} />
 
-## Square
+### Square
 
 <Canvas of={AspectRatioStories.Square} />
 
-## Tall
+### Tall
 
 <Canvas of={AspectRatioStories.Tall} />
 
-## Extra Tall
+### Extra tall
 
 This variant may be suitable for telephones.
 Most devices nowadays have an aspect ratio of 9:19.5.

--- a/storybook/src/components/Avatar/Avatar.docs.mdx
+++ b/storybook/src/components/Avatar/Avatar.docs.mdx
@@ -27,6 +27,6 @@ A user icon displays if no label and image are provided.
 
 <Canvas of={AvatarStories.FallbackIcon} />
 
-### In a header
+### In a Header
 
 <Canvas of={AvatarStories.InAHeader} />

--- a/storybook/src/components/Avatar/Avatar.docs.mdx
+++ b/storybook/src/components/Avatar/Avatar.docs.mdx
@@ -8,27 +8,25 @@ import README from "../../../../packages/css/src/components/avatar/README.md?raw
 
 <Markdown>{README}</Markdown>
 
-## Stories
-
-### Default
-
 <Primary />
 
 <Controls />
 
-### With Picture
+## Examples
+
+### With image
 
 The Avatar can also display a photo or other image for the person.
 Make sure to scale the image down to around 100 pixels to prevent unnecessary data transfers.
 
-<Canvas of={AvatarStories.WithPicture} />
+<Canvas of={AvatarStories.WithImage} />
 
-### Fallback Icon
+### Fallback icon
 
 A user icon displays if no label and image are provided.
 
 <Canvas of={AvatarStories.FallbackIcon} />
 
-### In a Header
+### In a header
 
 <Canvas of={AvatarStories.InAHeader} />

--- a/storybook/src/components/Avatar/Avatar.stories.tsx
+++ b/storybook/src/components/Avatar/Avatar.stories.tsx
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
-export const WithPicture: Story = {
+export const WithImage: Story = {
   args: {
     label: 'PS',
     imageSrc: 'https://i.pravatar.cc/128',

--- a/storybook/src/components/Badge/Badge.docs.mdx
+++ b/storybook/src/components/Badge/Badge.docs.mdx
@@ -8,10 +8,6 @@ import README from "../../../../packages/css/src/components/badge/README.md?raw"
 
 <Markdown>{README}</Markdown>
 
-## Stories
-
-### Default
-
 <Primary />
 
 <Controls />

--- a/storybook/src/components/Breadcrumb/Breadcrumb.docs.mdx
+++ b/storybook/src/components/Breadcrumb/Breadcrumb.docs.mdx
@@ -10,6 +10,6 @@ import README from "../../../../packages/css/src/components/breadcrumb/README.md
 
 <Primary />
 
-## Usage
+## Guidelines
 
 - A breadcrumb should not display more than 8 items.

--- a/storybook/src/components/Button/Button.docs.mdx
+++ b/storybook/src/components/Button/Button.docs.mdx
@@ -14,9 +14,6 @@ import README from "../../../../packages/css/src/components/button/README.md?raw
 
 ## Examples
 
-Primary, secondary and tertiary buttons can be used side by side.
-Skipping levels is allowed.
-
 ### Primary
 
 The most important call-to-action button.
@@ -37,7 +34,7 @@ Use tertiary buttons for unimportant calls to action – as many as necessary.
 
 <Canvas of={ButtonStories.Tertiary} />
 
-### Button with an icon
+### With icon
 
 <Canvas of={ButtonStories.WithIcon} />
 

--- a/storybook/src/components/Button/Button.docs.mdx
+++ b/storybook/src/components/Button/Button.docs.mdx
@@ -16,21 +16,21 @@ import README from "../../../../packages/css/src/components/button/README.md?raw
 
 ### Primary
 
-The most important call-to-action button.
-One primary button may be used per screen.
+The most important call-to-action.
+One primary Button may be used per screen.
 
 <Canvas of={ButtonStories.Primary} />
 
 ### Secondary
 
-Use the secondary button for less prominent calls to action.
-It is possible to use more than 1 secondary button.
+Use the secondary Button for less prominent calls to action.
+It is possible to use more than 1 secondary Button.
 
 <Canvas of={ButtonStories.Secondary} />
 
 ### Tertiary
 
-Use tertiary buttons for unimportant calls to action – as many as necessary.
+Use tertiary Buttons for unimportant calls to action – as many as necessary.
 
 <Canvas of={ButtonStories.Tertiary} />
 

--- a/storybook/src/components/Card/Card.docs.mdx
+++ b/storybook/src/components/Card/Card.docs.mdx
@@ -10,7 +10,9 @@ import README from "../../../../packages/css/src/components/card/README.md?raw";
 
 <Primary />
 
-## With tagline
+## Examples
+
+### With tagline
 
 A card can display a tagline above the heading, a short term like a category or type of information.
 Wrap the tagline and the heading in a `Card.HeadingGroup`.
@@ -18,7 +20,7 @@ This ensures screen readers first read the heading and then the tagline.
 
 <Canvas of={CardStories.WithTagline} />
 
-## With image
+### With image
 
 A card often displays the image of the detail page.
 Use [Aspect Ratio](/docs/layout-aspect-ratio--docs) for the correct aspect ratio.

--- a/storybook/src/components/CharacterCount/CharacterCount.docs.mdx
+++ b/storybook/src/components/CharacterCount/CharacterCount.docs.mdx
@@ -12,7 +12,9 @@ import README from "../../../../packages/css/src/components/character-count/READ
 
 <Controls />
 
-## Error
+## Examples
+
+### Error
 
 When the length exceeds the maximum length, the color of the text changes to red.
 

--- a/storybook/src/components/Column/Column.docs.mdx
+++ b/storybook/src/components/Column/Column.docs.mdx
@@ -8,20 +8,18 @@ import README from "../../../../packages/css/src/components/column/README.md?raw
 
 <Markdown>{README}</Markdown>
 
-## How to Use
+## Guidelines
 
 - Wrap a Column around a set of elements that need the same amount of white space between them.
 - The five sizes of [Component Space](/docs/brand-design-tokens-space--docs) are available for the width or height of the gap.
 - To add white space below a single element, you can add a [Margin Bottom](/docs/utilities-css-margin--docs) instead.
 - Align the elements horizontally or vertically through the alignment props.
 
-## Examples
-
-### Default
-
 <Primary />
 
 <Controls />
+
+## Examples
 
 ### Alignment
 
@@ -52,10 +50,10 @@ This example centers three items horizontally.
 
 <Canvas of={ColumnStories.HorizontalAlignment} />
 
-### Use another HTML element
+### Improve semantics
 
-By default, a Column renders a `<div>`.
+By default, a Column renders a `<div>` element in HTML.
 Use the `as` prop to make your markup more semantic.
 In this example, the Column uses a `<section>` element to group the heading and the cards.
 
-<Canvas of={ColumnStories.CustomTagName} />
+<Canvas of={ColumnStories.ImproveSemantics} />

--- a/storybook/src/components/Column/Column.stories.tsx
+++ b/storybook/src/components/Column/Column.stories.tsx
@@ -67,7 +67,7 @@ export const HorizontalAlignment: Story = {
   },
 }
 
-export const CustomTagName: Story = {
+export const ImproveSemantics: Story = {
   args: {
     as: 'section',
     children: [

--- a/storybook/src/components/DescriptionList/DescriptionList.docs.mdx
+++ b/storybook/src/components/DescriptionList/DescriptionList.docs.mdx
@@ -12,7 +12,9 @@ import README from "../../../../packages/css/src/components/description-list/REA
 
 <Controls />
 
-## Multiple details
+## Examples
+
+### Multiple details
 
 A term may have multiple details.
 

--- a/storybook/src/components/Dialog/Dialog.docs.mdx
+++ b/storybook/src/components/Dialog/Dialog.docs.mdx
@@ -12,26 +12,29 @@ import README from "../../../../packages/css/src/components/dialog/README.md?raw
 
 <Controls />
 
-## With Scrollbar
+## Examples
+
+### With scrollbar
 
 Content taller than the dialog itself will scroll.
 
 <Canvas of={DialogStories.WithScrollbar} className="ams-dialog-story" />
 
-## Open Dialog Button
+### Trigger button
 
-Click or tap the button to open a dialog.
+Click or tap this button to open the Dialog.
 
 <Canvas of={DialogStories.TriggerButton} />
 
-To open the dialog, use the `openDialog` function from the React package.
-Pass the Dialog’s `id` to the function to select it.
+#### Utility functions
 
+To open the Dialog, use the `openDialog` function from the React package.
+Pass the Dialog’s `id` to the function to select it.
 To close the Dialog, use the `closeDialog` function.
 
-## Vertically Stacked Buttons
+### Vertically stacked buttons
 
 If the buttons don’t fit next to each other, they will stack vertically and stretch to the full width.
-This can occur with a narrow Dialog, long Button labels, a large text size or zooming in.
+This can occur with a narrow Dialog, long Button labels, a large text size, or when zooming in.
 
 <Canvas of={DialogStories.VerticalButtons} />

--- a/storybook/src/components/Dialog/Dialog.docs.mdx
+++ b/storybook/src/components/Dialog/Dialog.docs.mdx
@@ -20,9 +20,9 @@ Content taller than the dialog itself will scroll.
 
 <Canvas of={DialogStories.WithScrollbar} className="ams-dialog-story" />
 
-### Trigger button
+### Trigger Button
 
-Click or tap this button to open the Dialog.
+Click or tap this Button to open the Dialog.
 
 <Canvas of={DialogStories.TriggerButton} />
 
@@ -32,9 +32,9 @@ To open the Dialog, use the `openDialog` function from the React package.
 Pass the Dialog’s `id` to the function to select it.
 To close the Dialog, use the `closeDialog` function.
 
-### Vertically stacked buttons
+### Vertically stacked Buttons
 
-If the buttons don’t fit next to each other, they will stack vertically and stretch to the full width.
+If the Buttons don’t fit next to each other, they will stack vertically and stretch to the full width.
 This can occur with a narrow Dialog, long Button labels, a large text size, or when zooming in.
 
 <Canvas of={DialogStories.VerticalButtons} />

--- a/storybook/src/components/ErrorMessage/ErrorMessage.docs.mdx
+++ b/storybook/src/components/ErrorMessage/ErrorMessage.docs.mdx
@@ -12,10 +12,12 @@ import README from "../../../../packages/css/src/components/error-message/README
 
 <Controls />
 
-## With a custom prefix
+## Examples
+
+### Custom prefix
 
 Error messages are automatically prefixed with a visually hidden text, the Dutch word "Invoerfout".
 This makes the error message more clear for screen reader users.
 If you want to change this prefix, to support another language for example, you can use the `prefix` prop.
 
-<Canvas of={ErrorMessageStories.WithCustomPrefix} />
+<Canvas of={ErrorMessageStories.CustomPrefix} />

--- a/storybook/src/components/ErrorMessage/ErrorMessage.stories.tsx
+++ b/storybook/src/components/ErrorMessage/ErrorMessage.stories.tsx
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
-export const WithCustomPrefix: Story = {
+export const CustomPrefix: Story = {
   args: {
     children: 'Enter an email address in the correct format, like name@example.com',
     prefix: 'Error',

--- a/storybook/src/components/Field/Field.docs.mdx
+++ b/storybook/src/components/Field/Field.docs.mdx
@@ -12,7 +12,9 @@ import README from "../../../../packages/css/src/components/field/README.md?raw"
 
 <Controls />
 
-## With description
+## Examples
+
+### With description
 
 A Field can have a description.
 Make sure to connect this description to the input in the Field,
@@ -21,10 +23,10 @@ Add an `aria-describedby` attribute to the input and provide the `id` of the des
 
 <Canvas of={FieldStories.WithDescription} />
 
-## With validation
+### With validation
 
 A Field can indicate if the contained input has a validation error.
-Use Error Message to describe the error.
+Use an [Error Message](/docs/components-forms-error-message--docs) to describe the error.
 Make sure to connect the Error Message to the input in the Field,
 otherwise it won’t be read by a screen reader.
 Add an `aria-describedby` attribute to the input and provide the `id` of Error Message as its value.

--- a/storybook/src/components/FieldSet/FieldSet.docs.mdx
+++ b/storybook/src/components/FieldSet/FieldSet.docs.mdx
@@ -14,7 +14,7 @@ import README from "../../../../packages/css/src/components/field-set/README.md?
 
 ## Examples
 
-## With description
+### With description
 
 A Field Set can have a description.
 Make sure to connect this description to the Field Set or a specific input,
@@ -24,10 +24,10 @@ and provide the `id` of the describing element as its value.
 
 <Canvas of={FieldSetStories.WithDescription} />
 
-## With validation
+### With validation
 
 A Field Set can indicate whether any of the inputs it contains has a validation error.
-Use Error Message to describe the error.
+Use an [Error Message](/docs/components-forms-error-message--docs) to describe the error.
 Make sure to connect the Error Message to the correct input in the Field Set,
 otherwise it won’t be read by a screen reader.
 Add an `aria-describedby` attribute to the input and provide the `id` of Error Message as its value.

--- a/storybook/src/components/FileInput/FileInput.docs.mdx
+++ b/storybook/src/components/FileInput/FileInput.docs.mdx
@@ -14,19 +14,19 @@ import README from "../../../../packages/css/src/components/file-input/README.md
 
 ## Examples
 
-### Multiple Files
+### Multiple files
 
 Allow multiple files to be selected. The label will update to show the number of files selected.
 
-<Canvas of={FileInputStories.Multiple} />
+<Canvas of={FileInputStories.MultipleFiles} />
 
-### Accept
+### Restrict file types
 
 Limit the types of files that can be selected. Some examples are `image/*`, `video/*`, or `audio/*`. To limit to a specific file type, use the MIME type, such as `application/pdf`.
 
 - [MDN File Input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#limiting_accepted_file_types): More examples
 
-<Canvas of={FileInputStories.Accept} />
+<Canvas of={FileInputStories.RestrictFileTypes} />
 
 ### Disabled
 

--- a/storybook/src/components/FileInput/FileInput.stories.tsx
+++ b/storybook/src/components/FileInput/FileInput.stories.tsx
@@ -40,11 +40,11 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
-export const Multiple: Story = {
+export const MultipleFiles: Story = {
   args: { multiple: true },
 }
 
-export const Accept: Story = {
+export const RestrictFileTypes: Story = {
   args: { accept: 'application/pdf' },
 }
 

--- a/storybook/src/components/Footer/Footer.docs.mdx
+++ b/storybook/src/components/Footer/Footer.docs.mdx
@@ -17,4 +17,4 @@ import README from "../../../../packages/css/src/components/footer/README.md?raw
 The footer for a specific website can be a bit different.
 Here’s an example for the ‘Onderzoek en Statistiek’ department.
 
-<Canvas of={FooterStories.Onderzoek} />
+<Canvas of={FooterStories.OnderzoekEnStatistiek} />

--- a/storybook/src/components/Footer/Footer.stories.tsx
+++ b/storybook/src/components/Footer/Footer.stories.tsx
@@ -114,7 +114,7 @@ export const Default: Story = {
   },
 }
 
-export const Onderzoek: Story = {
+export const OnderzoekEnStatistiek: Story = {
   args: {
     children: [
       <Footer.Top key="footer-top">

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -8,17 +8,17 @@ import README from "../../../../packages/css/src/components/grid/README.md?raw";
 
 <Markdown>{README}</Markdown>
 
-## Examples
-
-The pink areas below represent the columns of the grid.
-The spaces in between are white.
-
-The grid has 12 columns on wide screens, so all 12 cells in this example are in a row.
-On narrow screens, you will see three rows of four columns; on medium-wide screens, one row of eight and one of four.
-
 <Primary />
 
 <Controls />
+
+## Examples
+
+The pink areas represent the columns of the grid.
+The gaps between the columns are transparent.
+
+The grid has 12 columns on wide screens, so all 12 cells in the example above are in a row.
+On narrow screens, you will see three rows of four columns; on medium-wide screens, one row of eight and one of four.
 
 ### Vertical margin
 
@@ -79,16 +79,16 @@ An example with `start={2}`:
 
 <Canvas of={GridStories.StartPosition} />
 
-### Use another HTML element
+### Improve semantics
 
-By default, a Grid Cell renders a `<div>`.
+By default, a Grid Cell renders a `<div>` element in HTML.
 Use the `as` prop to make your markup more semantic.
 
-<Canvas of={GridStories.CustomTagName} />
+<Canvas of={GridStories.ImproveSemantics} />
 
 ## Guidelines
 
-Ensure that the number of columns you assign to a cell matches the amount of columns in the grid for the respective window width.
-The same applies to starting a cell in a later column.
-If the total of both values is too large, the browser adds columns to the grid.
-This is not allowed.
+- Ensure that the number of columns you assign to a cell matches the amount of columns in the grid for the respective window width.
+- The same applies to starting a cell in a later column.
+- If the total of both values is too large, the browser adds columns to the grid.
+  This is not allowed.

--- a/storybook/src/components/Grid/Grid.stories.tsx
+++ b/storybook/src/components/Grid/Grid.stories.tsx
@@ -148,7 +148,7 @@ export const StartPosition: CellStory = {
   },
 }
 
-export const CustomTagName: CellStory = {
+export const ImproveSemantics: CellStory = {
   ...CellStoryTemplate,
   args: {
     as: 'section',

--- a/storybook/src/components/Header/Header.docs.mdx
+++ b/storybook/src/components/Header/Header.docs.mdx
@@ -15,33 +15,35 @@ import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Controls />
 
-## With logo variant
+## Examples
 
-<Canvas of={HeaderStories.WithLogoVariant} />
+### For a sub-brand
 
-## With app name
+<Canvas of={HeaderStories.ForSubBrand} />
+
+### With app name
 
 <Canvas of={HeaderStories.WithAppName} />
 
-## With menu
+### With menu button
 
-<Canvas of={HeaderStories.WithMenu} />
+<Canvas of={HeaderStories.WithMenuButton} />
 
-## With links
+### With links
 
 Use a [Page Menu](/docs/components-navigation-page-menu--docs) to add links.
 A Page Menu in the Header should not wrap.
 
 <Canvas of={HeaderStories.WithLinks} />
 
-## With links and menu
+### With links and menu button
 
-<Canvas of={HeaderStories.WithLinksAndMenu} />
+<Canvas of={HeaderStories.WithLinksAndMenuButton} />
 
-## With app name and menu
+### With app name and menu button
 
-<Canvas of={HeaderStories.WithAppNameAndMenu} />
+<Canvas of={HeaderStories.WithAppNameAndMenuButton} />
 
-## With app name, links and menu
+### With app name, links and menu button
 
-<Canvas of={HeaderStories.WithAppNameLinksAndMenu} />
+<Canvas of={HeaderStories.WithAppNameLinksAndMenuButton} />

--- a/storybook/src/components/Header/Header.stories.tsx
+++ b/storybook/src/components/Header/Header.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
-export const WithLogoVariant: Story = {
+export const ForSubBrand: Story = {
   args: {
     logoBrand: 'ggd-amsterdam',
     logoLink: 'https://www.ggd.amsterdam.nl/',
@@ -47,13 +47,13 @@ export const WithLinks: Story = {
   },
 }
 
-export const WithMenu: Story = {
+export const WithMenuButton: Story = {
   args: {
     menu: <button className="ams-header__menu-button">Menu</button>,
   },
 }
 
-export const WithLinksAndMenu: Story = {
+export const WithLinksAndMenuButton: Story = {
   args: {
     links: (
       <PageMenu alignEnd wrap={false}>
@@ -68,14 +68,14 @@ export const WithLinksAndMenu: Story = {
   },
 }
 
-export const WithAppNameAndMenu: Story = {
+export const WithAppNameAndMenuButton: Story = {
   args: {
     appName: 'Aan de Amsterdamse grachten',
     menu: <button className="ams-header__menu-button">Menu</button>,
   },
 }
 
-export const WithAppNameLinksAndMenu: Story = {
+export const WithAppNameLinksAndMenuButton: Story = {
   args: {
     appName: 'Aan de Amsterdamse grachten',
     links: (

--- a/storybook/src/components/IconButton/IconButton.docs.mdx
+++ b/storybook/src/components/IconButton/IconButton.docs.mdx
@@ -32,15 +32,15 @@ import README from "../../../../packages/css/src/components/icon-button/README.m
 
 ### On a coloured background
 
-An icon button on a coloured background must adjust its foreground colour to provide enough contrast.
-We have lighter and darker background colours, and icon buttons behave differently on each.
+An Icon Button on a coloured background must adjust its foreground colour to provide enough contrast.
+We have lighter and darker background colours, and Icon Buttons behave differently on each.
 Stijlweb shows [which colours suit which backgrounds](https://amsterdam.nl/stijlweb/basiselementen/kleuren/).
-Although they only address headings and paragraphs, the same principle applies to icon buttons.
+Although they only address headings and paragraphs, the same principle applies to Icon Buttons.
 
 - Set the `contrastColor` prop on a yellow, orange or green background.
-  It will make the icon button black.
+  It will make the Icon Button black.
 - Use the `inverseColor` prop on a purple or dark blue background.
-  It will make the icon button white.
+  It will make the Icon Button white.
 - On the other background colours, choose either one, but do so consistently.
 - There is no current scenario to set both properties at the same time.
   For now, the 'inverse' appearance will prevail.

--- a/storybook/src/components/IconButton/IconButton.docs.mdx
+++ b/storybook/src/components/IconButton/IconButton.docs.mdx
@@ -30,7 +30,7 @@ import README from "../../../../packages/css/src/components/icon-button/README.m
 
 <Canvas of={IconButtonStories.Level6} />
 
-### On a Coloured Background
+### On a coloured background
 
 An icon button on a coloured background must adjust its foreground colour to provide enough contrast.
 We have lighter and darker background colours, and icon buttons behave differently on each.
@@ -45,10 +45,10 @@ Although they only address headings and paragraphs, the same principle applies t
 - There is no current scenario to set both properties at the same time.
   For now, the 'inverse' appearance will prevail.
 
-#### Contrast Colour
+#### Contrast colour
 
 <Canvas of={IconButtonStories.ContrastColour} />
 
-#### Inverse Colour
+#### Inverse colour
 
 <Canvas of={IconButtonStories.InverseColour} />

--- a/storybook/src/components/Image/Image.docs.mdx
+++ b/storybook/src/components/Image/Image.docs.mdx
@@ -8,13 +8,13 @@ import README from "../../../../packages/css/src/components/image/README.md?raw"
 
 <Markdown>{README}</Markdown>
 
-## Examples
-
 <Primary />
 
 <Controls />
 
-## Provide multiple sources
+## Examples
+
+### Provide multiple sources
 
 Use the srcSet prop, which controls the corresponding HTML attribute (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#srcset)), to let the browser select the optimal source file for the image.
 A mobile device can often download a smaller file, saving the user’s bandwidth and time.
@@ -22,7 +22,7 @@ Don’t forget to still include the required `src` attribute.
 
 <Canvas of={ImageStories.MultipleSources} />
 
-## Prevent unnecessary loading
+### Prevent unnecessary loading
 
 Set the `loading` attribute (see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading)) to `lazy` and the browser will wait to load the image until it is close to the viewport.
 Consider setting this for images below the top area of the page.

--- a/storybook/src/components/Link/Link.docs.mdx
+++ b/storybook/src/components/Link/Link.docs.mdx
@@ -30,7 +30,7 @@ Don’t use too many inline links on the same page, as it may confuse the user.
 
 <Canvas of={LinkStories.Inline} />
 
-### On a Coloured Background
+### On a coloured background
 
 A link on a coloured background must adjust its text colour to provide enough contrast.
 We have lighter and darker background colours, and links behave differently on each.
@@ -45,10 +45,10 @@ Although they only address headings and paragraphs, the same principle applies t
 - There is no current scenario to set both properties at the same time.
   For now, the 'inverse' appearance will prevail.
 
-#### Contrast Colour
+#### Contrast colour
 
 <Canvas of={LinkStories.ContrastColour} />
 
-#### Inverse Colour
+#### Inverse colour
 
 <Canvas of={LinkStories.InverseColour} />

--- a/storybook/src/components/LinkList/LinkList.docs.mdx
+++ b/storybook/src/components/LinkList/LinkList.docs.mdx
@@ -8,23 +8,18 @@ import README from "../../../../packages/css/src/components/link-list/README.md?
 
 <Markdown>{README}</Markdown>
 
-## Examples
-
-### Default
-
-The Link List has no props.
-It is just a container for the items, rendering a `<ul>` element.
-
 <Primary />
 
-### Custom Icons
+## Examples
+
+### Custom icons
 
 Replace the list icon with a more meaningful one to help understand a link more quickly or easily.
 Avoid using both semantic and list icons in the same list.
 
 <Canvas of={LinkListStories.CustomIcons} />
 
-### Small Text
+### Small text
 
 In the [Footer](/docs/components-containers-footer--docs), we use small text, also for lists.
 Specify this for each item in the list.
@@ -41,7 +36,7 @@ Any attributes and the `ref` are passed on to the `<a>` element.
 
 <Controls of={LinkListStories.Link} />
 
-### On a Coloured Background
+### On a coloured background
 
 A link on a coloured background must adjust its text colour to provide enough contrast.
 We have lighter and darker background colours, and links behave differently on each.
@@ -56,10 +51,10 @@ Although they only address headings and paragraphs, the same principle applies t
 - There is no current scenario to set both properties at the same time.
   For now, the 'inverse' appearance will prevail.
 
-#### Contrast Colour
+#### Contrast colour
 
 <Canvas of={LinkListStories.ContrastColour} />
 
-#### Inverse Colour
+#### Inverse colour
 
 <Canvas of={LinkListStories.InverseColour} />

--- a/storybook/src/components/Logo/Logo.docs.mdx
+++ b/storybook/src/components/Logo/Logo.docs.mdx
@@ -12,22 +12,24 @@ import README from "../../../../packages/css/src/components/logo/README.md?raw";
 
 <Controls />
 
-## GGD Amsterdam
+## Examples
+
+### GGD Amsterdam
 
 <Canvas of={LogoStories.GgdAmsterdam} />
 
-## Stadsarchief
+### Stadsarchief
 
 <Canvas of={LogoStories.Stadsarchief} />
 
-## Stadsbank van Lening
+### Stadsbank van Lening
 
 <Canvas of={LogoStories.StadsbankVanLening} />
 
-## VGA Verzekeringen
+### VGA Verzekeringen
 
 <Canvas of={LogoStories.VgaVerzekeringen} />
 
-## Museum Weesp
+### Museum Weesp
 
 <Canvas of={LogoStories.MuseumWeesp} />

--- a/storybook/src/components/Mark/Mark.docs.mdx
+++ b/storybook/src/components/Mark/Mark.docs.mdx
@@ -8,8 +8,6 @@ import README from "../../../../packages/css/src/components/mark/README.md?raw";
 
 <Markdown>{README}</Markdown>
 
-## Example
-
 <Primary />
 
 <Controls />

--- a/storybook/src/components/MegaMenu/MegaMenu.docs.mdx
+++ b/storybook/src/components/MegaMenu/MegaMenu.docs.mdx
@@ -13,6 +13,8 @@ import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Primary />
 
-## With Categories
+## Examples
+
+### With categories
 
 <Canvas of={MegaMenuStories.MultipleCategories} />

--- a/storybook/src/components/OrderedList/OrderedList.docs.mdx
+++ b/storybook/src/components/OrderedList/OrderedList.docs.mdx
@@ -8,45 +8,40 @@ import README from "../../../../packages/css/src/components/ordered-list/README.
 
 <Markdown>{README}</Markdown>
 
-## Examples
-
-### Default
-
-The list uses ascending numbers as markers, providing enough space for numbers up to 99.
-Extra white space between items enhances the distinction, mainly when they consist of multiple lines of text.
-
 <Primary />
 
 <Controls />
 
-## Small
+## Examples
+
+### Small text
 
 Use a list with a smaller font size in form descriptions and captions and the like.
 
-<Canvas of={OrderedListStories.Small} />
+<Canvas of={OrderedListStories.SmallText} />
 
-### Two Levels
+### Two levels
 
 A list may have one nested level.
 In this case, lowercase letters are used as markers.
 
 <Canvas of={OrderedListStories.TwoLevels} />
 
-### Starting Number
+### Starting number
 
 When necessary, the list can start with a higher number.
 Use the HTML attribute `start`.
 
 <Canvas of={OrderedListStories.StartingNumber} />
 
-### Reverse Order
+### Reverse order
 
 The numbers can also be in reverse order.
 Use the HTML attribute `reversed`.
 
 <Canvas of={OrderedListStories.DescendingNumbers} />
 
-### Without Markers
+### Without markers
 
 An overview of articles or search results can be presented as an ordered can be seen as an unordered list.
 In such cases, apply the list semantics while hiding markers.
@@ -59,7 +54,7 @@ For example, here are three news articles:
 
 <Canvas of={OrderedListStories.WithoutMarkers} />
 
-### Inverse Colour
+### Inverse colour
 
 Set the `inverseColor` prop if the List sits on a dark background.
 This ensures the colour of the text provides enough contrast.

--- a/storybook/src/components/OrderedList/OrderedList.stories.tsx
+++ b/storybook/src/components/OrderedList/OrderedList.stories.tsx
@@ -49,7 +49,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
-export const Small: Story = {
+export const SmallText: Story = {
   args: {
     size: 'small',
   },

--- a/storybook/src/components/Overlap/Overlap.docs.mdx
+++ b/storybook/src/components/Overlap/Overlap.docs.mdx
@@ -10,7 +10,7 @@ import README from "../../../../packages/css/src/components/overlap/README.md?ra
 
 ## Examples
 
-### Hero image with search field
+### Hero image with Search Field
 
 This allows for the use of a mood-setting image as a background.
 A [Grid](/docs/components-layout-grid--docs) provides horizontal space on both sides and columns for layout.

--- a/storybook/src/components/Overlap/Overlap.docs.mdx
+++ b/storybook/src/components/Overlap/Overlap.docs.mdx
@@ -8,9 +8,9 @@ import README from "../../../../packages/css/src/components/overlap/README.md?ra
 
 <Markdown>{README}</Markdown>
 
-## Example
+## Examples
 
-### Hero Image with Search Field
+### Hero image with search field
 
 This allows for the use of a mood-setting image as a background.
 A [Grid](/docs/components-layout-grid--docs) provides horizontal space on both sides and columns for layout.
@@ -18,9 +18,8 @@ Note: the library does not yet offer an option to vertically center the form.
 
 <Primary />
 
-#### Guidelines
+## Guidelines
 
-- First, implement the underlying component.
 - Follow [the general guidelines for images](/docs/components-media-image--docs#guidelines).
 - Use a sufficiently large image.
   The aspect ratio of 32:9 is most suitable.

--- a/storybook/src/components/PageHeading/PageHeading.docs.mdx
+++ b/storybook/src/components/PageHeading/PageHeading.docs.mdx
@@ -8,13 +8,11 @@ import README from "../../../../packages/css/src/components/page-heading/README.
 
 <Markdown>{README}</Markdown>
 
-## Examples
-
-### Default
-
 <Primary />
 
 <Controls />
+
+## Examples
 
 ### Inverse colour
 

--- a/storybook/src/components/Paragraph/Paragraph.docs.mdx
+++ b/storybook/src/components/Paragraph/Paragraph.docs.mdx
@@ -8,30 +8,28 @@ import README from "../../../../packages/css/src/components/paragraph/README.md?
 
 <Markdown>{README}</Markdown>
 
-## Examples
-
-### Default
-
 <Primary />
 
 <Controls />
 
-### Large
+## Examples
 
-Use this size only for the introductory text of a page.
-It is not mandatory to use an introductory text, and there should be a maximum of 1 per page.
+### Large text
 
-An introductory text is a concise description of the page’s content.
+Use this size only for the lead paragraph of a page.
+It is not mandatory to use a lead paragraph, but there must be no more than 1 per page.
+
+A lead paragraph introduces the page’s content.
 Use this text to entice the reader to continue reading.
 
-<Canvas of={ParagraphStories.Large} />
+<Canvas of={ParagraphStories.LargeText} />
 
-### Small
+### Small text
 
 Use this size for auxiliary texts, captions, metadata, etc.
 Keep these texts short.
 
-<Canvas of={ParagraphStories.Small} />
+<Canvas of={ParagraphStories.SmallText} />
 
 ### Inverse colour
 

--- a/storybook/src/components/Paragraph/Paragraph.stories.tsx
+++ b/storybook/src/components/Paragraph/Paragraph.stories.tsx
@@ -39,13 +39,13 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
-export const Large: Story = {
+export const LargeText: Story = {
   args: {
     size: 'large',
   },
 }
 
-export const Small: Story = {
+export const SmallText: Story = {
   args: {
     size: 'small',
   },

--- a/storybook/src/components/Radio/Radio.docs.mdx
+++ b/storybook/src/components/Radio/Radio.docs.mdx
@@ -28,7 +28,7 @@ Check [the Field Set docs](/docs/components-forms-field-set--docs) for more info
 
 <Canvas of={RadioStories.InAFieldSet} />
 
-### In a Field Set With Validation
+### In a Field Set with validation
 
 If the Radio can become invalid, add an Error Message component and its `id` to the `aria-describedby` attribute of the Field Set.
 

--- a/storybook/src/components/Row/Row.docs.mdx
+++ b/storybook/src/components/Row/Row.docs.mdx
@@ -8,19 +8,17 @@ import README from "../../../../packages/css/src/components/row/README.md?raw";
 
 <Markdown>{README}</Markdown>
 
-## How to use
+## Guidelines
 
 - Wrap a Row around a set of elements that need the same amount of white space between them.
 - The five sizes of [Component Space](/docs/brand-design-tokens-space--docs) are available for the width of the gap.
 - Align the elements horizontally or vertically through the alignment props.
 
-## Examples
-
-### Default
-
 <Primary />
 
 <Controls />
+
+## Examples
 
 ### Alignment
 

--- a/storybook/src/components/Screen/Screen.docs.mdx
+++ b/storybook/src/components/Screen/Screen.docs.mdx
@@ -12,6 +12,8 @@ import README from "../../../../packages/css/src/components/screen/README.md?raw
 
 <Controls />
 
-## Extra wide
+## Examples
+
+### Extra wide
 
 <Canvas of={ScreenStories.ExtraWide} />

--- a/storybook/src/components/SearchField/SearchField.docs.mdx
+++ b/storybook/src/components/SearchField/SearchField.docs.mdx
@@ -24,6 +24,6 @@ A Search Field can have a placeholder text.
 
 By default, the search field is not managed by React but by the browser.
 However, it can be controlled by React.
-If you enter a value in this search field and use the search button or the Enter key, you will receive a notification.
+If you enter a value in this search field and use the search Button or the Enter key, you will receive a notification.
 
 <Canvas of={SearchFieldStories.Controlled} />

--- a/storybook/src/components/SearchField/SearchField.docs.mdx
+++ b/storybook/src/components/SearchField/SearchField.docs.mdx
@@ -12,6 +12,8 @@ import README from "../../../../packages/css/src/components/search-field/README.
 
 <Controls />
 
+## Examples
+
 ### With placeholder
 
 A Search Field can have a placeholder text.

--- a/storybook/src/components/Select/Select.docs.mdx
+++ b/storybook/src/components/Select/Select.docs.mdx
@@ -8,29 +8,29 @@ import README from "../../../../packages/css/src/components/select/README.md?raw
 
 <Markdown>{README}</Markdown>
 
-# Default
-
 <Primary />
 
 <Controls />
 
-## Multiple
+## Examples
+
+### Multiple
 
 Avoid adding functionality to allow selecting multiple options. Multi select is harder to use
 on desktop as they require the user to hold down the `Ctrl` or `Cmd` key while clicking on the options.
 It is recommended to use checkboxes instead.
 
-## Grouped
+### Grouped
 
 Use the `Select.Group` component to group options.
 The component requires a `label` attribute.
 
 <Canvas of={SelectStories.Grouped} />
 
-## Invalid
+### Invalid
 
 <Canvas of={SelectStories.Invalid} />
 
-## Disabled
+### Disabled
 
 <Canvas of={SelectStories.Disabled} />

--- a/storybook/src/components/SkipLink/SkipLink.docs.mdx
+++ b/storybook/src/components/SkipLink/SkipLink.docs.mdx
@@ -12,13 +12,15 @@ import README from "../../../../packages/css/src/components/skip-link/README.md?
 
 <Controls />
 
-## Display on Focus
+## Examples
+
+### Display on focus
 
 A Skip Link is only displayed when it receives focus.
 
 <Canvas of={SkipLinkStories.OnFocus} />
 
-## Multiple Links
+### Multiple links
 
 You can use more than one Skip Link if you have a complex page with multiple sections.
 

--- a/storybook/src/components/Spotlight/Spotlight.docs.mdx
+++ b/storybook/src/components/Spotlight/Spotlight.docs.mdx
@@ -12,6 +12,8 @@ import README from "../../../../packages/css/src/components/spotlight/README.md?
 
 <Controls />
 
+## Examples
+
 ### Blue
 
 <Canvas of={SpotlightStories.Blue} />
@@ -44,9 +46,9 @@ import README from "../../../../packages/css/src/components/spotlight/README.md?
 
 <Canvas of={SpotlightStories.Yellow} />
 
-### Custom HTML Element
+### Improve semantics
 
-By default, a Spotlight renders a `<div>`.
+By default, a Spotlight renders a `<div>` element in HTML.
 Use the `as` prop to make your markup more semantic.
 
-<Canvas of={SpotlightStories.CustomTagName} />
+<Canvas of={SpotlightStories.ImproveSemantics} />

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -78,7 +78,7 @@ export const Yellow: Story = {
   },
 }
 
-export const CustomTagName: Story = {
+export const ImproveSemantics: Story = {
   args: {
     as: 'section',
   },

--- a/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
+++ b/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
@@ -12,6 +12,8 @@ import README from "../../../../packages/css/src/components/table-of-contents/RE
 
 <Controls />
 
-## Multilevel
+## Examples
 
-<Canvas of={TableOfContentsStories.MultiLevel} />
+### Multiple levels
+
+<Canvas of={TableOfContentsStories.MultipleLevels} />

--- a/storybook/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/storybook/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -28,7 +28,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
-export const MultiLevel: Story = {
+export const MultipleLevels: Story = {
   args: {
     heading: 'Inhoudsopgave',
     children: (

--- a/storybook/src/components/Tabs/Tabs.docs.mdx
+++ b/storybook/src/components/Tabs/Tabs.docs.mdx
@@ -8,16 +8,11 @@ import README from "../../../../packages/css/src/components/tabs/README.md?raw";
 
 <Markdown>{README}</Markdown>
 
-## Examples
-
-### Default
-
-Each tab consists of a button and a panel.
-A `tab` prop with a corresponding value connects them.
-
 <Primary />
 
-### With Initial Tab
+## Examples
+
+### With initial tab
 
 The first tab is active by default.
 Another tab’s panel can be displayed initially as well.

--- a/storybook/src/components/TextArea/TextArea.docs.mdx
+++ b/storybook/src/components/TextArea/TextArea.docs.mdx
@@ -12,27 +12,29 @@ import README from "../../../../packages/css/src/components/text-area/README.md?
 
 <Controls />
 
-## Vertical Resize
+## Examples
+
+### Vertical resize
 
 <Canvas of={TextAreaStories.VerticalResize} />
 
-## Horizontal Resize
+### Horizontal resize
 
 <Canvas of={TextAreaStories.HorizontalResize} />
 
-## No Resize
+### No resize
 
 <Canvas of={TextAreaStories.NoResize} />
 
-## Invalid
+### Invalid
 
 <Canvas of={TextAreaStories.Invalid} />
 
-## Disabled
+### Disabled
 
 <Canvas of={TextAreaStories.Disabled} />
 
-### In a Field
+#### In a Field
 
 Use a Field to group a Text Area with a Label, description and / or an Error Message.
 
@@ -42,7 +44,7 @@ Check [the Field docs](/docs/components-forms-field--docs) for more information 
 
 <Canvas of={TextAreaStories.InAField} />
 
-### In a Field With Validation
+#### In a Field with validation
 
 If the Text Area can become invalid, add an Error Message and its `id` to the `aria-describedby` prop of the Text Area.
 

--- a/storybook/src/components/TimeInput/TimeInput.docs.mdx
+++ b/storybook/src/components/TimeInput/TimeInput.docs.mdx
@@ -12,10 +12,12 @@ import README from "../../../../packages/css/src/components/time-input/README.md
 
 <Controls />
 
-## Invalid
+## Examples
+
+### Invalid
 
 <Canvas of={TimeInputStories.Invalid} />
 
-## Disabled
+### Disabled
 
 <Canvas of={TimeInputStories.Disabled} />

--- a/storybook/src/components/TopTaskLink/TopTaskLink.docs.mdx
+++ b/storybook/src/components/TopTaskLink/TopTaskLink.docs.mdx
@@ -15,9 +15,9 @@ import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Controls />
 
-### Meerdere links
+### Multiple links
 
 Top tasks usually come in groups.
 Present them in a grid.
 
-<Canvas of={TopTaskLinkStories.Multiple} />
+<Canvas of={TopTaskLinkStories.MultipleLinks} />

--- a/storybook/src/components/TopTaskLink/TopTaskLink.stories.tsx
+++ b/storybook/src/components/TopTaskLink/TopTaskLink.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
   },
 }
 
-export const Multiple: Story = {
+export const MultipleLinks: Story = {
   args: {
     description: 'Omschrijving',
     label: 'Titel',

--- a/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
+++ b/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
@@ -8,19 +8,13 @@ import README from "../../../../packages/css/src/components/unordered-list/READM
 
 <Markdown>{README}</Markdown>
 
-## Examples
-
-### Default
-
-Items of an unordered list have square markers.
-There is extra white space between the items.
-This provides better distinction between the items, especially when they consist of multiple lines of text.
-
 <Primary />
 
 <Controls />
 
-### Two Levels
+## Examples
+
+### Two levels
 
 A list can have one deeper level.
 In this case, an en dash is used as the list item marker.
@@ -28,7 +22,7 @@ It is left-aligned with the text of the higher-level item.
 
 <Canvas of={UnorderedListStories.TwoLevels} />
 
-### Without Markers
+### Without markers
 
 An overview of equivalent elements is also an unordered list.
 In such cases, apply the list semantics while hiding markers.
@@ -41,7 +35,7 @@ This example is based on the top tasks on the homepage of the website:
 
 <Canvas of={UnorderedListStories.WithoutMarkers} />
 
-### Inverse Colour
+### Inverse colour
 
 Set the `inverseColor` prop if the List sits on a dark background.
 This ensures the colour of the text provides enough contrast.
@@ -49,8 +43,8 @@ When nesting lists, set the prop on all lists.
 
 <Canvas of={UnorderedListStories.InverseColor} />
 
-### Small
+### Small text
 
 Use a list with a smaller font size in form descriptions and captions and the like.
 
-<Canvas of={UnorderedListStories.Small} />
+<Canvas of={UnorderedListStories.SmallText} />

--- a/storybook/src/components/UnorderedList/UnorderedList.stories.tsx
+++ b/storybook/src/components/UnorderedList/UnorderedList.stories.tsx
@@ -138,7 +138,7 @@ export const InverseColor: Story = {
   ),
 }
 
-export const Small: Story = {
+export const SmallText: Story = {
   args: {
     size: 'small',
   },

--- a/storybook/src/docs/developer-guide/web-app.docs.mdx
+++ b/storybook/src/docs/developer-guide/web-app.docs.mdx
@@ -87,7 +87,7 @@ The symlink(s) and copied and edited files can be committed to the repository.
 
 <WebAppIcons />
 
-Include `icons` object in `*.webmanifest` (see [Usage](#usage)):
+Include `icons` object in `*.webmanifest` (see [How to use](#how-to-use)):
 
 ```json
 {


### PR DESCRIPTION
# Describe the pull request

## What

- Uses sentence case for headings, instead of title case and documents this in Storybook contribution guidelines
- Changes ‘How to use’ and ‘Usage’ to ‘Guidelines’ for consistency, where appropriate
- Removes ‘When to use’ and ‘What to avoid’ for now – this distinction will return but more clearly and consistently 
- Marks up guidelines as a list everywhere
- Move some instances of text from the ‘Examples’ section to ‘Guidelines’
- Fixes heading levels where necessary
- Increases consistency in Story names and headings
- Improves consistency for examples of the `as` prop

## Why

The main goal was to stop using ‘Title Case’ in headings, even though it introduces a difference with the table of contents that Storybook generates, and to put the ‘Examples’ heading in the correct place for all components.

## How

Manually :)

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- None