### PR TITLE
feat!: Introduce brand color palettes and rename color tokens

### DIFF
--- a/packages/css/src/components/checkbox/checkbox.scss
+++ b/packages/css/src/components/checkbox/checkbox.scss
@@ -151,7 +151,6 @@
 :is(.ams-checkbox__input:invalid, .ams-checkbox__input[aria-invalid="true"])
   + .ams-checkbox__label:hover
   .ams-checkbox__checkmark::after {
-  // TODO: this should be the (currently non-existent) dark red hover color
   border-color: var(--ams-checkbox-checkmark-invalid-hover-border-color);
 }
 
@@ -169,7 +168,6 @@
 :is(.ams-checkbox__input:invalid:checked, .ams-checkbox__input[aria-invalid="true"]:checked)
   + .ams-checkbox__label:hover
   .ams-checkbox__checkmark::after {
-  // TODO: this should be the (currently non-existent) dark red hover color
   background-color: var(--ams-checkbox-checkmark-invalid-checked-hover-background-color);
 }
 
@@ -177,7 +175,6 @@
 :is(.ams-checkbox__input:invalid:indeterminate, .ams-checkbox__input[aria-invalid="true"]:indeterminate)
   + .ams-checkbox__label:hover
   .ams-checkbox__checkmark::after {
-  // TODO: this should be the (currently non-existent) dark red hover color
   background-color: var(--ams-checkbox-checkmark-invalid-indeterminate-hover-background-color);
 }
 

--- a/packages/css/src/components/date-input/date-input.scss
+++ b/packages/css/src/components/date-input/date-input.scss
@@ -71,7 +71,6 @@
   box-shadow: var(--ams-date-input-invalid-box-shadow);
 
   &:hover {
-    // TODO: this should be the (currently non-existent) dark red hover color
     box-shadow: var(--ams-date-input-invalid-hover-box-shadow);
   }
 }

--- a/packages/css/src/components/password-input/password-input.scss
+++ b/packages/css/src/components/password-input/password-input.scss
@@ -53,7 +53,6 @@
   box-shadow: var(--ams-password-input-invalid-box-shadow);
 
   &:hover {
-    // TODO: this should be the (currently non-existent) dark red hover color
     box-shadow: var(--ams-password-input-invalid-hover-box-shadow);
   }
 }

--- a/packages/css/src/components/radio/radio.scss
+++ b/packages/css/src/components/radio/radio.scss
@@ -116,12 +116,10 @@
 // Invalid hover
 .ams-radio__input[aria-invalid="true"] + .ams-radio__label:hover {
   .ams-radio__circle {
-    // TODO: this should be the (currently non-existent) dark red hover color
     stroke: var(--ams-radio-circle-invalid-hover-stroke);
   }
 
   .ams-radio__checked-indicator {
-    // TODO: this should be the (currently non-existent) dark red hover color
     fill: var(--ams-radio-checked-indicator-invalid-hover-fill);
   }
 }

--- a/packages/css/src/components/search-field/search-field.scss
+++ b/packages/css/src/components/search-field/search-field.scss
@@ -50,7 +50,6 @@
   box-shadow: var(--ams-search-field-input-invalid-box-shadow);
 
   &:hover {
-    // TODO: this should be the (currently non-existent) dark red hover color
     box-shadow: var(--ams-search-field-input-invalid-hover-box-shadow);
   }
 }

--- a/packages/css/src/components/text-area/text-area.scss
+++ b/packages/css/src/components/text-area/text-area.scss
@@ -55,7 +55,6 @@
   box-shadow: var(--ams-text-area-invalid-box-shadow);
 
   &:hover {
-    // TODO: this should be the (currently non-existent) dark red hover color
     box-shadow: var(--ams-text-area-invalid-hover-box-shadow);
   }
 }

--- a/packages/css/src/components/text-input/text-input.scss
+++ b/packages/css/src/components/text-input/text-input.scss
@@ -53,7 +53,6 @@
   box-shadow: var(--ams-text-input-invalid-box-shadow);
 
   &:hover {
-    // TODO: this should be the (currently non-existent) dark red hover color
     box-shadow: var(--ams-text-input-invalid-hover-box-shadow);
   }
 }

--- a/packages/css/src/components/time-input/time-input.scss
+++ b/packages/css/src/components/time-input/time-input.scss
@@ -72,7 +72,6 @@
   box-shadow: var(--ams-time-input-invalid-box-shadow);
 
   &:hover {
-    // TODO: this should be the (currently non-existent) dark red hover color
     box-shadow: var(--ams-time-input-invalid-hover-box-shadow);
   }
 }

--- a/proprietary/tokens/README.md
+++ b/proprietary/tokens/README.md
@@ -80,7 +80,7 @@ Examples:
 
 ```css
 :root {
-  --ams-color-primary-red: #ec0000;
+  --ams-brand-color-red-60: #ec0000;
   --ams-space-md: 1rem;
   --ams-aspect-ratio-wide: 4/3;
   --ams-border-width-lg: 0.1875rem;
@@ -168,8 +168,9 @@ Use ‘dot notation’ or square brackets to access the tokens.
 ```ts
 import tokens from "@amsterdam/design-system-tokens/dist/index.json"
 
-const buttonBackgroundColor = tokens.ams.color["primary-blue"]
-const rowGap = tokens.ams.space.md
+const { ams } = tokens
+const buttonBackgroundColor = ams.brand.color.blue['60']
+const rowGap = ams.space.md
 ```
 
 Import and merge the compact tokens if you need them.
@@ -180,7 +181,7 @@ Then you can use the tokens in scripting or css-in-js libraries.
 import spaciousTokens from "@amsterdam/design-system-tokens/dist/index.json"
 import compactTokens from "@amsterdam/design-system-tokens/dist/compact.json"
 
-const tokens = { ...spaciousTokens, ...compactTokens }
+const { ams } = { ...spaciousTokens, ...compactTokens }
 ```
 
 ## Usage in Figma

