### PR TITLE
feat: Allow the logo to grow a bit in wide windows

### DIFF
--- a/packages/css/src/components/logo/README.md
+++ b/packages/css/src/components/logo/README.md
@@ -34,7 +34,7 @@ The sub-brands are:
 - The logo links to the homepage of the website or application.
 - If the application is a form, application, or tool without a homepage, the logo links to the page where the form, application, or tool is referred to.
 
-The height of the logo is always 40 pixels.
+The logo is 40 pixels tall at its minimum, growing to 56 pixels in wider windows.
 This also applies to sub-brand logos.
 
 ## Download

--- a/packages/css/src/components/logo/logo.scss
+++ b/packages/css/src/components/logo/logo.scss
@@ -6,6 +6,7 @@
 .ams-logo {
   block-size: var(--ams-logo-block-size);
   display: block;
+  min-block-size: var(--ams-logo-min-block-size);
 }
 
 .ams-logo__emblem {

--- a/proprietary/tokens/src/components/ams/logo.tokens.json
+++ b/proprietary/tokens/src/components/ams/logo.tokens.json
@@ -1,8 +1,9 @@
 {
   "ams": {
     "logo": {
-      "block-size": { "value": "2.5rem" },
+      "block-size": { "value": "{ams.space.grid.md}" },
       "emblem": { "color": { "value": "{ams.color.primary-red}" } },
+      "min-block-size": { "value": "2.5rem" },
       "title": { "color": { "value": "{ams.color.primary-red}" } },
       "subsite": { "color": { "value": "{ams.color.primary-black}" } }
     }


### PR DESCRIPTION
# Describe the pull request

## What

This allows the logo to grow to 56 pixels tall, the width of a grid gutter. This divides the future Header in three equal vertical parts: 56 pixels white space, 56 pixels logo, 56 pixels white space.

## Why

The logo seemed too small for the rest of the website at 40 pixels tall.

## How

One new token, two lines of CSS.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Provide links to any related issues or discussions.
- Add a link to the specific story in the feature branch deploy.
- Mention any areas where additional review or feedback is needed.
