### PR TITLE
fix: Center-align menu button content vertically

### DIFF
--- a/packages/css/src/components/header/header.scss
+++ b/packages/css/src/components/header/header.scss
@@ -129,6 +129,7 @@
 }
 
 .ams-header__mega-menu-button {
+  align-items: center;
   column-gap: var(--ams-header-menu-item-column-gap);
   cursor: pointer;
   display: grid;


### PR DESCRIPTION
After zooming in or out, the button label and hamburger icon were no longer aligned vertically. The misplacement differed between Safari and Firefox, but this resolves both.