### PR TITLE
chore(docs): Make token tables consistent

### DIFF
--- a/packages/css/src/components/gap/README.md
+++ b/packages/css/src/components/gap/README.md
@@ -9,7 +9,7 @@ Adds white space between a set of elements.
 The five sizes of [Component Space](/docs/brand-design-tokens-space--docs) are available for the width or height of the gap.
 
 | Class name    | Example                                                                                   |
-| ------------- | ----------------------------------------------------------------------------------------- |
+| :------------ | :---------------------------------------------------------------------------------------- |
 | `ams-gap--xs` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-xs);" /> |
 | `ams-gap--sm` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-sm);" /> |
 | `ams-gap--md` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-md);" /> |

--- a/packages/css/src/components/margin/README.md
+++ b/packages/css/src/components/margin/README.md
@@ -9,7 +9,7 @@ Adds white space below a single element.
 The five sizes of [Component Space](/docs/brand-design-tokens-space--docs) are available for the height of the bottom margin.
 
 | Class name   | Example                                                                                      |
-| ------------ | -------------------------------------------------------------------------------------------- |
+| :----------- | :------------------------------------------------------------------------------------------- |
 | `ams-mb--xs` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-xs);" /> |
 | `ams-mb--sm` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-sm);" /> |
 | `ams-mb--md` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-md);" /> |

--- a/storybook/src/components/CharacterCount/CharacterCount.docs.mdx
+++ b/storybook/src/components/CharacterCount/CharacterCount.docs.mdx
@@ -16,6 +16,6 @@ import README from "../../../../packages/css/src/components/character-count/READ
 
 ### Error
 
-When the length exceeds the maximum length, the color of the text changes to red.
+When the length exceeds the maximum length, the colour of the text changes to red.
 
 <Canvas of={CharacterCountStories.Error} />

--- a/storybook/src/docs/developer-guide/interactivity.docs.mdx
+++ b/storybook/src/docs/developer-guide/interactivity.docs.mdx
@@ -36,7 +36,7 @@ Colour should not be the only indicator of interactivity so that people with dif
 
 ### Relevant WCAG requirements
 
