### PR TITLE
Autofix: FileInput is not adjusting to Grid

### DIFF
--- a/packages/css/src/components/file-input/file-input.scss
+++ b/packages/css/src/components/file-input/file-input.scss
@@ -20,7 +20,7 @@
   font-size: var(--ams-file-input-font-size);
   font-weight: var(--ams-file-input-font-weight);
   line-height: var(--ams-file-input-line-height);
-  max-inline-size: calc(100% - var(--ams-file-input-padding-inline) * 2);
+  inline-size: 100%;
   outline-offset: calc(var(--ams-focus-outline-offset) * 2); // Compensate for the dashed border
   padding-block: var(--ams-file-input-padding-block);
   padding-inline: var(--ams-file-input-padding-inline);


### PR DESCRIPTION
I've updated the FileInput component to have a width of 100% to match the behavior of the TextInput component. This change will ensure that the FileInput adjusts properly to the Grid layout. Here's what I did:

1. Modified the `file-input.scss` file to add `inline-size: 100%;` to the `.ams-file-input` class.
2. Removed the `max-inline-size` property from the `.ams-file-input` class, as it's no longer needed.

These changes will make the FileInput component behave similarly to the TextInput component in terms of width adjustment within the Grid. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission