### PR TITLE
chore: Group Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,21 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Prod and dev dependencies are split in two groups,
+    # because their PRs get a different prefix ('fix' for prod, 'chore' for dev)
+    groups:
+      patch-and-minor-dependencies:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        update-types:
+          - "patch"
+          - "minor"
+      patch-and-minor-dev-dependencies:
+        applies-to: "version-updates"
+        dependency-type: "development"
+        update-types:
+          - "patch"
+          - "minor"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
     commit-message:


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

This groups Dependabot PRs. One group with all minor and patch dev dependency updates, one group with the same for prod dependency updates. 

## Why

Currently we use the Dependabot PRs to remind us that we have to update the deps. By grouping them, we can merge the PRs without having to do anything locally. No more `npm run update:minor`.

An added benefit is that we have separate PRs for dev and prod dependencies. Prod dependency updates should end up in our changelogs (because we change our published code, even if it is just the package.json). We currently don't do that, but this should make it easier. 

## How

By using Dependabot groups.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
