### PR TITLE
fix(Tabs): Execute click handler on Button

### DIFF
--- a/packages/css/src/components/tabs/tabs.scss
+++ b/packages/css/src/components/tabs/tabs.scss
@@ -62,6 +62,10 @@
       background-color: SelectedItem;
     }
   }
+
+  * {
+    pointer-events: none;
+  }
 }
 
 .ams-tabs__button-label,

--- a/packages/css/src/components/tabs/tabs.scss
+++ b/packages/css/src/components/tabs/tabs.scss
@@ -62,10 +62,6 @@
       background-color: SelectedItem;
     }
   }
-
-  * {
-    pointer-events: none;
-  }
 }
 
 .ams-tabs__button-label,

--- a/packages/react/src/Tabs/TabsButton.tsx
+++ b/packages/react/src/Tabs/TabsButton.tsx
@@ -5,7 +5,7 @@
 
 import clsx from 'clsx'
 import { forwardRef, startTransition, useContext } from 'react'
-import type { ButtonHTMLAttributes, ForwardedRef, PropsWithChildren } from 'react'
+import type { ButtonHTMLAttributes, ForwardedRef, MouseEvent, PropsWithChildren } from 'react'
 import { TabsContext } from './TabsContext'
 
 export type TabsButtonProps = {
@@ -14,8 +14,15 @@ export type TabsButtonProps = {
 } & PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>
 
 export const TabsButton = forwardRef(
-  ({ children, className, tab = 0, ...restProps }: TabsButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
+  ({ children, className, onClick, tab = 0, ...restProps }: TabsButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
     const { activeTab, tabsId, updateTab } = useContext(TabsContext)
+
+    const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+      onClick?.(e)
+      startTransition(() => {
+        updateTab(tab)
+      })
+    }
 
     return (
       <button
@@ -24,11 +31,7 @@ export const TabsButton = forwardRef(
         aria-selected={activeTab === tab}
         className={clsx('ams-tabs__button', className)}
         id={`${tabsId}-tab-${tab}`}
-        onClick={() => {
-          startTransition(() => {
-            updateTab(tab)
-          })
-        }}
+        onClick={handleClick}
         ref={ref}
         role="tab"
         tabIndex={activeTab === tab ? 0 : -1}

--- a/packages/react/src/Tabs/TabsButton.tsx
+++ b/packages/react/src/Tabs/TabsButton.tsx
@@ -17,8 +17,8 @@ export const TabsButton = forwardRef(
   ({ children, className, onClick, tab = 0, ...restProps }: TabsButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
     const { activeTab, tabsId, updateTab } = useContext(TabsContext)
 
-    const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
-      onClick?.(e)
+    const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event)
       startTransition(() => {
         updateTab(tab)
       })


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Disallows children of a `Tabs.Button` to become the target of pointer events.

## Why

To ensure the click event always returns the button as its target.

## How

Through CSS.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Adresses #1846.
- We can release this as a 0.14.1 hotfix. This is why it merges into a release branch.
- I considered adding a Storybook interaction test, but decided against it to keep the bugfix minimal. We should make a start with the subject, though.
- Test this by adding `onClick: (e: MouseEvent<HTMLElement>) => console.log('e.target:', e.target)` to the `args` of the Tabs stories while importing `MouseEvent` from React.