### PR TITLE
fix(Tabs)!: Rename onChange to onTabChange

### DIFF
--- a/packages/react/src/Tabs/Tabs.test.tsx
+++ b/packages/react/src/Tabs/Tabs.test.tsx
@@ -91,12 +91,12 @@ describe('Tabs', () => {
     expect(screen.getByRole('tabpanel')).toHaveTextContent('Content 2')
   })
 
-  it('calls onChange with the newly activated tab', async () => {
+  it('calls onTabChange with the newly activated tab', async () => {
     const user = userEvent.setup()
 
-    const onChange = jest.fn()
+    const onTabChange = jest.fn()
     render(
-      <Tabs onChange={onChange}>
+      <Tabs onTabChange={onTabChange}>
         <Tabs.List>
           <Tabs.Button tab={1}>Tab 1</Tabs.Button>
         </Tabs.List>
@@ -106,7 +106,7 @@ describe('Tabs', () => {
     const button = screen.getByRole('tab', { name: 'Tab 1' })
     await user.click(button)
 
-    expect(onChange).toHaveBeenCalledWith(1)
+    expect(onTabChange).toHaveBeenCalledWith(1)
   })
 
   it('should be able to set the initially active tab', () => {

--- a/packages/react/src/Tabs/Tabs.tsx
+++ b/packages/react/src/Tabs/Tabs.tsx
@@ -16,11 +16,11 @@ export type TabsProps = {
   /** The number of the active tab. Corresponds to its `tab` value. */
   activeTab?: number
   /* Provides the id of the activated tab. */
-  onChange?: (tabId: number) => void
+  onTabChange?: (tabId: number) => void
 } & PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 
 const TabsRoot = forwardRef(
-  ({ activeTab, children, className, onChange, ...restProps }: TabsProps, ref: ForwardedRef<HTMLDivElement>) => {
+  ({ activeTab, children, className, onTabChange, ...restProps }: TabsProps, ref: ForwardedRef<HTMLDivElement>) => {
     const tabsId = useId()
     const innerRef = useRef<HTMLDivElement>(null)
     const [activeTabId, setActiveTabId] = useState(0)
@@ -45,7 +45,7 @@ const TabsRoot = forwardRef(
 
     const updateTab = (tab: number) => {
       setActiveTabId(tab)
-      onChange?.(tab)
+      onTabChange?.(tab)
     }
 
     // Use a passed ref if it's there, otherwise use innerRef

--- a/storybook/src/components/Tabs/Tabs.stories.tsx
+++ b/storybook/src/components/Tabs/Tabs.stories.tsx
@@ -76,7 +76,7 @@ const meta = {
         type: 'number',
       },
     },
-    onChange: {
+    onTabChange: {
       action: 'clicked',
       description: 'Provides the id of the activated tab.',
     },


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

This renames the `onChange` prop to `onTabChange`.

## Why

`onChange` seemed to conflict with the native React `onChange` prop. 

See also [this issue](https://github.com/Amsterdam/design-system/issues/1846).

## How

(How were these changes implemented? Provide a brief overview of the approach taken and any key considerations.)

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Do we also want to change `tabId` to `string` now? Or should that be a separate PR? 