### PR TITLE
chore: Remove trailing slash from homepage field in package.jsons

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.0",
   "author": "Design System Team, City of Amsterdam <designsystem@amsterdam.nl>",
   "description": "Reusable components, patterns and guidelines powering the City of Amsterdam’s digital services.",
-  "homepage": "https://designsystem.amsterdam/",
+  "homepage": "https://designsystem.amsterdam",
   "license": "EUPL-1.2",
   "name": "@amsterdam/design-system",
   "keywords": [

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -2,7 +2,7 @@
   "version": "0.14.0",
   "author": "Design System Team, City of Amsterdam <designsystem@amsterdam.nl>",
   "description": "Stylesheets for all components from the Amsterdam Design System and some general utilities. Use it to apply the visual design of the City of Amsterdam to your HTML elements or non-React components.",
-  "homepage": "https://designsystem.amsterdam/",
+  "homepage": "https://designsystem.amsterdam",
   "license": "EUPL-1.2",
   "name": "@amsterdam/design-system-css",
   "keywords": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,7 @@
   "version": "0.14.0",
   "author": "Design System Team, City of Amsterdam <designsystem@amsterdam.nl>",
   "description": "All React components from the Amsterdam Design System. Use it to compose pages in your website or application.",
-  "homepage": "https://designsystem.amsterdam/",
+  "homepage": "https://designsystem.amsterdam",
   "license": "EUPL-1.2",
   "name": "@amsterdam/design-system-react",
   "keywords": [

--- a/proprietary/assets/package.json
+++ b/proprietary/assets/package.json
@@ -2,7 +2,7 @@
   "version": "0.3.0",
   "author": "Design System Team, City of Amsterdam <designsystem@amsterdam.nl>",
   "description": "All assets from the Amsterdam Design System. Use it to include the correct fonts, icons or logos in your website or application.",
-  "homepage": "https://designsystem.amsterdam/",
+  "homepage": "https://designsystem.amsterdam",
   "license": "SEE LICENSE IN LICENSE.md",
   "name": "@amsterdam/design-system-assets",
   "keywords": [

--- a/proprietary/react-icons/package.json
+++ b/proprietary/react-icons/package.json
@@ -2,7 +2,7 @@
   "version": "0.1.13",
   "author": "Design System Team, City of Amsterdam <designsystem@amsterdam.nl>",
   "description": "All icons from the Amsterdam Design System as React components. Use it to use the correct icons in your React project.",
-  "homepage": "https://designsystem.amsterdam/",
+  "homepage": "https://designsystem.amsterdam",
   "license": "SEE LICENSE IN LICENSE.md",
   "name": "@amsterdam/design-system-react-icons",
   "keywords": [

--- a/proprietary/tokens/package.json
+++ b/proprietary/tokens/package.json
@@ -2,7 +2,7 @@
   "version": "0.14.0",
   "author": "Design System Team, City of Amsterdam <designsystem@amsterdam.nl>",
   "description": "All design tokens from the Amsterdam Design System. Use it to apply its visual design to your website or application.",
-  "homepage": "https://designsystem.amsterdam/",
+  "homepage": "https://designsystem.amsterdam",
   "license": "SEE LICENSE IN LICENSE.md",
   "name": "@amsterdam/design-system-tokens",
   "type": "module",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -2,7 +2,7 @@
   "version": "0.0.0",
   "author": "Design System Team, City of Amsterdam <designsystem@amsterdam.nl>",
   "description": "The handbook for the Amsterdam Design System, created with Storybook.",
-  "homepage": "https://designsystem.amsterdam/",
+  "homepage": "https://designsystem.amsterdam",
   "license": "EUPL-1.2",
   "name": "@amsterdam/storybook",
   "keywords": [],


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Remove trailing slash from homepage field in package.jsons

## Why

This field is [shown on npm](https://www.npmjs.com/package/@amsterdam/design-system-tokens), and looks ugly imo. 

## How

Find and replace

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
