### PR TITLE
feat: Add border to Avatar in forced colors mode

### DIFF
--- a/packages/css/src/components/avatar/avatar.scss
+++ b/packages/css/src/components/avatar/avatar.scss
@@ -20,6 +20,15 @@
   }
 }
 
+.ams-avatar:not(.ams-avatar--has-image) {
+  @media (forced-colors: active) {
+    border-style: solid;
+    border-width: var(--ams-avatar-forced-colors-border-width);
+    padding-block: calc(var(--ams-avatar-padding-block) - var(--ams-avatar-forced-colors-border-width));
+    padding-inline: calc(var(--ams-avatar-padding-inline) - var(--ams-avatar-forced-colors-border-width));
+  }
+}
+
 .ams-avatar--has-image {
   inline-size: calc(var(--ams-avatar-line-height) * var(--ams-avatar-font-size) + 2 * var(--ams-avatar-padding-inline));
   overflow: hidden;

--- a/proprietary/tokens/src/components/ams/avatar.tokens.json
+++ b/proprietary/tokens/src/components/ams/avatar.tokens.json
@@ -20,6 +20,9 @@
         "background-color": { "value": "{ams.color.dark-green}" },
         "color": { "value": "{ams.color.primary-white}" }
       },
+      "forced-colors": {
+        "border-width": { "value": "{ams.border.width.md}" }
+      },
       "green": {
         "background-color": { "value": "{ams.color.green}" },
         "color": { "value": "{ams.color.primary-black}" }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It adds a border to Avatar in forced colors mode.

## Why

Avatar relies on a background color to show its edges. In forced colors mode, the background color isn't visible.

## How

This adds a border to Avatar in forced colors mode, and subtracts the width of the border from the padding, in order to keep the same dimensions. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
