### PR TITLE
feat(Spotlight)!: Use updated color names for lime and green and remove purple as an explicit option

### DIFF
--- a/packages/css/src/components/spotlight/README.md
+++ b/packages/css/src/components/spotlight/README.md
@@ -11,8 +11,8 @@ Emphasizes a section on a page through a distinctive background colour.
 - Use any of the [highlight colours](/docs/brand-design-tokens-colour--docs) for the background.
   The design system does not prescribe a meaning to any of these colours.
   The default is purple.
-- Use the default text colour (black) on an azure, lime, orange or yellow background.
-  Use the inverse text colour (white) on a green, magenta or purple background.
+- Use the default text colour (black) on a lime, orange or yellow background.
+  Use the inverse text colour (white) on an azure, green, magenta or purple background.
 
 ## Relevant WCAG requirements
 

--- a/packages/css/src/components/spotlight/README.md
+++ b/packages/css/src/components/spotlight/README.md
@@ -8,11 +8,11 @@ Emphasizes a section on a page through a distinctive background colour.
 
 - Display the Spotlight at the entire width of the [Screen](/docs/components-layout-screen--docs); do not position it on the [Grid](/docs/components-layout-grid--docs).
 - Add a Grid with medium vertical padding inside the Spotlight to add whitespace around the content, even for a single element.
-- The default background is purple.
-  Any [colour](/docs/brand-design-tokens-colour--docs) from the ‘highlight’ group can be used for the background.
-  The design system does not prescribe a meaning to any of these colours of a Spotlight.
+- Use any of the [highlight colours](/docs/brand-design-tokens-colour--docs) for the background.
+  The design system does not prescribe a meaning to any of these colours.
+  The default is purple.
 - Use the default text colour (black) on an azure, lime, orange or yellow background.
-  Use the inverse text colour (white) on a blue, green, magenta or purple background.
+  Use the inverse text colour (white) on a green, magenta or purple background.
 
 ## Relevant WCAG requirements
 

--- a/packages/css/src/components/spotlight/README.md
+++ b/packages/css/src/components/spotlight/README.md
@@ -11,8 +11,8 @@ Emphasizes a section on a page through a distinctive background colour.
 - Use any of the [highlight colours](/docs/brand-design-tokens-colour--docs) for the background.
   The design system does not prescribe a meaning to any of these colours.
   The default is purple.
-- Use the default text colour (black) on a lime, orange or yellow background.
-  Use the inverse text colour (white) on an azure, green, magenta or purple background.
+- Use the default text colour (black) on an azure, lime, orange or yellow background.
+  Use the inverse text colour (white) on a green, magenta or purple background.
 
 ## Relevant WCAG requirements
 

--- a/packages/css/src/components/spotlight/README.md
+++ b/packages/css/src/components/spotlight/README.md
@@ -8,8 +8,11 @@ Emphasizes a section on a page through a distinctive background colour.
 
 - Display the Spotlight at the entire width of the [Screen](/docs/components-layout-screen--docs); do not position it on the [Grid](/docs/components-layout-grid--docs).
 - Add a Grid with medium vertical padding inside the Spotlight to add whitespace around the content, even for a single element.
-- The default background is purple, but the colours can be chosen freely – they do not convey a meaning or theme in itself.
-- Refer to [this overview on Stijlweb](https://amsterdam.nl/stijlweb/basiselementen/kleuren/#PagCls_15671872) to determine whether you can use black or white text on the background colour of your choice.
+- The default background is purple.
+  Any [colour](/docs/brand-design-tokens-colour--docs) from the ‘highlight’ group can be used for the background.
+  The design system does not prescribe a meaning to any of these colours of a Spotlight.
+- Use the default text colour (black) on an azure, lime, orange or yellow background.
+  Use the inverse text colour (white) on a blue, green, magenta or purple background.
 
 ## Relevant WCAG requirements
 

--- a/packages/css/src/components/spotlight/spotlight.scss
+++ b/packages/css/src/components/spotlight/spotlight.scss
@@ -7,8 +7,8 @@
   background-color: var(--ams-spotlight-background-color);
 }
 
