### PR TITLE
feat: File input with preview

### DIFF
--- a/packages/css/src/components/file-input/file-input.scss
+++ b/packages/css/src/components/file-input/file-input.scss
@@ -11,7 +11,7 @@
   box-sizing: border-box;
 }
 
-.ams-file-input {
+.ams-file-input:not(.ams-file-input--has-preview) {
   background-color: var(--ams-file-input-background-color);
   border: var(--ams-file-input-border);
   color: var(--ams-file-input-color);
@@ -34,7 +34,7 @@
   cursor: var(--ams-file-input-disabled-cursor);
 }
 
-.ams-file-input::file-selector-button {
+.ams-file-input:not(.ams-file-input--has-preview)::file-selector-button {
   -webkit-appearance: none; // Reset appearance for Safari < 15.4
   appearance: none; // Reset native appearance, this causes issues on iOS and Android devices
   background-color: var(--ams-file-input-file-selector-button-background-color);
@@ -66,4 +66,20 @@
 .ams-file-input:not(:disabled):hover::file-selector-button {
   box-shadow: var(--ams-file-input-file-selector-button-hover-box-shadow);
   color: var(--ams-file-input-file-selector-button-hover-color);
+}
+
+.ams-file-input--has-preview {
+  appearance: none;
+  display: none;
+}
+
+.ams-file-input__label {
+  border: 2px dashed var(--ams-color-neutral-grey3);
+  display: block;
+  padding-block: 2rem;
+  padding-inline: 2rem;
+}
+
+.ams-file-input__preview {
+  padding-block: 1rem;
 }

--- a/packages/css/src/components/file-input/file-input.scss
+++ b/packages/css/src/components/file-input/file-input.scss
@@ -81,5 +81,20 @@
 }
 
 .ams-file-input__preview {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   padding-block: 1rem;
+}
+
+.ams-file-input__file {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+}
+
+.ams-file-input__thumb {
+  display: grid;
+  flex: 0 0 100px;
+  place-items: center;
 }

--- a/packages/react/src/FileInput/FileInput.tsx
+++ b/packages/react/src/FileInput/FileInput.tsx
@@ -4,15 +4,84 @@
  */
 
 import clsx from 'clsx'
-import { forwardRef } from 'react'
+import { forwardRef, useEffect, useId, useImperativeHandle, useRef, useState } from 'react'
 import type { ForwardedRef, InputHTMLAttributes } from 'react'
+import { Paragraph } from '../Paragraph'
 
-export type FileInputProps = InputHTMLAttributes<HTMLInputElement>
+export type FileInputProps = {
+  showFiles?: boolean
+} & InputHTMLAttributes<HTMLInputElement>
 
-export const FileInput = forwardRef(
-  ({ className, ...restProps }: FileInputProps, ref: ForwardedRef<HTMLInputElement>) => (
-    <input {...restProps} ref={ref} className={clsx('ams-file-input', className)} type="file" />
-  ),
+export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
+  ({ showFiles, className, ...restProps }, ref: ForwardedRef<HTMLInputElement>) => {
+    const fileInputId = useId()
+    const previewRef = useRef<HTMLDivElement>(null)
+    const [files, setFiles] = useState<FileList | null>(null)
+
+    const inputRef = useRef<HTMLInputElement | null>(null)
+
+    useImperativeHandle(ref, () => inputRef.current as HTMLInputElement)
+
+    const updateFilesPreview = () => {
+      if (inputRef.current) {
+        setFiles(inputRef.current.files)
+      }
+    }
+
+    useEffect(() => {
+      if (showFiles && inputRef.current) {
+        inputRef.current.addEventListener('change', updateFilesPreview)
+        return () => {
+          inputRef.current?.removeEventListener('change', updateFilesPreview)
+        }
+      }
+      return () => window.removeEventListener('change', updateFilesPreview)
+    }, [showFiles])
+
+    const prettyBytes = (num: number, precision = 3, addSpace = true) => {
+      const UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+      if (Math.abs(num) < 1) {
+        return num + (addSpace ? ' ' : '') + UNITS[0]
+      }
+
+      const exponent = Math.min(Math.floor(Math.log10(Math.abs(num)) / 3), UNITS.length - 1)
+      const n = Number((Math.abs(num) / 1000 ** exponent).toPrecision(precision))
+
+      return (num < 0 ? '-' : '') + n + (addSpace ? ' ' : '') + UNITS[exponent]
+    }
+
+    return (
+      <>
+        {showFiles && (
+          <label htmlFor={fileInputId} className="ams-file-input__label">
+            <Paragraph>Selecteer of sleep uw bestanden hier</Paragraph>
+          </label>
+        )}
+        <input
+          {...restProps}
+          id={showFiles ? fileInputId : undefined}
+          ref={inputRef}
+          className={clsx('ams-file-input', showFiles && 'ams-file-input--has-preview', className)}
+          type="file"
+        />
+        {showFiles && (
+          <div ref={previewRef} className="ams-file-input__preview">
+            {files && files.length > 0 ? (
+              Array.from(files).map((file, index) => (
+                <Paragraph key={index}>
+                  <img src={URL.createObjectURL(file)} alt={file.name} width={100} height={'auto'} />
+                  {file.name} ({prettyBytes(file.size)}) ({file.type})
+                </Paragraph>
+              ))
+            ) : (
+              <Paragraph>Geen bestanden geselecteerd</Paragraph>
+            )}
+          </div>
+        )}
+      </>
+    )
+  },
 )
 
 FileInput.displayName = 'FileInput'

--- a/packages/react/src/FileInput/FileInput.tsx
+++ b/packages/react/src/FileInput/FileInput.tsx
@@ -3,9 +3,11 @@
  * Copyright Gemeente Amsterdam
  */
 
+import { DocumentIcon } from '@amsterdam/design-system-react-icons'
 import clsx from 'clsx'
 import { forwardRef, useEffect, useId, useImperativeHandle, useRef, useState } from 'react'
 import type { ForwardedRef, InputHTMLAttributes } from 'react'
+import { Icon } from '../Icon'
 import { Paragraph } from '../Paragraph'
 
 export type FileInputProps = {
@@ -69,10 +71,20 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
           <div ref={previewRef} className="ams-file-input__preview">
             {files && files.length > 0 ? (
               Array.from(files).map((file, index) => (
-                <Paragraph key={index}>
-                  <img src={URL.createObjectURL(file)} alt={file.name} width={100} height={'auto'} />
-                  {file.name} ({prettyBytes(file.size)}) ({file.type})
-                </Paragraph>
+                <div className="ams-file-input__file">
+                  <div className="ams-file-input__thumb">
+                    {file.type.includes('image') ? (
+                      <img src={URL.createObjectURL(file)} alt={file.name} width={100} height="auto" />
+                    ) : (
+                      <Icon svg={DocumentIcon} size="level-5" square />
+                    )}
+                  </div>
+                  <Paragraph key={index}>
+                    {file.name}
+                    <br />
+                    {prettyBytes(file.size)} ({file.type})
+                  </Paragraph>
+                </div>
               ))
             ) : (
               <Paragraph>Geen bestanden geselecteerd</Paragraph>

--- a/storybook/src/components/FileInput/FileInput.stories.tsx
+++ b/storybook/src/components/FileInput/FileInput.stories.tsx
@@ -63,3 +63,7 @@ export const InAField: Story = {
     </Field>
   ),
 }
+
+export const WithPreview: Story = {
+  args: { showFiles: true, multiple: true },
+}


### PR DESCRIPTION
# Describe the pull request

PoC for File input that displays a file preview list. Based on the MDN example and using the FileList interface. This is a logical enrichment of the native file input that allows you to show file previews or a document icon.

## What

This would need cleanup if this is something we want.

## Why

The designs often ask for such a component, allthough it would be hard to display an upload progress bar (maybe on submit) it looks a lot like the original idea.

It uses a label for a drop (or click) zone to allow for custom text where the native upload button displays browser/language specific text.

## How

Only if you use the boolean `showFiles` and if you want a list f files you also need the multiple attribute.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [ ] Add or update unit tests
- [ ] Add or update documentation
- [ ] Add or update stories
- [ ] Add or update exports in index.\* files
- [ ] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Provide links to any related issues or discussions.
- Add a link to the specific story in the feature branch deploy.
- Mention any areas where additional review or feedback is needed.
