### PR TITLE
fix: Don’t render a Description List class for an undefined value

### DIFF
--- a/packages/react/src/DescriptionList/DescriptionList.tsx
+++ b/packages/react/src/DescriptionList/DescriptionList.tsx
@@ -29,7 +29,7 @@ const DescriptionListRoot = forwardRef(
       ref={ref}
       className={clsx(
         'ams-description-list',
-        `ams-description-list--terms-width-${termsWidth}`,
+        termsWidth && `ams-description-list--terms-width-${termsWidth}`,
         inverseColor && 'ams-description-list--inverse-color',
         className,
       )}


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Prevents rendering a class name of `ams-description-list--terms-width-undefined`.

## Why

The class is useless.

## How

Added a condition.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

–