### PR TITLE
feat: Stretch File Input to full width to match other inputs

### DIFF
--- a/packages/css/src/components/file-input/file-input.scss
+++ b/packages/css/src/components/file-input/file-input.scss
@@ -13,13 +13,14 @@
 .ams-file-input {
   background-color: var(--ams-file-input-background-color);
   border: var(--ams-file-input-border);
+  box-sizing: border-box;
   color: var(--ams-file-input-color);
   cursor: var(--ams-file-input-cursor);
   font-family: var(--ams-file-input-font-family);
   font-size: var(--ams-file-input-font-size);
   font-weight: var(--ams-file-input-font-weight);
+  inline-size: 100%;
   line-height: var(--ams-file-input-line-height);
-  max-inline-size: calc(100% - var(--ams-file-input-padding-inline) * 2);
   outline-offset: calc(var(--ams-focus-outline-offset) * 2); // Compensate for the dashed border
   padding-block: var(--ams-file-input-padding-block);
   padding-inline: var(--ams-file-input-padding-inline);


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It lets File Input take up all available width.

## Why

Because all comparable inputs (Text Input, Password Input, Text Area, Select, Search Field) do so. And because not doing so [has been filed as an issue](https://github.com/Amsterdam/design-system/issues/1733).

## How

Replaced `max-inline-size` with `inline-size` and added border box sizing to let sizing work with padding.
