### PR TITLE
poc: Add bottom margin to text components

### DIFF
--- a/packages/css/src/components/card/card.scss
+++ b/packages/css/src/components/card/card.scss
@@ -40,7 +40,7 @@
   }
 
   > .ams-image {
-    @extend %ams-mb--md;
+    @extend %ams-mb--medium;
   }
 }
 

--- a/packages/css/src/components/card/card.scss
+++ b/packages/css/src/components/card/card.scss
@@ -3,6 +3,8 @@
  * Copyright Gemeente Amsterdam
  */
 
+@use "../margin/mixins" as *;
+
 .ams-card {
   display: grid;
   gap: var(--ams-card-gap);
@@ -35,6 +37,10 @@
     inset-block: 0;
     inset-inline: 0;
     position: absolute;
+  }
+
+  > .ams-image {
+    @extend %ams-mb--md;
   }
 }
 

--- a/packages/css/src/components/heading/heading.scss
+++ b/packages/css/src/components/heading/heading.scss
@@ -23,14 +23,17 @@
   @include text-rendering;
   @include reset-hx;
 
-  &:has(+ .ams-accordion),
-  &:has(+ .ams-button),
-  &:has(+ .ams-description-list),
   &:has(+ .ams-link--standalone),
-  &:has(+ .ams-link-list),
   &:has(+ .ams-ordered-list),
   &:has(+ .ams-paragraph),
   &:has(+ .ams-unordered-list) {
+    @extend %ams-mb--xs;
+  }
+
+  &:has(+ .ams-accordion),
+  &:has(+ .ams-button),
+  &:has(+ .ams-description-list),
+  &:has(+ .ams-link-list) {
     @extend %ams-mb--md;
   }
 

--- a/packages/css/src/components/heading/heading.scss
+++ b/packages/css/src/components/heading/heading.scss
@@ -27,25 +27,25 @@
   &:has(+ .ams-ordered-list),
   &:has(+ .ams-paragraph),
   &:has(+ .ams-unordered-list) {
-    @extend %ams-mb--xs;
+    @extend %ams-mb--x-small;
   }
 
   &:has(+ .ams-accordion),
   &:has(+ .ams-button),
   &:has(+ .ams-description-list),
   &:has(+ .ams-link-list) {
-    @extend %ams-mb--md;
+    @extend %ams-mb--medium;
   }
 
   &:has(+ .ams-blockquote),
   &:has(+ .ams-image),
   &:has(+ .ams-image-slider),
   &:has(+ .ams-table) {
-    @extend %ams-mb--lg;
+    @extend %ams-mb--large;
   }
 
   &:has(+ .ams-alert) {
-    @extend %ams-mb--xl;
+    @extend %ams-mb--x-large;
   }
 }
 
@@ -54,7 +54,7 @@
   line-height: var(--ams-heading-1-line-height);
 
   &:has(+ .ams-heading--level-3) {
-    @extend %ams-mb--xxl;
+    @extend %ams-mb--2x-large;
   }
 }
 
@@ -63,7 +63,7 @@
   line-height: var(--ams-heading-2-line-height);
 
   &:has(+ .ams-heading--level-3) {
-    @extend %ams-mb--lg;
+    @extend %ams-mb--large;
   }
 }
 
@@ -72,7 +72,7 @@
   line-height: var(--ams-heading-3-line-height);
 
   &:has(+ .ams-heading--level-4) {
-    @extend %ams-mb--lg;
+    @extend %ams-mb--large;
   }
 }
 
@@ -81,7 +81,7 @@
   line-height: var(--ams-heading-4-line-height);
 
   &:has(+ .ams-heading--level-5) {
-    @extend %ams-mb--lg;
+    @extend %ams-mb--large;
   }
 }
 
@@ -90,7 +90,7 @@
   line-height: var(--ams-heading-5-line-height);
 
   &:has(+ .ams-heading--level-6) {
-    @extend %ams-mb--lg;
+    @extend %ams-mb--large;
   }
 }
 

--- a/packages/css/src/components/heading/heading.scss
+++ b/packages/css/src/components/heading/heading.scss
@@ -3,6 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
+@use "../margin/mixins" as *;
 @use "../../common/hyphenation" as *;
 @use "../../common/text-rendering" as *;
 
@@ -21,31 +22,73 @@
   @include hyphenation;
   @include text-rendering;
   @include reset-hx;
