### PR TITLE
feat: Add responsive version of Amsterdam Logo in Header

### DIFF
--- a/packages/css/src/components/header/header.scss
+++ b/packages/css/src/components/header/header.scss
@@ -30,6 +30,22 @@
   user-select: none; // The hidden branding section should not be selectable
 }
 
+// Increase the specificity to override the default logo styles
+.ams-header__logo.ams-header__logo {
+  display: none;
+
+  @media screen and (min-width: $ams-breakpoint-medium) {
+    display: block;
+  }
+}
+
+// Increase the specificity to override the default logo styles
+.ams-header__logo--emblem-only.ams-header__logo--emblem-only {
+  @media screen and (min-width: $ams-breakpoint-medium) {
+    display: none;
+  }
+}
+
 .ams-header__logo-link {
   outline-offset: var(--ams-header-logo-link-outline-offset);
 }

--- a/packages/react/src/Header/Header.test.tsx
+++ b/packages/react/src/Header/Header.test.tsx
@@ -66,6 +66,22 @@ describe('Header', () => {
     expect(component).toBeInTheDocument()
   })
 
+  it('renders two logo’s when brand is "amsterdam" and responsiveLogo is true', () => {
+    const { container } = render(<Header logoBrand="amsterdam" responsiveLogo={true} />)
+
+    const component = container.querySelectorAll('.ams-logo')
+
+    expect(component).toHaveLength(2)
+  })
+
+  it('renders one logo when brand is "amsterdam" and responsiveLogo is false', () => {
+    const { container } = render(<Header logoBrand="amsterdam" responsiveLogo={false} />)
+
+    const component = container.querySelectorAll('.ams-logo')
+
+    expect(component).toHaveLength(1)
+  })
+
   it('renders a custom logo link', () => {
     render(<Header logoLink="/home" />)
 

--- a/packages/react/src/Header/Header.tsx
+++ b/packages/react/src/Header/Header.tsx
@@ -15,10 +15,12 @@ import { HeaderMenuIcon } from './HeaderMenuIcon'
 import { HeaderMenuLink } from './HeaderMenuLink'
 import useIsAfterBreakpoint from '../common/useIsAfterBreakpoint'
 
-const LogoComponent = ({ logoBrand }: { logoBrand: LogoBrand }) => (
+const LogoComponent = ({ logoBrand, responsiveLogo }: { logoBrand: LogoBrand; responsiveLogo: boolean }) => (
   <>
-    <Logo brand={logoBrand} className="ams-header__logo" />
-    {logoBrand === 'amsterdam' && <Logo brand="amsterdam-emblem-only" className="ams-header__logo--emblem-only" />}
+    <Logo brand={logoBrand} className={clsx(logoBrand === 'amsterdam' && responsiveLogo && 'ams-header__logo')} />
+    {logoBrand === 'amsterdam' && responsiveLogo && (
+      <Logo brand="amsterdam-emblem-only" className="ams-header__logo--emblem-only" />
+    )}
   </>
 )
 
@@ -26,7 +28,7 @@ export type HeaderProps = {
   /** The name of the application. */
   brandName?: string
   /** The name of the brand for which to display the logo. */
-  logoBrand?: LogoBrand
+  logoBrand?: Exclude<LogoBrand, 'amsterdam-emblem-only'>
   /** The url for the link on the logo. */
   logoLink?: string
   /** The accessible text for the link on the logo. */
@@ -39,6 +41,8 @@ export type HeaderProps = {
   navigationLabel?: string
   /** Whether the menu button is visible on wide screens.  */
   noMenuButtonOnWideWindow?: boolean
+  /** Whether the Amsterdam logo should be responsive. */
+  responsiveLogo?: boolean
 } & HTMLAttributes<HTMLElement>
 
 const HeaderRoot = forwardRef(
@@ -54,6 +58,7 @@ const HeaderRoot = forwardRef(
       menuItems,
       navigationLabel = 'Hoofdnavigatie',
       noMenuButtonOnWideWindow,
+      responsiveLogo = true,
       ...restProps
     }: HeaderProps,
     ref: ForwardedRef<HTMLElement>,
@@ -74,7 +79,7 @@ const HeaderRoot = forwardRef(
         <div className="ams-header__branding">
           <a className="ams-header__logo-link" href={logoLink}>
             <span className="ams-visually-hidden">{logoLinkTitle}</span>
-            <LogoComponent logoBrand={logoBrand} />
+            <LogoComponent logoBrand={logoBrand} responsiveLogo={responsiveLogo} />
           </a>
           {brandName && (
             <Heading className="ams-header__brand-name" level={1} size="level-5">
@@ -91,7 +96,7 @@ const HeaderRoot = forwardRef(
             {/* The branding section is recreated here, to make sure the page menu breaks at the right spot */}
             <div aria-hidden className="ams-header__branding ams-header__branding--hidden">
               <div className="ams-header__logo-link">
-                <LogoComponent logoBrand={logoBrand} />
+                <LogoComponent logoBrand={logoBrand} responsiveLogo={responsiveLogo} />
               </div>
               {brandName && (
                 <span className="ams-heading ams-heading--level-5 ams-header__brand-name">{brandName}</span>

--- a/packages/react/src/Header/Header.tsx
+++ b/packages/react/src/Header/Header.tsx
@@ -15,6 +15,13 @@ import { HeaderMenuIcon } from './HeaderMenuIcon'
 import { HeaderMenuLink } from './HeaderMenuLink'
 import useIsAfterBreakpoint from '../common/useIsAfterBreakpoint'
 
+const LogoComponent = ({ logoBrand }: { logoBrand: LogoBrand }) => (
+  <>
+    <Logo brand={logoBrand} className="ams-header__logo" />
+    {logoBrand === 'amsterdam' && <Logo brand="amsterdam-emblem-only" className="ams-header__logo--emblem-only" />}
+  </>
+)
+
 export type HeaderProps = {
   /** The name of the application. */
   brandName?: string
@@ -67,7 +74,7 @@ const HeaderRoot = forwardRef(
         <div className="ams-header__branding">
           <a className="ams-header__logo-link" href={logoLink}>
             <span className="ams-visually-hidden">{logoLinkTitle}</span>
-            <Logo brand={logoBrand} />
+            <LogoComponent logoBrand={logoBrand} />
           </a>
           {brandName && (
             <Heading className="ams-header__brand-name" level={1} size="level-5">
@@ -84,7 +91,7 @@ const HeaderRoot = forwardRef(
             {/* The branding section is recreated here, to make sure the page menu breaks at the right spot */}
             <div aria-hidden className="ams-header__branding ams-header__branding--hidden">
               <div className="ams-header__logo-link">
-                <Logo brand={logoBrand} />
+                <LogoComponent logoBrand={logoBrand} />
               </div>
               {brandName && (
                 <span className="ams-heading ams-heading--level-5 ams-header__brand-name">{brandName}</span>

--- a/packages/react/src/Logo/Logo.tsx
+++ b/packages/react/src/Logo/Logo.tsx
@@ -8,6 +8,7 @@ import { forwardRef } from 'react'
 import type { ForwardedRef, ForwardRefExoticComponent, RefAttributes, SVGProps } from 'react'
 import {
   LogoAmsterdam,
+  LogoAmsterdamEmblemOnly,
   LogoGgdAmsterdam,
   LogoMuseumWeesp,
   LogoStadsarchief,
@@ -17,6 +18,7 @@ import {
 
 export type LogoBrand =
   | 'amsterdam'
+  | 'amsterdam-emblem-only'
   | 'ggd-amsterdam'
   | 'museum-weesp'
   | 'stadsarchief'
@@ -33,6 +35,7 @@ const logoConfig: Record<
   ForwardRefExoticComponent<SVGProps<SVGSVGElement> & RefAttributes<SVGSVGElement>>
 > = {
   amsterdam: LogoAmsterdam,
+  'amsterdam-emblem-only': LogoAmsterdamEmblemOnly,
   'ggd-amsterdam': LogoGgdAmsterdam,
   'museum-weesp': LogoMuseumWeesp,
   stadsarchief: LogoStadsarchief,

--- a/packages/react/src/Logo/brand/LogoAmsterdamEmblemOnly.tsx
+++ b/packages/react/src/Logo/brand/LogoAmsterdamEmblemOnly.tsx
@@ -1,0 +1,24 @@
+import { forwardRef } from 'react'
+import type { ForwardedRef, SVGProps } from 'react'
+
+const LogoAmsterdamEmblemOnly = forwardRef((props: SVGProps<SVGSVGElement>, ref: ForwardedRef<SVGSVGElement>) => (
+  <svg
+    aria-hidden="true"
+    className="ams-logo"
+    focusable="false"
+    ref={ref}
+    viewBox="0 0 12 40"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      className="ams-logo__emblem"
+      d="m0 37.648 3.527-3.527L0 30.593l2.352-2.351 3.527 3.527 3.528-3.527 2.351 2.351-3.527 3.528 3.527 3.527L9.407 40l-3.528-3.527L2.352 40 0 37.648ZM0 23.54l3.527-3.528L0 16.485l2.352-2.352 3.527 3.528 3.528-3.528 2.351 2.352-3.527 3.527 3.527 3.528-2.351 2.351-3.528-3.527-3.527 3.527L0 23.54ZM0 9.407l3.527-3.528L0 2.352 2.352 0l3.527 3.527L9.407 0l2.351 2.352-3.527 3.527 3.527 3.528-2.351 2.351-3.528-3.527-3.526 3.527L0 9.407Z"
+      fill="#EC0000"
+    />
+  </svg>
+))
+
+LogoAmsterdamEmblemOnly.displayName = 'LogoAmsterdamEmblemOnly'
+
+export default LogoAmsterdamEmblemOnly

--- a/packages/react/src/Logo/brand/index.ts
+++ b/packages/react/src/Logo/brand/index.ts
@@ -1,4 +1,5 @@
 export { default as LogoAmsterdam } from './LogoAmsterdam'
+export { default as LogoAmsterdamEmblemOnly } from './LogoAmsterdamEmblemOnly'
 export { default as LogoGgdAmsterdam } from './LogoGgdAmsterdam'
 export { default as LogoMuseumWeesp } from './LogoMuseumWeesp'
 export { default as LogoStadsarchief } from './LogoStadsarchief'

--- a/storybook/src/components/Header/Header.docs.mdx
+++ b/storybook/src/components/Header/Header.docs.mdx
@@ -55,3 +55,13 @@ as well as the logo itself.
 The text of the menu button and the accessible navigation description can be customized.
 
 <Canvas of={HeaderStories.WithCustomTexts} />
+
+### Without responsive Amsterdam logo
+
+The Amsterdam logo is responsive by default.
+On narrow screens, only the emblem is shown.
+To turn off this feature, set the `responsiveLogo` prop to `false`.
+Note, only the Amsterdam logo is responsive; subbrand logos are not.
+If that were the case, the subbrand name would disappear on small screens.
+
+<Canvas of={HeaderStories.WithoutResponsiveAmsterdamLogo} />

--- a/storybook/src/components/Header/Header.stories.tsx
+++ b/storybook/src/components/Header/Header.stories.tsx
@@ -194,3 +194,16 @@ export const WithCustomTexts: Story = {
     navigationLabel: 'Navigatie',
   },
 }
+
+export const WithoutResponsiveAmsterdamLogo: Story = {
+  args: {
+    responsiveLogo: false,
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: '<Header responsiveLogo={false} />', // Storybook removes boolean props set to `false`, which it should not here.
+      },
+    },
+  },
+}


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It adds a smaller logo (emblem only) to the Header, which is shown on narrow screens. 

## Why

It is in the original design, we didn't implement it yet. 

## How

By adding an emblem-only version of the Amsterdam logo to our Logo component, and showing and hiding that in our Header component. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
