### PR TITLE
feat(Avatar)!: Use updated color names for azure, lime and green 

### DIFF
--- a/packages/css/src/components/avatar/README.md
+++ b/packages/css/src/components/avatar/README.md
@@ -7,13 +7,10 @@ A circular badge representing a person.
 ## Design
 
 - The avatar contains 1 or 2 initial letters from the person’s full name, a picture, or a generic icon.
-- To personalize the Avatar, the user can be allowed to choose one of the [colours](/docs/brand-design-tokens-colour--docs) from the ‘highlight’ group.
-  The default is purple.
-  The design system does not define a meaning to any of these background colours.
-- The default text colour (black) is used on an azure, lime, orange or yellow background.
-  The inverse text colour (white) is used on a green, magenta or purple background.
-- Blue is only an option for an interactive Avatar, which we expect to add in the future.
 
 ## Guidelines
 
 - Show an avatar for the user of the application, or to associate a person with a content item.
+- To personalize the Avatar, the user can be allowed to choose one of the [highlight colours](/docs/brand-design-tokens-colour--docs).
+  The default is purple.
+  The design system does not define a meaning to any of these background colours.

--- a/packages/css/src/components/avatar/README.md
+++ b/packages/css/src/components/avatar/README.md
@@ -6,11 +6,14 @@ A circular badge representing a person.
 
 ## Design
 
-The avatar contains 1 or 2 initial letters from the person’s full name, a picture, or a generic icon.
-To personalize the avatar, the user can be allowed to choose one of the highlight colours.
-The default background colour is purple.
+- The avatar contains 1 or 2 initial letters from the person’s full name, a picture, or a generic icon.
+- To personalize the Avatar, the user can be allowed to choose one of the [colours](/docs/brand-design-tokens-colour--docs) from the ‘highlight’ group.
+  The default is purple.
+  The design system does not define a meaning to any of these background colours.
+- The default text colour (black) is used on an azure, lime, orange or yellow background.
+  The inverse text colour (white) is used on a green, magenta or purple background.
+- Blue is only an option for an interactive Avatar, which we expect to add in the future.
 
 ## Guidelines
 
-- Show an avatar for the user of the application,
-  or to associate a person with a content item.
+- Show an avatar for the user of the application, or to associate a person with a content item.

--- a/packages/css/src/components/avatar/avatar.scss
+++ b/packages/css/src/components/avatar/avatar.scss
@@ -39,14 +39,14 @@
   vertical-align: middle; /* Remove ‘phantom’ white space when image doesn’t load */
 }
 
-.ams-avatar--dark-green {
-  background-color: var(--ams-avatar-dark-green-background-color);
-  color: var(--ams-avatar-dark-green-color);
-}
-
 .ams-avatar--light-blue {
   background-color: var(--ams-avatar-light-blue-background-color);
   color: var(--ams-avatar-light-blue-color);
+}
+
+.ams-avatar--green {
+  background-color: var(--ams-avatar-green-background-color);
+  color: var(--ams-avatar-green-color);
 }
 
 .ams-avatar--lime {

--- a/packages/css/src/components/avatar/avatar.scss
+++ b/packages/css/src/components/avatar/avatar.scss
@@ -39,9 +39,9 @@
   vertical-align: middle; /* Remove ‘phantom’ white space when image doesn’t load */
 }
 
-.ams-avatar--light-blue {
-  background-color: var(--ams-avatar-light-blue-background-color);
-  color: var(--ams-avatar-light-blue-color);
+.ams-avatar--azure {
+  background-color: var(--ams-avatar-azure-background-color);
+  color: var(--ams-avatar-azure-color);
 }
 
 .ams-avatar--green {

--- a/packages/css/src/components/avatar/avatar.scss
+++ b/packages/css/src/components/avatar/avatar.scss
@@ -44,14 +44,14 @@
   color: var(--ams-avatar-dark-green-color);
 }
 
-.ams-avatar--green {
-  background-color: var(--ams-avatar-green-background-color);
-  color: var(--ams-avatar-green-color);
-}
-
 .ams-avatar--light-blue {
   background-color: var(--ams-avatar-light-blue-background-color);
   color: var(--ams-avatar-light-blue-color);
+}
+
+.ams-avatar--lime {
+  background-color: var(--ams-avatar-lime-background-color);
+  color: var(--ams-avatar-lime-color);
 }
 
 .ams-avatar--magenta {

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -9,7 +9,7 @@ import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes } from 'react'
 import { Icon } from '../Icon'
 
-export const avatarColors = ['green', 'light-blue', 'lime', 'magenta', 'orange', 'yellow'] as const
+export const avatarColors = ['azure', 'green', 'lime', 'magenta', 'orange', 'yellow'] as const
 
 type AvatarColor = (typeof avatarColors)[number]
 

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -9,7 +9,7 @@ import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes } from 'react'
 import { Icon } from '../Icon'
 
