### PR TITLE
feat(Header): Allow opening and closing to toggle the Mega Menu

### DIFF
--- a/packages/react/src/Header/Header.test.tsx
+++ b/packages/react/src/Header/Header.test.tsx
@@ -192,4 +192,28 @@ describe('Header', () => {
   it.skip('it closes the mega menu when it is open and the screen width passes the breakpoint', () => {
     // TODO: Add this test
   })
+
+  it('renders with the mega menu open when the open prop is true', () => {
+    render(<Header open>Test</Header>)
+
+    const openMegaMenu = screen.getByRole('navigation').querySelector('.ams-header__mega-menu')
+    expect(openMegaMenu).toBeInTheDocument()
+    expect(openMegaMenu).not.toHaveClass('ams-header__mega-menu--closed')
+  })
+
+  it('calls onClose when the mega menu is closed', async () => {
+    const user = userEvent.setup()
+    const onClose = jest.fn()
+
+    render(
+      <Header onClose={onClose} open>
+        Test
+      </Header>,
+    )
+
+    const menuButton = screen.getByRole('button', { name: 'Menu' })
+    await user.click(menuButton)
+
+    expect(onClose).toHaveBeenCalled()
+  })
 })

--- a/packages/react/src/Header/Header.tsx
+++ b/packages/react/src/Header/Header.tsx
@@ -32,6 +32,10 @@ export type HeaderProps = {
   navigationLabel?: string
   /** Whether the menu button is visible on wide screens.  */
   noMenuButtonOnWideWindow?: boolean
+  /** Fires after the menu button closes the header. */
+  onClose?: () => void
+  /** Whether the header is open, showing the mega menu. */
+  open?: boolean
 } & HTMLAttributes<HTMLElement>
 
 const HeaderRoot = forwardRef(
@@ -47,18 +51,33 @@ const HeaderRoot = forwardRef(
       menuItems,
       navigationLabel = 'Hoofdnavigatie',
       noMenuButtonOnWideWindow,
+      onClose,
+      open,
       ...restProps
     }: HeaderProps,
     ref: ForwardedRef<HTMLElement>,
   ) => {
-    const [open, setOpen] = useState(false)
+    const [isOpen, setIsOpen] = useState(Boolean(open))
 
     const isWideWindow = useIsAfterBreakpoint('wide')
+
+    const toggleIsOpen = () => {
+      const willClose = isOpen
+      setIsOpen(willClose ? false : true)
+
+      if (willClose) {
+        onClose?.()
+      }
+    }
+
+    useEffect(() => {
+      setIsOpen(Boolean(open))
+    }, [open])
 
     useEffect(() => {
       // Close the menu when the menu button disappears
       if (noMenuButtonOnWideWindow && isWideWindow) {
-        setOpen(false)
+        setIsOpen(false)
       }
     }, [isWideWindow])
 
@@ -100,9 +119,9 @@ const HeaderRoot = forwardRef(
                   <button
                     {...restProps}
                     aria-controls="ams-mega-menu"
-                    aria-expanded={open}
+                    aria-expanded={isOpen}
                     className="ams-header__mega-menu-button"
-                    onClick={() => setOpen(!open)}
+                    onClick={toggleIsOpen}
                     type="button"
                   >
                     <span className="ams-header__mega-menu-button-label">{menuButtonText}</span>
@@ -113,7 +132,7 @@ const HeaderRoot = forwardRef(
                       size="level-5"
                       svg={
                         <HeaderMenuIcon
-                          className={clsx('ams-header__menu-icon', open && 'ams-header__menu-icon--open')}
+                          className={clsx('ams-header__menu-icon', isOpen && 'ams-header__menu-icon--open')}
                         />
                       }
                     />
@@ -124,7 +143,7 @@ const HeaderRoot = forwardRef(
 
             {children && (
               <div
-                className={clsx('ams-header__mega-menu', !open && 'ams-header__mega-menu--closed')}
+                className={clsx('ams-header__mega-menu', !isOpen && 'ams-header__mega-menu--closed')}
                 id="ams-mega-menu"
               >
                 {children}


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Allows a parent component to open or close the Header.

## Why

The Header should close after clicking a link in the Mega Menu.

## How

- Rename the local state variable from `open` to `isOpen`
- Add an `open` prop and an `onClose` callback

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a