-- [WCAG 1.4.1](https://www.w3.org/TR/WCAG22/#use-of-color): color should not be the only way to indicate that something is interactive
+- [WCAG 1.4.1](https://www.w3.org/TR/WCAG22/#use-of-color): colour should not be the only way to indicate that something is interactive
 - [WCAG 1.4.3](https://www.w3.org/TR/WCAG21/#contrast-minimum): text has sufficient contrast with the background
 
 ## Format

--- a/storybook/src/foundation/design-tokens/aspect-ratio.docs.mdx
+++ b/storybook/src/foundation/design-tokens/aspect-ratio.docs.mdx
@@ -17,14 +17,14 @@ Content with intrinsic dimensions that do not match an aspect ratio will be crop
 
 ## Tokens
 
-| Token name                 |  Value | Example                                                                                                      |
-| :------------------------- | -----: | ------------------------------------------------------------------------------------------------------------ |
-| `ams.aspect-ratio.x-tall`  | 9 / 16 | <div className="ams-docs-token-example--space" style={{ aspectRatio: 'var(--ams-aspect-ratio-x-tall)' }} />  |
-| `ams.aspect-ratio.tall`    |  3 / 4 | <div className="ams-docs-token-example--space" style={{ aspectRatio: 'var(--ams-aspect-ratio-tall)' }} />    |
-| `ams.aspect-ratio.square`  |  1 / 1 | <div className="ams-docs-token-example--space" style={{ aspectRatio: 'var(--ams-aspect-ratio-square)' }} />  |
-| `ams.aspect-ratio.wide`    |  4 / 3 | <div className="ams-docs-token-example--space" style={{ aspectRatio: 'var(--ams-aspect-ratio-wide)' }} />    |
-| `ams.aspect-ratio.x-wide`  | 16 / 9 | <div className="ams-docs-token-example--space" style={{ aspectRatio: 'var(--ams-aspect-ratio-x-wide)' }} />  |
-| `ams.aspect-ratio.2x-wide` | 16 / 5 | <div className="ams-docs-token-example--space" style={{ aspectRatio: 'var(--ams-aspect-ratio-2x-wide)' }} /> |
+| CSS variable                      | Value  | Example                                                                                                      |
+| :-------------------------------- | :----: | :----------------------------------------------------------------------------------------------------------- |
+| `var(--ams-aspect-ratio-x-tall)`  | 9 / 16 | <div className="ams-docs-token-example--space" style={{ aspectRatio: 'var(--ams-aspect-ratio-x-tall)' }} />  |
+| `var(--ams-aspect-ratio-tall)`    | 3 / 4  | <div className="ams-docs-token-example--space" style={{ aspectRatio: 'var(--ams-aspect-ratio-tall)' }} />    |
+| `var(--ams-aspect-ratio-square)`  | 1 / 1  | <div className="ams-docs-token-example--space" style={{ aspectRatio: 'var(--ams-aspect-ratio-square)' }} />  |
+| `var(--ams-aspect-ratio-wide)`    | 4 / 3  | <div className="ams-docs-token-example--space" style={{ aspectRatio: 'var(--ams-aspect-ratio-wide)' }} />    |
+| `var(--ams-aspect-ratio-x-wide)`  | 16 / 9 | <div className="ams-docs-token-example--space" style={{ aspectRatio: 'var(--ams-aspect-ratio-x-wide)' }} />  |
+| `var(--ams-aspect-ratio-2x-wide)` | 16 / 5 | <div className="ams-docs-token-example--space" style={{ aspectRatio: 'var(--ams-aspect-ratio-2x-wide)' }} /> |
 
 ## Related components
 

--- a/storybook/src/foundation/design-tokens/border.docs.mdx
+++ b/storybook/src/foundation/design-tokens/border.docs.mdx
@@ -14,9 +14,9 @@ We use a limited set of border widths for consistency.
 
 ## Tokens
 
-| Token name            |     Value | Value (px) | Example                                                                                                             |
-| :-------------------- | --------: | :--------: | ------------------------------------------------------------------------------------------------------------------- |
-| `ams.border.width.sm` | 0.0625rem |     1      | <div className="ams-docs-token-example--border" style={{ borderInlineStartWidth: 'var(--ams-border-width-sm)' }} /> |
-| `ams.border.width.md` |  0.125rem |     2      | <div className="ams-docs-token-example--border" style={{ borderInlineStartWidth: 'var(--ams-border-width-md)' }} /> |
-| `ams.border.width.lg` | 0.1875rem |     3      | <div className="ams-docs-token-example--border" style={{ borderInlineStartWidth: 'var(--ams-border-width-lg)' }} /> |
-| `ams.border.width.xl` |   0.25rem |     4      | <div className="ams-docs-token-example--border" style={{ borderInlineStartWidth: 'var(--ams-border-width-xl)' }} /> |
+| CSS variable                 |     Value | Value (px) | Example                                                                                                             |
+| :--------------------------- | --------: | :--------: | :------------------------------------------------------------------------------------------------------------------ |
+| `var(--ams-border-width-sm)` | 0.0625rem |     1      | <div className="ams-docs-token-example--border" style={{ borderInlineStartWidth: 'var(--ams-border-width-sm)' }} /> |
+| `var(--ams-border-width-md)` |  0.125rem |     2      | <div className="ams-docs-token-example--border" style={{ borderInlineStartWidth: 'var(--ams-border-width-md)' }} /> |
+| `var(--ams-border-width-lg)` | 0.1875rem |     3      | <div className="ams-docs-token-example--border" style={{ borderInlineStartWidth: 'var(--ams-border-width-lg)' }} /> |
+| `var(--ams-border-width-xl)` |   0.25rem |     4      | <div className="ams-docs-token-example--border" style={{ borderInlineStartWidth: 'var(--ams-border-width-xl)' }} /> |

--- a/storybook/src/foundation/design-tokens/colour.docs.mdx
+++ b/storybook/src/foundation/design-tokens/colour.docs.mdx
@@ -69,7 +69,7 @@ Please reach out to us if you require a different colour token.
 
 These are the potential foreground colours for text.
 
-| CSS variable                      | Color name  | Example                                                                                                                                             |
+| CSS variable                      | Colour      | Example                                                                                                                                             |
 | :-------------------------------- | :---------- | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `var(--ams-color-text)`           | neutral-100 | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-text)' }} />                                              |
 | `var(--ams-color-text-secondary)` | neutral-60  | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-text-secondary)' }} />                                    |
@@ -79,27 +79,27 @@ These are the potential foreground colours for text.
 
 We have one background colour for the page and various components.
 
-| CSS variable                  | Color name | Example                                                                                                                                           |
-| :---------------------------- | :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `var(--ams-color-background)` | neutral-0  | <div className="ams-docs-token-example--color ams-docs-token-example--color-border" style={{ backgroundColor: 'var(--ams-color-background)' }} /> |
+| CSS variable                  | Colour    | Example                                                                                                                                           |
+| :---------------------------- | :-------- | :------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `var(--ams-color-background)` | neutral-0 | <div className="ams-docs-token-example--color ams-docs-token-example--color-border" style={{ backgroundColor: 'var(--ams-color-background)' }} /> |
 
 ### Feedback
 
 Use these colours for positive and negative feedback, warnings, and messages that need attention.
 Interactive elements in an invalid state use the 'invalid interactive' token, not the 'error feedback' token.
 
-| CSS variable                        | Color name | Example                                                                                                            |
-| :---------------------------------- | :--------- | :----------------------------------------------------------------------------------------------------------------- |
-| `var(--ams-color-feedback-error)`   | red-60     | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-feedback-error)' }} />   |
-| `var(--ams-color-feedback-info)`    | azure-60   | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-feedback-info)' }} />    |
-| `var(--ams-color-feedback-success)` | green-60   | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-feedback-success)' }} /> |
-| `var(--ams-color-feedback-warning)` | orange-60  | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-feedback-warning)' }} /> |
+| CSS variable                        | Colour    | Example                                                                                                            |
+| :---------------------------------- | :-------- | :----------------------------------------------------------------------------------------------------------------- |
+| `var(--ams-color-feedback-error)`   | red-60    | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-feedback-error)' }} />   |
+| `var(--ams-color-feedback-info)`    | azure-60  | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-feedback-info)' }} />    |
+| `var(--ams-color-feedback-success)` | green-60  | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-feedback-success)' }} /> |
+| `var(--ams-color-feedback-warning)` | orange-60 | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-feedback-warning)' }} /> |
 
 ### Interactive
 
 These colours show elements that the user can interact with, like links, buttons, and form controls.
 
