### PR TITLE
feat: Remove Beta status from Header and deprecate Mega Menu

### DIFF
--- a/packages/react/src/MegaMenu/MegaMenu.tsx
+++ b/packages/react/src/MegaMenu/MegaMenu.tsx
@@ -20,4 +20,5 @@ const MegaMenuRoot = forwardRef(
 
 MegaMenuRoot.displayName = 'MegaMenu'
 
+/** @deprecated Use child components in Header instead. */
 export const MegaMenu = Object.assign(MegaMenuRoot, { ListCategory: MegaMenuListCategory })

--- a/storybook/src/components/Header/Header.docs.mdx
+++ b/storybook/src/components/Header/Header.docs.mdx
@@ -3,11 +3,8 @@
 import { Canvas, Controls, Markdown, Meta, Primary } from "@storybook/blocks";
 import * as HeaderStories from "./Header.stories.tsx";
 import README from "../../../../packages/css/src/components/header/README.md?raw";
-import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Meta of={HeaderStories} />
-
-<StatusBadge description="Needs work for narrow screens and integration with Mega Menu." />
 
 <Markdown>{README}</Markdown>
 

--- a/storybook/src/components/Header/Header.docs.mdx
+++ b/storybook/src/components/Header/Header.docs.mdx
@@ -7,7 +7,7 @@ import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Meta of={HeaderStories} />
 
-<StatusBadge reason="Needs work for narrow screens and integration with Mega Menu." />
+<StatusBadge description="Needs work for narrow screens and integration with Mega Menu." />
 
 <Markdown>{README}</Markdown>
 

--- a/storybook/src/components/Icon/Icon.docs.mdx
+++ b/storybook/src/components/Icon/Icon.docs.mdx
@@ -7,7 +7,7 @@ import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Meta of={IconStories} />
 
-<StatusBadge reason="The set of available icon names and the component API will change." />
+<StatusBadge description="The set of available icon names and the component API will change." />
 
 <Markdown>{README}</Markdown>
 

--- a/storybook/src/components/MegaMenu/MegaMenu.docs.mdx
+++ b/storybook/src/components/MegaMenu/MegaMenu.docs.mdx
@@ -7,7 +7,7 @@ import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Meta of={MegaMenuStories} />
 
-<StatusBadge reason="Needs work for narrow screens and integration with Mega Menu." />
+<StatusBadge description="Needs work for narrow screens and integration with Mega Menu." />
 
 <Markdown>{README}</Markdown>
 

--- a/storybook/src/components/MegaMenu/MegaMenu.docs.mdx
+++ b/storybook/src/components/MegaMenu/MegaMenu.docs.mdx
@@ -7,7 +7,7 @@ import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Meta of={MegaMenuStories} />
 
-<StatusBadge description="Needs work for narrow screens and integration with Mega Menu." />
+<StatusBadge status="deprecated" description="Use child components in Header instead." />
 
 <Markdown>{README}</Markdown>
 

--- a/storybook/src/components/PageMenu/PageMenu.docs.mdx
+++ b/storybook/src/components/PageMenu/PageMenu.docs.mdx
@@ -7,7 +7,7 @@ import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Meta of={PageMenuStories} />
 
-<StatusBadge reason="May be affected by changes to Header and/or have its name changed." />
+<StatusBadge description="Will be affected by changes to Header and/or have its name changed." />
 
 <Markdown>{README}</Markdown>
 

--- a/storybook/src/components/TopTaskLink/TopTaskLink.docs.mdx
+++ b/storybook/src/components/TopTaskLink/TopTaskLink.docs.mdx
@@ -7,7 +7,7 @@ import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Meta of={TopTaskLinkStories} />
 
-<StatusBadge reason="Will probably be removed in favour of Card." />
+<StatusBadge description="Will probably be removed in favour of Card." />
 
 <Markdown>{README}</Markdown>
 

--- a/storybook/src/docs/components/StatusBadge.tsx
+++ b/storybook/src/docs/components/StatusBadge.tsx
@@ -2,14 +2,16 @@ import './status-badge.css'
 import { Badge } from '@amsterdam/design-system-react/src'
 
 type StatusBadgeProps = {
-  /* Explains how the component must change to transition into another status. */
-  reason: string
+  /* Describes the reason for the status or suggests an alternative for a deprecated component. */
+  description: string
+  /* The status of the component. */
+  status: 'beta' | 'deprecated' | string
 }
 
 /** Indicates the status of a component. Use this to prepare implementers for API changes. */
-export const StatusBadge = ({ reason }: StatusBadgeProps) => (
+export const StatusBadge = ({ description, status = 'beta' }: StatusBadgeProps) => (
   <span className="ams-storybook-status-badge">
-    <Badge color="orange" label="beta" />
-    <span>{reason}</span>
+    <Badge color={status === 'deprecated' ? 'red' : 'orange'} label={status} />
+    <span>{description}</span>
   </span>
 )

--- a/storybook/src/foundation/assets/icons.docs.mdx
+++ b/storybook/src/foundation/assets/icons.docs.mdx
@@ -6,7 +6,7 @@ import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Meta title="Brand/Assets/Icons" />
 
-<StatusBadge reason="The set of available icons will change." />
+<StatusBadge description="The set of available icons will change." />
 
 # Icons
 

--- a/storybook/src/foundation/design-tokens/colour.docs.mdx
+++ b/storybook/src/foundation/design-tokens/colour.docs.mdx
@@ -7,7 +7,7 @@ import { StatusBadge } from "../../docs/components/StatusBadge";
 
 <Meta title="Brand/Design Tokens/Colour" />
 
-<StatusBadge reason="The set of available colours and their names will change." />
+<StatusBadge description="The set of available colours and their names will change." />
 
 # Colour
 


### PR DESCRIPTION
The Header component is no longer in Beta.

The Mega Menu component is deprecated. I’ve updated the Status Badge component to allow customizing the status label and making it red for a deprecation.