### PR TITLE
feat(Icon): Add invisble text content to simplify baseline alignment

### DIFF
--- a/packages/css/src/components/icon/icon.scss
+++ b/packages/css/src/components/icon/icon.scss
@@ -5,7 +5,7 @@
 
 .ams-icon {
   align-self: baseline; // Aligns the icon with text in flex or grid context
-  display: inline-flex; // Stretches the svg vertically (align-items: normal)
+  display: inline-flex; // Stretches the svg in order to align the icon vertically
   font-size: var(--ams-icon-font-size);
   line-height: var(--ams-icon-line-height);
 

--- a/packages/css/src/components/icon/icon.scss
+++ b/packages/css/src/components/icon/icon.scss
@@ -4,14 +4,19 @@
  */
 
 .ams-icon {
-  align-items: center;
-  block-size: calc(var(--ams-icon-font-size) * var(--ams-icon-line-height));
-  display: inline-flex;
+  align-self: baseline; // Aligns the icon with text in flex or grid context
+  display: inline-flex; // Stretches the svg vertically (align-items: normal)
+  font-family: var(--ams-typography-font-family);
+  font-size: var(--ams-icon-font-size);
+  line-height: var(--ams-icon-line-height);
+
+  &::after {
+    content: "\00200B"; // This zero width space enables baseline alignment.
+  }
 
   svg {
-    block-size: var(--ams-icon-font-size);
     fill: currentColor;
-    inline-size: var(--ams-icon-font-size);
+    inline-size: 1em;
   }
 }
 
@@ -25,55 +30,31 @@
 }
 
 .ams-icon--small {
-  block-size: calc(var(--ams-icon-small-font-size) * var(--ams-icon-small-line-height));
-
-  svg {
-    block-size: var(--ams-icon-small-font-size);
-    inline-size: var(--ams-icon-small-font-size);
-  }
+  font-size: var(--ams-icon-small-font-size);
+  line-height: var(--ams-icon-small-line-height);
 }
 
 .ams-icon--large {
-  block-size: calc(var(--ams-icon-large-font-size) * var(--ams-icon-large-line-height));
-
-  svg {
-    block-size: var(--ams-icon-large-font-size);
-    inline-size: var(--ams-icon-large-font-size);
-  }
+  font-size: var(--ams-icon-large-font-size);
+  line-height: var(--ams-icon-large-line-height);
 }
 
 .ams-icon--heading-3 {
-  block-size: calc(var(--ams-icon-heading-3-font-size) * var(--ams-icon-heading-3-line-height));
-
-  svg {
-    block-size: var(--ams-icon-heading-3-font-size);
-    inline-size: var(--ams-icon-heading-3-font-size);
-  }
+  font-size: var(--ams-icon-heading-3-font-size);
+  line-height: var(--ams-icon-heading-3-line-height);
 }
 
 .ams-icon--heading-4 {
-  block-size: calc(var(--ams-icon-heading-4-font-size) * var(--ams-icon-heading-4-line-height));
-
-  svg {
-    block-size: var(--ams-icon-heading-4-font-size);
-    inline-size: var(--ams-icon-heading-4-font-size);
-  }
+  font-size: var(--ams-icon-heading-4-font-size);
+  line-height: var(--ams-icon-heading-4-line-height);
 }
 
 .ams-icon--heading-5 {
-  block-size: calc(var(--ams-icon-heading-5-font-size) * var(--ams-icon-heading-5-line-height));
-
-  svg {
-    block-size: var(--ams-icon-heading-5-font-size);
-    inline-size: var(--ams-icon-heading-5-font-size);
-  }
+  font-size: var(--ams-icon-heading-5-font-size);
+  line-height: var(--ams-icon-heading-5-line-height);
 }
 
 .ams-icon--heading-6 {
-  block-size: calc(var(--ams-icon-heading-6-font-size) * var(--ams-icon-heading-6-line-height));
-
-  svg {
-    block-size: var(--ams-icon-heading-6-font-size);
-    inline-size: var(--ams-icon-heading-6-font-size);
-  }
+  font-size: var(--ams-icon-heading-6-font-size);
+  line-height: var(--ams-icon-heading-6-line-height);
 }

--- a/packages/css/src/components/icon/icon.scss
+++ b/packages/css/src/components/icon/icon.scss
@@ -6,7 +6,6 @@
 .ams-icon {
   align-self: baseline; // Aligns the icon with text in flex or grid context
   display: inline-flex; // Stretches the svg vertically (align-items: normal)
-  font-family: var(--ams-icon-font-family);
   font-size: var(--ams-icon-font-size);
   line-height: var(--ams-icon-line-height);
 

--- a/packages/css/src/components/icon/icon.scss
+++ b/packages/css/src/components/icon/icon.scss
@@ -6,7 +6,7 @@
 .ams-icon {
   align-self: baseline; // Aligns the icon with text in flex or grid context
   display: inline-flex; // Stretches the svg vertically (align-items: normal)
-  font-family: var(--ams-typography-font-family);
+  font-family: var(--ams-icon-font-family);
   font-size: var(--ams-icon-font-size);
   line-height: var(--ams-icon-line-height);
 

--- a/proprietary/tokens/src/components/ams/icon.tokens.json
+++ b/proprietary/tokens/src/components/ams/icon.tokens.json
@@ -1,7 +1,6 @@
 {
   "ams": {
     "icon": {
-      "font-family": { "value": "{ams.typography.font-family}" },
       "font-size": { "value": "{ams.typography.body-text.font-size}" },
       "line-height": { "value": "{ams.typography.body-text.line-height}" },
       "small": {

--- a/proprietary/tokens/src/components/ams/icon.tokens.json
+++ b/proprietary/tokens/src/components/ams/icon.tokens.json
@@ -1,6 +1,7 @@
 {
   "ams": {
     "icon": {
+      "font-family": { "value": "{ams.typography.font-family}" },
       "font-size": { "value": "{ams.typography.body-text.font-size}" },
       "line-height": { "value": "{ams.typography.body-text.line-height}" },
       "small": {


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

This lets the browser use baseline alignment to align an icon with text. We make the icon adhere to that feature by adding a zero-width space to its `::after` pseudo-element.

## Why

It seems more idiomatic to use the browser’s baseline alignment feature to align an icon to accompanying text. We still need to apply typography to the icon, but that’s logical: we treat an icon as a typographic element. Stretching the icon and the pseudo-element and using a width of `1em` are more examples of using what CSS offers us. We don’t need to multiply font size with line height anymore, and we don’t need to manually size the SVG while we were already sizing its container.

## How

See above.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a