+
+  &:has(+ .ams-accordion),
+  &:has(+ .ams-button),
+  &:has(+ .ams-description-list),
+  &:has(+ .ams-link--standalone),
+  &:has(+ .ams-link-list),
+  &:has(+ .ams-ordered-list),
+  &:has(+ .ams-paragraph),
+  &:has(+ .ams-unordered-list) {
+    @extend %ams-mb--md;
+  }
+
+  &:has(+ .ams-blockquote),
+  &:has(+ .ams-image),
+  &:has(+ .ams-image-slider),
+  &:has(+ .ams-table) {
+    @extend %ams-mb--lg;
+  }
+
+  &:has(+ .ams-alert) {
+    @extend %ams-mb--xl;
+  }
 }
 
 .ams-heading--level-1 {
   font-size: var(--ams-heading-1-font-size);
   line-height: var(--ams-heading-1-line-height);
+
+  &:has(+ .ams-heading--level-3) {
+    @extend %ams-mb--xxl;
+  }
 }
 
 .ams-heading--level-2 {
   font-size: var(--ams-heading-2-font-size);
   line-height: var(--ams-heading-2-line-height);
+
+  &:has(+ .ams-heading--level-3) {
+    @extend %ams-mb--lg;
+  }
 }
 
 .ams-heading--level-3 {
   font-size: var(--ams-heading-3-font-size);
   line-height: var(--ams-heading-3-line-height);
+
+  &:has(+ .ams-heading--level-4) {
+    @extend %ams-mb--lg;
+  }
 }
 
 .ams-heading--level-4 {
   font-size: var(--ams-heading-4-font-size);
   line-height: var(--ams-heading-4-line-height);
+
+  &:has(+ .ams-heading--level-5) {
+    @extend %ams-mb--lg;
+  }
 }
 
 .ams-heading--level-5 {
   font-size: var(--ams-heading-5-font-size);
   line-height: var(--ams-heading-5-line-height);
+
+  &:has(+ .ams-heading--level-6) {
+    @extend %ams-mb--lg;
+  }
 }
 
 .ams-heading--level-6 {

--- a/packages/css/src/components/image/image.scss
+++ b/packages/css/src/components/image/image.scss
@@ -3,6 +3,8 @@
  * Copyright Gemeente Amsterdam
  */
 
+@use "../margin/mixins" as *;
+
 .ams-image {
   aspect-ratio: var(--ams-image-aspect-ratio);
   block-size: auto; /* [1] */
@@ -11,6 +13,32 @@
   max-inline-size: 100%; /* [1] */
   object-fit: cover; /* [4] */
   vertical-align: middle; /* [2] */
+
+  &:has(+ .ams-image) {
+    @extend %ams-mb--md;
+  }
+
+  &:has(+ .ams-blockquote),
+  &:has(+ .ams-button),
+  &:has(+ .ams-description-list),
+  &:has(+ .ams-heading--level-5),
+  &:has(+ .ams-heading--level-6),
+  &:has(+ .ams-image-slider),
+  &:has(+ .ams-link--standalone),
+  &:has(+ .ams-link-list),
+  &:has(+ .ams-ordered-list),
+  &:has(+ .ams-paragraph),
+  &:has(+ .ams-table),
+  &:has(+ .ams-unordered-list) {
+    @extend %ams-mb--lg;
+  }
+
+  &:has(+ .ams-alert),
+  &:has(+ .ams-heading--level-2),
+  &:has(+ .ams-heading--level-3),
+  &:has(+ .ams-heading--level-4) {
+    @extend %ams-mb--xl;
+  }
 }
 
 // [1] Allow for fluid image sizing while maintaining aspect ratio governed by inline/block size attributes

--- a/packages/css/src/components/image/image.scss
+++ b/packages/css/src/components/image/image.scss
@@ -15,7 +15,7 @@
   vertical-align: middle; /* [2] */
 
   &:has(+ .ams-image) {
-    @extend %ams-mb--md;
+    @extend %ams-mb--medium;
   }
 
   &:has(+ .ams-blockquote),
@@ -30,14 +30,14 @@
   &:has(+ .ams-paragraph),
   &:has(+ .ams-table),
   &:has(+ .ams-unordered-list) {
-    @extend %ams-mb--lg;
+    @extend %ams-mb--large;
   }
 
   &:has(+ .ams-alert),
   &:has(+ .ams-heading--level-2),
   &:has(+ .ams-heading--level-3),
   &:has(+ .ams-heading--level-4) {
-    @extend %ams-mb--xl;
+    @extend %ams-mb--x-large;
   }
 }
 

--- a/packages/css/src/components/link/link.scss
+++ b/packages/css/src/components/link/link.scss
@@ -37,7 +37,7 @@
   &:has(+ .ams-ordered-list),
   &:has(+ .ams-paragraph),
   &:has(+ .ams-unordered-list) {
-    @extend %ams-mb--md;
+    @extend %ams-mb--medium;
   }
 
   &:has(+ .ams-blockquote),
