### PR TITLE
chore: Fix CODEOWNERS.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@Amsterdam/design-system-maintainers
+* @Amsterdam/design-system-maintainers


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It specifies that the design-system-maintainers group is code owner of all code in the repo.

## Why

Because that is what we want, but CODEOWNERS.md didn't specify this. 

## How

By adding an asterix before `@Amsterdam/design-system-maintainers`.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
