### PR TITLE
feat: Build separate React components alongside barrel file

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,8 +34,7 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/",
-    "src/"
+    "dist/"
   ],
   "dependencies": {
     "@amsterdam/design-system-react-icons": "workspace:*",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,7 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "rollup -c",
+    "build": "tsc && rollup -c",
     "build:watch": "rollup -c --watch",
     "clean": "rimraf dist/",
     "lint": "tsc --noEmit --project ./tsconfig.json && tsc --noEmit --project ./tsconfig.test.json",

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -61,14 +61,8 @@ export default [
     ],
   },
   {
-    input: './dist/dts/index.d.ts',
+    input: './dist/index.d.ts',
     output: [{ file: 'dist/index.d.ts', format: 'es' }],
-    plugins: [
-      dts(),
-      del({
-        targets: 'dist/dts',
-        hook: 'buildEnd',
-      }),
-    ],
+    plugins: [dts()],
   },
 ]

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -4,7 +4,6 @@
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "declaration": true,
-    "declarationDir": "dist/dts",
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Generate separate React components and their corresponding types alongside the barrel files we already generate.

## Why

Only having barrel files isn't always flexible enough. See also [this PR](https://github.com/Amsterdam/design-system/pull/1925) and [this ticket](https://gemeente-amsterdam.atlassian.net/browse/DES-1223). 

## How

By running the `tsc` command and not messing with the generated types. 

I've compared the generated files before and after this change. They're identical, with the exception of some ordering in `index.d.ts`, which shouldn't be a problem.

I've also checked if `build:watch` and HMR in Storybook still works as aspected, that seems to be the case. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

I forgot I already tried publishing `src` 😁. That doesn't work, because you can't import TypeScript files directly from `node_modules`. I think it's a (somewhat arbitrary) boundary put in place by `node`, but I can't find the official docs to back that up. 