### PR TITLE
chore: Wrap all stories in a Screen

### DIFF
--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -4,6 +4,7 @@ import '@amsterdam/design-system-assets/font/index.css'
 import '@amsterdam/design-system-css/dist/index.css'
 import '../src/styles/docs.css'
 import '../src/styles/overrides.css'
+import { Screen } from '@amsterdam/design-system-react'
 import { withThemeByClassName } from '@storybook/addon-themes'
 import { viewports } from './viewports'
 
@@ -13,12 +14,12 @@ export const argTypes = {
   },
 }
 
-// Set language to Dutch for Canvas and Stories
+// Wrap in Screen, set language to Dutch for Canvas and Stories
 export const decorators = [
   (Story: any) => (
-    <div lang="nl">
+    <Screen lang="nl">
       <Story />
-    </div>
+    </Screen>
   ),
   withThemeByClassName({
     themes: {
@@ -57,7 +58,4 @@ export const parameters = {
     viewports,
   },
   viewMode: 'docs',
-  html: {
-    root: 'div[lang="nl"]',
-  },
 }

--- a/storybook/src/components/Breakout/Breakout.stories.tsx
+++ b/storybook/src/components/Breakout/Breakout.stories.tsx
@@ -3,20 +3,13 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { AspectRatio, Image, Paragraph, Screen, Spotlight } from '@amsterdam/design-system-react'
+import { AspectRatio, Image, Paragraph, Spotlight } from '@amsterdam/design-system-react'
 import { Breakout } from '@amsterdam/design-system-react/src'
 import { Meta, StoryObj } from '@storybook/react'
 
 const meta = {
   title: 'Components/Layout/Breakout',
   component: Breakout,
-  decorators: [
-    (Story) => (
-      <Screen>
-        <Story />
-      </Screen>
-    ),
-  ],
 } satisfies Meta<typeof Breakout>
 
 export default meta

--- a/storybook/src/components/Grid/Grid.stories.tsx
+++ b/storybook/src/components/Grid/Grid.stories.tsx
@@ -3,7 +3,6 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { Screen } from '@amsterdam/design-system-react'
 import { Grid } from '@amsterdam/design-system-react/src'
 import type { GridCellProps } from '@amsterdam/design-system-react/src'
 import { Meta, StoryObj } from '@storybook/react'
@@ -85,10 +84,10 @@ const BackgroundGrid = () => (
 const StoryTemplate: Story = {
   decorators: [
     (Story) => (
-      <Screen>
+      <>
         <BackgroundGrid />
         <Story />
-      </Screen>
+      </>
     ),
   ],
 }
@@ -96,12 +95,12 @@ const StoryTemplate: Story = {
 const CellStoryTemplate: CellStory = {
   decorators: [
     (Story) => (
-      <Screen>
+      <>
         <BackgroundGrid />
         <Grid paddingVertical="medium">
           <Story />
         </Grid>
-      </Screen>
+      </>
     ),
   ],
   render: ({ children, ...args }) => <Grid.Cell {...args}>{children}</Grid.Cell>,

--- a/storybook/src/components/ImageSlider/ImageSlider.stories.tsx
+++ b/storybook/src/components/ImageSlider/ImageSlider.stories.tsx
@@ -3,9 +3,8 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { ImageSlider, Screen } from '@amsterdam/design-system-react/src'
+import { ImageSlider } from '@amsterdam/design-system-react/src'
 import { Meta, StoryObj } from '@storybook/react'
-import React from 'react'
 
 const meta = {
   title: 'Components/Media/Image Slider',
@@ -40,13 +39,6 @@ const meta = {
       },
     ],
   },
-  decorators: [
-    (Story) => (
-      <Screen>
-        <Story />
-      </Screen>
-    ),
-  ],
 } satisfies Meta<typeof ImageSlider>
 
 export default meta

--- a/storybook/src/components/MegaMenu/MegaMenu.stories.tsx
+++ b/storybook/src/components/MegaMenu/MegaMenu.stories.tsx
@@ -3,7 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { Grid, Heading, LinkList, Screen } from '@amsterdam/design-system-react'
+import { Grid, Heading, LinkList } from '@amsterdam/design-system-react'
 import { MegaMenu } from '@amsterdam/design-system-react/src'
 import { Meta, StoryObj } from '@storybook/react'
 
@@ -13,13 +13,6 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
-  decorators: [
-    (Story) => (
-      <Screen>
-        <Story />
-      </Screen>
-    ),
-  ],
 } satisfies Meta<typeof MegaMenu>
 
 export default meta

--- a/storybook/src/components/SkipLink/SkipLink.stories.tsx
+++ b/storybook/src/components/SkipLink/SkipLink.stories.tsx
@@ -3,7 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { Grid, Paragraph, Screen } from '@amsterdam/design-system-react'
+import { Grid, Paragraph } from '@amsterdam/design-system-react'
 import { SkipLink } from '@amsterdam/design-system-react/src'
 import { Meta, StoryObj } from '@storybook/react'
 
@@ -28,13 +28,13 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <Screen>
+      <>
         <Grid>
           <Grid.Cell span="all">
             <Story />
           </Grid.Cell>
         </Grid>
-      </Screen>
+      </>
     ),
   ],
 } satisfies Meta<typeof SkipLink>

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -3,7 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { Blockquote, Grid, Screen } from '@amsterdam/design-system-react'
+import { Blockquote, Grid } from '@amsterdam/design-system-react'
 import { Spotlight } from '@amsterdam/design-system-react/src'
 import { Meta, StoryObj } from '@storybook/react'
 import { exampleQuote } from '../shared/exampleContent'
