### PR TITLE
feat(Badge)!: Use updated color names for azure and lime

### DIFF
--- a/packages/css/src/components/badge/README.md
+++ b/packages/css/src/components/badge/README.md
@@ -5,12 +5,13 @@
 A prominently coloured box containing 1 or 2 words.
 Guides the user in taking a specific action or describes its surrounding content.
 
-## Design
+## Guidelines
 
-- The badge can contain a short text or a number.
-- Any [colour](/docs/brand-design-tokens-colour--docs) from the ‘highlight’ and ‘feedback’ groups can be used for the background.
+- Let the badge contain a short text or a number.
+- Use any of the feedback or highlight [colours](/docs/brand-design-tokens-colour--docs) for the background.
   The default is green.
-  The design system does not define a meaning to any of these background colours, although it makes sense to use green and red for positive and negative feedback.
+  Red, orange and green are especially useful for showing an error, warning, or success.
+  However, they can also be combined with the other colours without carrying these meanings.
 - The default text colour (black) is used on an azure, lime, orange or yellow background.
   The inverse text colour (white) is used on a green, magenta, red or purple background.
 - Blue is not an option because it is used exclusively to indicate interactivity.

--- a/packages/css/src/components/badge/README.md
+++ b/packages/css/src/components/badge/README.md
@@ -9,4 +9,4 @@ Guides the user in taking a specific action or describes its surrounding content
 
 The badge can contain a short text or a number.
 Any colour from the ‘highlight’ and ‘feedback’ groups can be used as a background colour.
-The default is dark green.
+The default is green.

--- a/packages/css/src/components/badge/README.md
+++ b/packages/css/src/components/badge/README.md
@@ -11,6 +11,3 @@ A prominent label that indicates a category, property or instruction.
   The default is green.
   Red, orange and green are especially useful for showing an error, warning, or success.
   However, they can also be combined with the other colours without carrying these meanings.
-- The default text colour (black) is used on an azure, lime, orange or yellow background.
-  The inverse text colour (white) is used on a green, magenta, red or purple background.
-- Blue is not an option because it is used exclusively to indicate interactivity.

--- a/packages/css/src/components/badge/README.md
+++ b/packages/css/src/components/badge/README.md
@@ -7,6 +7,10 @@ Guides the user in taking a specific action or describes its surrounding content
 
 ## Design
 
-The badge can contain a short text or a number.
-Any colour from the ‘highlight’ and ‘feedback’ groups can be used as a background colour.
-The default is green.
+- The badge can contain a short text or a number.
+- Any [colour](/docs/brand-design-tokens-colour--docs) from the ‘highlight’ and ‘feedback’ groups can be used for the background.
+  The default is green.
+  The design system does not define a meaning to any of these background colours, although it makes sense to use green and red for positive and negative feedback.
+- The default text colour (black) is used on an azure, lime, orange or yellow background.
+  The inverse text colour (white) is used on a green, magenta, red or purple background.
+- Blue is not an option because it is used exclusively to indicate interactivity.

--- a/packages/css/src/components/badge/README.md
+++ b/packages/css/src/components/badge/README.md
@@ -2,8 +2,7 @@
 
 # Badge
 
-A prominently coloured box containing 1 or 2 words.
-Guides the user in taking a specific action or describes its surrounding content.
+A prominent label that indicates a category, property or instruction.
 
 ## Guidelines
 

--- a/packages/css/src/components/badge/badge.scss
+++ b/packages/css/src/components/badge/badge.scss
@@ -14,14 +14,14 @@
   padding-inline: var(--ams-badge-padding-inline);
 }
 
-.ams-badge--green {
-  background-color: var(--ams-badge-green-background-color);
-  color: var(--ams-badge-green-color);
-}
-
 .ams-badge--light-blue {
   background-color: var(--ams-badge-light-blue-background-color);
   color: var(--ams-badge-light-blue-color);
+}
+
+.ams-badge--lime {
+  background-color: var(--ams-badge-lime-background-color);
+  color: var(--ams-badge-lime-color);
 }
 
 .ams-badge--magenta {

--- a/packages/css/src/components/badge/badge.scss
+++ b/packages/css/src/components/badge/badge.scss
@@ -14,9 +14,9 @@
   padding-inline: var(--ams-badge-padding-inline);
 }
 
