### PR TITLE
feat(Tabs): Scroll wide content of a Tab Panel horizontally

### DIFF
--- a/packages/css/src/components/tabs/tabs.scss
+++ b/packages/css/src/components/tabs/tabs.scss
@@ -77,3 +77,7 @@
   user-select: none;
   visibility: hidden;
 }
+
+.ams-tabs__panel {
+  overflow-x: auto;
+}

--- a/storybook/src/components/Tabs/Tabs.docs.mdx
+++ b/storybook/src/components/Tabs/Tabs.docs.mdx
@@ -18,3 +18,9 @@ The first tab is active by default.
 Another tab’s panel can be displayed initially as well.
 
 <Canvas of={TabsStories.WithInitialTab} />
+
+### With wide content
+
+The Tab Buttons list and the content within the active Tab Panel will scroll horizontally when their width exceeds the available space.
+
+<Canvas of={TabsStories.WithWideContent} />

--- a/storybook/src/components/Tabs/Tabs.stories.tsx
+++ b/storybook/src/components/Tabs/Tabs.stories.tsx
@@ -3,11 +3,11 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { Heading, Paragraph } from '@amsterdam/design-system-react'
+import { Heading, Paragraph, Table } from '@amsterdam/design-system-react'
 import { Tabs } from '@amsterdam/design-system-react/src'
 import { Meta, StoryObj } from '@storybook/react'
 import { PropsWithChildren, ReactNode } from 'react'
-import { exampleParagraph } from '../shared/exampleContent'
+import { cityParts, exampleParagraph } from '../shared/exampleContent'
 
 const slowPanelDelay = 1000
 
@@ -88,5 +88,48 @@ export const Default: Story = {}
 export const WithInitialTab: Story = {
   args: {
     activeTab: 3,
+  },
+}
+
+export const WithWideContent: Story = {
+  args: {
+    children: [
+      <Tabs.List key="tabsList">
+        {cityParts.map((name, index) => (
+          <Tabs.Button key={name} tab={index}>
+            {name}
+          </Tabs.Button>
+        ))}
+      </Tabs.List>,
+      cityParts.map((name, index) => (
+        <Tabs.Panel key={name} tab={index}>
+          <Table>
+            <Table.Caption>
+              Voorbeeld van een tabel voor {name === 'Weesp' ? 'stadsgebied' : 'stadsdeel'} {name}
+            </Table.Caption>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell></Table.HeaderCell>
+                {Array.from({ length: 12 }, (_, index) => (
+                  <Table.HeaderCell key={index}>Kolom</Table.HeaderCell>
+                ))}
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {Array.from({ length: 3 }, (_, rowIndex) => (
+                <Table.Row key={rowIndex}>
+                  <Table.HeaderCell scope="row">Rij</Table.HeaderCell>
+                  {Array.from({ length: 12 }, (_, columnIndex) => (
+                    <Table.Cell key={columnIndex} style={{ textAlign: 'end' }}>
+                      {(rowIndex + 1) * (columnIndex + 1)}.000
+                    </Table.Cell>
+                  ))}
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </Tabs.Panel>
+      )),
+    ],
   },
 }

--- a/storybook/src/components/shared/exampleContent.ts
+++ b/storybook/src/components/shared/exampleContent.ts
@@ -5,6 +5,8 @@
 
 const pickRandomContent = <T>(list: Array<T>): T => list[Math.floor(Math.random() * list.length)]
 
+export const cityParts = ['Centrum', 'Nieuw-West', 'Noord', 'Weesp', 'West', 'Westpoort', 'Zuid', 'Zuidoost']
+
 export const exampleAccordionHeading = () =>
   pickRandomContent([
     'Dit grof afval halen we niet op',


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Allows the content of a Tab Panel to scroll horizontally.

## Why

To prevent the Tabs from growing to contain its content, after which may overflow its container.

## How

By adding `.ams-tabs__panel { overflow-x: auto; }` and an example.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- There has been some discussion on a composition of a Table in a Description List in a Tab Panel causing overflow. We concluded this is expected behaviour of CSS and that a responsive appearance of our table component may resolve this in the future. I recommended a local inline style to influence the local sizing behaviour of CSS Grid. 