-.ams-spotlight--blue {
-  background-color: var(--ams-spotlight-blue-background-color);
+.ams-spotlight--azure {
+  background-color: var(--ams-spotlight-azure-background-color);
 }
 
 .ams-spotlight--green {

--- a/packages/css/src/components/spotlight/spotlight.scss
+++ b/packages/css/src/components/spotlight/spotlight.scss
@@ -11,8 +11,8 @@
   background-color: var(--ams-spotlight-blue-background-color);
 }
 
-.ams-spotlight--dark-green {
-  background-color: var(--ams-spotlight-dark-green-background-color);
+.ams-spotlight--green {
+  background-color: var(--ams-spotlight-green-background-color);
 }
 
 .ams-spotlight--lime {

--- a/packages/css/src/components/spotlight/spotlight.scss
+++ b/packages/css/src/components/spotlight/spotlight.scss
@@ -15,8 +15,8 @@
   background-color: var(--ams-spotlight-dark-green-background-color);
 }
 
-.ams-spotlight--green {
-  background-color: var(--ams-spotlight-green-background-color);
+.ams-spotlight--lime {
+  background-color: var(--ams-spotlight-lime-background-color);
 }
 
 .ams-spotlight--magenta {

--- a/packages/react/src/Spotlight/Spotlight.tsx
+++ b/packages/react/src/Spotlight/Spotlight.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 import { forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 const defaultColor = 'purple'
-export const spotlightColors = ['blue', 'dark-green', 'green', 'magenta', 'orange', 'yellow'] as const
+export const spotlightColors = ['blue', 'dark-green', 'lime', 'magenta', 'orange', 'yellow'] as const
 
 type SpotlightColor = (typeof spotlightColors)[number] | typeof defaultColor
 

--- a/packages/react/src/Spotlight/Spotlight.tsx
+++ b/packages/react/src/Spotlight/Spotlight.tsx
@@ -6,7 +6,7 @@
 import clsx from 'clsx'
 import { forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
 
-export const spotlightColors = ['blue', 'green', 'lime', 'magenta', 'orange', 'yellow'] as const
+export const spotlightColors = ['azure', 'green', 'lime', 'magenta', 'orange', 'yellow'] as const
 
 type SpotlightColor = (typeof spotlightColors)[number]
 

--- a/packages/react/src/Spotlight/Spotlight.tsx
+++ b/packages/react/src/Spotlight/Spotlight.tsx
@@ -6,10 +6,9 @@
 import clsx from 'clsx'
 import { forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
 
-const defaultColor = 'purple'
 export const spotlightColors = ['blue', 'green', 'lime', 'magenta', 'orange', 'yellow'] as const
 
-type SpotlightColor = (typeof spotlightColors)[number] | typeof defaultColor
+type SpotlightColor = (typeof spotlightColors)[number]
 
 export type SpotlightProps = {
   /** The HTML element to use. */
@@ -19,12 +18,8 @@ export type SpotlightProps = {
 } & PropsWithChildren<HTMLAttributes<HTMLElement>>
 
 export const Spotlight = forwardRef(
-  ({ as: Tag = 'div', children, className, color = defaultColor, ...restProps }: SpotlightProps, ref: any) => (
-    <Tag
-      {...restProps}
-      className={clsx('ams-spotlight', color !== defaultColor && `ams-spotlight--${color}`, className)}
-      ref={ref}
-    >
+  ({ as: Tag = 'div', children, className, color, ...restProps }: SpotlightProps, ref: any) => (
+    <Tag {...restProps} className={clsx('ams-spotlight', color && `ams-spotlight--${color}`, className)} ref={ref}>
       {children}
     </Tag>
   ),

--- a/packages/react/src/Spotlight/Spotlight.tsx
+++ b/packages/react/src/Spotlight/Spotlight.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 import { forwardRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 const defaultColor = 'purple'
-export const spotlightColors = ['blue', 'dark-green', 'lime', 'magenta', 'orange', 'yellow'] as const
+export const spotlightColors = ['blue', 'green', 'lime', 'magenta', 'orange', 'yellow'] as const
 
 type SpotlightColor = (typeof spotlightColors)[number] | typeof defaultColor
 

--- a/proprietary/tokens/src/components/ams/spotlight.tokens.json
+++ b/proprietary/tokens/src/components/ams/spotlight.tokens.json
@@ -2,7 +2,7 @@
   "ams": {
     "spotlight": {
       "background-color": { "value": "{ams.color.highlight.purple}" },
-      "blue": {
+      "azure": {
         "background-color": { "value": "{ams.color.highlight.azure}" }
       },
       "green": {

--- a/proprietary/tokens/src/components/ams/spotlight.tokens.json
+++ b/proprietary/tokens/src/components/ams/spotlight.tokens.json
@@ -5,7 +5,7 @@
       "blue": {
         "background-color": { "value": "{ams.color.highlight.azure}" }
       },
-      "dark-green": {
+      "green": {
         "background-color": { "value": "{ams.color.highlight.green}" }
       },
       "lime": {

--- a/proprietary/tokens/src/components/ams/spotlight.tokens.json
+++ b/proprietary/tokens/src/components/ams/spotlight.tokens.json
@@ -8,7 +8,7 @@
       "dark-green": {
         "background-color": { "value": "{ams.color.highlight.green}" }
       },
-      "green": {
+      "lime": {
         "background-color": { "value": "{ams.color.highlight.lime}" }
       },
       "magenta": {

--- a/storybook/src/components/Breakout/Breakout.stories.tsx
+++ b/storybook/src/components/Breakout/Breakout.stories.tsx
@@ -27,7 +27,7 @@ export const Default: Story = {
   args: {
     children: [
       <Breakout.Cell colSpan="all" has="spotlight" key={1} rowSpan={{ narrow: 2, medium: 2, wide: 1 }} rowStart={2}>
-        <Spotlight color="dark-green" />
+        <Spotlight color="green" />
       </Breakout.Cell>,
       <Breakout.Cell
         colSpan={{ narrow: 4, medium: 8, wide: 6 }}

--- a/storybook/src/components/Spotlight/Spotlight.docs.mdx
+++ b/storybook/src/components/Spotlight/Spotlight.docs.mdx
@@ -22,9 +22,9 @@ import README from "../../../../packages/css/src/components/spotlight/README.md?
 
 <Canvas of={SpotlightStories.DarkGreen} />
 
-### Green
+### Lime
 
-<Canvas of={SpotlightStories.Green} />
+<Canvas of={SpotlightStories.Lime} />
 
 ### Magenta
 

--- a/storybook/src/components/Spotlight/Spotlight.docs.mdx
+++ b/storybook/src/components/Spotlight/Spotlight.docs.mdx
@@ -14,9 +14,9 @@ import README from "../../../../packages/css/src/components/spotlight/README.md?
 
 ## Examples
 
-### Blue
+### Azure
 
-<Canvas of={SpotlightStories.Blue} />
+<Canvas of={SpotlightStories.Azure} />
 
 ### Green
 

--- a/storybook/src/components/Spotlight/Spotlight.docs.mdx
+++ b/storybook/src/components/Spotlight/Spotlight.docs.mdx
@@ -18,9 +18,9 @@ import README from "../../../../packages/css/src/components/spotlight/README.md?
 
 <Canvas of={SpotlightStories.Blue} />
 
-### Dark Green
+### Green
 
-<Canvas of={SpotlightStories.DarkGreen} />
+<Canvas of={SpotlightStories.Green} />
 
 ### Lime
 

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
     <Spotlight as={as} color={color}>
       <Grid paddingVertical="medium">
         <Grid.Cell span="all">
-          <Blockquote color={!color || ['azure', 'green', 'magenta'].includes(color) ? 'inverse' : undefined}>
+          <Blockquote color={!color || ['green', 'magenta'].includes(color) ? 'inverse' : undefined}>
             {quote}
           </Blockquote>
         </Grid.Cell>

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -17,7 +17,9 @@ const meta = {
     <Spotlight as={as} color={color}>
       <Grid paddingVertical="medium">
         <Grid.Cell span="all">
-          <Blockquote color={!color || !['lime', 'yellow'].includes(color) ? 'inverse' : undefined}>{quote}</Blockquote>
+          <Blockquote color={!color || ['blue', 'green', 'magenta'].includes(color) ? 'inverse' : undefined}>
+            {quote}
+          </Blockquote>
         </Grid.Cell>
       </Grid>
     </Spotlight>

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -17,7 +17,7 @@ const meta = {
     <Spotlight as={as} color={color}>
       <Grid paddingVertical="medium">
         <Grid.Cell span="all">
-          <Blockquote color={!color || ['blue', 'green', 'magenta'].includes(color) ? 'inverse' : undefined}>
+          <Blockquote color={!color || ['green', 'magenta'].includes(color) ? 'inverse' : undefined}>
             {quote}
           </Blockquote>
         </Grid.Cell>

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
     <Spotlight as={as} color={color}>
       <Grid paddingVertical="medium">
         <Grid.Cell span="all">
-          <Blockquote color={!color || ['green', 'magenta'].includes(color) ? 'inverse' : undefined}>
+          <Blockquote color={!color || ['azure', 'green', 'magenta'].includes(color) ? 'inverse' : undefined}>
             {quote}
           </Blockquote>
         </Grid.Cell>

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -17,9 +17,7 @@ const meta = {
     <Spotlight as={as} color={color}>
       <Grid paddingVertical="medium">
         <Grid.Cell span="all">
-          <Blockquote color={!color || !['green', 'yellow'].includes(color) ? 'inverse' : undefined}>
-            {quote}
-          </Blockquote>
+          <Blockquote color={!color || !['lime', 'yellow'].includes(color) ? 'inverse' : undefined}>{quote}</Blockquote>
         </Grid.Cell>
       </Grid>
     </Spotlight>
@@ -44,9 +42,9 @@ export const DarkGreen: Story = {
   },
 }
 
-export const Green: Story = {
+export const Lime: Story = {
   args: {
-    color: 'green',
+    color: 'lime',
   },
 }
 

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -36,9 +36,9 @@ export const Blue: Story = {
   },
 }
 
-export const DarkGreen: Story = {
+export const Green: Story = {
   args: {
-    color: 'dark-green',
+    color: 'green',
   },
 }
 

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -41,9 +41,9 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
-export const Blue: Story = {
+export const Azure: Story = {
   args: {
-    color: 'blue',
+    color: 'azure',
   },
 }
 

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -5,6 +5,7 @@
 
 import { Blockquote, Grid } from '@amsterdam/design-system-react'
 import { Spotlight } from '@amsterdam/design-system-react/src'
+import { spotlightColors } from '@amsterdam/design-system-react/src/Spotlight/Spotlight'
 import { Meta, StoryObj } from '@storybook/react'
 import { exampleQuote } from '../shared/exampleContent'
 
@@ -13,6 +14,14 @@ const quote = exampleQuote()
 const meta = {
   title: 'Components/Containers/Spotlight',
   component: Spotlight,
+  argTypes: {
+    color: {
+      control: {
+        labels: { undefined: 'purple (default)' },
+      },
+      options: [undefined, ...spotlightColors],
+    },
+  },
   render: ({ as, color }) => (
     <Spotlight as={as} color={color}>
       <Grid paddingVertical="medium">


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

- Renames ‘green’ to ‘lime’ and ‘dark green’ to ‘green’ in the `color` prop of Spotlight.
- Updates documentation on text colour and fixes the example for an azure background.

## Why

To align with the updated colour names.

## How

Typing.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- None