### PR TITLE
fix: Fix link from Card docs to Aspect Ratio

### DIFF
--- a/storybook/src/components/Card/Card.docs.mdx
+++ b/storybook/src/components/Card/Card.docs.mdx
@@ -22,7 +22,7 @@ This ensures screen readers first read the heading and then the tagline.
 
 ### With image
 
-A card often displays the image of the detail page.
-Use [Aspect Ratio](/docs/layout-aspect-ratio--docs) for the correct aspect ratio.
+A card often displays the [image](/docs/components-media-image--docs) of the detail page.
+It must use one of the available [aspect ratios](/docs/brand-design-tokens-aspect-ratio--docs).
 
 <Canvas of={CardStories.WithImage} />


### PR DESCRIPTION
We received notice that this link to the Aspect Ratio no longer worked. That’s correct; it’s due to removing the component in the last release. I’ve checked all other links related to Aspect Ratio, and they are accurate.