-| CSS variable                                 | Color name  | Example                                                                                                                                                    |
+| CSS variable                                 | Colour      | Example                                                                                                                                                    |
 | :------------------------------------------- | :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `var(--ams-color-interactive)`               | blue-60     | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-interactive)' }} />                                              |
 | `var(--ams-color-interactive-hover)`         | blue-80     | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-interactive-hover)' }} />                                        |
@@ -114,7 +114,7 @@ These colours show elements that the user can interact with, like links, buttons
 
 Components can use these colours to stand out.
 
-| CSS variable                         | Color name | Example                                                                                                             |
+| CSS variable                         | Colour     | Example                                                                                                             |
 | :----------------------------------- | :--------- | :------------------------------------------------------------------------------------------------------------------ |
 | `var(--ams-color-highlight-azure)`   | azure-60   | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-highlight-azure)' }} />   |
 | `var(--ams-color-highlight-green)`   | green-60   | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-highlight-green)' }} />   |
@@ -128,6 +128,6 @@ Components can use these colours to stand out.
 
 This colour is used to separate components or space.
 
-| CSS variable                 | Color name | Example                                                                                                     |
+| CSS variable                 | Colour     | Example                                                                                                     |
 | :--------------------------- | :--------- | :---------------------------------------------------------------------------------------------------------- |
 | `var(--ams-color-separator)` | neutral-20 | <div className="ams-docs-token-example--color" style={{ backgroundColor: 'var(--ams-color-separator)' }} /> |

