### PR TITLE
chore: Revert using SHAs in GitHub workflows

### DIFF
--- a/.github/workflows/feature-branch-cleanup.yml
+++ b/.github/workflows/feature-branch-cleanup.yml
@@ -20,11 +20,11 @@ jobs:
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
       - name: Check out
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
 
-      - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
@@ -38,7 +38,7 @@ jobs:
           git push
 
       - name: Deactivate deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
+        uses: bobheadxi/deployments@v1
         if: always()
         with:
           step: deactivate-env

--- a/.github/workflows/feature-branch-deploy.yml
+++ b/.github/workflows/feature-branch-deploy.yml
@@ -21,21 +21,21 @@ jobs:
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
       - name: Check out
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4
 
       - name: Create deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
+        uses: bobheadxi/deployments@v1
         id: deployment
         with:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
           env: demo-${{ env.BRANCH_NAME }}
 
-      - uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
-      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+      - uses: pnpm/action-setup@v3
         name: Install pnpm
         id: pnpm-install
         with:
@@ -55,14 +55,14 @@ jobs:
           touch ./storybook/dist/${{ github.sha }}.txt
 
       - name: Pushing to pages branch
-        uses: JamesIves/github-pages-deploy-action@94f3c658273cf92fb48ef99e5fbc02bd2dc642b2 # v4.6.3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: storybook/dist
           target-folder: demo-${{ env.BRANCH_NAME }}
 
       - name: Wait for GitHub Pages to be deployed
-        uses: mydea/action-wait-for-api@45d9c58e690337a05eb5ae14a1478f29eacbf9db # v2.0.0
+        uses: mydea/action-wait-for-api@v1
         with:
           url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/demo-${{ env.BRANCH_NAME }}/${{ github.sha }}.txt
           expected-status: 200
@@ -70,7 +70,7 @@ jobs:
           interval: 15
 
       - name: Update deployment status
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
+        uses: bobheadxi/deployments@v1
         if: always()
         with:
           step: finish

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -11,15 +11,15 @@ jobs:
 
     steps:
       - name: Check out branch
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4
 
       - name: Set up Node.js version
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
       - name: Install pnpm
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        uses: pnpm/action-setup@v3
         id: pnpm-install
         with:
           run_install: false
@@ -30,7 +30,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Set up pnpm cache
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -48,15 +48,15 @@ jobs:
 
     steps:
       - name: Check out branch
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4
 
       - name: Set up Node.js version
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
       - name: Install pnpm
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        uses: pnpm/action-setup@v4
         id: pnpm-install
         with:
           run_install: false
@@ -67,7 +67,7 @@ jobs:
           echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Set up pnpm cache
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -91,7 +91,7 @@ jobs:
           pnpm run --if-present test
 
       - name: "Retain build artifact: Storybook"
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@v4
         with:
           name: storybook
           path: storybook/dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Create release
-        uses: googleapis/release-please-action@d1a8f221d7723166f48a584aebba00ef3f6febec # v4.1.4
+        uses: google-github-actions/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -21,7 +21,7 @@ jobs:
 
       # The logic below handles the npm publication:
       - name: Check out branch
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@v4
         with:
           # This is necessary because on.workflow_run always runs on the
           # default branch, which is 'develop' in our case
@@ -31,14 +31,14 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Set up Node.js version
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           registry-url: "https://registry.npmjs.org"
         if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        uses: pnpm/action-setup@v3
         id: pnpm-install
         with:
           run_install: false
@@ -51,7 +51,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Set up pnpm cache
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -75,7 +75,7 @@ jobs:
 
       # The logic below handles the Storybook deploy:
       - name: "Restore build artifact: Storybook"
-        uses: dawidd6/action-download-artifact#bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
+        uses: dawidd6/action-download-artifact@v3
         with:
           workflow: "lint-test.yml"
           name: storybook
@@ -83,7 +83,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@94f3c658273cf92fb48ef99e5fbc02bd2dc642b2 # v4.6.3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: dist/storybook


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It reverts using SHAs instead of version numbers in our GitHub workflows.

## Why

Using SHAs is a good idea ([see this for more info](https://devopsjournal.io/blog/2021/12/11/GitHub-Actions-Maturity-Levels)), but our organisation GitHub Action allowlist uses version number currently, which means the Actions using SHAs are blocked. We have to change the allowlist first before implementing this again.

## How

Copy-pasting the old values back. I couldn't revert the files in their entirety, because I wanted to keep some of the changes. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
