### PR TITLE
feat!: Introduce Page Menu Item and Button

### DIFF
--- a/packages/css/src/components/page-menu/README.md
+++ b/packages/css/src/components/page-menu/README.md
@@ -7,11 +7,12 @@ A small set of links for use in the Header and Footer.
 ## Guidelines
 
 - Limit the amount of menu items in the Header to 5 items or less, including ‘Search’ and ‘Menu’.
-- The menu should fit on a single line and is right-aligned.
-- The menu in the footer is left-aligned.
+- The menu in the Header aligns to the end; the one in the Footer aligns to the start.
 - Submenus are not allowed.
-- The ‘Menu’ button opens the Mega Menu.
+- The ‘Menu’ button in the Header opens the Mega Menu.
 - On narrow screens, menu items other than ‘Search’ and ‘Menu’ move from the Page Menu to the Mega Menu.
+- Labels should be short so that the menu wraps to multiple lines only if necessary.
+- If a very well-known icon exists for the function of a link or button, it can be added at the end of it.
 
 ### Using links with routing libraries
 

--- a/packages/css/src/components/page-menu/page-menu.scss
+++ b/packages/css/src/components/page-menu/page-menu.scss
@@ -3,6 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
+@import "../../common/breakpoint";
 @import "../../common/text-rendering";
 
 @mixin reset-list {
@@ -13,6 +14,17 @@
 
 @mixin reset-item {
   box-sizing: border-box;
+}
+
+@mixin reset-button {
+  background: none;
+  border: 0;
+  margin-block: 0; // [1]
+  margin-inline: 0; // [1]
+  padding-block: 0;
+  padding-inline: 0;
+
+  // [1] Remove the margin in older Safari.
 }
 
 .ams-page-menu {
@@ -28,21 +40,26 @@
 }
 
 .ams-page-menu--align-end {
-  justify-content: end;
+  justify-content: flex-end;
+  margin-inline-start: auto;
 }
 
-.ams-page-menu--no-wrap {
-  flex-wrap: nowrap;
+.ams-page-menu__item {
+  &--secondary {
+    @media screen and (not (min-width: $ams-breakpoint-medium)) {
+      display: none;
+    }
+  }
 }
 
-@mixin page-menu-item {
+@mixin ams-page-menu-element {
   color: var(--ams-page-menu-item-color);
+  column-gap: var(--ams-page-menu-item-column-gap);
   display: inline-flex;
   flex-direction: row;
   font-family: var(--ams-page-menu-item-font-family);
   font-size: var(--ams-page-menu-item-font-size);
   font-weight: var(--ams-page-menu-item-font-weight);
-  gap: var(--ams-page-menu-item-gap);
   line-height: var(--ams-page-menu-item-line-height);
   outline-offset: var(--ams-page-menu-item-outline-offset);
   text-align: center;
@@ -51,20 +68,30 @@
   text-underline-offset: var(--ams-page-menu-item-text-underline-offset);
   touch-action: manipulation;
   white-space: nowrap;
+
+  @include text-rendering;
+
+  &:hover {
+    color: var(--ams-page-menu-item-hover-color);
+  }
+
+  svg {
+    color: currentColor;
+  }
 }
 
 .ams-page-menu__link {
-  @include page-menu-item;
-  @include text-rendering;
+  @include ams-page-menu-element;
   @include reset-item;
+
+  &:hover {
+    text-decoration-line: var(--ams-page-menu-item-hover-text-decoration-line);
+  }
 }
 
-.ams-page-menu__link:hover,
-.ams-page-menu__button:hover {
-  color: var(--ams-page-menu-item-hover-color);
-  text-decoration-line: var(--ams-page-menu-item-hover-text-decoration-line);
-}
+.ams-page-menu__button {
+  cursor: var(--ams-page-menu-button-cursor);
 
-.ams-page-menu__link svg {
-  color: currentColor;
+  @include ams-page-menu-element;
+  @include reset-button;
 }

--- a/packages/react/src/PageMenu/PageMenu.test.tsx
+++ b/packages/react/src/PageMenu/PageMenu.test.tsx
@@ -4,16 +4,20 @@ import { createRef } from 'react'
 import { PageMenu } from './PageMenu'
 import '@testing-library/jest-dom'
 
-describe('Page menu', () => {
+describe('Page Menu', () => {
   it('renders a page menu with children', () => {
     const { container } = render(
       <PageMenu>
-        <PageMenu.Link href="#" lang="en">
-          English
-        </PageMenu.Link>
-        <PageMenu.Link href="#" icon={LoginIcon}>
-          Mijn Amsterdam
-        </PageMenu.Link>
+        <PageMenu.Item>
+          <PageMenu.Link href="#" lang="en">
+            English
+          </PageMenu.Link>
+        </PageMenu.Item>
+        <PageMenu.Item>
+          <PageMenu.Link href="#" icon={LoginIcon}>
+            Mijn Amsterdam
+          </PageMenu.Link>
+        </PageMenu.Item>
       </PageMenu>,
     )
 
@@ -36,6 +40,15 @@ describe('Page menu', () => {
     expect(component).toHaveClass('ams-page-menu')
   })
 
+  it('renders an additional class name', () => {
+    const { container } = render(<PageMenu className="intro" />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('intro')
+    expect(component).toHaveClass('ams-page-menu')
+  })
+
   it('renders a class name for end alignment', () => {
     const { container } = render(<PageMenu alignEnd />)
 
@@ -44,36 +57,21 @@ describe('Page menu', () => {
     expect(component).toHaveClass('ams-page-menu--align-end')
   })
 
-  it('renders a class name to prevent wrapping', () => {
-    const { container } = render(<PageMenu wrap={false} />)
-
-    const component = container.querySelector(':only-child')
-
-    expect(component).toHaveClass('ams-page-menu--no-wrap')
-  })
-
   it('is able to pass a React ref', () => {
     const ref = createRef<HTMLUListElement>()
 
     const { container } = render(
       <PageMenu ref={ref}>
-        <PageMenu.Link href="#" lang="en">
-          English
-        </PageMenu.Link>
+        <PageMenu.Item>
+          <PageMenu.Link href="#" lang="en">
+            English
+          </PageMenu.Link>
+        </PageMenu.Item>
       </PageMenu>,
     )
 
     const component = container.querySelector(':only-child')
 
     expect(ref.current).toBe(component)
-  })
-
-  it('renders an additional class name', () => {
-    const { container } = render(<PageMenu className="intro" />)
-
-    const component = container.querySelector(':only-child')
-
-    expect(component).toHaveClass('intro')
-    expect(component).toHaveClass('ams-page-menu')
   })
 })

--- a/packages/react/src/PageMenu/PageMenu.tsx
+++ b/packages/react/src/PageMenu/PageMenu.tsx
@@ -6,30 +6,18 @@
 import clsx from 'clsx'
 import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
+import { PageMenuButton } from './PageMenuButton'
+import { PageMenuItem } from './PageMenuItem'
 import { PageMenuLink } from './PageMenuLink'
 
 export type PageMenuProps = {
   /** Whether the items align to the end margin. Set to `true` if the Page Menu itself does so. */
   alignEnd?: boolean
-  /** Whether menu items should wrap if they don’t fit on a single row. */
-  wrap?: boolean
 } & PropsWithChildren<HTMLAttributes<HTMLUListElement>>
 
 const PageMenuRoot = forwardRef(
-  (
-    { alignEnd, children, className, wrap = true, ...restProps }: PageMenuProps,
-    ref: ForwardedRef<HTMLUListElement>,
-  ) => (
-    <ul
-      {...restProps}
-      className={clsx(
-        'ams-page-menu',
-        alignEnd && `ams-page-menu--align-end`,
-        !wrap && `ams-page-menu--no-wrap`,
-        className,
-      )}
-      ref={ref}
-    >
+  ({ alignEnd, children, className, ...restProps }: PageMenuProps, ref: ForwardedRef<HTMLUListElement>) => (
+    <ul {...restProps} className={clsx('ams-page-menu', alignEnd && `ams-page-menu--align-end`, className)} ref={ref}>
       {children}
     </ul>
   ),
@@ -37,4 +25,8 @@ const PageMenuRoot = forwardRef(
 
 PageMenuRoot.displayName = 'PageMenu'
 
-export const PageMenu = Object.assign(PageMenuRoot, { Link: PageMenuLink })
+export const PageMenu = Object.assign(PageMenuRoot, {
+  Button: PageMenuButton,
+  Item: PageMenuItem,
+  Link: PageMenuLink,
+})

--- a/packages/react/src/PageMenu/PageMenuButton.test.tsx
+++ b/packages/react/src/PageMenu/PageMenuButton.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { createRef } from 'react'
+import { PageMenuButton } from './PageMenuButton'
+
+describe('Page Menu Button', () => {
+  it('renders an element with role button', () => {
+    render(<PageMenuButton>Click me!</PageMenuButton>)
+
+    const button = screen.getByRole('button', {
+      name: 'Click me!',
+    })
+
+    expect(button).toBeInTheDocument()
+    expect(button).toBeVisible()
+  })
+
+  it('renders a design system BEM class name', () => {
+    render(<PageMenuButton>Click me!</PageMenuButton>)
+
+    const component = screen.getByRole('button', {
+      name: 'Click me!',
+    })
+
+    expect(component).toHaveClass('ams-page-menu__button')
+  })
+
+  it('renders an additional class name', () => {
+    render(<PageMenuButton className="extra">Click me!</PageMenuButton>)
+
+    const button = screen.getByRole('button', {
+      name: 'Click me!',
+    })
+
+    expect(button).toHaveClass('ams-page-menu__button extra')
+  })
+
+  it('is able to pass a React ref', () => {
+    const ref = createRef<HTMLButtonElement>()
+
+    render(<PageMenuButton ref={ref} />)
+
+    const component = screen.getByRole('button')
+
+    expect(ref.current).toBe(component)
+  })
+})

--- a/packages/react/src/PageMenu/PageMenuButton.tsx
+++ b/packages/react/src/PageMenu/PageMenuButton.tsx
@@ -1,0 +1,24 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import clsx from 'clsx'
+import type { ButtonHTMLAttributes, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import { Icon } from '../Icon'
+
+export type PageMenuButtonProps = {
+  icon?: Function
+} & PropsWithChildren<ButtonHTMLAttributes<Omit<HTMLButtonElement, 'disabled' | 'type'>>>
+
+export const PageMenuButton = forwardRef<HTMLButtonElement, PageMenuButtonProps>(
+  ({ children, className, icon, ...restProps }, ref) => (
+    <button {...restProps} className={clsx('ams-page-menu__button', className)} ref={ref} type="button">
+      {children}
+      {icon && <Icon svg={icon} size="level-6" />}
+    </button>
+  ),
+)
+
+PageMenuButton.displayName = 'PageMenuButton'

--- a/packages/react/src/PageMenu/PageMenuItem.test.tsx
+++ b/packages/react/src/PageMenu/PageMenuItem.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { PageMenuItem } from './PageMenuItem'
+import '@testing-library/jest-dom'
+
+describe('Page Menu Item', () => {
+  it('renders', () => {
+    render(<PageMenuItem />)
+
+    const component = screen.getByRole('listitem')
+
+    expect(component).toBeInTheDocument()
+  })
+
+  it('renders a design system BEM class name', () => {
+    render(<PageMenuItem />)
+
+    const component = screen.getByRole('listitem')
+
+    expect(component).toHaveClass('ams-page-menu__item')
+  })
+
+  it('renders an additional class name', () => {
+    render(<PageMenuItem className="extra" />)
+
+    const component = screen.getByRole('listitem')
+
+    expect(component).toHaveClass('ams-page-menu__item extra')
+  })
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLLIElement>()
+
+    render(<PageMenuItem ref={ref} />)
+
+    const component = screen.getByRole('listitem')
+
+    expect(ref.current).toBe(component)
+  })
+})

--- a/packages/react/src/PageMenu/PageMenuItem.tsx
+++ b/packages/react/src/PageMenu/PageMenuItem.tsx
@@ -1,0 +1,27 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import clsx from 'clsx'
+import { forwardRef } from 'react'
+import type { ForwardedRef, LiHTMLAttributes, PropsWithChildren } from 'react'
+
+export type PageMenuItemProps = {
+  /** Secondary items only appear in the Page Menu if there is enough space for them. */
+  rank?: 'secondary'
+} & PropsWithChildren<LiHTMLAttributes<HTMLLIElement>>
+
+export const PageMenuItem = forwardRef(
+  ({ children, className, rank, ...restProps }: PageMenuItemProps, ref: ForwardedRef<HTMLLIElement>) => (
+    <li
+      {...restProps}
+      className={clsx('ams-page-menu__item', rank && `ams-page-menu__item--${rank}`, className)}
+      ref={ref}
+    >
+      {children}
+    </li>
+  ),
+)
+
+PageMenuItem.displayName = 'PageMenu.Item'

--- a/packages/react/src/PageMenu/PageMenuLink.test.tsx
+++ b/packages/react/src/PageMenu/PageMenuLink.test.tsx
@@ -4,7 +4,7 @@ import { createRef } from 'react'
 import { PageMenuLink } from './PageMenuLink'
 import '@testing-library/jest-dom'
 
-describe('Page menu link', () => {
+describe('Page Menu Link', () => {
   it('renders with href attribute', () => {
     render(<PageMenuLink href="#">Link</PageMenuLink>)
 

--- a/packages/react/src/PageMenu/PageMenuLink.tsx
+++ b/packages/react/src/PageMenu/PageMenuLink.tsx
@@ -14,12 +14,10 @@ export type PageMenuLinkProps = {
 
 export const PageMenuLink = forwardRef(
   ({ children, className, icon, ...restProps }: PageMenuLinkProps, ref: ForwardedRef<HTMLAnchorElement>) => (
-    <li>
-      <a {...restProps} ref={ref} className={clsx('ams-page-menu__link', className)}>
-        {children}
-        {icon && <Icon svg={icon} size="level-6" />}
-      </a>
-    </li>
+    <a {...restProps} ref={ref} className={clsx('ams-page-menu__link', className)}>
+      {children}
+      {icon && <Icon svg={icon} size="level-6" />}
+    </a>
   ),
 )
 

--- a/proprietary/tokens/src/components/ams/page-menu.tokens.json
+++ b/proprietary/tokens/src/components/ams/page-menu.tokens.json
@@ -3,12 +3,15 @@
     "page-menu": {
       "column-gap": { "value": "{ams.space.grid.md}" },
       "row-gap": { "value": "{ams.space.grid.xs}" },
+      "button": {
+        "cursor": { "value": "{ams.action.activate.cursor}" }
+      },
       "item": {
         "color": { "value": "{ams.link-appearance.color}" },
+        "column-gap": { "value": "{ams.space.xs}" },
         "font-family": { "value": "{ams.text.font-family}" },
         "font-size": { "value": "{ams.text.level.6.font-size}" },
         "font-weight": { "value": "{ams.text.font-weight.normal}" },
-        "gap": { "value": "{ams.space.sm}" },
         "line-height": { "value": "{ams.text.level.6.line-height}" },
         "outline-offset": { "value": "{ams.focus.outline-offset}" },
         "text-decoration-line": { "value": "{ams.link-appearance.subtle.text-decoration-line}" },

--- a/storybook/src/components/Avatar/Avatar.stories.tsx
+++ b/storybook/src/components/Avatar/Avatar.stories.tsx
@@ -45,13 +45,17 @@ export const InAHeader: Story = {
     <Header
       links={
         <PageMenu alignEnd>
-          <PageMenu.Link href="#">Contact</PageMenu.Link>
-          <PageMenu.Link href="#" icon={SearchIcon}>
-            Zoeken
-          </PageMenu.Link>
-          <li>
+          <PageMenu.Item>
+            <PageMenu.Link href="#">Contact</PageMenu.Link>
+          </PageMenu.Item>
+          <PageMenu.Item>
+            <PageMenu.Button icon={SearchIcon} onClick={() => {}}>
+              Zoeken
+            </PageMenu.Button>
+          </PageMenu.Item>
+          <PageMenu.Item>
             <Avatar {...args} />
-          </li>
+          </PageMenu.Item>
         </PageMenu>
       }
     />

--- a/storybook/src/components/Header/Header.stories.tsx
+++ b/storybook/src/components/Header/Header.stories.tsx
@@ -29,19 +29,25 @@ export const ForSubBrand: Story = {
 
 export const WithAppName: Story = {
   args: {
-    appName: 'Aan de Amsterdamse grachten',
+    appName: 'Onderzoek en Statistiek',
   },
 }
 
 export const WithLinks: Story = {
   args: {
     links: (
-      <PageMenu alignEnd wrap={false}>
-        <PageMenu.Link href="#">Contact</PageMenu.Link>
-        <PageMenu.Link href="#">Mijn Amsterdam</PageMenu.Link>
-        <PageMenu.Link href="#" icon={SearchIcon}>
-          Zoeken
-        </PageMenu.Link>
+      <PageMenu alignEnd>
+        <PageMenu.Item>
+          <PageMenu.Link href="#">Contact</PageMenu.Link>
+        </PageMenu.Item>
+        <PageMenu.Item>
+          <PageMenu.Link href="#">Mijn Amsterdam</PageMenu.Link>
+        </PageMenu.Item>
+        <PageMenu.Item>
+          <PageMenu.Button icon={SearchIcon} onClick={() => {}}>
+            Zoeken
+          </PageMenu.Button>
+        </PageMenu.Item>
       </PageMenu>
     ),
   },
@@ -56,12 +62,18 @@ export const WithMenuButton: Story = {
 export const WithLinksAndMenuButton: Story = {
   args: {
     links: (
-      <PageMenu alignEnd wrap={false}>
-        <PageMenu.Link href="#">Contact</PageMenu.Link>
-        <PageMenu.Link href="#">Mijn Amsterdam</PageMenu.Link>
-        <PageMenu.Link href="#" icon={SearchIcon}>
-          Zoeken
-        </PageMenu.Link>
+      <PageMenu alignEnd>
+        <PageMenu.Item>
+          <PageMenu.Link href="#">Contact</PageMenu.Link>
+        </PageMenu.Item>
+        <PageMenu.Item>
+          <PageMenu.Link href="#">Mijn Amsterdam</PageMenu.Link>
+        </PageMenu.Item>
+        <PageMenu.Item>
+          <PageMenu.Button icon={SearchIcon} onClick={() => {}}>
+            Zoeken
+          </PageMenu.Button>
+        </PageMenu.Item>
       </PageMenu>
     ),
     menu: <button className="ams-header__menu-button">Menu</button>,
@@ -70,21 +82,27 @@ export const WithLinksAndMenuButton: Story = {
 
 export const WithAppNameAndMenuButton: Story = {
   args: {
-    appName: 'Aan de Amsterdamse grachten',
+    appName: 'Onderzoek en Statistiek',
     menu: <button className="ams-header__menu-button">Menu</button>,
   },
 }
 
 export const WithAppNameLinksAndMenuButton: Story = {
   args: {
-    appName: 'Aan de Amsterdamse grachten',
+    appName: 'Onderzoek en Statistiek',
     links: (
-      <PageMenu alignEnd wrap={false}>
-        <PageMenu.Link href="#">Contact</PageMenu.Link>
-        <PageMenu.Link href="#">Mijn Amsterdam</PageMenu.Link>
-        <PageMenu.Link href="#" icon={SearchIcon}>
-          Zoeken
-        </PageMenu.Link>
+      <PageMenu alignEnd>
+        <PageMenu.Item>
+          <PageMenu.Link href="#">Contact</PageMenu.Link>
+        </PageMenu.Item>
+        <PageMenu.Item>
+          <PageMenu.Link href="#">Mijn Amsterdam</PageMenu.Link>
+        </PageMenu.Item>
+        <PageMenu.Item>
+          <PageMenu.Button icon={SearchIcon} onClick={() => {}}>
+            Zoeken
+          </PageMenu.Button>
+        </PageMenu.Item>
       </PageMenu>
     ),
     menu: <button className="ams-header__menu-button">Menu</button>,

--- a/storybook/src/components/PageMenu/PageMenu.docs.mdx
+++ b/storybook/src/components/PageMenu/PageMenu.docs.mdx
@@ -3,11 +3,8 @@
 import { Canvas, Controls, Markdown, Meta, Primary } from "@storybook/blocks";
 import * as PageMenuStories from "./PageMenu.stories.tsx";
 import README from "../../../../packages/css/src/components/page-menu/README.md?raw";
-import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Meta of={PageMenuStories} />
-
-<StatusBadge reason="May be affected by changes to Header and/or have its name changed." />
 
 <Markdown>{README}</Markdown>
 
@@ -27,6 +24,5 @@ In the [Header](/docs/components-containers-header--docs), the menu aligns to th
 
 If all menu items do not fit on a single line, e.g. on a narrow screen or with zoomed-in text, they wrap to new lines.
 This is often useful in the [Footer](/docs/components-containers-footer--docs).
-The Header has its own responsive behaviour; its Page Menu should be configured not to wrap.
 
 <Canvas of={PageMenuStories.Wrapping} />

--- a/storybook/src/components/PageMenu/PageMenu.stories.tsx
+++ b/storybook/src/components/PageMenu/PageMenu.stories.tsx
@@ -12,7 +12,6 @@ const meta = {
   component: PageMenu,
   args: {
     alignEnd: false,
-    wrap: undefined,
   },
 } satisfies Meta<typeof PageMenu>
 
@@ -23,15 +22,15 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     children: [
-      <PageMenu.Link href="#" key={1}>
-        Over deze site
-      </PageMenu.Link>,
-      <PageMenu.Link href="#" key={2}>
-        Privacy
-      </PageMenu.Link>,
-      <PageMenu.Link href="#" key={3}>
-        Cookies
-      </PageMenu.Link>,
+      <PageMenu.Item key={1}>
+        <PageMenu.Link href="#">Over deze site</PageMenu.Link>
+      </PageMenu.Item>,
+      <PageMenu.Item key={2}>
+        <PageMenu.Link href="#">Privacy</PageMenu.Link>
+      </PageMenu.Item>,
+      <PageMenu.Item key={3}>
+        <PageMenu.Link href="#">Cookies</PageMenu.Link>
+      </PageMenu.Item>,
     ],
   },
 }
@@ -40,15 +39,19 @@ export const Alignment: Story = {
   args: {
     alignEnd: true,
     children: [
-      <PageMenu.Link href="#" key={1} lang="en">
-        English
-      </PageMenu.Link>,
-      <PageMenu.Link href="#" key={2}>
-        Contact
-      </PageMenu.Link>,
-      <PageMenu.Link href="#" key={3} icon={SearchIcon}>
-        Zoeken
-      </PageMenu.Link>,
+      <PageMenu.Item key={1}>
+        <PageMenu.Link href="#" lang="en">
+          English
+        </PageMenu.Link>
+      </PageMenu.Item>,
+      <PageMenu.Item key={2}>
+        <PageMenu.Link href="#">Contact</PageMenu.Link>
+      </PageMenu.Item>,
+      <PageMenu.Item key={3}>
+        <PageMenu.Button icon={SearchIcon} onClick={() => {}}>
+          Zoeken
+        </PageMenu.Button>
+      </PageMenu.Item>,
     ],
   },
 }
@@ -56,33 +59,21 @@ export const Alignment: Story = {
 export const Wrapping: Story = {
   args: {
     children: [
-      <PageMenu.Link href="#" key={1}>
-        Onderzoeken
-      </PageMenu.Link>,
-      <PageMenu.Link href="#" key={2}>
-        Bezoeken
-      </PageMenu.Link>,
-      <PageMenu.Link href="#" key={3}>
-        Archiveren
-      </PageMenu.Link>,
-      <PageMenu.Link href="#" key={4}>
-        Nieuws
-      </PageMenu.Link>,
-      <PageMenu.Link href="#" key={5}>
-        Themasites
-      </PageMenu.Link>,
-      <PageMenu.Link href="#" key={6}>
-        Onderwijs
-      </PageMenu.Link>,
-      <PageMenu.Link href="#" key={7}>
-        Steun ons
-      </PageMenu.Link>,
-      <PageMenu.Link href="#" key={8}>
-        Organisatie
-      </PageMenu.Link>,
-      <PageMenu.Link href="#" key={9}>
-        Contact
-      </PageMenu.Link>,
-    ],
+      'Onderzoeken',
+      'Bezoeken',
+      'Archiveren',
+      'Nieuws',
+      'Themasites',
+      'Onderwijs',
+      'Steun ons',
+      'Organisatie',
+      'Contact',
+    ].map((label, index) => (
+      <PageMenu.Item>
+        <PageMenu.Link href="#" key={index}>
+          {label}
+        </PageMenu.Link>
+      </PageMenu.Item>
+    )),
   },
 }


### PR DESCRIPTION
# Describe the pull request

## What

- Extracts render of the `li` element from the `PageMenu.Link` subcomponent into a new `PageMenu.Item` subcomponent
- Hides secondary Page Menu Items on narrow windows
- Adds a `PageMenu.Button` subcomponent
- Removes the `wrap` prop from `PageMenu`
- Updates examples of other components using a Page Menu

## Why

In preparation of the new Header and Mega Menu patterns.

## How

Extracted from #1607.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Provide links to any related issues or discussions.
- Add a link to the specific story in the feature branch deploy.
- Mention any areas where additional review or feedback is needed.