@@ -48,12 +48,12 @@
   &:has(+ .ams-image),
   &:has(+ .ams-image-slider),
   &:has(+ .ams-table) {
-    @extend %ams-mb--lg;
+    @extend %ams-mb--large;
   }
 
   &:has(+ .ams-alert),
   &:has(+ .ams-heading--level-2) {
-    @extend %ams-mb--xl;
+    @extend %ams-mb--x-large;
   }
 
   &:hover {

--- a/packages/css/src/components/link/link.scss
+++ b/packages/css/src/components/link/link.scss
@@ -3,6 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
+@use "../margin/mixins" as *;
 @use "../../common/hyphenation" as *;
 @use "../../common/text-rendering" as *;
 
@@ -27,6 +28,33 @@
   text-underline-offset: var(--ams-link-standalone-text-underline-offset);
 
   @include hyphenation;
+
+  &:has(+ .ams-accordion),
+  &:has(+ .ams-button),
+  &:has(+ .ams-description-list),
+  &:has(+ .ams-link--standalone),
+  &:has(+ .ams-link-list),
+  &:has(+ .ams-ordered-list),
+  &:has(+ .ams-paragraph),
+  &:has(+ .ams-unordered-list) {
+    @extend %ams-mb--md;
+  }
+
+  &:has(+ .ams-blockquote),
+  &:has(+ .ams-heading--level-3),
+  &:has(+ .ams-heading--level-4),
+  &:has(+ .ams-heading--level-5),
+  &:has(+ .ams-heading--level-6),
+  &:has(+ .ams-image),
+  &:has(+ .ams-image-slider),
+  &:has(+ .ams-table) {
+    @extend %ams-mb--lg;
+  }
+
+  &:has(+ .ams-alert),
+  &:has(+ .ams-heading--level-2) {
+    @extend %ams-mb--xl;
+  }
 
   &:hover {
     text-decoration-thickness: var(--ams-link-standalone-hover-text-decoration-thickness);

--- a/packages/css/src/components/margin/mixins.scss
+++ b/packages/css/src/components/margin/mixins.scss
@@ -3,26 +3,26 @@
  * Copyright Gemeente Amsterdam
  */
 
-%ams-mb--xs {
+%ams-mb--x-small {
   margin-block-end: var(--ams-margin-xs) !important;
 }
 
-%ams-mb--sm {
+%ams-mb--small {
   margin-block-end: var(--ams-margin-sm) !important;
 }
 
-%ams-mb--md {
+%ams-mb--medium {
   margin-block-end: var(--ams-margin-md) !important;
 }
 
-%ams-mb--lg {
+%ams-mb--large {
   margin-block-end: var(--ams-margin-lg) !important;
 }
 
-%ams-mb--xl {
+%ams-mb--x-large {
   margin-block-end: var(--ams-space-xl) !important;
 }
 
-%ams-mb--xxl {
-  margin-block-end: var(--ams-space-xxl) !important;
+%ams-mb--2x-large {
+  margin-block-end: var(--ams-space-2xl) !important;
 }

--- a/packages/css/src/components/margin/mixins.scss
+++ b/packages/css/src/components/margin/mixins.scss
@@ -1,0 +1,30 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+%ams-mb--xs {
+  margin-block-end: var(--ams-margin-xs);
+}
+
+%ams-mb--sm {
+  margin-block-end: var(--ams-margin-sm);
+}
+
+%ams-mb--md {
+  margin-block-end: var(--ams-margin-md);
+}
+
+%ams-mb--lg {
+  margin-block-end: var(--ams-margin-lg);
+}
+
+%ams-mb--xl {
+  // TODO
+  margin-block-end: var(--ams-space-grid-md);
+}
+
+%ams-mb--xxl {
+  // TODO
+  margin-block-end: var(--ams-space-grid-lg);
+}

--- a/packages/css/src/components/margin/mixins.scss
+++ b/packages/css/src/components/margin/mixins.scss
@@ -4,27 +4,25 @@
  */
 
 %ams-mb--xs {
-  margin-block-end: var(--ams-margin-xs);
+  margin-block-end: var(--ams-margin-xs) !important;
 }
 
 %ams-mb--sm {
-  margin-block-end: var(--ams-margin-sm);
+  margin-block-end: var(--ams-margin-sm) !important;
 }
 
 %ams-mb--md {
-  margin-block-end: var(--ams-margin-md);
+  margin-block-end: var(--ams-margin-md) !important;
 }
 
 %ams-mb--lg {
-  margin-block-end: var(--ams-margin-lg);
+  margin-block-end: var(--ams-margin-lg) !important;
 }
 
 %ams-mb--xl {
-  // TODO
-  margin-block-end: var(--ams-space-grid-md);
+  margin-block-end: var(--ams-space-xl) !important;
 }
 
 %ams-mb--xxl {
-  // TODO
-  margin-block-end: var(--ams-space-grid-lg);
+  margin-block-end: var(--ams-space-xxl) !important;
 }

--- a/packages/css/src/components/ordered-list/ordered-list.scss
+++ b/packages/css/src/components/ordered-list/ordered-list.scss
@@ -30,7 +30,7 @@
   &:has(+ .ams-ordered-list),
   &:has(+ .ams-paragraph),
   &:has(+ .ams-unordered-list) {
-    @extend %ams-mb--md;
+    @extend %ams-mb--medium;
   }
 
   &:has(+ .ams-blockquote),
@@ -40,12 +40,12 @@
   &:has(+ .ams-heading--level-6),
   &:has(+ .ams-image),
   &:has(+ .ams-image-slider) {
-    @extend %ams-mb--lg;
+    @extend %ams-mb--large;
   }
 
   &:has(+ .ams-alert),
   &:has(+ .ams-heading--level-2) {
-    @extend %ams-mb--xl;
+    @extend %ams-mb--x-large;
   }
 }
 

--- a/packages/css/src/components/ordered-list/ordered-list.scss
+++ b/packages/css/src/components/ordered-list/ordered-list.scss
@@ -3,6 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
+@use "../margin/mixins" as *;
 @use "../../common/hyphenation" as *;
 @use "../../common/text-rendering" as *;
 
@@ -20,6 +21,32 @@
   @include text-rendering;
   @include hyphenation;
   @include reset-ol;
+
+  &:has(+ .ams-accordion),
+  &:has(+ .ams-button),
+  &:has(+ .ams-description-list),
+  &:has(+ .ams-link--standalone),
+  &:has(+ .ams-link-list),
+  &:has(+ .ams-ordered-list),
+  &:has(+ .ams-paragraph),
+  &:has(+ .ams-unordered-list) {
+    @extend %ams-mb--md;
+  }
+
+  &:has(+ .ams-blockquote),
+  &:has(+ .ams-heading--level-3),
+  &:has(+ .ams-heading--level-4),
+  &:has(+ .ams-heading--level-5),
+  &:has(+ .ams-heading--level-6),
+  &:has(+ .ams-image),
+  &:has(+ .ams-image-slider) {
+    @extend %ams-mb--lg;
+  }
+
+  &:has(+ .ams-alert),
+  &:has(+ .ams-heading--level-2) {
+    @extend %ams-mb--xl;
+  }
 }
 
 .ams-ordered-list:not(.ams-ordered-list--no-markers) {

--- a/packages/css/src/components/paragraph/paragraph.scss
+++ b/packages/css/src/components/paragraph/paragraph.scss
@@ -3,6 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
+@use "../margin/mixins" as *;
 @use "../../common/hyphenation" as *;
 @use "../../common/text-rendering" as *;
 
@@ -21,6 +22,32 @@
   @include text-rendering;
   @include hyphenation;
   @include reset-p;
+
+  &:has(+ .ams-accordion),
+  &:has(+ .ams-button),
+  &:has(+ .ams-description-list),
+  &:has(+ .ams-link--standalone),
+  &:has(+ .ams-link-list),
+  &:has(+ .ams-ordered-list),
+  &:has(+ .ams-paragraph),
+  &:has(+ .ams-unordered-list) {
+    @extend %ams-mb--md;
+  }
+
+  &:has(+ .ams-blockquote),
+  &:has(+ .ams-heading--level-3),
+  &:has(+ .ams-heading--level-4),
+  &:has(+ .ams-heading--level-5),
+  &:has(+ .ams-heading--level-6),
+  &:has(+ .ams-image),
+  &:has(+ .ams-image-slider) {
+    @extend %ams-mb--lg;
+  }
+
+  &:has(+ .ams-alert),
+  &:has(+ .ams-heading--level-2) {
+    @extend %ams-mb--xl;
+  }
 }
 
 .ams-paragraph--small {
@@ -31,6 +58,10 @@
 .ams-paragraph--large {
   font-size: var(--ams-paragraph-large-font-size);
   line-height: var(--ams-paragraph-large-line-height);
+
+  &:has(+ .ams-heading--level-2) {
+    @extend %ams-mb--xxl;
+  }
 }
 
 .ams-paragraph--inverse {

--- a/packages/css/src/components/paragraph/paragraph.scss
+++ b/packages/css/src/components/paragraph/paragraph.scss
@@ -31,7 +31,7 @@
   &:has(+ .ams-ordered-list),
   &:has(+ .ams-paragraph),
   &:has(+ .ams-unordered-list) {
-    @extend %ams-mb--md;
+    @extend %ams-mb--medium;
   }
 
   &:has(+ .ams-blockquote),
@@ -41,12 +41,12 @@
   &:has(+ .ams-heading--level-6),
   &:has(+ .ams-image),
   &:has(+ .ams-image-slider) {
-    @extend %ams-mb--lg;
+    @extend %ams-mb--large;
   }
 
   &:has(+ .ams-alert),
   &:has(+ .ams-heading--level-2) {
-    @extend %ams-mb--xl;
+    @extend %ams-mb--x-large;
   }
 }
 
@@ -60,7 +60,7 @@
   line-height: var(--ams-paragraph-large-line-height);
 
   &:has(+ .ams-heading--level-2) {
-    @extend %ams-mb--xxl;
+    @extend %ams-mb--2x-large;
   }
 }
 

--- a/packages/css/src/components/unordered-list/unordered-list.scss
+++ b/packages/css/src/components/unordered-list/unordered-list.scss
@@ -30,7 +30,7 @@
   &:has(+ .ams-ordered-list),
   &:has(+ .ams-paragraph),
   &:has(+ .ams-unordered-list) {
-    @extend %ams-mb--md;
+    @extend %ams-mb--medium;
   }
 
   &:has(+ .ams-blockquote),
@@ -40,12 +40,12 @@
   &:has(+ .ams-heading--level-6),
   &:has(+ .ams-image),
   &:has(+ .ams-image-slider) {
-    @extend %ams-mb--lg;
+    @extend %ams-mb--large;
   }
 
   &:has(+ .ams-alert),
   &:has(+ .ams-heading--level-2) {
-    @extend %ams-mb--xl;
+    @extend %ams-mb--x-large;
   }
 }
 

--- a/packages/css/src/components/unordered-list/unordered-list.scss
+++ b/packages/css/src/components/unordered-list/unordered-list.scss
@@ -3,6 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
+@use "../margin/mixins" as *;
 @use "../../common/hyphenation" as *;
 @use "../../common/text-rendering" as *;
 
@@ -20,6 +21,32 @@
   @include hyphenation;
   @include text-rendering;
   @include reset-ul;
+
+  &:has(+ .ams-accordion),
+  &:has(+ .ams-button),
+  &:has(+ .ams-description-list),
+  &:has(+ .ams-link--standalone),
+  &:has(+ .ams-link-list),
+  &:has(+ .ams-ordered-list),
+  &:has(+ .ams-paragraph),
+  &:has(+ .ams-unordered-list) {
+    @extend %ams-mb--md;
+  }
+
+  &:has(+ .ams-blockquote),
+  &:has(+ .ams-heading--level-3),
+  &:has(+ .ams-heading--level-4),
+  &:has(+ .ams-heading--level-5),
+  &:has(+ .ams-heading--level-6),
+  &:has(+ .ams-image),
+  &:has(+ .ams-image-slider) {
+    @extend %ams-mb--lg;
+  }
+
+  &:has(+ .ams-alert),
+  &:has(+ .ams-heading--level-2) {
+    @extend %ams-mb--xl;
+  }
 }
 
 .ams-unordered-list:not(.ams-unordered-list--no-markers) {

--- a/proprietary/tokens/src/brand/ams/space.tokens.json
+++ b/proprietary/tokens/src/brand/ams/space.tokens.json
@@ -6,7 +6,7 @@
       "md": { "value": "clamp(1.125rem, 1.0313rem + 0.4688vw, 1.5rem)" },
       "lg": { "value": "clamp(1.6875rem, 1.5469rem + 0.7031vw, 2.25rem)" },
       "xl": { "value": "clamp(2.625rem, 2.4063rem + 1.0938vw, 3.5rem)" },
-      "xxl": { "value": "clamp(3.9375rem, 3.6094rem + 1.6406vw, 5.25rem)" },
+      "2xl": { "value": "clamp(3.9375rem, 3.6094rem + 1.6406vw, 5.25rem)" },
       "grid": {
         "xs": { "value": "clamp(0.25rem, calc(0.09375rem + 0.78125vw), 0.875rem)" },
         "sm": { "value": "clamp(0.5rem, calc(0.1875rem + 1.5625vw), 1.75rem)" },

--- a/proprietary/tokens/src/brand/ams/space.tokens.json
+++ b/proprietary/tokens/src/brand/ams/space.tokens.json
@@ -5,7 +5,8 @@
       "sm": { "value": "clamp(0.5625rem, 0.5156rem + 0.2344vw, 0.75rem)" },
       "md": { "value": "clamp(1.125rem, 1.0313rem + 0.4688vw, 1.5rem)" },
       "lg": { "value": "clamp(1.6875rem, 1.5469rem + 0.7031vw, 2.25rem)" },
-      "xl": { "value": "clamp(2.25rem, 2.0625rem + 0.9375vw, 3rem)" },
+      "xl": { "value": "clamp(2.625rem, 2.4063rem + 1.0938vw, 3.5rem)" },
+      "xxl": { "value": "clamp(3.9375rem, 3.6094rem + 1.6406vw, 5.25rem)" },
       "grid": {
         "xs": { "value": "clamp(0.25rem, calc(0.09375rem + 0.78125vw), 0.875rem)" },
         "sm": { "value": "clamp(0.5rem, calc(0.1875rem + 1.5625vw), 1.75rem)" },

--- a/proprietary/tokens/src/brand/ams/typography.tokens.json
+++ b/proprietary/tokens/src/brand/ams/typography.tokens.json
@@ -5,52 +5,52 @@
       "body-text": {
         "font-size": { "value": "clamp(1.125rem, calc(1.0313rem + 0.4688vw), 1.5rem)" },
         "font-weight": { "value": "400" },
-        "line-height": { "value": "1.6" },
+        "line-height": { "value": "1.6667" },
         "bold": {
           "font-weight": { "value": "800" }
         },
         "small": {
           "font-size": { "value": "clamp(0.9643rem, calc(0.9054rem + 0.2946vw), 1.2rem)" },
-          "line-height": { "value": "{ams.typography.body-text.line-height}" }
+          "line-height": { "value": "1.5152" }
         },
         "large": {
           "font-size": { "value": "clamp(1.3125rem, calc(1.1719rem + 0.7031vw), 1.875rem)" },
-          "line-height": { "value": "1.5" }
+          "line-height": { "value": "1.5152" }
         },
         "x-large": {
           "font-size": { "value": "clamp(1.5313rem, calc(1.3281rem + 1.0156vw), 2.3438rem)" },
-          "line-height": { "value": "1.3" }
+          "line-height": { "value": "1.3776" }
         }
       },
       "heading": {
         "font-weight": { "value": "800" },
         "0": {
           "font-size": { "value": "clamp(2.4316rem, calc(1.8951rem + 2.6826vw), 4.5776rem)" },
-          "line-height": { "value": "1.15" }
+          "line-height": { "value": "1.1386" }
         },
         "1": {
           "font-size": { "value": "clamp(2.0842rem, calc(1.6897rem + 1.9724vw), 3.6621rem)" },
-          "line-height": { "value": "1.2" }
+          "line-height": { "value": "1.1754" }
         },
         "2": {
           "font-size": { "value": "clamp(1.7865rem, calc(1.5007rem + 1.429vw), 2.9297rem)" },
-          "line-height": { "value": "1.25" }
+          "line-height": { "value": "1.2133" }
         },
         "3": {
           "font-size": { "value": "{ams.typography.body-text.x-large.font-size}" },
-          "line-height": { "value": "{ams.typography.body-text.x-large.line-height}" }
+          "line-height": { "value": "1.2524" }
         },
         "4": {
           "font-size": { "value": "{ams.typography.body-text.large.font-size}" },
-          "line-height": { "value": "{ams.typography.body-text.large.line-height}" }
+          "line-height": { "value": "1.2928" }
         },
         "5": {
           "font-size": { "value": "{ams.typography.body-text.font-size}" },
-          "line-height": { "value": "{ams.typography.body-text.line-height}" }
+          "line-height": { "value": "1.3345" }
         },
         "6": {
           "font-size": { "value": "{ams.typography.body-text.small.font-size}" },
-          "line-height": { "value": "{ams.typography.body-text.small.line-height}" }
+          "line-height": { "value": "1.3776" }
         }
       }
     }

--- a/proprietary/tokens/src/components/ams/card.tokens.json
+++ b/proprietary/tokens/src/components/ams/card.tokens.json
@@ -1,9 +1,9 @@
 {
   "ams": {
     "card": {
-      "gap": { "value": "{ams.space.sm}" },
+      "gap": { "value": "0" },
       "heading-group": {
-        "gap": { "value": "{ams.space.sm}" }
+        "gap": { "value": "0" }
       },
       "link": {
         "color": { "value": "{ams.links.color}" },

--- a/proprietary/tokens/src/components/ams/gap.tokens.json
+++ b/proprietary/tokens/src/components/ams/gap.tokens.json
@@ -1,11 +1,11 @@
 {
   "ams": {
     "gap": {
-      "xs": { "value": "{ams.space.grid.xs}" },
-      "sm": { "value": "{ams.space.grid.sm}" },
-      "md": { "value": "{ams.space.grid.md}" },
-      "lg": { "value": "{ams.space.grid.lg}" },
-      "xl": { "value": "{ams.space.grid.xl}" }
+      "xs": { "value": "{ams.space.xs}" },
+      "sm": { "value": "{ams.space.sm}" },
+      "md": { "value": "{ams.space.md}" },
+      "lg": { "value": "{ams.space.lg}" },
+      "xl": { "value": "{ams.space.xl}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/ams/margin.tokens.json
+++ b/proprietary/tokens/src/components/ams/margin.tokens.json
@@ -1,11 +1,11 @@
 {
   "ams": {
     "margin": {
-      "xs": { "value": "{ams.space.grid.xs}" },
-      "sm": { "value": "{ams.space.grid.sm}" },
-      "md": { "value": "{ams.space.grid.md}" },
-      "lg": { "value": "{ams.space.grid.lg}" },
-      "xl": { "value": "{ams.space.grid.xl}" }
+      "xs": { "value": "{ams.space.xs}" },
+      "sm": { "value": "{ams.space.sm}" },
+      "md": { "value": "{ams.space.md}" },
+      "lg": { "value": "{ams.space.lg}" },
+      "xl": { "value": "{ams.space.xl}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/ams/ordered-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/ordered-list.tokens.json
@@ -5,7 +5,7 @@
       "font-family": { "value": "{ams.typography.font-family}" },
       "font-size": { "value": "{ams.typography.body-text.font-size}" },
       "font-weight": { "value": "{ams.typography.body-text.font-weight}" },
-      "gap": { "value": "{ams.space.md}" },
+      "gap": { "value": "0" },
       "line-height": { "value": "{ams.typography.body-text.line-height}" },
       "list-style-type": { "value": "decimal" },
       "small": {
@@ -26,7 +26,7 @@
         }
       },
       "ordered-list": {
-        "gap": { "value": "{ams.space.sm}" },
+        "gap": { "value": "0" },
         "list-style-type": { "value": "lower-alpha" },
         "padding-block-end": { "value": "0" },
         "padding-block-start": { "value": "{ams.space.sm}" },

--- a/proprietary/tokens/src/components/ams/unordered-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/unordered-list.tokens.json
@@ -5,7 +5,7 @@
       "font-family": { "value": "{ams.typography.font-family}" },
       "font-size": { "value": "{ams.typography.body-text.font-size}" },
       "font-weight": { "value": "{ams.typography.body-text.font-weight}" },
-      "gap": { "value": "{ams.space.md}" },
+      "gap": { "value": "0" },
       "line-height": { "value": "{ams.typography.body-text.line-height}" },
       "list-style-type": { "value": "'\\2022'" },
       "inverse": {
@@ -26,7 +26,7 @@
         }
       },
       "unordered-list": {
-        "gap": { "value": "{ams.space.sm}" },
+        "gap": { "value": "0" },
         "list-style-type": { "value": "'\\2013'" },
         "padding-block-end": { "value": "0" },
         "padding-block-start": { "value": "{ams.space.sm}" },

--- a/storybook/src/pages/amsterdam/ArticlePage/ArticleBody.tsx
+++ b/storybook/src/pages/amsterdam/ArticlePage/ArticleBody.tsx
@@ -1,13 +1,4 @@
-import {
-  Column,
-  Grid,
-  Heading,
-  Link,
-  LinkList,
-  Paragraph,
-  Spotlight,
-  UnorderedList,
-} from '@amsterdam/design-system-react'
+import { Grid, Heading, Link, LinkList, Paragraph, Spotlight, UnorderedList } from '@amsterdam/design-system-react'
 import type { ArticlePageProps } from './ArticlePage'
 
 type ArticleBodyProps = Pick<ArticlePageProps, 'lead' | 'paragraph1' | 'spotlightHeading' | 'spotlightLinkLabel'>
@@ -16,100 +7,70 @@ export const ArticleBody = ({ lead, paragraph1, spotlightHeading, spotlightLinkL
   <>
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Paragraph className="ams-mb--md" size="large">
-          {lead}
-        </Paragraph>
+        <Paragraph size="large">{lead}</Paragraph>
         <Paragraph>{paragraph1}</Paragraph>
       </Grid.Cell>
     </Grid>
     <Spotlight as="section">
       <Grid paddingBottom="large" paddingTop="medium">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 8 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-          <Column gap="small">
-            <Heading color="inverse" level={2}>
-              {spotlightHeading}
-            </Heading>
-            <UnorderedList color="inverse">
-              <UnorderedList.Item>
-                Vraag uw paspoort of ID-kaart aan bij een Stadsloket in Amsterdam.
-              </UnorderedList.Item>
-              <UnorderedList.Item>
-                U kunt elke dag langskomen van 9.00 uur tot 17.00 uur en op donderdag tot 20.00 uur.
-              </UnorderedList.Item>
-              <UnorderedList.Item>Op amsterdam.nl/paspoort staat wat u mee moet nemen.</UnorderedList.Item>
-              <UnorderedList.Item>
-                Laat aan het loket bij uw aanvraag weten dat u kiest voor gratis bezorgen.
-              </UnorderedList.Item>
-              <UnorderedList.Item>
-                Als uw paspoort of ID-kaart klaar is, krijgt u een e-mail en sms-bericht met inloggegevens. Met deze
-                inloggegevens kunt u zelf inplannen wanneer u uw reisdocument bezorgd wilt hebben.
-              </UnorderedList.Item>
-            </UnorderedList>
-            <Paragraph color="inverse">
-              <Link color="inverse" href="https://amsterdam.nl/paspoort/">
-                {spotlightLinkLabel}
-              </Link>
-            </Paragraph>
-          </Column>
+          <Heading color="inverse" level={2}>
+            {spotlightHeading}
+          </Heading>
+          <UnorderedList color="inverse">
+            <UnorderedList.Item>Vraag uw paspoort of ID-kaart aan bij een Stadsloket in Amsterdam.</UnorderedList.Item>
+            <UnorderedList.Item>
+              U kunt elke dag langskomen van 9.00 uur tot 17.00 uur en op donderdag tot 20.00 uur.
+            </UnorderedList.Item>
+            <UnorderedList.Item>Op amsterdam.nl/paspoort staat wat u mee moet nemen.</UnorderedList.Item>
+            <UnorderedList.Item>
+              Laat aan het loket bij uw aanvraag weten dat u kiest voor gratis bezorgen.
+            </UnorderedList.Item>
+            <UnorderedList.Item>
+              Als uw paspoort of ID-kaart klaar is, krijgt u een e-mail en sms-bericht met inloggegevens. Met deze
+              inloggegevens kunt u zelf inplannen wanneer u uw reisdocument bezorgd wilt hebben.
+            </UnorderedList.Item>
+          </UnorderedList>
+          <Paragraph color="inverse">
+            <Link color="inverse" href="https://amsterdam.nl/paspoort/">
+              {spotlightLinkLabel}
+            </Link>
+          </Paragraph>
         </Grid.Cell>
       </Grid>
     </Spotlight>
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Column>
-          <section>
-            <Heading className="ams-mb--xs" level={2}>
-              Wanneer bezorgen we
-            </Heading>
-            <Paragraph>
-              We bezorgen op werkdagen en zaterdag tussen 8.00 en 18.00 uur. De ene week bezorgen wij op dinsdag en
-              donderdag ook tot 21.00 uur en de andere week op woensdag tot 21.00 uur.
-            </Paragraph>
-          </section>
-          <section>
-            <Heading className="ams-mb--xs" level={2}>
-              Tekenen voor ontvangst
-            </Heading>
-            <Paragraph>
-              Zorg dat u thuis bent om uw paspoort of ID-kaart te ontvangen. Bij bezorging voor meerdere personen moeten
-              alle personen aanwezig zijn. Ook kinderen vanaf 12 jaar moeten tekenen voor ontvangst. Tot 12 jaar tekent
-              de ouder of wettelijk vertegenwoordiger van het kind.
-            </Paragraph>
-          </section>
-          <section>
-            <Heading className="ams-mb--xs" level={2}>
-              Bezorgen met waarde-transport
-            </Heading>
-            <Paragraph>
-              De gemeente laat uw paspoort of ID-kaart bezorgen met een waarde-transport. Op{' '}
-              <Link href="https://mijnafspraak.nl/">mijnafspraak.nl</Link> ziet u wie er langskomt. De pasfoto van de
-              medewerker is vanaf 8.00 uur zichtbaar. De bezorger controleert bij aankomst uw identiteit en geeft u het
-              nieuwe reisdocument. U geeft uw oude reisdocument aan de bezorger. De bezorger maakt uw oude reisdocument
-              ongeldig waar u bij bent. Daarna mag u het zelf houden of meegeven aan de bezorger, die het vernietigt.
-            </Paragraph>
-          </section>
-          <section>
-            <Heading className="ams-mb--xs" level={2}>
-              Wanneer kan bezorgen niet?
-            </Heading>
-            <UnorderedList>
-              <UnorderedList.Item>Bij een spoedaanvraag.</UnorderedList.Item>
-              <UnorderedList.Item>
-                Als u een geldig visum in uw paspoort hebt dat u nog wilt gebruiken.
-              </UnorderedList.Item>
-              <UnorderedList.Item>Als u het oude reisdocument kwijt bent.</UnorderedList.Item>
-              <UnorderedList.Item>Als u op een van de Waddeneilanden woont. Daar bezorgen we niet.</UnorderedList.Item>
-            </UnorderedList>
-          </section>
-          <section>
-            <Heading className="ams-mb--xs" level={2}>
-              Meer weten
-            </Heading>
-            <LinkList>
-              <LinkList.Link href="https://amsterdam.nl/paspoort/">amsterdam.nl/paspoort</LinkList.Link>
-            </LinkList>
-          </section>
-        </Column>
+        <Heading level={2}>Wanneer bezorgen we</Heading>
+        <Paragraph>
+          We bezorgen op werkdagen en zaterdag tussen 8.00 en 18.00 uur. De ene week bezorgen wij op dinsdag en
+          donderdag ook tot 21.00 uur en de andere week op woensdag tot 21.00 uur.
+        </Paragraph>
+        <Heading level={2}>Tekenen voor ontvangst</Heading>
+        <Paragraph>
+          Zorg dat u thuis bent om uw paspoort of ID-kaart te ontvangen. Bij bezorging voor meerdere personen moeten
+          alle personen aanwezig zijn. Ook kinderen vanaf 12 jaar moeten tekenen voor ontvangst. Tot 12 jaar tekent de
+          ouder of wettelijk vertegenwoordiger van het kind.
+        </Paragraph>
+        <Heading level={2}>Bezorgen met waarde-transport</Heading>
+        <Paragraph>
+          De gemeente laat uw paspoort of ID-kaart bezorgen met een waarde-transport. Op{' '}
+          <Link href="https://mijnafspraak.nl/">mijnafspraak.nl</Link> ziet u wie er langskomt. De pasfoto van de
+          medewerker is vanaf 8.00 uur zichtbaar. De bezorger controleert bij aankomst uw identiteit en geeft u het
+          nieuwe reisdocument. U geeft uw oude reisdocument aan de bezorger. De bezorger maakt uw oude reisdocument
+          ongeldig waar u bij bent. Daarna mag u het zelf houden of meegeven aan de bezorger, die het vernietigt.
+        </Paragraph>
+        <Heading level={2}>Wanneer kan bezorgen niet?</Heading>
+        <UnorderedList>
+          <UnorderedList.Item>Bij een spoedaanvraag.</UnorderedList.Item>
+          <UnorderedList.Item>Als u een geldig visum in uw paspoort hebt dat u nog wilt gebruiken.</UnorderedList.Item>
+          <UnorderedList.Item>Als u het oude reisdocument kwijt bent.</UnorderedList.Item>
+          <UnorderedList.Item>Als u op een van de Waddeneilanden woont. Daar bezorgen we niet.</UnorderedList.Item>
+        </UnorderedList>
+        <Heading level={2}>Meer weten</Heading>
+        <LinkList>
+          <LinkList.Link href="https://amsterdam.nl/paspoort/">amsterdam.nl/paspoort</LinkList.Link>
+        </LinkList>
       </Grid.Cell>
     </Grid>
   </>

--- a/storybook/src/pages/amsterdam/HomePage/HomeSpotlight.tsx
+++ b/storybook/src/pages/amsterdam/HomePage/HomeSpotlight.tsx
@@ -4,10 +4,10 @@ export const HomeSpotlight = () => (
   <Spotlight>
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-        <Heading className="ams-mb--xs" color="inverse" level={1} size="level-2">
+        <Heading color="inverse" level={1} size="level-2">
           Ontheffing of vergunning
         </Heading>
-        <Paragraph className="ams-mb--sm" color="inverse">
+        <Paragraph color="inverse">
           Check welke ontheffing of vergunning u nodig heeft. Bijvoorbeeld een RVV, TVM, objectvergunning,{' '}
           nachtwerkontheffing, e-RVV, e-TVM of filmmelding. Dat regult u allemaal met 1 formulier.
         </Paragraph>
@@ -16,10 +16,10 @@ export const HomeSpotlight = () => (
         </Link>
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-        <Heading className="ams-mb--xs" color="inverse" level={1} size="level-2">
+        <Heading color="inverse" level={1} size="level-2">
           Werkzaamheden
         </Heading>
-        <Paragraph className="ams-mb--sm" color="inverse">
+        <Paragraph color="inverse">
           Lees waar en wanneer we werken aan nieuwbouw, groot onderhoud, herinrichting van straten en wegen, aanpak van
           parken of ontwikkeling van hele gebieden.
         </Paragraph>

--- a/storybook/src/pages/amsterdam/NewsPage/NewsPage.docs.mdx
+++ b/storybook/src/pages/amsterdam/NewsPage/NewsPage.docs.mdx
@@ -1,0 +1,10 @@
+{/* @license CC0-1.0 */}
+
+import { Meta } from "@storybook/blocks";
+import * as NewsStories from "./NewsPage.stories.tsx";
+
+<Meta of={NewsStories} />
+
+# News page
+
+Testing vertical space here.

--- a/storybook/src/pages/amsterdam/NewsPage/NewsPage.stories.tsx
+++ b/storybook/src/pages/amsterdam/NewsPage/NewsPage.stories.tsx
@@ -1,0 +1,18 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { Meta, StoryObj } from '@storybook/react'
+import { NewsPage } from './NewsPage'
+import { commonMeta } from '../common/config'
+
+const meta = {
+  ...commonMeta,
+  title: 'Pages/Amsterdam.nl/News Page',
+  component: NewsPage,
+} satisfies Meta<typeof NewsPage>
+
+export default meta
+
+export const Default: StoryObj = {}

--- a/storybook/src/pages/amsterdam/NewsPage/NewsPage.tsx
+++ b/storybook/src/pages/amsterdam/NewsPage/NewsPage.tsx
@@ -1,0 +1,103 @@
+import { Breadcrumb, Grid, Heading, Image, Link, LinkList, Paragraph } from '@amsterdam/design-system-react'
+
+export const NewsPage = () => (
+  <>
+    <Grid>
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 8 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
+        <Breadcrumb>
+          <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+          <Breadcrumb.Link href="#">Nieuws</Breadcrumb.Link>
+        </Breadcrumb>
+      </Grid.Cell>
+    </Grid>
+    <main id="main">
+      <Grid paddingVertical="medium">
+        {/* Create Grid.ArticleHeader etc. components to encapsulate column config and improve consistency. */}
+        <Grid.Cell span={{ narrow: 4, medium: 6, wide: 8 }} start={{ narrow: 1, medium: 2, wide: 2 }}>
+          <Heading level={1}>Flevopark deels dicht voor publiek door festival</Heading>
+          <Paragraph style={{ color: 'var(--ams-color-text-secondary)' }}>
+            Taxonomie tag, tag, tag – systeemdatum 21 juni 2023
+          </Paragraph>
+        </Grid.Cell>
+      </Grid>
+      {/* Create Image stories at various column sizes for easy reuse in pages. */}
+      <Image
+        alt=""
+        aspectRatio="2x-wide"
+        sizes="(max-width: 36rem) 640px, (max-width: 68rem) 1280px, 1600px"
+        src="https://picsum.photos/1600/500"
+        srcSet="https://picsum.photos/640/200 640w, https://picsum.photos/1280/400 1280w, https://picsum.photos/1600/500 1600w"
+      />
+      <Grid paddingVertical="medium">
+        <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+          <Paragraph size="large">
+            Het Flevopark is deels dicht voor het publiek vanwege een festival op 23 en 24 juni. De velden rond de grote
+            vijver zijn met hekken afgezet.
+          </Paragraph>
+          <Heading level={2}>H2 subtitel</Heading>
+          <Paragraph>
+            De Wet Natuurbescherming verbiedt festivals in het broedseizoen niet. Festivalorganisatoren moeten wel extra
+            maatregelen nemen om de planten en dieren in het park te beschermen. Volgens een natuurtoets door een
+            adviesbureau voldoet de festivalorganisator aan de eisen van de natuurbeschermingswet. Het stadsdeel moet
+            daarom de vergunning verlenen.
+          </Paragraph>
+          <Paragraph>
+            Volgens een natuurtoets door een adviesbureau voldoet de festivalorganisator aan de eisen van de
+            natuurbeschermingswet. Het stadsdeel moet daarom de vergunning verlenen.
+          </Paragraph>
+          <Heading level={2}>H2 subtitel</Heading>
+          <Paragraph>
+            De Wet Natuurbescherming verbiedt festivals in het broedseizoen niet. Festivalorganisatoren moeten wel extra
+            maatregelen nemen om de planten en dieren in het park te beschermen. Volgens een natuurtoets door een
+            adviesbureau voldoet de festivalorganisator aan de eisen van de natuurbeschermingswet. Het stadsdeel moet
+            daarom de vergunning verlenen.
+          </Paragraph>
+          <Heading level={3}>H3 subtitel</Heading>
+          <Paragraph>
+            Natuurtoets door een adviesbureau voldoet de festivalorganisator aan de eisen van de natuurbeschermingswet.
+            Het stadsdeel moet daarom de vergunning verlenen.
+          </Paragraph>
+          <Paragraph>
+            Adviesbureau voldoet de festivalorganisator aan de eisen van de natuurbeschermingswet. Het stadsdeel moet
+            daarom de vergunning verlenen.
+          </Paragraph>
+          <Heading level={4}>H4 subtitel</Heading>
+          <Paragraph>
+            Extra maatregelen nemen om de planten en dieren in het park te beschermen. Volgens een natuurtoets door een
+            adviesbureau voldoet de festivalorganisator aan de eisen van de natuurbeschermingswet. Het stadsdeel moet
+            daarom de vergunning verlenen.
+          </Paragraph>
+          <Paragraph>
+            Planten en dieren in het park te beschermen. Volgens een natuurtoets door een adviesbureau voldoet de
+            festivalorganisator aan de eisen van de natuurbeschermingswet. Het stadsdeel moet daarom de vergunning
+            verlenen.
+          </Paragraph>
+          <Heading level={2}>H2 subtitel</Heading>
+          <Paragraph>
+            Tot het Nationaal Slavernijmuseum er is, zijn er op verschillende plekken in Nederland tentoonstellingen en
+            andere activiteiten te zien en te doen. Er is een voorkeursplek uitgesproken voor de bouw van het Nationaal
+            Slavernijmuseum op de kop van het Java-eiland.
+          </Paragraph>
+          <Image alt="" aspectRatio="tall" src="https://picsum.photos/960/1280" />
+          <Heading level={2}>H2 subtitel bijv. Aanmelden</Heading>
+          <Paragraph>Aanmelden voor deze avond kunt u doen via de Kalender van Amsterdam.</Paragraph>
+          <Link href="#" variant="standalone">
+            Link naar kalender-item waar de CTA staat
+          </Link>
+          <Heading level={2}>Contact</Heading>
+          <Paragraph>Contactinformatie uit CT Contact</Paragraph>
+          <Heading level={2}>Locatie</Heading>
+          <Paragraph>Beschrijving objecttype locatie</Paragraph>
+          <Image alt="" aspectRatio="square" src="https://picsum.photos/960/960" />
+          <Heading level={2}>Lees ook</Heading>
+          <LinkList>
+            <LinkList.Link href="#">Vaccinaties voor kinderen en jongeren beginnen weer, dicht bij huis</LinkList.Link>
+            <LinkList.Link href="#">
+              Gedenktekens bij 3 tramhaltes vanwaar Joodse Amsterdammers werden gedeporteerd
+            </LinkList.Link>
+          </LinkList>
+        </Grid.Cell>
+      </Grid>
+    </main>
+  </>
+)


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

- This implements vertical margins between text components.
- The amount of space has been [designed](https://www.figma.com/design/7ezwZsPmFcRDnwJgzBG5SN/DES-616-%7C-Verticale-witruimte-tussen-tekst?node-id=32543-7254&t=gjfDxnIWEIA98i29-4) between each combination of 22 components.
- I’ve implemented 6 of them (Heading, Image, Standalone Link, Ordered List, Paragraph and Unordered List) and added the News Page with which the spacing was designed.
- I decreased the space between Headings and following body text. I think this groups the sections better, making them easier to scan. The new line heights are active as well.
- I’ve removed manual space classes from the Home Page and Article Page and tweaked some tokens for Card and Lists.

### Links to full-screen pages

- [News Page](https://designsystem.amsterdam/demo-DES-1180-vertical-space/iframe.html?globals=&args=&id=pages-amsterdam-nl-news-page--default&viewMode=story)
- [Article Page](https://designsystem.amsterdam/demo-DES-1180-vertical-space/iframe.html?globals=&args=&id=pages-amsterdam-nl-article-page--default&viewMode=story)
- [Home Page](https://designsystem.amsterdam/demo-DES-1180-vertical-space/iframe.html?globals=&args=&id=pages-amsterdam-nl-home-page--default&viewMode=story)
- Form Page not included, this one needs work.

## Why

To make it easy for our users to apply space in prose consistently.

## How

- I’ve created Sass placeholders for the various margin options.
- And used them in the 6 components mentioned above. I’m using the `:has` selector to let the bottom margin of a component depend on the component that follows it. This is as designed, logical, and prevents the use of `:last-child` which is error-prone for this context.
- I changed the value of `xl` space from 48 to 56 and added an `xxl` of 84, both according to the design. This could be the start of merging Component Space and Grid Space, although both currently shrink and grow quite differently.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Marked this as a POC because of a few out-of-scope changes.
This generates quite a few lines of CSS, but I see no way around it. We must use our classes and explicitly address all combinations. The built stylesheet increased from 99 to 103 kB, so I guess around 1 kB per component that uses this.
- We could consider making a medium bottom margin the default for our components, but we would need to add a way to negate that for our users, and the ‘last child’ problem may re-emerge.
- Components referencing other components’ class names (which is not new, but at a larger scale) will hinder our ability to package our components separately in the future.
- Sass placeholders seem helpful in making maintenance more efficient. We can even take a step further if we can group components by the amount of space they use, e.g.

```
.ams-fieldset__legend,
.ams-heading,
.ams-label {
  @extend %headings;
}

.ams-paragraph,
.ams-ordered-list,
.ams-unordered-list {
  @extend %body-text;
}

.ams-action-group,
.ams-button,
.ams-link--standalone {
  @extend %actions;
}
```

Then this would create all the selectors to add space between all kinds of headings and all kinds of body text:

```
%headings :has(+%body-text) {
  @extend %ams-mb--medium;
}
```
