### PR TITLE
fix(Avatar): Remove incorrect aspect ratio for image

### DIFF
--- a/packages/css/src/components/avatar/avatar.scss
+++ b/packages/css/src/components/avatar/avatar.scss
@@ -15,10 +15,6 @@
   padding-inline: var(--ams-avatar-padding-inline);
   place-content: center;
 
-  .ams-image {
-    aspect-ratio: initial;
-  }
-
   svg {
     fill: currentColor;
   }

--- a/packages/css/src/components/avatar/avatar.scss
+++ b/packages/css/src/components/avatar/avatar.scss
@@ -15,6 +15,10 @@
   padding-inline: var(--ams-avatar-padding-inline);
   place-content: center;
 
+  .ams-image {
+    aspect-ratio: initial;
+  }
+
   svg {
     fill: currentColor;
   }

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -8,7 +8,6 @@ import clsx from 'clsx'
 import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes } from 'react'
 import { Icon } from '../Icon'
-import { Image } from '../Image'
 
 export const avatarColors = [
   'black',
@@ -36,7 +35,7 @@ type AvatarContentProps = {
 
 const AvatarContent = ({ imageSrc, initials }: AvatarContentProps) => {
   if (imageSrc) {
-    return <Image alt="" src={imageSrc} />
+    return <img alt="" src={imageSrc} />
   }
 
   if (initials.length) {

--- a/storybook/src/components/Avatar/Avatar.docs.mdx
+++ b/storybook/src/components/Avatar/Avatar.docs.mdx
@@ -18,6 +18,7 @@ import README from "../../../../packages/css/src/components/avatar/README.md?raw
 
 The Avatar can also display a photo or other image for the person.
 Make sure to scale the image down to around 100 pixels to prevent unnecessary data transfers.
+The center of the image will be visible; provide a square image if possible.
 
 <Canvas of={AvatarStories.WithImage} />
 


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Restores the correct display of an Image in an Avatar.

## Why

The new default aspect ratio for the Image component (introduced in #1593) forces it to 16:9.

## How

I’m resetting the aspect ratio for an `.ams-image` in an `.ams-avatar`. We don’t know its dimensions, and the user can’t easily provide them. We already ensured to show the center of the image; I’ve made that explicit in the docs.

I decided against using a clean HTML `img` element because we still want to apply the other base styles of our image component.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

None.