-export const avatarColors = ['dark-green', 'light-blue', 'lime', 'magenta', 'orange', 'yellow'] as const
+export const avatarColors = ['green', 'light-blue', 'lime', 'magenta', 'orange', 'yellow'] as const
 
 type AvatarColor = (typeof avatarColors)[number]
 

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -9,7 +9,7 @@ import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes } from 'react'
 import { Icon } from '../Icon'
 
-export const avatarColors = ['dark-green', 'green', 'light-blue', 'magenta', 'orange', 'yellow'] as const
+export const avatarColors = ['dark-green', 'light-blue', 'lime', 'magenta', 'orange', 'yellow'] as const
 
 type AvatarColor = (typeof avatarColors)[number]
 

--- a/proprietary/tokens/src/components/ams/avatar.tokens.json
+++ b/proprietary/tokens/src/components/ams/avatar.tokens.json
@@ -10,12 +10,12 @@
       "line-height": { "value": "{ams.text.level.6.line-height}" },
       "padding-block": { "value": "{ams.space.xs}" },
       "padding-inline": { "value": "{ams.space.xs}" },
-      "dark-green": {
-        "background-color": { "value": "{ams.color.highlight.green}" },
-        "color": { "value": "{ams.color.text.inverse}" }
-      },
       "forced-colors": {
         "border-width": { "value": "{ams.border.width.md}" }
+      },
+      "green": {
+        "background-color": { "value": "{ams.color.highlight.green}" },
+        "color": { "value": "{ams.color.text.inverse}" }
       },
       "light-blue": {
         "background-color": { "value": "{ams.color.highlight.azure}" },

--- a/proprietary/tokens/src/components/ams/avatar.tokens.json
+++ b/proprietary/tokens/src/components/ams/avatar.tokens.json
@@ -17,12 +17,12 @@
       "forced-colors": {
         "border-width": { "value": "{ams.border.width.md}" }
       },
-      "green": {
-        "background-color": { "value": "{ams.color.highlight.lime}" },
-        "color": { "value": "{ams.color.text.default}" }
-      },
       "light-blue": {
         "background-color": { "value": "{ams.color.highlight.azure}" },
+        "color": { "value": "{ams.color.text.default}" }
+      },
+      "lime": {
+        "background-color": { "value": "{ams.color.highlight.lime}" },
         "color": { "value": "{ams.color.text.default}" }
       },
       "magenta": {

--- a/proprietary/tokens/src/components/ams/avatar.tokens.json
+++ b/proprietary/tokens/src/components/ams/avatar.tokens.json
@@ -13,13 +13,13 @@
       "forced-colors": {
         "border-width": { "value": "{ams.border.width.md}" }
       },
+      "azure": {
+        "background-color": { "value": "{ams.color.highlight.azure}" },
+        "color": { "value": "{ams.color.text.default}" }
+      },
       "green": {
         "background-color": { "value": "{ams.color.highlight.green}" },
         "color": { "value": "{ams.color.text.inverse}" }
-      },
-      "light-blue": {
-        "background-color": { "value": "{ams.color.highlight.azure}" },
-        "color": { "value": "{ams.color.text.default}" }
       },
       "lime": {
         "background-color": { "value": "{ams.color.highlight.lime}" },


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

- Renames ‘light blue’ to ‘azure’, ‘green’ to ‘lime’, and ‘dark green’ to ‘green’ in the `color` prop of Avatar.
- Updates documentation on text colour.

## Why

To align with the updated colour names.

## How

Typing.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- None