@@ -13,13 +13,6 @@ const quote = exampleQuote()
 const meta = {
   title: 'Components/Containers/Spotlight',
   component: Spotlight,
-  decorators: [
-    (Story) => (
-      <Screen>
-        <Story />
-      </Screen>
-    ),
-  ],
   render: ({ as, color }) => (
     <Spotlight as={as} color={color}>
       <Grid paddingVertical="medium">

--- a/storybook/src/pages/amsterdam/HomePage/HomePage.docs.mdx
+++ b/storybook/src/pages/amsterdam/HomePage/HomePage.docs.mdx
@@ -14,8 +14,8 @@ The starting page of an application generally provides a broad overview of subje
 A typical layout for a homepage:
 
 ```tsx
-<SkipLink href="#main">Direct naar inhoud</SkipLink>
-<Screen maxWidth="wide">
+<Screen>
+  <SkipLink href="#main">Direct naar inhoud</SkipLink>
   <Grid>
     <Header />
   </Grid>

--- a/storybook/src/pages/amsterdam/common/Layout.tsx
+++ b/storybook/src/pages/amsterdam/common/Layout.tsx
@@ -1,4 +1,4 @@
-import { Footer, Screen, SkipLink } from '@amsterdam/design-system-react'
+import { Footer, SkipLink } from '@amsterdam/design-system-react'
 import type { HTMLAttributes, PropsWithChildren } from 'react'
 import { AppHeader } from './AppHeader'
 import { Default as FooterStory } from '../../../components/Footer/Footer.stories'
@@ -8,10 +8,8 @@ type LayoutProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
 export const Layout = ({ children }: LayoutProps) => (
   <>
     <SkipLink href="#main">Direct naar inhoud</SkipLink>
-    <Screen maxWidth="wide">
-      <AppHeader />
-      {children}
-      <Footer>{FooterStory.args?.children}</Footer>
-    </Screen>
+    <AppHeader />
+    {children}
+    <Footer>{FooterStory.args?.children}</Footer>
   </>
 )


### PR DESCRIPTION
# Describe the pull request

## What

This wraps all stories of Storybook in a `Screen` component.

I’ve not made an exception for our page examples to keep the Skip Link spanning the entire page width. I think it’s best to limit that link to the Screen's width to prevent it from growing overly large on very wide screens. This doesn’t change its functionality. Few screens will be affected in practice.

## Why

To ensure no example is wider than a `Screen`, which should not happen as we demand every page to be wrapped in such a component.

We could override the decorator for application screens later, but there’s no need now.

## How

- Replaced the `div lang="nl"` that wrapped all stories, keeping the language attribute
- Removed decorators wrapping a Screen for component stories

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

–