--- a/storybook/src/foundation/design-tokens/cursor.docs.mdx
+++ b/storybook/src/foundation/design-tokens/cursor.docs.mdx
@@ -8,7 +8,7 @@ import { Meta } from "@storybook/blocks";
 
 [Interactive elements](/docs/docs-developer-guide-interactivity--docs) that do not have a cursor style, such as buttons, should use one of these `cursor` values.
 
-| CSS variable                    | Value         | Description                                                                            |
-| :------------------------------ | :------------ | :------------------------------------------------------------------------------------- |
-| `var(--ams-cursor-interactive)` | `pointer`     | Use this for all interactive elements in their default state that lack a cursor style. |
-| `var(--ams-cursor-disabled)`    | `not-allowed` | Use this for interactive elements that are disabled.                                   |
+| CSS variable                    | Value         | When to use                                                               |
+| :------------------------------ | :------------ | :------------------------------------------------------------------------ |
+| `var(--ams-cursor-interactive)` | `pointer`     | All interactive elements in their default state that lack a cursor style. |
+| `var(--ams-cursor-disabled)`    | `not-allowed` | Interactive elements that are disabled.                                   |

--- a/storybook/src/foundation/design-tokens/space.docs.mdx
+++ b/storybook/src/foundation/design-tokens/space.docs.mdx
@@ -72,7 +72,7 @@ In Spacious Mode, the medium grid space grows from 16 to 56 pixels between windo
 In Compact Mode, the medium grid space grows from 16 to 40 pixels between window widths of 1088 and 2624.
 
 | CSS variable                 | ≤&nbsp;1088 |  1344  |  1600  |  1856  |  2112  |  2368  | ≥&nbsp;2624 | Example                                                                                                                 |
-| ---------------------------- | :---------: | :----: | :----: | :----: | :----: | :----: | :---------: | ----------------------------------------------------------------------------------------------------------------------- |
+| :--------------------------- | :---------: | :----: | :----: | :----: | :----: | :----: | :---------: | :---------------------------------------------------------------------------------------------------------------------- |
 | `var(--ams-space-grid-xs--)` |      4      |   5    |   6    |   7    |   8    |   9    |     10      | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-xs)" }} /> |
 | `var(--ams-space-grid-sm--)` |      8      |   10   |   12   |   14   |   16   |   18   |     20      | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-sm)" }} /> |
 | `var(--ams-space-grid-md--)` |   **16**    | **20** | **24** | **28** | **32** | **36** |   **40**    | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-md)" }} /> |

--- a/storybook/src/foundation/design-tokens/space.docs.mdx
+++ b/storybook/src/foundation/design-tokens/space.docs.mdx
@@ -23,25 +23,25 @@ We offer 5 sizes.
 Because our typography is fluid in Spacious Mode, spacing is as well.
 The medium space grows from 18 to 24 pixels between window widths of 320 and 1600.
 
