### PR TITLE
chore(docs): Use ‘Menu’ as the menu button label in example pages 

### DIFF
--- a/storybook/src/components/Header/Header.stories.tsx
+++ b/storybook/src/components/Header/Header.stories.tsx
@@ -190,7 +190,7 @@ export const WithCustomTexts: Story = {
         </Grid.Cell>
       </Grid>
     ),
-    menuButtonText: 'Hoofdmenu',
+    menuButtonText: 'Alle onderwerpen',
     navigationLabel: 'Navigatie',
   },
 }

--- a/storybook/src/pages/amsterdam/common/AppHeader.tsx
+++ b/storybook/src/pages/amsterdam/common/AppHeader.tsx
@@ -3,7 +3,6 @@ import { headerMenuLinks, megaMenuLinks } from './menu'
 
 export const AppHeader = () => (
   <Header
-    menuButtonText="Alle onderwerpen"
     menuItems={headerMenuLinks.map(({ fixed, href, label, lang }) => (
       <Header.MenuLink fixed={fixed} href={href ?? '#'} key={label} lang={lang} rel={href ? 'external' : undefined}>
         {label}


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

This shows ‘Menu’ instead of ‘Alle onderwerpen’ in the menu button in the Header of our example pages.

## Why

We found that ‘Alle onderwerpen’ is too long to make the Header fit on one line in narrow windows. It’s also not a usual term for a menu.

‘Alle onderwerpen’ is still in the mega menu to explain how we structured our menu. And I kept it visible in our example for a custom menu button label.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a
