### PR TITLE
feat!: Make API for icon in button friendlier

### DIFF
--- a/packages/css/src/components/button/button.scss
+++ b/packages/css/src/components/button/button.scss
@@ -96,7 +96,7 @@
   }
 }
 
-.ams-button--icon-position-only {
-  padding-block: var(--ams-button-icon-position-only-padding-block);
-  padding-inline: var(--ams-button-icon-position-only-padding-inline);
+.ams-button--hide-label {
+  padding-block: var(--ams-button-hide-label-padding-block);
+  padding-inline: var(--ams-button-hide-label-padding-inline);
 }

--- a/packages/css/src/components/button/button.scss
+++ b/packages/css/src/components/button/button.scss
@@ -96,7 +96,7 @@
   }
 }
 
-.ams-button--hide-label {
-  padding-block: var(--ams-button-hide-label-padding-block);
-  padding-inline: var(--ams-button-hide-label-padding-inline);
+.ams-button--icon-only {
+  padding-block: var(--ams-button-icon-only-padding-block);
+  padding-inline: var(--ams-button-icon-only-padding-inline);
 }

--- a/packages/react/src/Button/Button.test.tsx
+++ b/packages/react/src/Button/Button.test.tsx
@@ -1,4 +1,4 @@
-import { ShareIcon } from '@amsterdam/design-system-react-icons'
+import { CloseIcon } from '@amsterdam/design-system-react-icons'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { createRef } from 'react'
@@ -114,13 +114,13 @@ describe('Button', () => {
 
   it('renders a button with an icon at the end', () => {
     render(
-      <Button icon={ShareIcon}>
-        <span>Share</span>
+      <Button icon={CloseIcon}>
+        <span>Sluiten</span>
       </Button>,
     )
 
     const button = screen.getByRole('button', {
-      name: 'Share',
+      name: 'Sluiten',
     })
 
     expect(button).toBeInTheDocument()
@@ -130,13 +130,13 @@ describe('Button', () => {
 
   it('renders a button with an icon before the label', () => {
     render(
-      <Button icon={ShareIcon} iconBefore>
-        <span>Share</span>
+      <Button icon={CloseIcon} iconBefore>
+        <span>Sluiten</span>
       </Button>,
     )
 
     const button = screen.getByRole('button', {
-      name: 'Share',
+      name: 'Sluiten',
     })
 
     expect(button).toBeInTheDocument()
@@ -146,17 +146,17 @@ describe('Button', () => {
 
   it('renders a button with an icon only', () => {
     render(
-      <Button hideLabel icon={ShareIcon} variant="tertiary">
-        Share
+      <Button hideLabel icon={CloseIcon} variant="tertiary">
+        Sluiten
       </Button>,
     )
 
     const button = screen.getByRole('button', {
-      name: 'Share',
+      name: 'Sluiten',
     })
 
     expect(button).toBeInTheDocument()
     const label = button.querySelector('.ams-visually-hidden')
-    expect(label).toHaveTextContent('Share')
+    expect(label).toHaveTextContent('Sluiten')
   })
 })

--- a/packages/react/src/Button/Button.test.tsx
+++ b/packages/react/src/Button/Button.test.tsx
@@ -122,9 +122,9 @@ describe('Button', () => {
     const button = screen.getByRole('button', {
       name: 'Sluiten',
     })
+    const icon = button.querySelector('.ams-icon:last-child')
 
     expect(button).toBeInTheDocument()
-    const icon = button.querySelector('.ams-icon:last-child')
     expect(icon).toBeInTheDocument()
   })
 
@@ -138,9 +138,9 @@ describe('Button', () => {
     const button = screen.getByRole('button', {
       name: 'Sluiten',
     })
+    const icon = button.querySelector('.ams-icon:first-child')
 
     expect(button).toBeInTheDocument()
-    const icon = button.querySelector('.ams-icon:first-child')
     expect(icon).toBeInTheDocument()
   })
 
@@ -154,9 +154,11 @@ describe('Button', () => {
     const button = screen.getByRole('button', {
       name: 'Sluiten',
     })
+    const icon = button.querySelector('.ams-icon')
+    const label = button.querySelector('.ams-visually-hidden')
 
     expect(button).toBeInTheDocument()
-    const label = button.querySelector('.ams-visually-hidden')
-    expect(label).toHaveTextContent('Sluiten')
+    expect(icon).toBeInTheDocument()
+    expect(label).toBeInTheDocument()
   })
 })

--- a/packages/react/src/Button/Button.test.tsx
+++ b/packages/react/src/Button/Button.test.tsx
@@ -146,7 +146,7 @@ describe('Button', () => {
 
   it('renders a button with an icon only', () => {
     render(
-      <Button icon={ShareIcon} iconPosition="only" variant="tertiary">
+      <Button hideLabel icon={ShareIcon} variant="tertiary">
         Share
       </Button>,
     )

--- a/packages/react/src/Button/Button.test.tsx
+++ b/packages/react/src/Button/Button.test.tsx
@@ -146,7 +146,7 @@ describe('Button', () => {
 
   it('renders a button with an icon only', () => {
     render(
-      <Button hideLabel icon={CloseIcon} variant="tertiary">
+      <Button icon={CloseIcon} iconOnly variant="tertiary">
         Sluiten
       </Button>,
     )

--- a/packages/react/src/Button/Button.test.tsx
+++ b/packages/react/src/Button/Button.test.tsx
@@ -128,9 +128,9 @@ describe('Button', () => {
     expect(icon).toBeInTheDocument()
   })
 
-  it('renders a button with an icon at the start', () => {
+  it('renders a button with an icon before the label', () => {
     render(
-      <Button icon={ShareIcon} iconPosition="start">
+      <Button icon={ShareIcon} iconBefore>
         <span>Share</span>
       </Button>,
     )
@@ -156,7 +156,6 @@ describe('Button', () => {
     })
 
     expect(button).toBeInTheDocument()
-    expect(button).toHaveClass('ams-button--icon-position-only')
     const label = button.querySelector('.ams-visually-hidden')
     expect(label).toHaveTextContent('Share')
   })

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -4,8 +4,8 @@
  */
 
 import clsx from 'clsx'
-import { forwardRef, type ReactNode } from 'react'
-import type { ButtonHTMLAttributes, ForwardedRef, PropsWithChildren } from 'react'
+import { forwardRef } from 'react'
+import type { ButtonHTMLAttributes, ForwardedRef, PropsWithChildren, ReactNode } from 'react'
 import { Icon } from '../Icon'
 import type { IconProps } from '../Icon'
 

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -10,18 +10,18 @@ import { Icon } from '../Icon'
 import type { IconProps } from '../Icon'
 
 type IconButtonProps = {
-  /** Leaves only the icon visible in the button. Requires the `icon` prop to be set. */
-  hideLabel?: boolean
   /** An icon to add to the button. */
   icon: IconProps['svg']
   /** Position the icon before the label. After is the default. Requires the `icon` prop to be set. */
   iconBefore?: boolean
+  /** Leaves only the icon visible in the button. Requires the `icon` prop to be set. */
+  iconOnly?: boolean
 }
 
 type TextButtonProps = {
-  hideLabel?: never
   icon?: never
   iconBefore?: never
+  iconOnly?: never
 }
 
 export type ButtonProps = {
@@ -32,17 +32,7 @@ export type ButtonProps = {
 
 export const Button = forwardRef(
   (
-    {
-      children,
-      className,
-      disabled,
-      icon,
-      iconBefore,
-      hideLabel,
-      type,
-      variant = 'primary',
-      ...restProps
-    }: ButtonProps,
+    { children, className, disabled, icon, iconBefore, iconOnly, type, variant = 'primary', ...restProps }: ButtonProps,
     ref: ForwardedRef<HTMLButtonElement>,
   ) => {
     return (
@@ -50,12 +40,12 @@ export const Button = forwardRef(
         {...restProps}
         ref={ref}
         disabled={disabled}
-        className={clsx('ams-button', `ams-button--${variant}`, hideLabel && `ams-button--hide-label`, className)}
+        className={clsx('ams-button', `ams-button--${variant}`, iconOnly && `ams-button--icon-only`, className)}
         type={type || 'button'}
       >
-        {icon && (iconBefore || hideLabel) && <Icon svg={icon} size="level-5" square={hideLabel} />}
-        {icon && hideLabel ? <span className="ams-visually-hidden">{children}</span> : children}
-        {icon && !iconBefore && !hideLabel && <Icon svg={icon} size="level-5" />}
+        {icon && (iconBefore || iconOnly) && <Icon svg={icon} size="level-5" square={iconOnly} />}
+        {icon && iconOnly ? <span className="ams-visually-hidden">{children}</span> : children}
+        {icon && !iconBefore && !iconOnly && <Icon svg={icon} size="level-5" />}
       </button>
     )
   },

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -64,7 +64,12 @@ export const Button = forwardRef(
     return (
       <button
         {...restProps}
-        className={clsx('ams-button', `ams-button--${variant}`, iconOnly && `ams-button--icon-only`, className)}
+        className={clsx(
+          'ams-button',
+          `ams-button--${variant}`,
+          iconOnly && !iconBefore && `ams-button--icon-only`,
+          className,
+        )}
         disabled={disabled}
         ref={ref}
         type={type || 'button'}

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -67,7 +67,7 @@ export const Button = forwardRef(
         className={clsx(
           'ams-button',
           `ams-button--${variant}`,
-          iconOnly && !iconBefore && `ams-button--icon-only`,
+          icon && iconOnly && !iconBefore && `ams-button--icon-only`,
           className,
         )}
         disabled={disabled}

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -14,14 +14,14 @@ type IconButtonProps = {
   hideLabel?: boolean
   /** An icon to add to the button. */
   icon: IconProps['svg']
-  /** The position of the icon. The default is after the label. */
-  iconPosition?: 'start'
+  /** Position the icon before the label. After is the default. Requires the `icon` prop to be set. */
+  iconBefore?: boolean
 }
 
 type TextButtonProps = {
   hideLabel?: never
   icon?: never
-  iconPosition?: never
+  iconBefore?: never
 }
 
 export type ButtonProps = {
@@ -37,7 +37,7 @@ export const Button = forwardRef(
       className,
       disabled,
       icon,
-      iconPosition,
+      iconBefore,
       hideLabel,
       type,
       variant = 'primary',
@@ -53,9 +53,9 @@ export const Button = forwardRef(
         className={clsx('ams-button', `ams-button--${variant}`, hideLabel && `ams-button--hide-label`, className)}
         type={type || 'button'}
       >
-        {icon && (iconPosition === 'start' || hideLabel) && <Icon svg={icon} size="level-5" square={hideLabel} />}
+        {icon && (iconBefore || hideLabel) && <Icon svg={icon} size="level-5" square={hideLabel} />}
         {icon && hideLabel ? <span className="ams-visually-hidden">{children}</span> : children}
-        {icon && !iconPosition && !hideLabel && <Icon svg={icon} size="level-5" />}
+        {icon && !iconBefore && !hideLabel && <Icon svg={icon} size="level-5" />}
       </button>
     )
   },

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -4,7 +4,7 @@
  */
 
 import clsx from 'clsx'
-import { forwardRef } from 'react'
+import { forwardRef, type ReactNode } from 'react'
 import type { ButtonHTMLAttributes, ForwardedRef, PropsWithChildren } from 'react'
 import { Icon } from '../Icon'
 import type { IconProps } from '../Icon'
@@ -35,17 +35,32 @@ export const Button = forwardRef(
     { children, className, disabled, icon, iconBefore, iconOnly, type, variant = 'primary', ...restProps }: ButtonProps,
     ref: ForwardedRef<HTMLButtonElement>,
   ) => {
+    const content = (): ReactNode => {
+      if (!icon) return children
+
+      if (iconOnly) {
+        return [
+          <Icon key={1} svg={icon} size="level-5" square={true} />,
+          <span className="ams-visually-hidden" key={2}>
+            {children}
+          </span>,
+        ]
+      }
+
+      if (iconBefore) return [<Icon svg={icon} size="level-5" />, children]
+
+      return [children, <Icon svg={icon} size="level-5" />]
+    }
+
     return (
       <button
         {...restProps}
-        ref={ref}
-        disabled={disabled}
         className={clsx('ams-button', `ams-button--${variant}`, iconOnly && `ams-button--icon-only`, className)}
+        disabled={disabled}
+        ref={ref}
         type={type || 'button'}
       >
-        {icon && (iconBefore || iconOnly) && <Icon svg={icon} size="level-5" square={iconOnly} />}
-        {icon && iconOnly ? <span className="ams-visually-hidden">{children}</span> : children}
-        {icon && !iconBefore && !iconOnly && <Icon svg={icon} size="level-5" />}
+        {content()}
       </button>
     )
   },

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -10,13 +10,16 @@ import { Icon } from '../Icon'
 import type { IconProps } from '../Icon'
 
 type IconButtonProps = {
+  /** Leaves only the icon visible in the button. Requires the `icon` prop to be set. */
+  hideLabel?: boolean
   /** An icon to add to the button. */
   icon: IconProps['svg']
   /** The position of the icon. The default is after the label. */
-  iconPosition?: 'start' | 'only'
+  iconPosition?: 'start'
 }
 
 type TextButtonProps = {
+  hideLabel?: never
   icon?: never
   iconPosition?: never
 }
@@ -29,7 +32,17 @@ export type ButtonProps = {
 
 export const Button = forwardRef(
   (
-    { children, className, disabled, icon, iconPosition, type, variant = 'primary', ...restProps }: ButtonProps,
+    {
+      children,
+      className,
+      disabled,
+      icon,
+      iconPosition,
+      hideLabel,
+      type,
+      variant = 'primary',
+      ...restProps
+    }: ButtonProps,
     ref: ForwardedRef<HTMLButtonElement>,
   ) => {
     return (
@@ -37,19 +50,12 @@ export const Button = forwardRef(
         {...restProps}
         ref={ref}
         disabled={disabled}
-        className={clsx(
-          'ams-button',
-          `ams-button--${variant}`,
-          icon && iconPosition === 'only' && `ams-button--icon-position-only`,
-          className,
-        )}
+        className={clsx('ams-button', `ams-button--${variant}`, hideLabel && `ams-button--hide-label`, className)}
         type={type || 'button'}
       >
-        {icon && (iconPosition === 'start' || iconPosition === 'only') && (
-          <Icon svg={icon} size="level-5" square={iconPosition === 'only'} />
-        )}
-        {icon && iconPosition === 'only' ? <span className="ams-visually-hidden">{children}</span> : children}
-        {icon && !iconPosition && <Icon svg={icon} size="level-5" />}
+        {icon && (iconPosition === 'start' || hideLabel) && <Icon svg={icon} size="level-5" square={hideLabel} />}
+        {icon && hideLabel ? <span className="ams-visually-hidden">{children}</span> : children}
+        {icon && !iconPosition && !hideLabel && <Icon svg={icon} size="level-5" />}
       </button>
     )
   },

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -9,14 +9,22 @@ import type { ButtonHTMLAttributes, ForwardedRef, PropsWithChildren, ReactNode }
 import { Icon } from '../Icon'
 import type { IconProps } from '../Icon'
 
-type IconButtonProps = {
-  /** An icon to add to the button. */
-  icon: IconProps['svg']
-  /** Position the icon before the label. After is the default. Requires the `icon` prop to be set. */
+type IconBeforeProp = {
+  /** Shows the icon before the label. Requires a value for `icon`. Cannot be used together with `iconOnly`. */
   iconBefore?: boolean
-  /** Leaves only the icon visible in the button. Requires the `icon` prop to be set. */
+  iconOnly?: never
+}
+
+type IconOnlyProp = {
+  iconBefore?: never
+  /** Shows the icon without the label. Requires a value for `icon`. Cannot be used together with `iconBefore`. */
   iconOnly?: boolean
 }
+
+type IconButtonProps = {
+  /** Adds an icon to the button, showing it after the label. */
+  icon: IconProps['svg']
+} & (IconBeforeProp | IconOnlyProp)
 
 type TextButtonProps = {
   icon?: never

--- a/packages/react/src/Button/Button.tsx
+++ b/packages/react/src/Button/Button.tsx
@@ -44,20 +44,21 @@ export const Button = forwardRef(
     ref: ForwardedRef<HTMLButtonElement>,
   ) => {
     const content = (): ReactNode => {
-      if (!icon) return children
-
-      if (iconOnly) {
-        return [
-          <Icon key={1} svg={icon} size="level-5" square={true} />,
-          <span className="ams-visually-hidden" key={2}>
-            {children}
-          </span>,
-        ]
+      switch (true) {
+        case !icon:
+          return children
+        case iconBefore:
+          return [<Icon svg={icon} size="level-5" />, children]
+        case iconOnly:
+          return [
+            <Icon key={1} svg={icon} size="level-5" square={true} />,
+            <span className="ams-visually-hidden" key={2}>
+              {children}
+            </span>,
+          ]
+        default:
+          return [children, <Icon svg={icon} size="level-5" />]
       }
-
-      if (iconBefore) return [<Icon svg={icon} size="level-5" />, children]
-
-      return [children, <Icon svg={icon} size="level-5" />]
     }
 
     return (

--- a/proprietary/tokens/src/components/ams/button.tokens.json
+++ b/proprietary/tokens/src/components/ams/button.tokens.json
@@ -57,7 +57,7 @@
           "color": { "value": "{ams.color.neutral-grey2}" }
         }
       },
-      "hide-label": {
+      "icon-only": {
         "padding-block": { "value": "{ams.space.sm}" },
         "padding-inline": { "value": "{ams.space.sm}" }
       }

--- a/proprietary/tokens/src/components/ams/button.tokens.json
+++ b/proprietary/tokens/src/components/ams/button.tokens.json
@@ -57,7 +57,7 @@
           "color": { "value": "{ams.color.neutral-grey2}" }
         }
       },
-      "icon-position-only": {
+      "hide-label": {
         "padding-block": { "value": "{ams.space.sm}" },
         "padding-inline": { "value": "{ams.space.sm}" }
       }

--- a/storybook/src/components/Button/Button.docs.mdx
+++ b/storybook/src/components/Button/Button.docs.mdx
@@ -49,8 +49,9 @@ The icon can also appear before the label.
 
 ### With icon only
 
-A button can even consist of an icon only.
-Do this only for icons that are universally recognized.
+A button may display an icon alone if its meaning is generally intuitive without a label:
+Examples: audio and video controls, close (cross), delete (trash bin), download (downward arrow), favourite (heart), menu (hamburger), save (disk), search (magnifying glass), settings (gear or cog) and toggle (chevron).
+
 You must still provide a label – it will be used to make the button accessible.
 
 <Canvas of={ButtonStories.WithIconOnly} />

--- a/storybook/src/components/Button/Button.docs.mdx
+++ b/storybook/src/components/Button/Button.docs.mdx
@@ -45,7 +45,7 @@ The icon will appear after the label.
 
 The icon can also appear before the label.
 
-<Canvas of={ButtonStories.WithiconBefore} />
+<Canvas of={ButtonStories.WithIconBefore} />
 
 ### With icon only
 

--- a/storybook/src/components/Button/Button.docs.mdx
+++ b/storybook/src/components/Button/Button.docs.mdx
@@ -34,20 +34,20 @@ They are also a good choice for buttons with an icon only.
 
 <Canvas of={ButtonStories.Tertiary} />
 
-### With an icon
+### With icon
 
 Add an icon if it makes it easier or faster to understand its purpose.
 The icon will appear after the label.
 
 <Canvas of={ButtonStories.WithIcon} />
 
-### With an icon at the start
+### With icon before
 
 The icon can also appear before the label.
 
-<Canvas of={ButtonStories.WithIconAtStart} />
+<Canvas of={ButtonStories.WithiconBefore} />
 
-### With an icon only
+### With icon only
 
 A button can even consist of an icon only.
 Do this only for icons that are universally recognized.

--- a/storybook/src/components/Button/Button.docs.mdx
+++ b/storybook/src/components/Button/Button.docs.mdx
@@ -49,9 +49,8 @@ The icon can also appear before the label.
 
 ### With icon only
 
-A button may display an icon alone if its meaning is generally intuitive without a label:
-Examples: audio and video controls, close (cross), delete (trash bin), download (downward arrow), favourite (heart), menu (hamburger), save (disk), search (magnifying glass), settings (gear or cog) and toggle (chevron).
-
+A button can even consist of an icon only.
+Do this only for icons that are universally recognized.
 You must still provide a label – it will be used to make the button accessible.
 
 <Canvas of={ButtonStories.WithIconOnly} />

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -36,15 +36,13 @@ const meta = {
       options: [undefined, ...Object.keys(Icons)],
       mapping: Icons,
     },
-    iconPosition: {
+    iconBefore: {
       control: {
-        type: 'inline-radio',
-        labels: { undefined: 'end', start: 'start' },
+        type: 'boolean',
       },
       if: {
         arg: 'icon',
       },
-      options: [undefined, 'start'],
     },
   },
 } satisfies Meta<typeof Button>
@@ -76,11 +74,11 @@ export const WithIcon: Story = {
   },
 }
 
-export const WithIconAtStart: Story = {
+export const WithiconBefore: Story = {
   args: {
     children: 'Sluiten',
     icon: Icons.CloseIcon,
-    iconPosition: 'start',
+    iconBefore: true,
   },
 }
 

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -13,20 +13,12 @@ const meta = {
   args: {
     children: 'Versturen',
     disabled: false,
-    hideLabel: false,
+    iconOnly: false,
     variant: 'primary',
   },
   argTypes: {
     disabled: {
       description: 'Prevents interaction. Avoid if possible.',
-    },
-    hideLabel: {
-      control: {
-        type: 'boolean',
-      },
-      if: {
-        arg: 'icon',
-      },
     },
     icon: {
       control: {
@@ -37,6 +29,14 @@ const meta = {
       mapping: Icons,
     },
     iconBefore: {
+      control: {
+        type: 'boolean',
+      },
+      if: {
+        arg: 'icon',
+      },
+    },
+    iconOnly: {
       control: {
         type: 'boolean',
       },
@@ -85,8 +85,8 @@ export const WithiconBefore: Story = {
 export const WithIconOnly: Story = {
   args: {
     children: 'Sluiten',
-    hideLabel: true,
     icon: Icons.CloseIcon,
+    iconOnly: true,
     variant: 'tertiary',
   },
 }

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -13,11 +13,20 @@ const meta = {
   args: {
     children: 'Versturen',
     disabled: false,
+    hideLabel: false,
     variant: 'primary',
   },
   argTypes: {
     disabled: {
       description: 'Prevents interaction. Avoid if possible.',
+    },
+    hideLabel: {
+      control: {
+        type: 'boolean',
+      },
+      if: {
+        arg: 'icon',
+      },
     },
     icon: {
       control: {
@@ -30,9 +39,12 @@ const meta = {
     iconPosition: {
       control: {
         type: 'inline-radio',
-        labels: { undefined: 'end', start: 'start', only: 'only' },
+        labels: { undefined: 'end', start: 'start' },
       },
-      options: [undefined, 'start', 'only'],
+      if: {
+        arg: 'icon',
+      },
+      options: [undefined, 'start'],
     },
   },
 } satisfies Meta<typeof Button>
@@ -75,8 +87,8 @@ export const WithIconAtStart: Story = {
 export const WithIconOnly: Story = {
   args: {
     children: 'Sluiten',
+    hideLabel: true,
     icon: Icons.CloseIcon,
-    iconPosition: 'only',
     variant: 'tertiary',
   },
 }

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -13,6 +13,7 @@ const meta = {
   args: {
     children: 'Versturen',
     disabled: false,
+    icon: undefined,
     iconBefore: false,
     iconOnly: false,
     variant: 'primary',

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -74,7 +74,7 @@ export const WithIcon: Story = {
   },
 }
 
-export const WithiconBefore: Story = {
+export const WithIconBefore: Story = {
   args: {
     children: 'Sluiten',
     icon: Icons.CloseIcon,

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -13,6 +13,7 @@ const meta = {
   args: {
     children: 'Versturen',
     disabled: false,
+    iconBefore: false,
     iconOnly: false,
     variant: 'primary',
   },


### PR DESCRIPTION
Although the `iconPosition` enum is a bit more robust, we think an API with `iconBefore` and `iconOnly` booleans is friendlier.
