### PR TITLE
fix: Remove lodash

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,7 +54,6 @@
     "@types/react": "18.3.11",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
-    "lodash": "4.17.21",
     "next": "14.2.15",
     "npm-run-all": "4.1.5",
     "postcss": "8.4.47",

--- a/packages/react/src/ImageSlider/ImageSlider.tsx
+++ b/packages/react/src/ImageSlider/ImageSlider.tsx
@@ -4,7 +4,6 @@
  */
 
 import clsx from 'clsx'
-import { debounce } from 'lodash'
 import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ForwardedRef, HTMLAttributes } from 'react'
 import { ImageSliderContext } from './ImageSliderContext'
@@ -148,9 +147,8 @@ export const ImageSliderRoot = forwardRef(
         goToSlide(currentSlideElement)
       }
 
-      const debouncedHandleResize = debounce(handleResize, 200)
-      window.addEventListener('resize', debouncedHandleResize)
-      return () => window.removeEventListener('resize', debouncedHandleResize)
+      window.addEventListener('resize', handleResize)
+      return () => window.removeEventListener('resize', handleResize)
     }, [currentSlideId, goToSlide])
 
     return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,9 +186,6 @@ importers:
       jest-environment-jsdom:
         specifier: 29.7.0
         version: 29.7.0
-      lodash:
-        specifier: 4.17.21
-        version: 4.17.21
       next:
         specifier: 14.2.15
         version: 14.2.15(@babel/core@7.25.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.79.5)


### PR DESCRIPTION
# Describe the pull request

Lodash was not needed to debounce a resize event in ImageSlider.

## What

- Uninstalled lodash
- Removed debounce from ImageSlider

## Why

The 200ms delay isn't needed. Tested on iOs where the bug occurred.

- [X] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Provide links to any related issues or discussions.
- Add a link to the specific story in the feature branch deploy.
- Mention any areas where additional review or feedback is needed.
