### PR TITLE
fix(Header): Only use matchMedia when there is a mega menu

### DIFF
--- a/packages/react/src/Header/Header.tsx
+++ b/packages/react/src/Header/Header.tsx
@@ -65,7 +65,8 @@ const HeaderRoot = forwardRef(
   ) => {
     const [open, setOpen] = useState(false)
 
-    const isWideWindow = useIsAfterBreakpoint('wide')
+    const hasMegaMenu = Boolean(children)
+    const isWideWindow = hasMegaMenu && useIsAfterBreakpoint('wide')
 
     useEffect(() => {
       // Close the menu when the menu button disappears
@@ -80,7 +81,7 @@ const HeaderRoot = forwardRef(
           <span className="ams-visually-hidden">{logoLinkTitle}</span>
           <LogoLinkContent brandName={brandName} logoBrand={logoBrand} />
         </a>
-        {(children || menuItems) && (
+        {(hasMegaMenu || menuItems) && (
           <nav aria-labelledby="primary-navigation" className="ams-header__navigation">
             <h2 className="ams-visually-hidden" id="primary-navigation">
               {navigationLabel}
@@ -93,7 +94,7 @@ const HeaderRoot = forwardRef(
 
             <ul className="ams-header__menu">
               {menuItems}
-              {children && (
+              {hasMegaMenu && (
                 <li
                   className={clsx(noMenuButtonOnWideWindow && 'ams-header__mega-menu-button-item--hide-on-wide-window')}
                 >
@@ -121,7 +122,7 @@ const HeaderRoot = forwardRef(
               )}
             </ul>
 
-            {children && (
+            {hasMegaMenu && (
               <div
                 className={clsx('ams-header__mega-menu', !open && 'ams-header__mega-menu--closed')}
                 id="ams-mega-menu"


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Checks if Header has a mega menu and only then calls `useIsAfterBreakpoint`.

## Why

`useIsAfterBreakpoint` uses `matchMedia`, which you have to mock in unit tests. If we don't do this check, users that do not have a mega menu still have to mock matchMedia in their tests, although it isn't necessary. 

## How

Add a condition.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
