### PR TITLE
feat: Add Icon to Error Message

### DIFF
--- a/packages/css/src/components/error-message/error-message.scss
+++ b/packages/css/src/components/error-message/error-message.scss
@@ -12,9 +12,11 @@
 
 .ams-error-message {
   color: var(--ams-error-message-color);
+  display: inline-flex;
   font-family: var(--ams-error-message-font-family);
   font-size: var(--ams-error-message-font-size);
   font-weight: var(--ams-error-message-font-weight);
+  gap: var(--ams-error-message-gap);
   line-height: var(--ams-error-message-line-height);
 
   @include text-rendering;

--- a/packages/react/src/ErrorMessage/ErrorMessage.test.tsx
+++ b/packages/react/src/ErrorMessage/ErrorMessage.test.tsx
@@ -54,4 +54,18 @@ describe('Error message', () => {
 
     expect(ref.current).toBe(component)
   })
+
+  it('shows an icon', () => {
+    const { container } = render(<ErrorMessage />)
+
+    const iconWrapper = container.querySelector('.ams-icon')
+    const icon = container.querySelector('svg')
+
+    expect(iconWrapper).toBeInTheDocument()
+    expect(icon).toBeInTheDocument()
+  })
+
+  // TODO: we can't currently test this, because we can't pass a class or anything to the SVG
+  // We plan on changing this, so we can test this in the future
+  it.skip('shows a custom icon', () => {})
 })

--- a/packages/react/src/ErrorMessage/ErrorMessage.tsx
+++ b/packages/react/src/ErrorMessage/ErrorMessage.tsx
@@ -3,21 +3,26 @@
  * Copyright Gemeente Amsterdam
  */
 
+import { AlertIcon } from '@amsterdam/design-system-react-icons'
 import clsx from 'clsx'
 import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
+import { Icon } from '../Icon'
 
 export type ErrorMessageProps = {
+  /** An icon to display instead of the default icon. */
+  icon?: Function
   /** An accessible phrase that screen readers announce before the error message. Should translate to something like ‘input error’. */
   prefix?: string
 } & PropsWithChildren<HTMLAttributes<HTMLParagraphElement>>
 
 export const ErrorMessage = forwardRef(
   (
-    { children, className, prefix = 'Invoerfout', ...restProps }: ErrorMessageProps,
+    { children, className, icon, prefix = 'Invoerfout', ...restProps }: ErrorMessageProps,
     ref: ForwardedRef<HTMLParagraphElement>,
   ) => (
     <p {...restProps} ref={ref} className={clsx('ams-error-message', className)}>
+      <Icon svg={icon ? icon : AlertIcon} size="level-6" />
       <span className="ams-visually-hidden">
         {prefix}
         {': '}

--- a/proprietary/tokens/src/components/ams/error-message.tokens.json
+++ b/proprietary/tokens/src/components/ams/error-message.tokens.json
@@ -5,6 +5,7 @@
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.6.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
+      "gap": { "value": "{ams.space.xs}" },
       "line-height": { "value": "{ams.text.level.6.line-height}" }
     }
   }

--- a/storybook/src/components/ErrorMessage/ErrorMessage.docs.mdx
+++ b/storybook/src/components/ErrorMessage/ErrorMessage.docs.mdx
@@ -21,3 +21,10 @@ This makes the error message more clear for screen reader users.
 If you want to change this prefix, to support another language for example, you can use the `prefix` prop.
 
 <Canvas of={ErrorMessageStories.CustomPrefix} />
+
+### With custom icon
+
+Replace the icon with another to use Error Message in a different theme or visual identity.
+Applications for the City of Amsterdam must use the default icon.
+
+<Canvas of={ErrorMessageStories.WithCustomIcon} />

--- a/storybook/src/components/ErrorMessage/ErrorMessage.stories.tsx
+++ b/storybook/src/components/ErrorMessage/ErrorMessage.stories.tsx
@@ -4,6 +4,7 @@
  */
 
 import { ErrorMessage } from '@amsterdam/design-system-react/src'
+import { AnnouncementIcon } from '@amsterdam/design-system-react-icons'
 import { Meta, StoryObj } from '@storybook/react'
 
 const meta = {
@@ -29,5 +30,11 @@ export const CustomPrefix: Story = {
   args: {
     children: 'Enter an email address in the correct format, like name@example.com',
     prefix: 'Error',
+  },
+}
+
+export const WithCustomIcon: Story = {
+  args: {
+    icon: AnnouncementIcon,
   },
 }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Adds an Icon to Error Message

## Why

Error Message wasn't very prominent, and for colour-blind people or people using high contrast themes the Error Message wasn't very noticeable.

## How

By adding a default icon and an `icon` prop.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

The ticket specifies to add the Icon the same way we did for Radio. This isn't quite possible though, because we use the Icon component here, and it needs a Function instead of a ReactNode. We plan on changing this in the future though. 