-| Token name     | ≤&nbsp;320 |      832 | ≥&nbsp;1600 | Example                                                                                         |
-| :------------- | ---------: | -------: | ----------: | ----------------------------------------------------------------------------------------------- |
-| `ams-space-xs` |        4.5 |      5.1 |           6 | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-xs)' }} /> |
-| `ams-space-sm` |          9 |      8.3 |          12 | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-sm)' }} /> |
-| `ams-space-md` |     **18** | **16.5** |      **24** | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-md)' }} /> |
-| `ams-space-lg` |         27 |     24.9 |          36 | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-lg)' }} /> |
-| `ams-space-xl` |         36 |     33.2 |          48 | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-xl)' }} /> |
+| CSS variable          | ≤&nbsp;320 |      832 | ≥&nbsp;1600 | Example                                                                                         |
+| :-------------------- | ---------: | -------: | ----------: | :---------------------------------------------------------------------------------------------- |
+| `var(--ams-space-xs)` |        4.5 |      5.1 |           6 | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-xs)' }} /> |
+| `var(--ams-space-sm)` |          9 |      8.3 |          12 | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-sm)' }} /> |
+| `var(--ams-space-md)` |     **18** | **16.5** |      **24** | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-md)' }} /> |
+| `var(--ams-space-lg)` |         27 |     24.9 |          36 | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-lg)' }} /> |
+| `var(--ams-space-xl)` |         36 |     33.2 |          48 | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-xl)' }} /> |
 
 ### Compact
 
 In Compact Mode, the medium space is 16 pixels.
 
-| Token name     |        | Example                                                                                                            |
-| :------------- | -----: | ------------------------------------------------------------------------------------------------------------------ |
-| `ams-space-xs` |      4 | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-xs)' }} /> |
-| `ams-space-sm` |      8 | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-sm)' }} /> |
-| `ams-space-md` | **16** | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-md)' }} /> |
-| `ams-space-lg` |     24 | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-lg)' }} /> |
-| `ams-space-xl` |     32 | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-xl)' }} /> |
+| CSS variable          |        | Example                                                                                                            |
+| :-------------------- | -----: | :----------------------------------------------------------------------------------------------------------------- |
+| `var(--ams-space-xs)` |      4 | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-xs)' }} /> |
+| `var(--ams-space-sm)` |      8 | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-sm)' }} /> |
+| `var(--ams-space-md)` | **16** | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-md)' }} /> |
+| `var(--ams-space-lg)` |     24 | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-lg)' }} /> |
+| `var(--ams-space-xl)` |     32 | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-xl)' }} /> |
 
 ## Grid Space
 
@@ -59,25 +59,25 @@ The tables below show the resulting pixel widths at some reference widths.
 
 In Spacious Mode, the medium grid space grows from 16 to 56 pixels between window widths of 320 and 1600.
 
-| Token name          | ≤&nbsp;320 |  576   |  832   |  1088  |  1344  | ≥&nbsp;1600 | Example                                                                                              |
-| :------------------ | :--------: | :----: | :----: | :----: | :----: | :---------: | ---------------------------------------------------------------------------------------------------- |
-| `ams-space-grid-xs` |     4      |   6    |   8    |   10   |   12   |     14      | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-grid-xs)' }} /> |
-| `ams-space-grid-sm` |     8      |   12   |   16   |   20   |   24   |     28      | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-grid-sm)' }} /> |
-| `ams-space-grid-md` |   **16**   | **24** | **32** | **40** | **48** |   **56**    | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-grid-md)' }} /> |
-| `ams-space-grid-lg` |     24     |   36   |   48   |   60   |   72   |     84      | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-grid-lg)' }} /> |
-| `ams-space-grid-xl` |     32     |   48   |   64   |   80   |   96   |     112     | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-grid-xl)' }} /> |
+| CSS variable                 | ≤&nbsp;320 |  576   |  832   |  1088  |  1344  | ≥&nbsp;1600 | Example                                                                                              |
+| :--------------------------- | :--------: | :----: | :----: | :----: | :----: | :---------: | ---------------------------------------------------------------------------------------------------- |
+| `var(--ams-space-grid-xs--)` |     4      |   6    |   8    |   10   |   12   |     14      | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-grid-xs)' }} /> |
+| `var(--ams-space-grid-sm--)` |     8      |   12   |   16   |   20   |   24   |     28      | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-grid-sm)' }} /> |
+| `var(--ams-space-grid-md--)` |   **16**   | **24** | **32** | **40** | **48** |   **56**    | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-grid-md)' }} /> |
+| `var(--ams-space-grid-lg--)` |     24     |   36   |   48   |   60   |   72   |     84      | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-grid-lg)' }} /> |
+| `var(--ams-space-grid-xl--)` |     32     |   48   |   64   |   80   |   96   |     112     | <div className="ams-docs-token-example--space" style={{ inlineSize: 'var(--ams-space-grid-xl)' }} /> |
 
 #### Compact
 
 In Compact Mode, the medium grid space grows from 16 to 40 pixels between window widths of 1088 and 2624.
 