--- a/proprietary/tokens/src/brand/ams/color.tokens.json
+++ b/proprietary/tokens/src/brand/ams/color.tokens.json
@@ -1,21 +1,130 @@
 {
   "ams": {
-    "color": {
-      "primary-black": { "value": "#000000" },
-      "primary-white": { "value": "#FFFFFF" },
-      "primary-blue": { "value": "#004699" },
-      "primary-red": { "value": "#EC0000" },
-      "dark-blue": { "value": "#102E62" },
-      "orange": { "value": "#FF9100" },
-      "yellow": { "value": "#FFE600" },
-      "green": { "value": "#BED200" },
-      "dark-green": { "value": "#00A03C" },
-      "blue": { "value": "#009DE6" },
-      "purple": { "value": "#A00078" },
-      "magenta": { "value": "#E50082" },
-      "neutral-grey1": { "value": "#E8E8E8" },
-      "neutral-grey2": { "value": "#BEBEBE" },
-      "neutral-grey3": { "value": "#767676" }
+    "brand": {
+      "color": {
+        "azure": {
+          "10": { "value": "#F2F7FD" },
+          "20": { "value": "#E4EFFA" },
+          "30": { "value": "#C6DDF5" },
+          "40": { "value": "#A1CAF0" },
+          "50": { "value": "#72B5EB" },
+          "60": { "value": "#009DE6" },
+          "70": { "value": "#008CCE" },
+          "80": { "value": "#007AB2" },
+          "90": { "value": "#006391" },
+          "100": { "value": "#004667" }
+        },
+        "blue": {
+          "10": { "value": "#F2F3F7" },
+          "20": { "value": "#E4E6EE" },
+          "30": { "value": "#C6CADC" },
+          "40": { "value": "#A1AAC8" },
+          "50": { "value": "#7282B2" },
+          "60": { "value": "#004699" },
+          "70": { "value": "#003F89" },
+          "80": { "value": "#003677" },
+          "90": { "value": "#002C61" },
+          "100": { "value": "#001F44" }
+        },
+        "green": {
+          "10": { "value": "#F2F7F3" },
+          "20": { "value": "#E4EFE6" },
+          "30": { "value": "#C6DEC9" },
+          "40": { "value": "#A1CBA8" },
+          "50": { "value": "#72B77E" },
+          "60": { "value": "#00A03C" },
+          "70": { "value": "#008F36" },
+          "80": { "value": "#007C2E" },
+          "90": { "value": "#006526" },
+          "100": { "value": "#00481B" }
+        },
+        "lime": {
+          "10": { "value": "#F9FBF2" },
+          "20": { "value": "#F3F7E4" },
+          "30": { "value": "#E7EEC6" },
+          "40": { "value": "#DAE5A1" },
+          "50": { "value": "#CDDC72" },
+          "60": { "value": "#BED200" },
+          "70": { "value": "#AABC00" },
+          "80": { "value": "#93A300" },
+          "90": { "value": "#788500" },
+          "100": { "value": "#555E00" }
+        },
+        "magenta": {
+          "10": { "value": "#FDF2F5" },
+          "20": { "value": "#FAE4EB" },
+          "30": { "value": "#F5C6D6" },
+          "40": { "value": "#F0A1BE" },
+          "50": { "value": "#EA72A3" },
+          "60": { "value": "#E50082" },
+          "70": { "value": "#CD0074" },
+          "80": { "value": "#B10065" },
+          "90": { "value": "#910052" },
+          "100": { "value": "#66003A" }
+        },
+        "neutral": {
+          "0": { "value": "#FFFFFF" },
+          "10": { "value": "#E8E8E8" },
+          "20": { "value": "#D1D1D1" },
+          "30": { "value": "#BBBBBB" },
+          "40": { "value": "#A4A4A4" },
+          "50": { "value": "#8D8D8D" },
+          "60": { "value": "#767676" },
+          "70": { "value": "#5E5E5E" },
+          "80": { "value": "#474747" },
+          "90": { "value": "#2F2F2F" },
+          "100": { "value": "#181818" },
+          "110": { "value": "#000000" }
+        },
+        "orange": {
+          "10": { "value": "#FFF6F2" },
+          "20": { "value": "#FFEDE4" },
+          "30": { "value": "#FFDAC6" },
+          "40": { "value": "#FFC5A1" },
+          "50": { "value": "#FFAD72" },
+          "60": { "value": "#FF9100" },
+          "70": { "value": "#E48200" },
+          "80": { "value": "#C67000" },
+          "90": { "value": "#A15C00" },
+          "100": { "value": "#724100" }
+        },
+        "purple": {
+          "10": { "value": "#F7F2F5" },
+          "20": { "value": "#EFE4EA" },
+          "30": { "value": "#DEC6D4" },
+          "40": { "value": "#CBA1BA" },
+          "50": { "value": "#B7729D" },
+          "60": { "value": "#A00078" },
+          "70": { "value": "#8F006B" },
+          "80": { "value": "#7C005D" },
+          "90": { "value": "#65004C" },
+          "100": { "value": "#480036" }
+        },
+        "red": {
+          "10": { "value": "#FDF2F2" },
+          "20": { "value": "#FBE4E4" },
+          "30": { "value": "#F8C6C6" },
+          "40": { "value": "#F4A1A1" },
+          "50": { "value": "#F07272" },
+          "60": { "value": "#EC0000" },
+          "70": { "value": "#D30000" },
+          "80": { "value": "#B70000" },
+          "90": { "value": "#950000" },
+          "100": { "value": "#6A0000" }
+        },
+        "yellow": {
+          "10": { "value": "#FFFDF2" },
+          "20": { "value": "#FFFAE4" },
+          "30": { "value": "#FFF5C6" },
+          "40": { "value": "#FFF0A1" },
+          "50": { "value": "#FFEB72" },
+          "60": { "value": "#FFE600" },
+          "70": { "value": "#E4CE00" },
+          "80": { "value": "#C6B200" },
+          "90": { "value": "#A19100" },
+          "100": { "value": "#726700" }
+        }
+      }
     }
   }
 }

--- a/proprietary/tokens/src/common/ams/link-appearance.tokens.json
+++ b/proprietary/tokens/src/common/ams/link-appearance.tokens.json
@@ -1,11 +1,11 @@
 {
   "ams": {
     "link-appearance": {
-      "color": { "value": "{ams.color.primary-blue}" },
+      "color": { "value": "{ams.brand.color.blue.60}" },
       "text-decoration-thickness": { "value": "{ams.border.width.md}" },
       "text-underline-offset": { "value": "0.3333em" },
       "hover": {
-        "color": { "value": "{ams.color.dark-blue}" }
+        "color": { "value": "{ams.brand.color.blue.80}" }
       },
       "regular": {
         "text-decoration-line": { "value": "underline" },
@@ -21,21 +21,21 @@
         }
       },
       "contrast": {
-        "color": { "value": "{ams.color.primary-black}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" },
         "hover": {
-          "color": { "value": "{ams.color.primary-black}" }
+          "color": { "value": "{ams.brand.color.neutral.100}" }
         },
         "visited": {
-          "color": { "value": "{ams.color.primary-black}" }
+          "color": { "value": "{ams.brand.color.neutral.100}" }
         }
       },
       "inverse": {
-        "color": { "value": "{ams.color.primary-white}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" },
         "hover": {
-          "color": { "value": "{ams.color.primary-white}" }
+          "color": { "value": "{ams.brand.color.neutral.0}" }
         },
         "visited": {
-          "color": { "value": "{ams.color.primary-white}" }
+          "color": { "value": "{ams.brand.color.neutral.0}" }
         }
       }
     }

--- a/proprietary/tokens/src/components/ams/accordion.tokens.json
+++ b/proprietary/tokens/src/components/ams/accordion.tokens.json
@@ -3,7 +3,7 @@
     "accordion": {
       "gap": { "value": "{ams.space.md}" },
       "button": {
-        "color": { "value": "{ams.color.primary-blue}" },
+        "color": { "value": "{ams.brand.color.blue.60}" },
         "font-family": { "value": "{ams.text.font-family}" },
         "font-size": { "value": "{ams.text.level.5.font-size}" },
         "font-weight": { "value": "{ams.text.font-weight.bold}" },
@@ -15,7 +15,7 @@
           "outline-offset": { "value": "{ams.focus.outline-offset}" }
         },
         "hover": {
-          "color": { "value": "{ams.color.dark-blue}" }
+          "color": { "value": "{ams.brand.color.blue.80}" }
         }
       },
       "panel": {

--- a/proprietary/tokens/src/components/ams/alert.tokens.json
+++ b/proprietary/tokens/src/components/ams/alert.tokens.json
@@ -7,21 +7,21 @@
       "padding-block": { "value": "{ams.space.md}" },
       "padding-inline": { "value": "{ams.space.lg}" },
       "error": {
-        "border-color": { "value": "{ams.color.primary-red}" }
+        "border-color": { "value": "{ams.brand.color.red.60}" }
       },
       "info": {
-        "border-color": { "value": "{ams.color.primary-blue}" }
+        "border-color": { "value": "{ams.brand.color.blue.60}" }
       },
       "success": {
-        "border-color": { "value": "{ams.color.dark-green}" }
+        "border-color": { "value": "{ams.brand.color.green.60}" }
       },
       "warning": {
-        "border-color": { "value": "{ams.color.orange}" }
+        "border-color": { "value": "{ams.brand.color.orange.60}" }
       },
       "close": {
-        "fill": { "value": "{ams.color.primary-black}" },
+        "fill": { "value": "{ams.brand.color.neutral.100}" },
         "hover": {
-          "fill": { "value": "{ams.color.primary-blue}" }
+          "fill": { "value": "{ams.brand.color.blue.60}" }
         }
       },
       "content": {

--- a/proprietary/tokens/src/components/ams/avatar.tokens.json
+++ b/proprietary/tokens/src/components/ams/avatar.tokens.json
@@ -9,63 +9,63 @@
       "padding-block": { "value": "{ams.space.xs}" },
       "padding-inline": { "value": "{ams.space.xs}" },
       "black": {
-        "background-color": { "value": "{ams.color.primary-black}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.neutral.100}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "blue": {
-        "background-color": { "value": "{ams.color.primary-blue}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.blue.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "dark-green": {
-        "background-color": { "value": "{ams.color.dark-green}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.green.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "forced-colors": {
         "border-width": { "value": "{ams.border.width.md}" }
       },
       "green": {
-        "background-color": { "value": "{ams.color.green}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.lime.60}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       },
       "grey-1": {
-        "background-color": { "value": "{ams.color.neutral-grey1}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.neutral.20}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       },
       "grey-2": {
-        "background-color": { "value": "{ams.color.neutral-grey2}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.neutral.40}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       },
       "grey-3": {
-        "background-color": { "value": "{ams.color.neutral-grey3}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.neutral.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "light-blue": {
-        "background-color": { "value": "{ams.color.blue}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.azure.60}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       },
       "magenta": {
-        "background-color": { "value": "{ams.color.magenta}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.magenta.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "orange": {
-        "background-color": { "value": "{ams.color.orange}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.orange.60}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       },
       "purple": {
-        "background-color": { "value": "{ams.color.purple}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.purple.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "red": {
-        "background-color": { "value": "{ams.color.primary-red}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.red.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "white": {
-        "background-color": { "value": "{ams.color.primary-white}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.neutral.0}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       },
       "yellow": {
-        "background-color": { "value": "{ams.color.yellow}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.yellow.60}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/badge.tokens.json
+++ b/proprietary/tokens/src/components/ams/badge.tokens.json
@@ -7,60 +7,60 @@
       "line-height": { "value": "{ams.text.level.5.line-height}" },
       "padding-inline": { "value": "{ams.space.xs}" },
       "black": {
-        "background-color": { "value": "{ams.color.primary-black}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.neutral.100}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "blue": {
-        "background-color": { "value": "{ams.color.primary-blue}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.blue.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "dark-green": {
-        "background-color": { "value": "{ams.color.dark-green}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.green.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "green": {
-        "background-color": { "value": "{ams.color.green}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.lime.60}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       },
       "grey-1": {
-        "background-color": { "value": "{ams.color.neutral-grey1}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.neutral.20}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       },
       "grey-2": {
-        "background-color": { "value": "{ams.color.neutral-grey2}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.neutral.40}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       },
       "grey-3": {
-        "background-color": { "value": "{ams.color.neutral-grey3}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.neutral.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "light-blue": {
-        "background-color": { "value": "{ams.color.blue}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.azure.60}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       },
       "magenta": {
-        "background-color": { "value": "{ams.color.magenta}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.magenta.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "orange": {
-        "background-color": { "value": "{ams.color.orange}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.orange.60}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       },
       "purple": {
-        "background-color": { "value": "{ams.color.purple}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.purple.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "red": {
-        "background-color": { "value": "{ams.color.primary-red}" },
-        "color": { "value": "{ams.color.primary-white}" }
+        "background-color": { "value": "{ams.brand.color.red.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" }
       },
       "white": {
-        "background-color": { "value": "{ams.color.primary-white}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.neutral.0}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       },
       "yellow": {
-        "background-color": { "value": "{ams.color.yellow}" },
-        "color": { "value": "{ams.color.primary-black}" }
+        "background-color": { "value": "{ams.brand.color.yellow.60}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/blockquote.tokens.json
+++ b/proprietary/tokens/src/components/ams/blockquote.tokens.json
@@ -1,12 +1,12 @@
 {
   "ams": {
     "blockquote": {
-      "color": { "value": "{ams.color.primary-black}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.3.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.bold}" },
       "line-height": { "value": "{ams.text.level.3.line-height}" },
-      "inverse-color": { "value": "{ams.color.primary-white}" }
+      "inverse-color": { "value": "{ams.brand.color.neutral.0}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/ams/breadcrumb.tokens.json
+++ b/proprietary/tokens/src/components/ams/breadcrumb.tokens.json
@@ -20,7 +20,7 @@
         "text-decoration-thickness": { "value": "{ams.link-appearance.text-decoration-thickness}" },
         "text-underline-offset": { "value": "{ams.link-appearance.text-underline-offset}" },
         "hover": {
-          "color": { "value": "{ams.color.dark-blue}" },
+          "color": { "value": "{ams.brand.color.blue.80}" },
           "text-decoration-line": { "value": "{ams.link-appearance.subtle.hover.text-decoration-line}" }
         }
       }

--- a/proprietary/tokens/src/components/ams/button.tokens.json
+++ b/proprietary/tokens/src/components/ams/button.tokens.json
@@ -16,45 +16,45 @@
         "border": { "value": "{ams.border.width.md} solid" }
       },
       "primary": {
-        "background-color": { "value": "{ams.color.primary-blue}" },
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-blue}" },
-        "color": { "value": "{ams.color.primary-white}" },
+        "background-color": { "value": "{ams.brand.color.blue.60}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.blue.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" },
         "disabled": {
-          "background-color": { "value": "{ams.color.neutral-grey2}" },
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.neutral-grey2}" }
+          "background-color": { "value": "{ams.brand.color.neutral.60}" },
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.neutral.60}" }
         },
         "hover": {
-          "background-color": { "value": "{ams.color.dark-blue}" },
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.dark-blue}" }
+          "background-color": { "value": "{ams.brand.color.blue.80}" },
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.blue.80}" }
         }
       },
       "secondary": {
-        "background-color": { "value": "{ams.color.primary-white}" },
-        "color": { "value": "{ams.color.primary-blue}" },
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-blue}" },
+        "background-color": { "value": "{ams.brand.color.neutral.0}" },
+        "color": { "value": "{ams.brand.color.blue.60}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.blue.60}" },
         "hover": {
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.lg} {ams.color.dark-blue}" },
-          "color": { "value": "{ams.color.dark-blue}" }
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.lg} {ams.brand.color.blue.80}" },
+          "color": { "value": "{ams.brand.color.blue.80}" }
         },
         "disabled": {
-          "background-color": { "value": "{ams.color.primary-white}" },
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.neutral-grey2}" },
-          "color": { "value": "{ams.color.neutral-grey2}" }
+          "background-color": { "value": "{ams.brand.color.neutral.0}" },
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.neutral.60}" },
+          "color": { "value": "{ams.brand.color.neutral.60}" }
         },
         "focus": {
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-blue}" }
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.blue.60}" }
         }
       },
       "tertiary": {
         "background-color": { "value": "transparent" },
-        "color": { "value": "{ams.color.primary-blue}" },
+        "color": { "value": "{ams.brand.color.blue.60}" },
         "hover": {
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.dark-blue}" },
-          "color": { "value": "{ams.color.dark-blue}" }
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.blue.80}" },
+          "color": { "value": "{ams.brand.color.blue.80}" }
         },
         "disabled": {
           "background-color": { "value": "transparent" },
-          "color": { "value": "{ams.color.neutral-grey2}" }
+          "color": { "value": "{ams.brand.color.neutral.60}" }
         }
       },
       "icon-only": {

--- a/proprietary/tokens/src/components/ams/character-count.tokens.json
+++ b/proprietary/tokens/src/components/ams/character-count.tokens.json
@@ -1,13 +1,13 @@
 {
   "ams": {
     "character-count": {
-      "color": { "value": "{ams.color.primary-black}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.6.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "line-height": { "value": "{ams.text.level.6.line-height}" },
       "error": {
-        "color": { "value": "{ams.color.primary-red}" }
+        "color": { "value": "{ams.brand.color.red.60}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/checkbox.tokens.json
+++ b/proprietary/tokens/src/components/ams/checkbox.tokens.json
@@ -1,7 +1,7 @@
 {
   "ams": {
     "checkbox": {
-      "color": { "value": "{ams.color.primary-black}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
@@ -9,70 +9,70 @@
       "line-height": { "value": "{ams.text.level.5.line-height}" },
       "outline-offset": { "value": "{ams.focus.outline-offset}" },
       "checkmark": {
-        "border-color": { "value": "{ams.color.primary-blue}" },
+        "border-color": { "value": "{ams.brand.color.blue.60}" },
         "border-width": { "value": "{ams.border.width.md}" },
         "checked": {
-          "background-color": { "value": "{ams.color.primary-blue}" },
+          "background-color": { "value": "{ams.brand.color.blue.60}" },
           "background-image": {
             "value": "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' fill='%23ffffff'%3E%3Cpath fill-rule='evenodd' d='M12.216 27.016 0 14.168l2.91-2.77 9.346 9.837L29.129 4 32 6.8z'/%3E%3C/svg%3E\")"
           },
           "hover": {
-            "background-color": { "value": "{ams.color.dark-blue}" }
+            "background-color": { "value": "{ams.brand.color.blue.80}" }
           }
         },
         "disabled": {
-          "border-color": { "value": "{ams.color.neutral-grey3}" },
+          "border-color": { "value": "{ams.brand.color.neutral.60}" },
           "border-width": { "value": "{ams.border.width.md}" },
           "checked": {
-            "background-color": { "value": "{ams.color.neutral-grey3}" },
+            "background-color": { "value": "{ams.brand.color.neutral.60}" },
             "hover": {
-              "background-color": { "value": "{ams.color.neutral-grey3}" }
+              "background-color": { "value": "{ams.brand.color.neutral.60}" }
             }
           },
           "indeterminate": {
-            "background-color": { "value": "{ams.color.neutral-grey3}" },
+            "background-color": { "value": "{ams.brand.color.neutral.60}" },
             "hover": {
-              "background-color": { "value": "{ams.color.neutral-grey3}" }
+              "background-color": { "value": "{ams.brand.color.neutral.60}" }
             }
           }
         },
         "hover": {
-          "border-color": { "value": "{ams.color.dark-blue}" },
+          "border-color": { "value": "{ams.brand.color.blue.80}" },
           "border-width": { "value": "{ams.border.width.lg}" }
         },
         "invalid": {
-          "border-color": { "value": "{ams.color.primary-red}" },
+          "border-color": { "value": "{ams.brand.color.red.60}" },
           "checked": {
-            "background-color": { "value": "{ams.color.primary-red}" },
+            "background-color": { "value": "{ams.brand.color.red.60}" },
             "hover": {
-              "background-color": { "value": "{ams.color.primary-red}" }
+              "background-color": { "value": "{ams.brand.color.red.80}" }
             }
           },
           "hover": {
-            "border-color": { "value": "{ams.color.primary-red}" }
+            "border-color": { "value": "{ams.brand.color.red.80}" }
           },
           "indeterminate": {
-            "background-color": { "value": "{ams.color.primary-red}" },
+            "background-color": { "value": "{ams.brand.color.red.60}" },
             "hover": {
-              "background-color": { "value": "{ams.color.primary-red}" }
+              "background-color": { "value": "{ams.brand.color.red.80}" }
             }
           }
         },
         "indeterminate": {
-          "background-color": { "value": "{ams.color.primary-blue}" },
+          "background-color": { "value": "{ams.brand.color.blue.60}" },
           "background-image": {
             "value": "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' fill='white'%3E%3Cpath fill-rule='evenodd' d='M0 13.714h32v4H0z'/%3E%3C/svg%3E\")"
           },
           "hover": {
-            "background-color": { "value": "{ams.color.dark-blue}" }
+            "background-color": { "value": "{ams.brand.color.blue.80}" }
           }
         }
       },
       "disabled": {
-        "color": { "value": "{ams.color.neutral-grey3}" }
+        "color": { "value": "{ams.brand.color.neutral.60}" }
       },
       "hover": {
-        "color": { "value": "{ams.color.dark-blue}" },
+        "color": { "value": "{ams.brand.color.blue.80}" },
         "text-decoration-thickness": { "value": "{ams.border.width.md}" }
       }
     }

--- a/proprietary/tokens/src/components/ams/date-input.tokens.json
+++ b/proprietary/tokens/src/components/ams/date-input.tokens.json
@@ -1,9 +1,9 @@
 {
   "ams": {
     "date-input": {
-      "background-color": { "value": "{ams.color.primary-white}" },
-      "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-black}" },
-      "color": { "value": "{ams.color.primary-black}" },
+      "background-color": { "value": "{ams.brand.color.neutral.0}" },
+      "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.100}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
@@ -17,9 +17,9 @@
         }
       },
       "disabled": {
-        "background-color": { "value": "{ams.color.primary-white}" },
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.neutral-grey2}" },
-        "color": { "value": "{ams.color.neutral-grey2}" },
+        "background-color": { "value": "{ams.brand.color.neutral.0}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.60}" },
+        "color": { "value": "{ams.brand.color.neutral.60}" },
         "calender-picker-indicator": {
           "background-image": {
             "value": "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' fill='%23BEBEBE'><path d='M28 6V2h-4v4H12V2H8v4H2v28h32V6zm2 24H6V14h24z'/><path d='M10 17h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zm-12 6h4v4h-4zm6 0h4v4h-4z'/></svg>\")"
@@ -27,7 +27,7 @@
         }
       },
       "hover": {
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-black}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.neutral.100}" },
         "calender-picker-indicator": {
           "background-image": {
             "value": "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' fill='%23102E62'><path d='M28 6V2h-4v4H12V2H8v4H2v28h32V6zm2 24H6V14h24z'/><path d='M10 17h4v4h-4zm6 0h4v4h-4zm6 0h4v4h-4zm-12 6h4v4h-4zm6 0h4v4h-4z'/></svg>\")"
@@ -35,9 +35,9 @@
         }
       },
       "invalid": {
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-red}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.red.60}" },
         "hover": {
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-red}" }
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.red.80}" }
         }
       }
     }

--- a/proprietary/tokens/src/components/ams/description-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/description-list.tokens.json
@@ -1,11 +1,11 @@
 {
   "ams": {
     "description-list": {
-      "color": { "value": "{ams.color.primary-black}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "column-gap": { "value": "{ams.space.lg}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
-      "inverse-color": { "value": "{ams.color.primary-white}" },
+      "inverse-color": { "value": "{ams.brand.color.neutral.0}" },
       "line-height": { "value": "{ams.text.level.5.line-height}" },
       "row-gap": { "value": "{ams.space.sm}" },
       "term": {

--- a/proprietary/tokens/src/components/ams/dialog.tokens.json
+++ b/proprietary/tokens/src/components/ams/dialog.tokens.json
@@ -1,7 +1,7 @@
 {
   "ams": {
     "dialog": {
-      "background-color": { "value": "{ams.color.primary-white}" },
+      "background-color": { "value": "{ams.brand.color.neutral.0}" },
       "border": { "value": "0" },
       "gap": { "value": "{ams.space.md}" },
       "inline-size": { "value": "calc(100% - 2 * {ams.space.grid.md})" },

--- a/proprietary/tokens/src/components/ams/error-message.tokens.json
+++ b/proprietary/tokens/src/components/ams/error-message.tokens.json
@@ -1,7 +1,7 @@
 {
   "ams": {
     "error-message": {
-      "color": { "value": "{ams.color.primary-red}" },
+      "color": { "value": "{ams.brand.color.red.60}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.6.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },

--- a/proprietary/tokens/src/components/ams/field-set.tokens.json
+++ b/proprietary/tokens/src/components/ams/field-set.tokens.json
@@ -2,11 +2,11 @@
   "ams": {
     "field-set": {
       "invalid": {
-        "border-inline-start": { "value": "{ams.border.width.lg} solid {ams.color.primary-red}" },
+        "border-inline-start": { "value": "{ams.border.width.lg} solid {ams.brand.color.red.60}" },
         "padding-inline-start": { "value": "{ams.space.md}" }
       },
       "legend": {
-        "color": { "value": "{ams.color.primary-black}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" },
         "font-family": { "value": "{ams.text.font-family}" },
         "font-size": { "value": "{ams.text.level.4.font-size}" },
         "font-weight": { "value": "{ams.text.font-weight.bold}" },

--- a/proprietary/tokens/src/components/ams/field.tokens.json
+++ b/proprietary/tokens/src/components/ams/field.tokens.json
@@ -3,7 +3,7 @@
     "field": {
       "gap": { "value": "{ams.space.sm}" },
       "invalid": {
-        "border-inline-start": { "value": "{ams.border.width.lg} solid {ams.color.primary-red}" },
+        "border-inline-start": { "value": "{ams.border.width.lg} solid {ams.brand.color.red.60}" },
         "padding-inline-start": { "value": "{ams.space.md}" }
       }
     }

--- a/proprietary/tokens/src/components/ams/file-input.tokens.json
+++ b/proprietary/tokens/src/components/ams/file-input.tokens.json
@@ -1,9 +1,9 @@
 {
   "ams": {
     "file-input": {
-      "background-color": { "value": "{ams.color.primary-white}" },
-      "border": { "value": "{ams.border.width.sm} dashed {ams.color.neutral-grey3}" },
-      "color": { "value": "{ams.color.primary-black}" },
+      "background-color": { "value": "{ams.brand.color.neutral.0}" },
+      "border": { "value": "{ams.border.width.sm} dashed {ams.brand.color.neutral.60}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "cursor": { "value": "{ams.action.activate.cursor}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
@@ -13,24 +13,24 @@
       "padding-block": { "value": "{ams.space.md}" },
       "padding-inline": { "value": "{ams.space.md}" },
       "disabled": {
-        "color": { "value": "{ams.color.neutral-grey2}" },
+        "color": { "value": "{ams.brand.color.neutral.60}" },
         "cursor": { "value": "{ams.action.disabled.cursor}" }
       },
       "file-selector-button": {
-        "background-color": { "value": "{ams.color.primary-white}" },
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-blue}" },
-        "color": { "value": "{ams.color.primary-blue}" },
+        "background-color": { "value": "{ams.brand.color.neutral.0}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.blue.60}" },
+        "color": { "value": "{ams.brand.color.blue.60}" },
         "cursor": { "value": "{ams.action.activate.cursor}" },
         "margin-inline-end": { "value": "{ams.space.md}" },
         "padding-block": { "value": "{ams.space.sm}" },
         "padding-inline": { "value": "{ams.space.md}" },
         "hover": {
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.lg} {ams.color.dark-blue}" },
-          "color": { "value": "{ams.color.dark-blue}" }
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.lg} {ams.brand.color.blue.80}" },
+          "color": { "value": "{ams.brand.color.blue.80}" }
         },
         "disabled": {
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.neutral-grey2}" },
-          "color": { "value": "{ams.color.neutral-grey2}" },
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.neutral.60}" },
+          "color": { "value": "{ams.brand.color.neutral.60}" },
           "cursor": { "value": "{ams.action.disabled.cursor}" }
         },
         "forced-color-mode": {

--- a/proprietary/tokens/src/components/ams/heading.tokens.json
+++ b/proprietary/tokens/src/components/ams/heading.tokens.json
@@ -1,10 +1,10 @@
 {
   "ams": {
     "heading": {
-      "color": { "value": "{ams.color.primary-black}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-weight": { "value": "{ams.text.font-weight.bold}" },
-      "inverse-color": { "value": "{ams.color.primary-white}" },
+      "inverse-color": { "value": "{ams.brand.color.neutral.0}" },
       "level": {
         "1": {
           "font-size": { "value": "{ams.text.level.1.font-size}" },

--- a/proprietary/tokens/src/components/ams/hint.tokens.json
+++ b/proprietary/tokens/src/components/ams/hint.tokens.json
@@ -1,7 +1,7 @@
 {
   "ams": {
     "hint": {
-      "color": { "value": "{ams.color.neutral-grey3}" }
+      "color": { "value": "{ams.brand.color.neutral.60}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/ams/icon-button.tokens.json
+++ b/proprietary/tokens/src/components/ams/icon-button.tokens.json
@@ -1,35 +1,35 @@
 {
   "ams": {
     "icon-button": {
-      "color": { "value": "{ams.color.primary-blue}" },
+      "color": { "value": "{ams.brand.color.blue.60}" },
       "outline-offset": { "value": "{ams.focus.outline-offset}" },
       "hover": {
         "background-color": { "value": "rgba(0, 70, 153, 0.125)" },
-        "color": { "value": "{ams.color.dark-blue}" }
+        "color": { "value": "{ams.brand.color.blue.80}" }
       },
       "disabled": {
-        "color": { "value": "{ams.color.neutral-grey2}" }
+        "color": { "value": "{ams.brand.color.neutral.60}" }
       },
       "contrast-color": {
-        "color": { "value": "{ams.color.primary-black}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" },
         "hover": {
           "background-color": { "value": "rgba(0, 0, 0, 0.125)" },
-          "color": { "value": "{ams.color.primary-black}" }
+          "color": { "value": "{ams.brand.color.neutral.100}" }
         },
         "disabled": {
-          "color": { "value": "{ams.color.neutral-grey2}" }
+          "color": { "value": "{ams.brand.color.neutral.60}" }
         }
       },
       "inverse-color": {
-        "background-color": { "value": "{ams.color.primary-blue}" },
-        "color": { "value": "{ams.color.primary-white}" },
+        "background-color": { "value": "{ams.brand.color.blue.60}" },
+        "color": { "value": "{ams.brand.color.neutral.0}" },
         "hover": {
-          "background-color": { "value": "{ams.color.dark-blue}" },
-          "color": { "value": "{ams.color.primary-white}" }
+          "background-color": { "value": "{ams.brand.color.blue.80}" },
+          "color": { "value": "{ams.brand.color.neutral.0}" }
         },
         "disabled": {
-          "color": { "value": "{ams.color.primary-white}" },
-          "background-color": { "value": "{ams.color.neutral-grey2}" }
+          "color": { "value": "{ams.brand.color.neutral.0}" },
+          "background-color": { "value": "{ams.brand.color.neutral.60}" }
         }
       }
     }

--- a/proprietary/tokens/src/components/ams/label.tokens.json
+++ b/proprietary/tokens/src/components/ams/label.tokens.json
@@ -1,7 +1,7 @@
 {
   "ams": {
     "label": {
-      "color": { "value": "{ams.color.primary-black}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.4.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.bold}" },

--- a/proprietary/tokens/src/components/ams/link.tokens.json
+++ b/proprietary/tokens/src/components/ams/link.tokens.json
@@ -22,7 +22,7 @@
           "text-underline-offset": { "value": "{ams.link-appearance.regular.hover.text-underline-offset}" }
         },
         "visited": {
-          "color": { "value": "{ams.color.purple}" }
+          "color": { "value": "{ams.brand.color.purple.60}" }
         }
       },
       "standalone": {

--- a/proprietary/tokens/src/components/ams/logo.tokens.json
+++ b/proprietary/tokens/src/components/ams/logo.tokens.json
@@ -2,9 +2,9 @@
   "ams": {
     "logo": {
       "block-size": { "value": "2.5rem" },
-      "emblem": { "color": { "value": "{ams.color.primary-red}" } },
-      "title": { "color": { "value": "{ams.color.primary-red}" } },
-      "subsite": { "color": { "value": "{ams.color.primary-black}" } }
+      "emblem": { "color": { "value": "{ams.brand.color.red.60}" } },
+      "title": { "color": { "value": "{ams.brand.color.red.60}" } },
+      "subsite": { "color": { "value": "{ams.brand.color.neutral.100}" } }
     }
   }
 }

--- a/proprietary/tokens/src/components/ams/mark.tokens.json
+++ b/proprietary/tokens/src/components/ams/mark.tokens.json
@@ -1,7 +1,7 @@
 {
   "ams": {
     "mark": {
-      "background-color": { "value": "{ams.color.yellow}" }
+      "background-color": { "value": "{ams.brand.color.yellow.60}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/ams/ordered-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/ordered-list.tokens.json
@@ -1,12 +1,12 @@
 {
   "ams": {
     "ordered-list": {
-      "color": { "value": "{ams.color.primary-black}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "gap": { "value": "{ams.space.md}" },
-      "inverse-color": { "value": "{ams.color.primary-white}" },
+      "inverse-color": { "value": "{ams.brand.color.neutral.0}" },
       "line-height": { "value": "{ams.text.level.5.line-height}" },
       "list-style-type": { "value": "decimal" },
       "small": {

--- a/proprietary/tokens/src/components/ams/page-heading.tokens.json
+++ b/proprietary/tokens/src/components/ams/page-heading.tokens.json
@@ -1,11 +1,11 @@
 {
   "ams": {
     "page-heading": {
-      "color": { "value": "{ams.color.primary-black}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.0.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.bold}" },
-      "inverse-color": { "value": "{ams.color.primary-white}" },
+      "inverse-color": { "value": "{ams.brand.color.neutral.0}" },
       "line-height": { "value": "{ams.text.level.0.font-size}" }
     }
   }

--- a/proprietary/tokens/src/components/ams/paragraph.tokens.json
+++ b/proprietary/tokens/src/components/ams/paragraph.tokens.json
@@ -1,12 +1,12 @@
 {
   "ams": {
     "paragraph": {
-      "color": { "value": "{ams.color.primary-black}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "line-height": { "value": "{ams.text.level.5.line-height}" },
-      "inverse-color": { "value": "{ams.color.primary-white}" },
+      "inverse-color": { "value": "{ams.brand.color.neutral.0}" },
       "small": {
         "font-size": { "value": "{ams.text.level.6.font-size}" },
         "line-height": { "value": "{ams.text.level.6.line-height}" }

--- a/proprietary/tokens/src/components/ams/password-input.tokens.json
+++ b/proprietary/tokens/src/components/ams/password-input.tokens.json
@@ -1,9 +1,9 @@
 {
   "ams": {
     "password-input": {
-      "background-color": { "value": "{ams.color.primary-white}" },
-      "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-black}" },
-      "color": { "value": "{ams.color.primary-black}" },
+      "background-color": { "value": "{ams.brand.color.neutral.0}" },
+      "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.100}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
@@ -12,21 +12,21 @@
       "padding-block": { "value": "{ams.space.sm}" },
       "padding-inline": { "value": "{ams.space.md}" },
       "disabled": {
-        "background-color": { "value": "{ams.color.primary-white}" },
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.neutral-grey2}" },
-        "color": { "value": "{ams.color.neutral-grey2}" }
+        "background-color": { "value": "{ams.brand.color.neutral.0}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.60}" },
+        "color": { "value": "{ams.brand.color.neutral.60}" }
       },
       "hover": {
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-black}" }
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.neutral.100}" }
       },
       "invalid": {
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-red}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.red.60}" },
         "hover": {
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-red}" }
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.red.80}" }
         }
       },
       "placeholder": {
-        "color": { "value": "{ams.color.neutral-grey3}" }
+        "color": { "value": "{ams.brand.color.neutral.60}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/radio.tokens.json
+++ b/proprietary/tokens/src/components/ams/radio.tokens.json
@@ -1,7 +1,7 @@
 {
   "ams": {
     "radio": {
-      "color": { "value": "{ams.color.primary-black}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
@@ -11,52 +11,52 @@
       "text-decoration-thickness": { "value": "{ams.link-appearance.text-decoration-thickness}" },
       "text-underline-offset": { "value": "{ams.link-appearance.text-underline-offset}" },
       "checked-indicator": {
-        "fill": { "value": "{ams.color.primary-blue}" },
+        "fill": { "value": "{ams.brand.color.blue.60}" },
         "disabled": {
-          "fill": { "value": "{ams.color.neutral-grey3}" }
+          "fill": { "value": "{ams.brand.color.neutral.60}" }
         },
         "disabled-invalid": {
-          "fill": { "value": "{ams.color.neutral-grey3}" },
+          "fill": { "value": "{ams.brand.color.neutral.60}" },
           "hover": {
-            "fill": { "value": "{ams.color.neutral-grey3}" }
+            "fill": { "value": "{ams.brand.color.neutral.60}" }
           }
         },
         "hover": {
-          "fill": { "value": "{ams.color.dark-blue}" }
+          "fill": { "value": "{ams.brand.color.blue.80}" }
         },
         "invalid": {
-          "fill": { "value": "{ams.color.primary-red}" },
+          "fill": { "value": "{ams.brand.color.red.60}" },
           "hover": {
-            "fill": { "value": "{ams.color.primary-red}" }
+            "fill": { "value": "{ams.brand.color.red.80}" }
           }
         }
       },
       "circle": {
-        "stroke": { "value": "{ams.color.primary-blue}" },
+        "stroke": { "value": "{ams.brand.color.blue.60}" },
         "disabled": {
-          "stroke": { "value": "{ams.color.neutral-grey3}" }
+          "stroke": { "value": "{ams.brand.color.neutral.60}" }
         },
         "disabled-invalid": {
-          "stroke": { "value": "{ams.color.neutral-grey3}" },
+          "stroke": { "value": "{ams.brand.color.neutral.60}" },
           "hover": {
-            "stroke": { "value": "{ams.color.neutral-grey3}" }
+            "stroke": { "value": "{ams.brand.color.neutral.60}" }
           }
         },
         "hover": {
-          "stroke": { "value": "{ams.color.dark-blue}" }
+          "stroke": { "value": "{ams.brand.color.blue.80}" }
         },
         "invalid": {
-          "stroke": { "value": "{ams.color.primary-red}" },
+          "stroke": { "value": "{ams.brand.color.red.60}" },
           "hover": {
-            "stroke": { "value": "{ams.color.primary-red}" }
+            "stroke": { "value": "{ams.brand.color.red.80}" }
           }
         }
       },
       "disabled": {
-        "color": { "value": "{ams.color.neutral-grey3}" }
+        "color": { "value": "{ams.brand.color.neutral.60}" }
       },
       "hover": {
-        "color": { "value": "{ams.color.dark-blue}" },
+        "color": { "value": "{ams.brand.color.blue.80}" },
         "text-decoration-line": { "value": "{ams.link-appearance.subtle.hover.text-decoration-line}" }
       },
       "icon-container": {

--- a/proprietary/tokens/src/components/ams/screen.tokens.json
+++ b/proprietary/tokens/src/components/ams/screen.tokens.json
@@ -1,7 +1,7 @@
 {
   "ams": {
     "screen": {
-      "background-color": { "value": "{ams.color.primary-white}" },
+      "background-color": { "value": "{ams.brand.color.neutral.0}" },
       "wide": {
         "max-inline-size": { "value": "100rem" }
       },

--- a/proprietary/tokens/src/components/ams/search-field.tokens.json
+++ b/proprietary/tokens/src/components/ams/search-field.tokens.json
@@ -2,9 +2,9 @@
   "ams": {
     "search-field": {
       "input": {
-        "background-color": { "value": "{ams.color.primary-white}" },
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-black}" },
-        "color": { "value": "{ams.color.primary-black}" },
+        "background-color": { "value": "{ams.brand.color.neutral.0}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.100}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" },
         "font-family": { "value": "{ams.text.font-family}" },
         "font-size": { "value": "{ams.text.level.5.font-size}" },
         "font-weight": { "value": "{ams.text.font-weight.normal}" },
@@ -17,22 +17,22 @@
             "value": "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><path fill='%23004699' fill-rule='evenodd' d='M29.333 5.47 26.53 2.668 16 13.187 5.47 2.666 2.668 5.47 13.187 16 2.666 26.53l2.804 2.803L16 18.813l10.53 10.52 2.803-2.804L18.813 16z'/></svg>\")"
           },
           "block-size": { "value": "{ams.text.level.5.font-size}" },
-          "color": { "value": "{ams.color.primary-blue}" },
+          "color": { "value": "{ams.brand.color.blue.60}" },
           "inline-size": { "value": "{ams.text.level.5.font-size}" }
         },
         "hover": {
           "box-shadow": {
-            "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-black}"
+            "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.neutral.100}"
           }
         },
         "invalid": {
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-red}" },
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.red.60}" },
           "hover": {
-            "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-red}" }
+            "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.red.80}" }
           }
         },
         "placeholder": {
-          "color": { "value": "{ams.color.neutral-grey3}" }
+          "color": { "value": "{ams.brand.color.neutral.60}" }
         }
       }
     }

--- a/proprietary/tokens/src/components/ams/select.tokens.json
+++ b/proprietary/tokens/src/components/ams/select.tokens.json
@@ -1,13 +1,13 @@
 {
   "ams": {
     "select": {
-      "background-color": { "value": "{ams.color.primary-white}" },
+      "background-color": { "value": "{ams.brand.color.neutral.0}" },
       "background-image": {
         "value": "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><path fill='%23004699' fill-rule='evenodd' d='m16 25.757-16-16 2.91-2.9L16 19.937l13.09-13.08 2.91 2.9z'/></svg>\")"
       },
       "background-position": { "value": "right {ams.space.md} center" },
-      "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-black}" },
-      "color": { "value": "{ams.color.primary-black}" },
+      "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.100}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
@@ -19,21 +19,21 @@
         "background-image": {
           "value": "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><path fill='%23BEBEBE' fill-rule='evenodd' d='m16 25.757-16-16 2.91-2.9L16 19.937l13.09-13.08 2.91 2.9z'/></svg>\")"
         },
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.neutral-grey2}" },
-        "color": { "value": "{ams.color.neutral-grey2}" }
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.60}" },
+        "color": { "value": "{ams.brand.color.neutral.60}" }
       },
       "hover": {
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-black}" }
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.neutral.100}" }
       },
       "invalid": {
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-red}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.red.60}" },
         "hover": {
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-red}" }
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.red.80}" }
         }
       },
       "option": {
         "disabled": {
-          "color": { "value": "{ams.color.neutral-grey2}" }
+          "color": { "value": "{ams.brand.color.neutral.60}" }
         }
       }
     }

--- a/proprietary/tokens/src/components/ams/skip-link.tokens.json
+++ b/proprietary/tokens/src/components/ams/skip-link.tokens.json
@@ -1,8 +1,8 @@
 {
   "ams": {
     "skip-link": {
-      "background-color": { "value": "{ams.color.primary-blue}" },
-      "color": { "value": "{ams.color.primary-white}" },
+      "background-color": { "value": "{ams.brand.color.blue.60}" },
+      "color": { "value": "{ams.brand.color.neutral.0}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.6.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
@@ -11,7 +11,7 @@
       "padding-block": { "value": "{ams.space.sm}" },
       "padding-inline": { "value": "{ams.space.md}" },
       "hover": {
-        "background-color": { "value": "{ams.color.dark-blue}" }
+        "background-color": { "value": "{ams.brand.color.blue.80}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/spotlight.tokens.json
+++ b/proprietary/tokens/src/components/ams/spotlight.tokens.json
@@ -2,28 +2,28 @@
   "ams": {
     "spotlight": {
       "blue": {
-        "background-color": { "value": "{ams.color.blue}" }
+        "background-color": { "value": "{ams.brand.color.azure.60}" }
       },
       "dark-blue": {
-        "background-color": { "value": "{ams.color.primary-blue}" }
+        "background-color": { "value": "{ams.brand.color.blue.60}" }
       },
       "dark-green": {
-        "background-color": { "value": "{ams.color.dark-green}" }
+        "background-color": { "value": "{ams.brand.color.green.60}" }
       },
       "green": {
-        "background-color": { "value": "{ams.color.green}" }
+        "background-color": { "value": "{ams.brand.color.lime.60}" }
       },
       "magenta": {
-        "background-color": { "value": "{ams.color.magenta}" }
+        "background-color": { "value": "{ams.brand.color.magenta.60}" }
       },
       "orange": {
-        "background-color": { "value": "{ams.color.orange}" }
+        "background-color": { "value": "{ams.brand.color.orange.60}" }
       },
       "purple": {
-        "background-color": { "value": "{ams.color.purple}" }
+        "background-color": { "value": "{ams.brand.color.purple.60}" }
       },
       "yellow": {
-        "background-color": { "value": "{ams.color.yellow}" }
+        "background-color": { "value": "{ams.brand.color.yellow.60}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/switch.tokens.json
+++ b/proprietary/tokens/src/components/ams/switch.tokens.json
@@ -1,24 +1,24 @@
 {
   "ams": {
     "switch": {
-      "background-color": { "value": "{ams.color.neutral-grey3}" },
+      "background-color": { "value": "{ams.brand.color.neutral.60}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "outline-offset": { "value": "{ams.focus.outline-offset}" },
       "inline-size": { "value": "3.5rem" },
       "thumb": {
-        "background-color": { "value": "{ams.color.primary-white}" },
+        "background-color": { "value": "{ams.brand.color.neutral.0}" },
         "inline-size": { "value": "1.75rem" },
         "block-size": { "value": "1.75rem" },
         "hover": {
           "box-shadow": { "value": "0 0 0 0.125rem {ams.switch.thumb.hover.color}" },
-          "color": { "value": "{ams.color.dark-blue}" }
+          "color": { "value": "{ams.brand.color.blue.80}" }
         }
       },
       "checked": {
-        "background-color": { "value": "{ams.color.primary-blue}" }
+        "background-color": { "value": "{ams.brand.color.blue.60}" }
       },
       "disabled": {
-        "background-color": { "value": "{ams.color.neutral-grey2}" }
+        "background-color": { "value": "{ams.brand.color.neutral.60}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/table.tokens.json
+++ b/proprietary/tokens/src/components/ams/table.tokens.json
@@ -1,7 +1,7 @@
 {
   "ams": {
     "table": {
-      "color": { "value": "{ams.color.primary-black}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
@@ -10,7 +10,7 @@
         "font-weight": { "value": "{ams.text.font-weight.bold}" }
       },
       "cell": {
-        "border-block-end": { "value": "{ams.border.width.sm} solid {ams.color.neutral-grey1}" },
+        "border-block-end": { "value": "{ams.border.width.sm} solid {ams.brand.color.neutral.20}" },
         "padding-block": { "value": "{ams.space.sm}" },
         "padding-inline": { "value": "{ams.space.md}" }
       },

--- a/proprietary/tokens/src/components/ams/tabs.tokens.json
+++ b/proprietary/tokens/src/components/ams/tabs.tokens.json
@@ -3,11 +3,11 @@
     "tabs": {
       "gap": { "value": "{ams.space.md}" },
       "list": {
-        "background-color": { "value": "{ams.color.primary-white}" },
-        "border-block-end": { "value": "{ams.border.width.md} solid {ams.color.primary-blue}" }
+        "background-color": { "value": "{ams.brand.color.neutral.0}" },
+        "border-block-end": { "value": "{ams.border.width.md} solid {ams.brand.color.blue.60}" }
       },
       "button": {
-        "color": { "value": "{ams.color.primary-blue}" },
+        "color": { "value": "{ams.brand.color.blue.60}" },
         "cursor": { "value": "{ams.action.activate.cursor}" },
         "font-family": { "value": "{ams.text.font-family}" },
         "font-size": { "value": "{ams.text.level.5.font-size}" },
@@ -17,15 +17,15 @@
         "padding-block": { "value": "{ams.space.sm}" },
         "padding-inline": { "value": "{ams.space.md}" },
         "hover": {
-          "color": { "value": "{ams.color.dark-blue}" },
-          "box-shadow": { "value": "inset 0 -0.125rem 0 0 {ams.color.dark-blue}" }
+          "color": { "value": "{ams.brand.color.blue.80}" },
+          "box-shadow": { "value": "inset 0 -0.125rem 0 0 {ams.brand.color.blue.80}" }
         },
         "selected": {
-          "background-color": { "value": "{ams.color.primary-blue}" },
-          "color": { "value": "{ams.color.primary-white}" }
+          "background-color": { "value": "{ams.brand.color.blue.60}" },
+          "color": { "value": "{ams.brand.color.neutral.0}" }
         },
         "disabled": {
-          "color": { "value": "{ams.color.neutral-grey2}" },
+          "color": { "value": "{ams.brand.color.neutral.60}" },
           "cursor": { "value": "{ams.action.disabled.cursor}" }
         }
       }

--- a/proprietary/tokens/src/components/ams/text-area.tokens.json
+++ b/proprietary/tokens/src/components/ams/text-area.tokens.json
@@ -1,9 +1,9 @@
 {
   "ams": {
     "text-area": {
-      "background-color": { "value": "{ams.color.primary-white}" },
-      "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-black}" },
-      "color": { "value": "{ams.color.primary-black}" },
+      "background-color": { "value": "{ams.brand.color.neutral.0}" },
+      "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.100}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
@@ -15,22 +15,22 @@
       "padding-block": { "value": "{ams.space.sm}" },
       "padding-inline": { "value": "{ams.space.md}" },
       "disabled": {
-        "background-color": { "value": "{ams.color.primary-white}" },
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.neutral-grey2}" },
-        "color": { "value": "{ams.color.neutral-grey2}" },
+        "background-color": { "value": "{ams.brand.color.neutral.0}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.60}" },
+        "color": { "value": "{ams.brand.color.neutral.60}" },
         "cursor": { "value": "{ams.action.disabled.cursor}" }
       },
       "hover": {
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-black}" }
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.neutral.100}" }
       },
       "invalid": {
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-red}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.red.60}" },
         "hover": {
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-red}" }
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.red.80}" }
         }
       },
       "placeholder": {
-        "color": { "value": "{ams.color.neutral-grey3}" }
+        "color": { "value": "{ams.brand.color.neutral.60}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/text-input.tokens.json
+++ b/proprietary/tokens/src/components/ams/text-input.tokens.json
@@ -1,9 +1,9 @@
 {
   "ams": {
     "text-input": {
-      "background-color": { "value": "{ams.color.primary-white}" },
-      "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-black}" },
-      "color": { "value": "{ams.color.primary-black}" },
+      "background-color": { "value": "{ams.brand.color.neutral.0}" },
+      "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.100}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
@@ -12,21 +12,21 @@
       "padding-block": { "value": "{ams.space.sm}" },
       "padding-inline": { "value": "{ams.space.md}" },
       "disabled": {
-        "background-color": { "value": "{ams.color.primary-white}" },
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.neutral-grey2}" },
-        "color": { "value": "{ams.color.neutral-grey2}" }
+        "background-color": { "value": "{ams.brand.color.neutral.0}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.60}" },
+        "color": { "value": "{ams.brand.color.neutral.60}" }
       },
       "hover": {
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-black}" }
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.neutral.100}" }
       },
       "invalid": {
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-red}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.red.60}" },
         "hover": {
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-red}" }
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.red.80}" }
         }
       },
       "placeholder": {
-        "color": { "value": "{ams.color.neutral-grey3}" }
+        "color": { "value": "{ams.brand.color.neutral.60}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/time-input.tokens.json
+++ b/proprietary/tokens/src/components/ams/time-input.tokens.json
@@ -1,9 +1,9 @@
 {
   "ams": {
     "time-input": {
-      "background-color": { "value": "{ams.color.primary-white}" },
-      "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-black}" },
-      "color": { "value": "{ams.color.primary-black}" },
+      "background-color": { "value": "{ams.brand.color.neutral.0}" },
+      "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.100}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
@@ -17,9 +17,9 @@
         }
       },
       "disabled": {
-        "background-color": { "value": "{ams.color.primary-white}" },
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.neutral-grey2}" },
-        "color": { "value": "{ams.color.neutral-grey2}" },
+        "background-color": { "value": "{ams.brand.color.neutral.0}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.neutral.60}" },
+        "color": { "value": "{ams.brand.color.neutral.60}" },
         "calender-picker-indicator": {
           "background-image": {
             "value": "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' fill='%23BEBEBE'><path d='M16 0C7.163 0 0 7.163 0 16s7.163 16 16 16 16-7.163 16-16A16 16 0 0 0 16 0zm.9 28v-2h-2v1.9A11.8 11.8 0 0 1 4.1 17H6v-2H4.1A11.8 11.8 0 0 1 15 4.1V6h2V4.1A11.8 11.8 0 0 1 27.9 15H26v2h1.9a11.9 11.9 0 0 1-11 11zm.1-13h4v2h-6V9h2v6z'/></svg>\")"
@@ -27,7 +27,7 @@
         }
       },
       "hover": {
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-black}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.neutral.100}" },
         "calender-picker-indicator": {
           "background-image": {
             "value": "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' fill='%23102E62'><path d='M16 0C7.163 0 0 7.163 0 16s7.163 16 16 16 16-7.163 16-16A16 16 0 0 0 16 0zm.9 28v-2h-2v1.9A11.8 11.8 0 0 1 4.1 17H6v-2H4.1A11.8 11.8 0 0 1 15 4.1V6h2V4.1A11.8 11.8 0 0 1 27.9 15H26v2h1.9a11.9 11.9 0 0 1-11 11zm.1-13h4v2h-6V9h2v6z'/></svg>\")"
@@ -35,9 +35,9 @@
         }
       },
       "invalid": {
-        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.color.primary-red}" },
+        "box-shadow": { "value": "inset 0 0 0 {ams.border.width.sm} {ams.brand.color.red.60}" },
         "hover": {
-          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.color.primary-red}" }
+          "box-shadow": { "value": "inset 0 0 0 {ams.border.width.md} {ams.brand.color.red.80}" }
         }
       }
     }

--- a/proprietary/tokens/src/components/ams/top-task-link.tokens.json
+++ b/proprietary/tokens/src/components/ams/top-task-link.tokens.json
@@ -3,7 +3,7 @@
     "top-task-link": {
       "gap": { "value": "{ams.space.sm}" },
       "description": {
-        "color": { "value": "{ams.color.primary-black}" },
+        "color": { "value": "{ams.brand.color.neutral.100}" },
         "font-family": { "value": "{ams.text.font-family}" },
         "font-size": { "value": "{ams.text.level.6.font-size}" },
         "font-weight": { "value": "{ams.text.font-weight.normal}" },
@@ -19,7 +19,7 @@
         "text-decoration-thickness": { "value": "{ams.link-appearance.text-decoration-thickness}" },
         "text-underline-offset": { "value": "{ams.link-appearance.text-underline-offset}" },
         "hover": {
-          "color": { "value": "{ams.color.dark-blue}" },
+          "color": { "value": "{ams.brand.color.blue.80}" },
           "text-decoration-line": { "value": "{ams.link-appearance.subtle.hover.text-decoration-line}" }
         }
       },

--- a/proprietary/tokens/src/components/ams/unordered-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/unordered-list.tokens.json
@@ -1,12 +1,12 @@
 {
   "ams": {
     "unordered-list": {
-      "color": { "value": "{ams.color.primary-black}" },
+      "color": { "value": "{ams.brand.color.neutral.100}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "gap": { "value": "{ams.space.md}" },
-      "inverse-color": { "value": "{ams.color.primary-white}" },
+      "inverse-color": { "value": "{ams.brand.color.neutral.0}" },
       "line-height": { "value": "{ams.text.level.5.line-height}" },
       "list-style-type": { "value": "'\\2022'" },
       "item": {

--- a/storybook/src/docs/components/ColorPalette.tsx
+++ b/storybook/src/docs/components/ColorPalette.tsx
@@ -1,38 +1,66 @@
 import './color-palette.css'
+import clsx from 'clsx'
 import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 export type DivProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 
 const ColorPaletteRoot = forwardRef(({ children, ...restProps }: DivProps, ref: ForwardedRef<HTMLDivElement>) => (
-  <div {...restProps} ref={ref} className="ams-storybook-color-palette">
+  <div {...restProps} ref={ref} className="ams-docs-color-palette">
     {children}
   </div>
 ))
 
 ColorPaletteRoot.displayName = 'ColorPalette'
 
-const ColorPaletteSection = ({ children }: DivProps) => (
-  <div className="ams-storybook-color-palette__section">{children}</div>
-)
-
-ColorPaletteSection.displayName = 'ColorPalette.Section'
-
-type ColorPaletteTileProps = {
-  color: string
+type ColorPaletteSwatchProps = {
+  color: Record<'0' | '20' | '40' | '60' | '80' | '100', string>
   name: string
 }
 
-const ColorPaletteTile = ({ name, color }: ColorPaletteTileProps) => (
-  <div className="ams-storybook-color-palette__tile">
-    <div className="ams-storybook-color-palette__example" style={{ backgroundColor: color }} />
-    <dl className="sb-unstyled ams-storybook-color-palette__description">
-      <dt className="ams-storybook-color-palette__name">{name}</dt>
-      <dd className="ams-storybook-color-palette__color">{color}</dd>
-    </dl>
+const ColorPaletteSwatch = ({ color, name }: ColorPaletteSwatchProps) => (
+  <div className={clsx('ams-docs-color-swatch', `ams-docs-color-swatch--${name}`)}>
+    <code className="ams-docs-color-code">ams.brand.color.{name}</code>
+    {name === 'neutral' ? (
+      <>
+        <ColorPaletteTile color={color['0']} level="0" />
+        <ColorPaletteTile color={color['20']} level="20" />
+        <ColorPaletteTile color={color['40']} level="40" />
+        <ColorPaletteTile color={color['60']} level="60" />
+        <ColorPaletteTile color={color['80']} level="80" />
+        <ColorPaletteTile color={color['100']} level="100" />
+      </>
+    ) : (
+      <>
+        <ColorPaletteTile color={color['20']} level="20" />
+        <ColorPaletteTile color={color['60']} level="60" />
+        <ColorPaletteTile color={color['80']} level="80" />
+      </>
+    )}
+  </div>
+)
+
+ColorPaletteSwatch.displayName = 'ColorPalette.Swatch'
+
+type ColorPaletteTileProps = {
+  color: string | undefined
+  level: string
+}
+
+const ColorPaletteTile = ({ color, level }: ColorPaletteTileProps) => (
+  <div className={clsx('ams-docs-color-tile', `ams-docs-color-tile--${level}`)}>
+    {color && (
+      <>
+        <code className="ams-docs-color-code">{level}</code>
+        <div className="ams-docs-color-sample" style={{ backgroundColor: color }} title={color} />
+      </>
+    )}
   </div>
 )
 
 ColorPaletteTile.displayName = 'ColorPalette.Tile'
 
-export const ColorPalette = Object.assign(ColorPaletteRoot, { Section: ColorPaletteSection, Tile: ColorPaletteTile })
+export const ColorPalette = Object.assign(ColorPaletteRoot, {
+  Swatch: ColorPaletteSwatch,
+  Tile: ColorPaletteTile,
+})

--- a/storybook/src/docs/components/color-palette.css
+++ b/storybook/src/docs/components/color-palette.css
@@ -1,50 +1,35 @@
-.ams-storybook-color-palette {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-}
-
-.ams-storybook-color-palette__section {
-  align-items: start;
+.ams-docs-color-palette {
+  align-items: center;
   display: grid;
-  gap: 2rem;
-  grid-template-columns: repeat(5, 1fr);
+  gap: 4rem;
+  grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
 }
 
-.ams-storybook-color-palette__tile {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+.ams-docs-color-swatch {
+  display: grid;
+  gap: 0 2px;
+  grid-template-columns: repeat(6, 1fr);
+
+  > :nth-child(1) {
+    grid-column: 1 / -1;
+  }
 }
 
-.ams-storybook-color-palette__example {
-  aspect-ratio: var(--ams-aspect-ratio-x-wide);
-  border: 0.0625rem solid rgb(0 0 0 / 12.5%);
-  grid-area: example;
+.ams-docs-color-code {
+  display: block;
+  font-size: 13px;
+  padding-block-end: 0.5rem;
+  text-align: center;
 }
 
-.ams-storybook-color-palette__description,
-.ams-storybook-color-palette__name,
-.ams-storybook-color-palette__color {
-  margin-block: 0;
-  margin-inline: 0;
-  padding-block: 0;
-  padding-inline: 0;
+:not(.ams-docs-color-swatch--neutral) > .ams-docs-color-tile--60 {
+  grid-column: span 4;
 }
 
-.ams-storybook-color-palette__description {
-  color: #000;
-  column-gap: 1ch;
-  display: flex;
-  flex-wrap: wrap;
-  font-family: "Amsterdam Sans", "Arial", sans-serif;
-  justify-content: space-between;
-}
+.ams-docs-color-sample {
+  block-size: 6rem;
 
-.ams-storybook-color-palette__name {
-  font-weight: 800;
-}
-
-.ams-storybook-color-palette__color {
-  text-align: end;
+  .ams-docs-color-swatch--neutral > .ams-docs-color-tile--0 & {
+    box-shadow: inset 0 0 0 0.0625rem rgb(0 0 0 / 12.5%);
+  }
 }

--- a/storybook/src/foundation/design-tokens/colour.docs.mdx
+++ b/storybook/src/foundation/design-tokens/colour.docs.mdx
@@ -3,39 +3,62 @@
 import tokens from "@amsterdam/design-system-tokens/dist/index.json";
 import { Meta } from "@storybook/blocks";
 import { ColorPalette } from "../../docs/components/ColorPalette";
-import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Meta title="Brand/Design Tokens/Colour" />
 
-<StatusBadge reason="The set of available colours and their names will change." />
-
 # Colour
 
-The basic colours of Amsterdam are white, red, and black.
-We have 8 additional colours and 3 shades of grey.
+Our colour palette is vibrant and crisp.
+The main colours are red, blue, black, and white.
+They are complemented by a range of accent colors and shades of gray.
 
 <ColorPalette>
-  <ColorPalette.Section>
-    <ColorPalette.Tile color={tokens.ams.color["primary-white"]} name="white" />
-    <ColorPalette.Tile color={tokens.ams.color["primary-red"]} name="red" />
-    <ColorPalette.Tile color={tokens.ams.color["primary-black"]} name="black" />
-  </ColorPalette.Section>
-  <ColorPalette.Section>
-    <ColorPalette.Tile color={tokens.ams.color["green"]} name="green" />
-    <ColorPalette.Tile color={tokens.ams.color["dark-green"]} name="dark green" />
-    <ColorPalette.Tile color={tokens.ams.color["blue"]} name="blue" />
-    <ColorPalette.Tile color={tokens.ams.color["primary-blue"]} name="dark blue" />
-    <ColorPalette.Tile color={tokens.ams.color["dark-blue"]} name="darker blue" />
-  </ColorPalette.Section>
-  <ColorPalette.Section>
-    <ColorPalette.Tile color={tokens.ams.color["yellow"]} name="yellow" />
-    <ColorPalette.Tile color={tokens.ams.color["orange"]} name="orange" />
-    <ColorPalette.Tile color={tokens.ams.color["magenta"]} name="magenta" />
-    <ColorPalette.Tile color={tokens.ams.color["purple"]} name="purple" />
-  </ColorPalette.Section>
-  <ColorPalette.Section>
-    <ColorPalette.Tile color={tokens.ams.color["neutral-grey1"]} name="light grey" />
-    <ColorPalette.Tile color={tokens.ams.color["neutral-grey2"]} name="grey" />
-    <ColorPalette.Tile color={tokens.ams.color["neutral-grey3"]} name="dark grey" />
-  </ColorPalette.Section>
+  <ColorPalette.Swatch color={tokens.ams.brand.color.red} name="red" />
+  <ColorPalette.Swatch color={tokens.ams.brand.color.azure} name="azure" />
+  <ColorPalette.Swatch color={tokens.ams.brand.color.blue} name="blue" />
+  <ColorPalette.Swatch color={tokens.ams.brand.color.yellow} name="yellow" />
+  <ColorPalette.Swatch color={tokens.ams.brand.color.lime} name="lime" />
+  <ColorPalette.Swatch color={tokens.ams.brand.color.green} name="green" />
+  <ColorPalette.Swatch color={tokens.ams.brand.color.orange} name="orange" />
+  <ColorPalette.Swatch color={tokens.ams.brand.color.magenta} name="magenta" />
+  <ColorPalette.Swatch color={tokens.ams.brand.color.purple} name="purple" />
+  <ColorPalette.Swatch color={tokens.ams.brand.color.neutral} name="neutral" />
 </ColorPalette>
+
+## Application
+
+### Red
+
+Red is obviously prominent in our logo.
+The only other usage for it is to indicate errors.
+
+### Blue
+
+Blue indicates interactivity.
+Literally all buttons and links are blue; and dark blue on hover.
+Only if they are on a coloured background do they become black or white.
+Radio, Checkbox and Switch are blue as well.
+Our Page Footer has a blue background.
+
+### Black
+
+Almost all text is black, as are links on a light background colour.
+Borders of inputs are black as well.
+
+### White
+
+Our pages have a white background, as do inputs.
+Text and links on a dark background are white instead of black and blue.
+
+### Neutral
+
+We use shades of gray for borders, backgrounds and labels of disabled controls.
+Secondary text is dark gray.
+
+### Azure, Lime, Green, Yellow, Orange, Magenta, Purple
+
+These colours are supplemental.
+Spotlight and Breakout use them to create prominent sections.
+Avatar and Badge can use them for a background.
+An Alert is blue, orange, red, or green.
+Highlighted text is yellow.

--- a/storybook/src/styles/docs.css
+++ b/storybook/src/styles/docs.css
@@ -167,7 +167,7 @@
 
 [class*="ams-docs-token-example--space"] {
   background-color: var(--ams-brand-color-neutral-0);
-  outline: 1px dashed var(--ams-brand-color-neutral-200);
+  outline: 1px dashed var(--ams-brand-color-neutral-40);
 }
 
 .ams-resize-horizontal {

--- a/storybook/src/styles/docs.css
+++ b/storybook/src/styles/docs.css
@@ -166,8 +166,8 @@
 }
 
 [class*="ams-docs-token-example--space"] {
-  background-color: var(--ams-color-primary-white);
-  outline: 1px dashed var(--ams-color-neutral-grey2);
+  background-color: var(--ams-brand-color-neutral-0);
+  outline: 1px dashed var(--ams-brand-color-neutral-200);
 }
 
 .ams-resize-horizontal {


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

- This introduces tints and shades of all our colours.
- All colour tokens have been renamed, e.g. from `ams.color.primary-blue` to `ams.brand.color.blue.60`.
- Interactive components that are invalid now become dark red on hover.
- The colour ‘green’ has been renamed to ‘lime’, ‘dark green’ to ‘green’, ‘blue’ to ‘azure’, and ‘primary-blue’ to ‘blue’, and the other ‘primary’ colours have lost that prefix as well.
- As little as possible usages of colour have been changed – only everything ‘disabled’ now uses `neutral.60` consistently.

## Why

- To define a darker hover color and a lighter background colour for every colour in the palette. 
- To introduce a consistent naming scheme for all colours.

## How

- Generated tints and shades through Supa Palette for Figma
- Replaced `ams.color.*` with `ams.brand.color.*`
- Updated all token references in components
- Updated the Color Palette component and colour docs

Upcoming pull requests will update the colour names in props, introduce common tokens, add more consistency, prefix other brand tokens, etc.
