### PR TITLE
chore: Improve Image Slider docs and resize handler

### DIFF
--- a/packages/css/src/components/image-slider/README.md
+++ b/packages/css/src/components/image-slider/README.md
@@ -15,9 +15,11 @@ The images do not slide automatically.
 ## How to use
 
 - Use this for a series of images that belong together.
+- Provide at least 2 images and at most 5.
 - Feature the most essential image first.
-- Display the Image Slider at the entire width of the [Screen](/docs/components-layout-screen--docs); do not position it on the [Grid](/docs/components-layout-grid--docs).
-- Provide at least 2 images but at most 5.
-- Assume that some or many users will not use the Slider and only see the first image.
+- Assume that some or many users will not navigate between the slides and only see the first image.
   Display all images separately if you want each of them to receive attention.
+- A full-width Image Slider should run from one edge of the Screen to the other;
+  position it next to a Grid, not in a Cell spanning all columns.
+  Smaller sliders are fine in a Grid Cell.
 - Consult the [Image](/docs/components-media-image--docs) docs for guidelines on the individual images.

--- a/packages/react/src/ImageSlider/ImageSlider.tsx
+++ b/packages/react/src/ImageSlider/ImageSlider.tsx
@@ -4,6 +4,7 @@
  */
 
 import clsx from 'clsx'
+import { debounce } from 'lodash'
 import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ForwardedRef, HTMLAttributes } from 'react'
 import { ImageSliderContext } from './ImageSliderContext'
@@ -147,8 +148,9 @@ export const ImageSliderRoot = forwardRef(
         goToSlide(currentSlideElement)
       }
 
-      window.addEventListener('resize', handleResize)
-      return () => window.removeEventListener('resize', handleResize)
+      const debouncedHandleResize = debounce(handleResize, 200)
+      window.addEventListener('resize', debouncedHandleResize)
+      return () => window.removeEventListener('resize', debouncedHandleResize)
     }, [currentSlideId, goToSlide])
 
     return (


### PR DESCRIPTION
The guideline for a full-width Image Slider wasn’t accurate.

The resize handler was too eager.