### PR TITLE
feat!: Support various column widths for Description List

### DIFF
--- a/packages/css/src/components/description-list/README.md
+++ b/packages/css/src/components/description-list/README.md
@@ -6,9 +6,11 @@ A collection of terms and their descriptions.
 
 ## Design
 
-On a narrow screen, descriptions appear indented below their term.
-From the medium breakpoint, terms and descriptions appear next to each other.
-The column for the descriptions is twice as wide as the one for the term.
+In a narrow window, descriptions appear indented below their term.
+After that, they display in a two-column layout.
+The column for the terms is as wide as the longest term, without wrapping.
+Its width can be adjusted to be ‘large’ (50%), ‘medium’ (33%), or ‘small’ (20%), which also allows the terms to wrap.
+
 The term is set in bold text.
 
 ## References

--- a/packages/css/src/components/description-list/description-list.scss
+++ b/packages/css/src/components/description-list/description-list.scss
@@ -21,9 +21,23 @@
 
   @include reset;
   @include text-rendering;
+}
 
-  @media screen and (min-width: $ams-breakpoint-medium) {
+@media screen and (min-width: $ams-breakpoint-medium) {
+  .ams-description-list {
+    grid-template-columns: auto 1fr;
+  }
+
+  .ams-description-list--terms-width-sm {
+    grid-template-columns: 1fr 4fr;
+  }
+
+  .ams-description-list--terms-width-md {
     grid-template-columns: 1fr 2fr;
+  }
+
+  .ams-description-list--terms-width-lg {
+    grid-template-columns: 1fr 1fr;
   }
 }
 

--- a/packages/css/src/components/description-list/description-list.scss
+++ b/packages/css/src/components/description-list/description-list.scss
@@ -13,11 +13,12 @@
 
 .ams-description-list {
   color: var(--ams-description-list-color);
+  column-gap: var(--ams-description-list-column-gap);
   display: grid;
   font-family: var(--ams-description-list-font-family);
   font-size: var(--ams-description-list-font-size);
-  gap: var(--ams-description-list-gap);
   line-height: var(--ams-description-list-line-height);
+  row-gap: var(--ams-description-list-row-gap);
 
   @include reset;
   @include text-rendering;

--- a/packages/react/src/DescriptionList/DescriptionList.test.tsx
+++ b/packages/react/src/DescriptionList/DescriptionList.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react'
 import { createRef } from 'react'
-import { DescriptionList } from './DescriptionList'
+import { DescriptionList, descriptionListTermsWidths } from './DescriptionList'
 import '@testing-library/jest-dom'
 
 describe('Description List', () => {
@@ -28,6 +28,16 @@ describe('Description List', () => {
 
     expect(component).toHaveClass('ams-description-list extra')
   })
+
+  descriptionListTermsWidths.map((width) =>
+    it(`renders the class name for the ‘${width}’ terms column width`, () => {
+      const { container } = render(<DescriptionList termsWidth={width} />)
+
+      const component = container.querySelector(':only-child')
+
+      expect(component).toHaveClass(`ams-description-list--terms-width-${width}`)
+    }),
+  )
 
   it('supports ForwardRef in React', () => {
     const ref = createRef<HTMLDListElement>()

--- a/packages/react/src/DescriptionList/DescriptionList.tsx
+++ b/packages/react/src/DescriptionList/DescriptionList.tsx
@@ -9,17 +9,30 @@ import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { DescriptionListDetails } from './DescriptionListDetails'
 import { DescriptionListTerm } from './DescriptionListTerm'
 
+export const descriptionListTermsWidths = ['sm', 'md', 'lg'] as const
+type DescriptionListTermsWidth = (typeof descriptionListTermsWidths)[number]
+
 export type DescriptionListProps = {
   /** Changes the text colour for readability on a dark background. */
   inverseColor?: boolean
+  /* The width of the column containing the terms. */
+  termsWidth?: DescriptionListTermsWidth
 } & PropsWithChildren<HTMLAttributes<HTMLDListElement>>
 
 const DescriptionListRoot = forwardRef(
-  ({ children, className, inverseColor, ...restProps }: DescriptionListProps, ref: ForwardedRef<HTMLDListElement>) => (
+  (
+    { children, className, inverseColor, termsWidth, ...restProps }: DescriptionListProps,
+    ref: ForwardedRef<HTMLDListElement>,
+  ) => (
     <dl
       {...restProps}
       ref={ref}
-      className={clsx('ams-description-list', inverseColor && 'ams-description-list--inverse-color', className)}
+      className={clsx(
+        'ams-description-list',
+        `ams-description-list--terms-width-${termsWidth}`,
+        inverseColor && 'ams-description-list--inverse-color',
+        className,
+      )}
     >
       {children}
     </dl>

--- a/proprietary/tokens/src/components/ams/description-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/description-list.tokens.json
@@ -2,14 +2,12 @@
   "ams": {
     "description-list": {
       "color": { "value": "{ams.color.primary-black}" },
+      "column-gap": { "value": "{ams.space.lg}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
-      "gap": { "value": "{ams.space.sm}" },
       "inverse-color": { "value": "{ams.color.primary-white}" },
       "line-height": { "value": "{ams.text.level.5.line-height}" },
-      "row": {
-        "gap": { "value": "{ams.space.sm}" }
-      },
+      "row-gap": { "value": "{ams.space.sm}" },
       "term": {
         "font-weight": { "value": "{ams.text.font-weight.bold}" }
       },

--- a/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -34,11 +34,6 @@ const meta = {
         labels: { undefined: 'auto', sm: 'small', md: 'medium', lg: 'large' },
       },
       options: [undefined, 'sm', 'md', 'lg'],
-      table: {
-        defaultValue: {
-          summary: 'auto',
-        },
-      },
     },
   },
 } satisfies Meta<typeof DescriptionList>

--- a/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -62,25 +62,29 @@ export const MultipleDescriptions: Story = {
 }
 
 export const RichDescription: Story = {
-  args: {
-    children: [
-      <DescriptionList.Term key={1}>Amsterdam Light Festival</DescriptionList.Term>,
+  render: (args) => (
+    <DescriptionList {...args}>
+      <DescriptionList.Term key={1}>Amsterdam Light Festival</DescriptionList.Term>
       <DescriptionList.Details key={2}>
-        <Paragraph className="ams-mb--sm">
+        <Paragraph className="ams-mb--sm" inverseColor={args.inverseColor}>
           Een jaarlijks evenement waarbij kunstenaars van over de hele wereld hun{' '}
           <strong>creatieve lichtinstallaties</strong> tonen. De kunstwerken zijn verspreid over de stad en zijn zowel
           vanaf het water als vanaf de kant te bewonderen.
         </Paragraph>
-        <UnorderedList>
+        <UnorderedList inverseColor={args.inverseColor}>
           <UnorderedList.Item>Kleed je warm aan, want de meeste exposities zijn buiten.</UnorderedList.Item>
           <UnorderedList.Item>Er zijn begeleide boottochten en wandelroutes beschikbaar.</UnorderedList.Item>
           <UnorderedList.Item>
-            Voor de volledige lijst met exposities kun je <Link href="#">de festivalbrochure downloaden</Link>.
+            Voor de volledige lijst met exposities kun je{' '}
+            <Link href="#" inverseColor={args.inverseColor}>
+              de festivalbrochure downloaden
+            </Link>
+            .
           </UnorderedList.Item>
         </UnorderedList>
-      </DescriptionList.Details>,
-    ],
-  },
+      </DescriptionList.Details>
+    </DescriptionList>
+  ),
 }
 
 export const MultipleTerms: Story = {

--- a/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -27,6 +27,20 @@ const meta = {
     ],
     inverseColor: false,
   },
+  argTypes: {
+    termsWidth: {
+      control: {
+        type: 'radio',
+        labels: { undefined: 'auto', sm: 'small', md: 'medium', lg: 'large' },
+      },
+      options: [undefined, 'sm', 'md', 'lg'],
+      table: {
+        defaultValue: {
+          summary: 'auto',
+        },
+      },
+    },
+  },
 } satisfies Meta<typeof DescriptionList>
 
 export default meta


### PR DESCRIPTION
# Describe the pull request

## What

- Adds an option to change the width of the column containing the term
- Changes the default behaviour to make the terms fit naturally
- Widens the gap between terms and columns; they were too close together
- Fixes toggling ‘inverse color’ for the ‘rich content’ example

## Why

- We received a request to support a different size than the one we offered
- Letting the size of content inform layout, like we now do, is often nicer

## How

- Added a `termWidth` prop with three options `sm`, `md`, and `lg`.
- If the prop is `undefined`, the default behaviour applies
- Replaced the `gap` token with `column-gap` (breaking change) and started using `row-gap`

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

–