-.ams-badge--light-blue {
-  background-color: var(--ams-badge-light-blue-background-color);
-  color: var(--ams-badge-light-blue-color);
+.ams-badge--azure {
+  background-color: var(--ams-badge-azure-background-color);
+  color: var(--ams-badge-azure-color);
 }
 
 .ams-badge--lime {

--- a/packages/react/src/Badge/Badge.tsx
+++ b/packages/react/src/Badge/Badge.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes } from 'react'
 
-export const badgeColors = ['light-blue', 'lime', 'magenta', 'orange', 'purple', 'red', 'yellow'] as const
+export const badgeColors = ['azure', 'lime', 'magenta', 'orange', 'purple', 'red', 'yellow'] as const
 
 type BadgeColor = (typeof badgeColors)[number]
 

--- a/packages/react/src/Badge/Badge.tsx
+++ b/packages/react/src/Badge/Badge.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes } from 'react'
 
-export const badgeColors = ['green', 'light-blue', 'magenta', 'orange', 'purple', 'red', 'yellow'] as const
+export const badgeColors = ['light-blue', 'lime', 'magenta', 'orange', 'purple', 'red', 'yellow'] as const
 
 type BadgeColor = (typeof badgeColors)[number]
 

--- a/proprietary/tokens/src/components/ams/badge.tokens.json
+++ b/proprietary/tokens/src/components/ams/badge.tokens.json
@@ -8,7 +8,7 @@
       "font-weight": { "value": "{ams.text.font-weight.bold}" },
       "line-height": { "value": "{ams.text.level.5.line-height}" },
       "padding-inline": { "value": "{ams.space.xs}" },
-      "light-blue": {
+      "azure": {
         "background-color": { "value": "{ams.color.highlight.azure}" },
         "color": { "value": "{ams.color.text.default}" }
       },

--- a/proprietary/tokens/src/components/ams/badge.tokens.json
+++ b/proprietary/tokens/src/components/ams/badge.tokens.json
@@ -8,12 +8,12 @@
       "font-weight": { "value": "{ams.text.font-weight.bold}" },
       "line-height": { "value": "{ams.text.level.5.line-height}" },
       "padding-inline": { "value": "{ams.space.xs}" },
-      "green": {
-        "background-color": { "value": "{ams.color.highlight.lime}" },
-        "color": { "value": "{ams.color.text.default}" }
-      },
       "light-blue": {
         "background-color": { "value": "{ams.color.highlight.azure}" },
+        "color": { "value": "{ams.color.text.default}" }
+      },
+      "lime": {
+        "background-color": { "value": "{ams.color.highlight.lime}" },
         "color": { "value": "{ams.color.text.default}" }
       },
       "magenta": {

--- a/proprietary/tokens/src/components/ams/badge.tokens.json
+++ b/proprietary/tokens/src/components/ams/badge.tokens.json
@@ -1,7 +1,7 @@
 {
   "ams": {
     "badge": {
-      "background-color": { "value": "{ams.color.highlight.green}" },
+      "background-color": { "value": "{ams.color.feedback.success}" },
       "color": { "value": "{ams.color.text.inverse}" },
       "font-family": { "value": "{ams.text.font-family}" },
       "font-size": { "value": "{ams.text.level.5.font-size}" },
@@ -9,7 +9,7 @@
       "line-height": { "value": "{ams.text.level.5.line-height}" },
       "padding-inline": { "value": "{ams.space.xs}" },
       "azure": {
-        "background-color": { "value": "{ams.color.highlight.azure}" },
+        "background-color": { "value": "{ams.color.feedback.info}" },
         "color": { "value": "{ams.color.text.default}" }
       },
       "lime": {
@@ -21,7 +21,7 @@
         "color": { "value": "{ams.color.text.inverse}" }
       },
       "orange": {
-        "background-color": { "value": "{ams.color.highlight.orange}" },
+        "background-color": { "value": "{ams.color.feedback.warning}" },
         "color": { "value": "{ams.color.text.default}" }
       },
       "purple": {

--- a/storybook/src/components/Badge/Badge.stories.tsx
+++ b/storybook/src/components/Badge/Badge.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
   argTypes: {
     color: {
       control: {
-        labels: { undefined: 'dark-green (default)' },
+        labels: { undefined: 'green (default)' },
       },
       options: [undefined, ...badgeColors],
     },


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

- Renames ‘light blue’ to ‘azure’, ‘green’ to ‘lime’, and ‘dark green’ to ‘green’ in the `color` prop of Badge.
- Updates documentation on text colour.

## Why

To align with the updated colour names.

## How

Typing.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- None