### PR TITLE
chore: Do not show transparent border in Storybook in forced colors mode

### DIFF
--- a/storybook/src/styles/overrides.css
+++ b/storybook/src/styles/overrides.css
@@ -117,3 +117,10 @@
 :is(#storybook-root, .sbdocs-content) a[href="#"] {
   cursor: not-allowed;
 }
+
+/* Override to make sure the default transparent border isn't shown in forced colors mode. */
+.innerZoomElementWrapper.innerZoomElementWrapper > div {
+  @media (forced-colors: active) {
+    border-color: Canvas !important;
+  }
+}


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It hides a transparent border that Storybook sets, which incorrectly shows in forced color mode. 

## Why

We want to support forced colors mode, this makes sure it also looks good in Storybook.

## How

By giving the border a Canvas system color when in forced colors mode. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).