### PR TITLE
fix(gap, margin): Use regular space tokens for gap and margin utilities

### DIFF
--- a/proprietary/tokens/src/components/ams/gap.tokens.json
+++ b/proprietary/tokens/src/components/ams/gap.tokens.json
@@ -1,11 +1,11 @@
 {
   "ams": {
     "gap": {
-      "xs": { "value": "{ams.space.grid.xs}" },
-      "sm": { "value": "{ams.space.grid.sm}" },
-      "md": { "value": "{ams.space.grid.md}" },
-      "lg": { "value": "{ams.space.grid.lg}" },
-      "xl": { "value": "{ams.space.grid.xl}" }
+      "xs": { "value": "{ams.space.xs}" },
+      "sm": { "value": "{ams.space.sm}" },
+      "md": { "value": "{ams.space.md}" },
+      "lg": { "value": "{ams.space.lg}" },
+      "xl": { "value": "{ams.space.xl}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/ams/margin.tokens.json
+++ b/proprietary/tokens/src/components/ams/margin.tokens.json
@@ -1,11 +1,11 @@
 {
   "ams": {
     "margin": {
-      "xs": { "value": "{ams.space.grid.xs}" },
-      "sm": { "value": "{ams.space.grid.sm}" },
-      "md": { "value": "{ams.space.grid.md}" },
-      "lg": { "value": "{ams.space.grid.lg}" },
-      "xl": { "value": "{ams.space.grid.xl}" }
+      "xs": { "value": "{ams.space.xs}" },
+      "sm": { "value": "{ams.space.sm}" },
+      "md": { "value": "{ams.space.md}" },
+      "lg": { "value": "{ams.space.lg}" },
+      "xl": { "value": "{ams.space.xl}" }
     }
   }
 }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It uses regular space tokens for the margin and gap utilities.

## Why

Because using grid space tokens here has been unintentional all along – we’re puzzled how this got through our code reviews.

This will decrease whitespace where these tokens are used. We apologise to users who must update many instances in their application.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a