### PR TITLE
chore(deps): Block lifecycle scripts of dependencies during installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,14 @@
     "typescript": "5.7.3",
     "typescript-eslint": "8.24.1",
     "wait-on": "8.0.2"
+  },
+  "pnpm": {
+    "ignoredBuiltDependencies": [
+      "@bundled-es-modules/glob",
+      "@parcel/watcher",
+      "esbuild",
+      "sharp",
+      "style-dictionary"
+    ]
   }
 }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Configures a breaking change of pnpm 10:
By default no dependency is allowed to run lifecycle scripts during installation ([PR](https://github.com/pnpm/pnpm/pull/8897)).

## Why

To slightly increase security (“This only makes one attack vector harder” – [maintainer](https://github.com/pnpm/pnpm/pull/8897#issuecomment-2558124547)).

## How

1. Ran `pnpm approve-builds`, select no packages, save.
2. Tested a clean reinstall.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- More info: https://socket.dev/blog/pnpm-10-0-0-blocks-lifecycle-scripts-by-default