### PR TITLE
chore: Remove CSS declarations that set the initial value for `flex-direction`

### DIFF
--- a/packages/css/src/components/alert/alert.scss
+++ b/packages/css/src/components/alert/alert.scss
@@ -9,7 +9,6 @@
   border-style: var(--ams-alert-border-style);
   border-width: var(--ams-alert-border-width);
   display: flex;
-  flex-direction: row;
   gap: var(--ams-alert-gap);
   justify-content: space-between;
   padding-block: var(--ams-alert-padding-block);

--- a/packages/css/src/components/file-list/file-list.scss
+++ b/packages/css/src/components/file-list/file-list.scss
@@ -23,7 +23,6 @@
 
 .ams-file-list__item {
   display: flex;
-  flex-direction: row;
   font-family: var(--ams-file-list-file-font-family);
   font-size: var(--ams-file-list-file-font-size);
   font-weight: var(--ams-file-list-file-font-weight);

--- a/packages/css/src/components/page-menu/page-menu.scss
+++ b/packages/css/src/components/page-menu/page-menu.scss
@@ -15,7 +15,6 @@
   box-sizing: border-box;
   column-gap: var(--ams-page-menu-column-gap);
   display: flex;
-  flex-direction: row;
   flex-wrap: wrap;
   list-style: none;
   row-gap: var(--ams-page-menu-row-gap);
@@ -34,7 +33,6 @@
 @mixin page-menu-item {
   color: var(--ams-page-menu-item-color);
   display: inline-flex;
-  flex-direction: row;
   font-family: var(--ams-page-menu-item-font-family);
   font-size: var(--ams-page-menu-item-font-size);
   font-weight: var(--ams-page-menu-item-font-weight);

--- a/packages/css/src/components/row/row.scss
+++ b/packages/css/src/components/row/row.scss
@@ -7,7 +7,6 @@
 
 .ams-row {
   display: flex;
-  flex-direction: row;
   gap: var(--ams-row-gap-md);
 }
 


### PR DESCRIPTION
Removes declarations of `flex-direction: row` as that’s the initial value.

I couldn’t quickly find a Stylelint rule that would automatically do this for the initial value of all non-inheriting properties.