### PR TITLE
feat(Avatar)!: Remove some colour options and make purple the default

### DIFF
--- a/packages/css/src/components/avatar/README.md
+++ b/packages/css/src/components/avatar/README.md
@@ -6,10 +6,11 @@ A circular badge representing a person.
 
 ## Design
 
-The avatar contains 1 or 2 initial letters from the person's full name, a picture, or a generic icon.
-The default background colour is dark blue.
+The avatar contains 1 or 2 initial letters from the person’s full name, a picture, or a generic icon.
+To personalize the avatar, the user can be allowd to choose one of the highlight colours.
+The default background colour is purple.
 
 ## Guidelines
 
-- Display an avatar for the person currently using the application,
+- Display an avatar for the person who is using the application,
   or to associate a person with a content item.

--- a/packages/css/src/components/avatar/README.md
+++ b/packages/css/src/components/avatar/README.md
@@ -7,10 +7,10 @@ A circular badge representing a person.
 ## Design
 
 The avatar contains 1 or 2 initial letters from the person’s full name, a picture, or a generic icon.
-To personalize the avatar, the user can be allowd to choose one of the highlight colours.
+To personalize the avatar, the user can be allowed to choose one of the highlight colours.
 The default background colour is purple.
 
 ## Guidelines
 
-- Display an avatar for the person who is using the application,
+- Show an avatar for the user of the application,
   or to associate a person with a content item.

--- a/packages/css/src/components/avatar/avatar.scss
+++ b/packages/css/src/components/avatar/avatar.scss
@@ -5,7 +5,9 @@
 
 .ams-avatar {
   aspect-ratio: var(--ams-avatar-aspect-ratio);
+  background-color: var(--ams-avatar-background-color);
   border-radius: 50%;
+  color: var(--ams-avatar-color);
   display: inline-flex;
   font-family: var(--ams-avatar-font-family);
   font-size: var(--ams-avatar-font-size);
@@ -37,16 +39,6 @@
   vertical-align: middle; /* Remove ‘phantom’ white space when image doesn’t load */
 }
 
