### PR TITLE
chore: Fix options for text size examples of lists

### DIFF
--- a/storybook/src/components/OrderedList/OrderedList.docs.mdx
+++ b/storybook/src/components/OrderedList/OrderedList.docs.mdx
@@ -14,12 +14,6 @@ import README from "../../../../packages/css/src/components/ordered-list/README.
 
 ## Examples
 
-### Small text
-
-Use a list with a smaller font size in form descriptions and captions and the like.
-
-<Canvas of={OrderedListStories.SmallText} />
-
 ### Two levels
 
 A list may have one nested level.
@@ -61,3 +55,9 @@ This ensures the colour of the text provides enough contrast.
 When nesting lists, set the prop on all lists.
 
 <Canvas of={OrderedListStories.InverseColor} />
+
+### Small text
+
+Use a list with a smaller font size in form descriptions and captions and the like.
+
+<Canvas of={OrderedListStories.SmallText} />

--- a/storybook/src/components/OrderedList/OrderedList.stories.tsx
+++ b/storybook/src/components/OrderedList/OrderedList.stories.tsx
@@ -49,12 +49,6 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
-export const SmallText: Story = {
-  args: {
-    size: 'small',
-  },
-}
-
 export const TwoLevels: Story = {
   render: (args) => (
     <OrderedList {...args}>
@@ -150,4 +144,10 @@ export const InverseColor: Story = {
       </OrderedList.Item>
     </OrderedList>
   ),
+}
+
+export const SmallText: Story = {
+  args: {
+    size: 'small',
+  },
 }

--- a/storybook/src/components/OrderedList/OrderedList.stories.tsx
+++ b/storybook/src/components/OrderedList/OrderedList.stories.tsx
@@ -37,7 +37,7 @@ const meta = {
         type: 'radio',
         labels: { small: 'small', undefined: 'medium' },
       },
-      options: ['small', undefined, 'large'],
+      options: ['small', undefined],
     },
   },
   decorators: [inverseColorDecorator],

--- a/storybook/src/components/UnorderedList/UnorderedList.stories.tsx
+++ b/storybook/src/components/UnorderedList/UnorderedList.stories.tsx
@@ -31,6 +31,15 @@ const meta = {
     inverseColor: false,
     markers: undefined,
   },
+  argTypes: {
+    size: {
+      control: {
+        type: 'radio',
+        labels: { small: 'small', undefined: 'medium' },
+      },
+      options: ['small', undefined],
+    },
+  },
   decorators: [inverseColorDecorator],
 } satisfies Meta<typeof UnorderedList>
 


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

- Removes the ‘large’ option for the `size` of Ordered Lists in Storybook
- Displays the default ‘medium’ option for Unordered Lists
- Moves the ‘Small Text’ example of OL to the bottom to match UL

## Why

They didn’t reflect the actual implementation of the components.
