### PR TITLE
feat: Restrict using Image Slider to landscape images

### DIFF
--- a/packages/css/src/components/image-slider/README.md
+++ b/packages/css/src/components/image-slider/README.md
@@ -17,6 +17,8 @@ The images do not slide automatically.
 - Use this for a series of images that belong together.
 - Provide at least 2 images and at most 5.
 - Feature the most essential image first.
+- All images must have the same aspect ratio.
+  Note that very wide or tall aspect ratios are not supported.
 - Assume that some or many users will not navigate between the slides and only see the first image.
   Display all images separately if you want each of them to receive attention.
 - A full-width Image Slider should run from one edge of the Screen to the other;

--- a/packages/react/src/ImageSlider/ImageSlider.tsx
+++ b/packages/react/src/ImageSlider/ImageSlider.tsx
@@ -15,7 +15,7 @@ import { Ratio } from '../AspectRatio'
 import { Image, ImageProps } from '../Image/Image'
 
 export type ImageSliderImageProps = Omit<ImageProps, 'aspectRatio'> & {
-  /** Specify the aspect ratio to use for the images. */
+  /** The aspect ratio to use for the images. Options: `tall`, `square`, `wide`, and `x-wide`. */
   aspectRatio: Pick<Ratio, 'tall' | 'square' | 'wide' | 'x-wide'>
 }
 

--- a/packages/react/src/ImageSlider/ImageSlider.tsx
+++ b/packages/react/src/ImageSlider/ImageSlider.tsx
@@ -16,7 +16,7 @@ import { Image, ImageProps } from '../Image/Image'
 
 export type ImageSliderImageProps = Omit<ImageProps, 'aspectRatio'> & {
   /** Specify the aspect ratio to use for the images. */
-  aspectRatio: Exclude<Ratio, 'tall' | 'x-tall' | '2x-wide'>
+  aspectRatio: Pick<Ratio, 'square' | 'wide' | 'x-wide'>
 }
 
 export type ImageSliderProps = {

--- a/packages/react/src/ImageSlider/ImageSlider.tsx
+++ b/packages/react/src/ImageSlider/ImageSlider.tsx
@@ -14,9 +14,9 @@ import { ImageSliderThumbnails } from './ImageSliderThumbnails'
 import { Ratio } from '../AspectRatio'
 import { Image, ImageProps } from '../Image/Image'
 
-export type ImageSliderImageProps = ImageProps & {
+export type ImageSliderImageProps = Omit<ImageProps, 'aspectRatio'> & {
   /** Specify the aspect ratio to use for the images. */
-  aspectRatio: Ratio
+  aspectRatio: Exclude<Ratio, 'tall' | 'x-tall' | '2x-wide'>
 }
 
 export type ImageSliderProps = {

--- a/packages/react/src/ImageSlider/ImageSlider.tsx
+++ b/packages/react/src/ImageSlider/ImageSlider.tsx
@@ -16,7 +16,7 @@ import { Image, ImageProps } from '../Image/Image'
 
 export type ImageSliderImageProps = Omit<ImageProps, 'aspectRatio'> & {
   /** Specify the aspect ratio to use for the images. */
-  aspectRatio: Pick<Ratio, 'square' | 'wide' | 'x-wide'>
+  aspectRatio: Pick<Ratio, 'tall' | 'square' | 'wide' | 'x-wide'>
 }
 
 export type ImageSliderProps = {


### PR DESCRIPTION
# Describe the pull request

The images in a image slider should only be able to use aspect-ratio 1:1, 4:3 and 16:9. landscape is nog an option.

## What

The exclusion of type values

## Why

To prevent the image slider from becomming to tall to scroll on small screens.

## How

(How were these changes implemented? Provide a brief overview of the approach taken and any key considerations.)

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [ ] Add or update unit tests
- [ ] Add or update documentation
- [ ] Add or update stories
- [ ] Add or update exports in index.\* files
- [ ] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Provide links to any related issues or discussions.
- Add a link to the specific story in the feature branch deploy.
- Mention any areas where additional review or feedback is needed.