-.ams-avatar--black {
-  background-color: var(--ams-avatar-black-background-color);
-  color: var(--ams-avatar-black-color);
-}
-
-.ams-avatar--blue {
-  background-color: var(--ams-avatar-blue-background-color);
-  color: var(--ams-avatar-blue-color);
-}
-
 .ams-avatar--dark-green {
   background-color: var(--ams-avatar-dark-green-background-color);
   color: var(--ams-avatar-dark-green-color);
@@ -55,21 +47,6 @@
 .ams-avatar--green {
   background-color: var(--ams-avatar-green-background-color);
   color: var(--ams-avatar-green-color);
-}
-
-.ams-avatar--grey-1 {
-  background-color: var(--ams-avatar-grey-1-background-color);
-  color: var(--ams-avatar-grey-1-color);
-}
-
-.ams-avatar--grey-2 {
-  background-color: var(--ams-avatar-grey-2-background-color);
-  color: var(--ams-avatar-grey-2-color);
-}
-
-.ams-avatar--grey-3 {
-  background-color: var(--ams-avatar-grey-3-background-color);
-  color: var(--ams-avatar-grey-3-color);
 }
 
 .ams-avatar--light-blue {
@@ -85,21 +62,6 @@
 .ams-avatar--orange {
   background-color: var(--ams-avatar-orange-background-color);
   color: var(--ams-avatar-orange-color);
-}
-
-.ams-avatar--purple {
-  background-color: var(--ams-avatar-purple-background-color);
-  color: var(--ams-avatar-purple-color);
-}
-
-.ams-avatar--red {
-  background-color: var(--ams-avatar-red-background-color);
-  color: var(--ams-avatar-red-color);
-}
-
-.ams-avatar--white {
-  background-color: var(--ams-avatar-white-background-color);
-  color: var(--ams-avatar-white-color);
 }
 
 .ams-avatar--yellow {

--- a/packages/react/src/Avatar/Avatar.test.tsx
+++ b/packages/react/src/Avatar/Avatar.test.tsx
@@ -65,14 +65,6 @@ describe('Avatar', () => {
     expect(component).toHaveTextContent('AB')
   })
 
-  it('renders with default color', () => {
-    const { container } = render(<Avatar label="VS" />)
-
-    const component = container.querySelector(':only-child')
-
-    expect(component).toHaveClass('ams-avatar--blue')
-  })
-
   avatarColors.map((color) =>
     it(`renders with ${color} color`, () => {
       const { container } = render(<Avatar label="AL" color={color} />)

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -10,10 +10,9 @@ import type { ForwardedRef, HTMLAttributes } from 'react'
 import { Icon } from '../Icon'
 import { Image } from '../Image'
 
-const defaultColor = 'purple'
 export const avatarColors = ['dark-green', 'green', 'light-blue', 'magenta', 'orange', 'yellow'] as const
 
-type AvatarColor = (typeof avatarColors)[number] | typeof defaultColor
+type AvatarColor = (typeof avatarColors)[number]
 
 type AvatarContentProps = {
   imageSrc?: string
@@ -42,10 +41,7 @@ export type AvatarProps = {
 } & HTMLAttributes<HTMLSpanElement>
 
 export const Avatar = forwardRef(
-  (
-    { label, imageSrc, className, color = defaultColor, ...restProps }: AvatarProps,
-    ref: ForwardedRef<HTMLSpanElement>,
-  ) => {
+  ({ label, imageSrc, className, color, ...restProps }: AvatarProps, ref: ForwardedRef<HTMLSpanElement>) => {
     const initials = label.slice(0, 2).toUpperCase()
 
     const a11yLabel = initials.length === 0 ? 'Gebruiker' : `Initialen gebruiker: ${initials}`
@@ -54,7 +50,7 @@ export const Avatar = forwardRef(
       <span
         {...restProps}
         ref={ref}
-        className={clsx('ams-avatar', `ams-avatar--${color}`, imageSrc && 'ams-avatar--has-image', className)}
+        className={clsx('ams-avatar', color && `ams-avatar--${color}`, imageSrc && 'ams-avatar--has-image', className)}
       >
         <span className="ams-visually-hidden">{a11yLabel}</span>
         <AvatarContent imageSrc={imageSrc} initials={initials} />

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -10,9 +10,10 @@ import type { ForwardedRef, HTMLAttributes } from 'react'
 import { Icon } from '../Icon'
 import { Image } from '../Image'
 
-export const avatarColors = ['dark-green', 'green', 'light-blue', 'magenta', 'orange', 'purple', 'yellow'] as const
+const defaultColor = 'purple'
+export const avatarColors = ['dark-green', 'green', 'light-blue', 'magenta', 'orange', 'yellow'] as const
 
-type AvatarColor = (typeof avatarColors)[number]
+type AvatarColor = (typeof avatarColors)[number] | typeof defaultColor
 
 type AvatarContentProps = {
   imageSrc?: string
@@ -41,7 +42,10 @@ export type AvatarProps = {
 } & HTMLAttributes<HTMLSpanElement>
 
 export const Avatar = forwardRef(
-  ({ label, imageSrc, className, color = 'purple', ...restProps }: AvatarProps, ref: ForwardedRef<HTMLSpanElement>) => {
+  (
+    { label, imageSrc, className, color = defaultColor, ...restProps }: AvatarProps,
+    ref: ForwardedRef<HTMLSpanElement>,
+  ) => {
     const initials = label.slice(0, 2).toUpperCase()
 
     const a11yLabel = initials.length === 0 ? 'Gebruiker' : `Initialen gebruiker: ${initials}`

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -10,22 +10,7 @@ import type { ForwardedRef, HTMLAttributes } from 'react'
 import { Icon } from '../Icon'
 import { Image } from '../Image'
 
-export const avatarColors = [
-  'black',
-  'blue',
-  'dark-green',
-  'green',
-  'grey-1',
-  'grey-2',
-  'grey-3',
-  'light-blue',
-  'magenta',
-  'orange',
-  'purple',
-  'red',
-  'white',
-  'yellow',
-] as const
+export const avatarColors = ['dark-green', 'green', 'light-blue', 'magenta', 'orange', 'purple', 'yellow'] as const
 
 type AvatarColor = (typeof avatarColors)[number]
 
@@ -56,7 +41,7 @@ export type AvatarProps = {
 } & HTMLAttributes<HTMLSpanElement>
 
 export const Avatar = forwardRef(
-  ({ label, imageSrc, className, color = 'blue', ...restProps }: AvatarProps, ref: ForwardedRef<HTMLSpanElement>) => {
+  ({ label, imageSrc, className, color = 'purple', ...restProps }: AvatarProps, ref: ForwardedRef<HTMLSpanElement>) => {
     const initials = label.slice(0, 2).toUpperCase()
 
     const a11yLabel = initials.length === 0 ? 'Gebruiker' : `Initialen gebruiker: ${initials}`

--- a/proprietary/tokens/src/components/ams/avatar.tokens.json
+++ b/proprietary/tokens/src/components/ams/avatar.tokens.json
@@ -2,20 +2,14 @@
   "ams": {
     "avatar": {
       "aspect-ratio": { "value": "{ams.aspect-ratio.square}" },
+      "background-color": { "value": "{ams.color.purple}" },
+      "color": { "value": "{ams.color.primary-white}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.6.font-size}" },
       "font-weight": { "value": "{ams.text.font-weight.normal}" },
       "line-height": { "value": "{ams.text.level.6.line-height}" },
       "padding-block": { "value": "{ams.space.xs}" },
       "padding-inline": { "value": "{ams.space.xs}" },
-      "black": {
-        "background-color": { "value": "{ams.color.primary-black}" },
-        "color": { "value": "{ams.color.primary-white}" }
-      },
-      "blue": {
-        "background-color": { "value": "{ams.color.primary-blue}" },
-        "color": { "value": "{ams.color.primary-white}" }
-      },
       "dark-green": {
         "background-color": { "value": "{ams.color.dark-green}" },
         "color": { "value": "{ams.color.primary-white}" }
@@ -27,18 +21,6 @@
         "background-color": { "value": "{ams.color.green}" },
         "color": { "value": "{ams.color.primary-black}" }
       },
-      "grey-1": {
-        "background-color": { "value": "{ams.color.neutral-grey1}" },
-        "color": { "value": "{ams.color.primary-black}" }
-      },
-      "grey-2": {
-        "background-color": { "value": "{ams.color.neutral-grey2}" },
-        "color": { "value": "{ams.color.primary-black}" }
-      },
-      "grey-3": {
-        "background-color": { "value": "{ams.color.neutral-grey3}" },
-        "color": { "value": "{ams.color.primary-white}" }
-      },
       "light-blue": {
         "background-color": { "value": "{ams.color.blue}" },
         "color": { "value": "{ams.color.primary-black}" }
@@ -49,18 +31,6 @@
       },
       "orange": {
         "background-color": { "value": "{ams.color.orange}" },
-        "color": { "value": "{ams.color.primary-black}" }
-      },
-      "purple": {
-        "background-color": { "value": "{ams.color.purple}" },
-        "color": { "value": "{ams.color.primary-white}" }
-      },
-      "red": {
-        "background-color": { "value": "{ams.color.primary-red}" },
-        "color": { "value": "{ams.color.primary-white}" }
-      },
-      "white": {
-        "background-color": { "value": "{ams.color.primary-white}" },
         "color": { "value": "{ams.color.primary-black}" }
       },
       "yellow": {

--- a/storybook/src/components/Avatar/Avatar.stories.tsx
+++ b/storybook/src/components/Avatar/Avatar.stories.tsx
@@ -5,6 +5,7 @@
 
 import { Avatar } from '@amsterdam/design-system-react/src'
 import { Meta, StoryObj } from '@storybook/react'
+import { avatarColors } from '../../../../packages/react/src/Avatar/Avatar'
 
 const meta = {
   title: 'Components/Feedback/Avatar',
@@ -12,6 +13,14 @@ const meta = {
   args: {
     label: 'DS',
     imageSrc: '',
+  },
+  argTypes: {
+    color: {
+      control: {
+        labels: { undefined: 'purple (default)' },
+      },
+      options: [undefined, ...avatarColors],
+    },
   },
 } satisfies Meta<typeof Avatar>
 

--- a/storybook/src/components/Avatar/Avatar.stories.tsx
+++ b/storybook/src/components/Avatar/Avatar.stories.tsx
@@ -4,8 +4,8 @@
  */
 
 import { Avatar } from '@amsterdam/design-system-react/src'
+import { avatarColors } from '@amsterdam/design-system-react/src/Avatar/Avatar'
 import { Meta, StoryObj } from '@storybook/react'
-import { avatarColors } from '../../../../packages/react/src/Avatar/Avatar'
 
 const meta = {
   title: 'Components/Feedback/Avatar',


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

This removes the possibility of making an Avatar blue (it is not interactive), red (it can’t communicate an error or an invalid interactive state), or neutral (we don’t have tokens for these options). The remaining colours are in the ‘highlight’ group that #1820 will introduce.

## Why

See above.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a