### PR TITLE
fix(storybook): Override superfluous block padding

### DIFF
--- a/storybook/src/utils/AspectRatio/AspectRatio.stories.tsx
+++ b/storybook/src/utils/AspectRatio/AspectRatio.stories.tsx
@@ -3,6 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
+import { aspectRatioOptions } from '@amsterdam/design-system-react/src/common/types'
 import { Meta, StoryObj } from '@storybook/react'
 import { AspectRatio } from './AspectRatio'
 
@@ -15,12 +16,12 @@ const meta = {
   argTypes: {
     aspectRatio: {
       control: 'radio',
-      options: ['2x-wide', 'x-wide', 'wide', 'square', 'tall', 'x-tall'],
+      options: aspectRatioOptions,
     },
   },
   render: ({ aspectRatio }) => (
     <div className="ams-docs-column ams-docs-aspect-ratio">
-      <div className={`ams-docs-item ams-aspect-ratio--${aspectRatio}`}></div>
+      <div className={`ams-docs-item ams-aspect-ratio--${aspectRatio}`} style={{ paddingBlock: 0 }}></div>
     </div>
   ),
 } satisfies Meta<typeof AspectRatio>


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Fixes an issue were Storybook examples of the Aspect Ratio tokens are incorrectly displayed.

## Why

Issue in the documentation.

## How

By adding an override via the `style` attribute.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update stories
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Is there a better, more elegant way to fix this issue than via the `style` attribute?