-| Token name          | ≤&nbsp;1088 |  1344  |  1600  |  1856  |  2112  |  2368  | ≥&nbsp;2624 | Example                                                                                                                 |
-| ------------------- | :---------: | :----: | :----: | :----: | :----: | :----: | :---------: | ----------------------------------------------------------------------------------------------------------------------- |
-| `ams-space-grid-xs` |      4      |   5    |   6    |   7    |   8    |   9    |     10      | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-xs)" }} /> |
-| `ams-space-grid-sm` |      8      |   10   |   12   |   14   |   16   |   18   |     20      | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-sm)" }} /> |
-| `ams-space-grid-md` |   **16**    | **20** | **24** | **28** | **32** | **36** |   **40**    | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-md)" }} /> |
-| `ams-space-grid-lg` |     24      |   30   |   36   |   42   |   48   |   54   |     60      | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-lg)" }} /> |
-| `ams-space-grid-xl` |     32      |   40   |   48   |   56   |   64   |   72   |     80      | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-xl)" }} /> |
+| CSS variable                 | ≤&nbsp;1088 |  1344  |  1600  |  1856  |  2112  |  2368  | ≥&nbsp;2624 | Example                                                                                                                 |
+| ---------------------------- | :---------: | :----: | :----: | :----: | :----: | :----: | :---------: | ----------------------------------------------------------------------------------------------------------------------- |
+| `var(--ams-space-grid-xs--)` |      4      |   5    |   6    |   7    |   8    |   9    |     10      | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-xs)" }} /> |
+| `var(--ams-space-grid-sm--)` |      8      |   10   |   12   |   14   |   16   |   18   |     20      | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-sm)" }} /> |
+| `var(--ams-space-grid-md--)` |   **16**    | **20** | **24** | **28** | **32** | **36** |   **40**    | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-md)" }} /> |
+| `var(--ams-space-grid-lg--)` |     24      |   30   |   36   |   42   |   48   |   54   |     60      | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-lg)" }} /> |
+| `var(--ams-space-grid-xl--)` |     32      |   40   |   48   |   56   |   64   |   72   |     80      | <div className="ams-theme--compact ams-docs-token-example--space" style={{ inlineSize: "var(--ams-space-grid-xl)" }} /> |
 
 ## Type Space
 

--- a/storybook/src/styles/docs.css
+++ b/storybook/src/styles/docs.css
@@ -179,8 +179,7 @@
 }
 
 [class*="ams-docs-token-example--space"] {
-  background-color: #fff;
-  outline: 1px dashed var(--ams-docs-grey);
+  background-color: var(--ams-docs-pink);
 }
 
 .ams-resize-horizontal {


### PR DESCRIPTION
- `ams.token.name` → `var(--ams-token-name)`; easier fo people to copy and paste
- Token name → CSS variable
- Color name → Colour
- Explicitly align Markdown table columns
- Dashed grey border → pink background for better visibility and consistency with Grid, Row, etc.
- Skipped `text.docs.md` because it gets deleted in PR 1845.