### PR TITLE
fix(Action Group): Align content to center instead of baseline

### DIFF
--- a/packages/css/src/components/action-group/action-group.scss
+++ b/packages/css/src/components/action-group/action-group.scss
@@ -4,7 +4,7 @@
  */
 
 .ams-action-group {
-  align-items: baseline;
+  align-items: center;
   display: inline-flex;
   flex-wrap: wrap;
   gap: var(--ams-action-group-gap);


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It aligns the items of an ActionGroup to center instead of baseline. 

## Why

Baseline alignment caused [an issue](https://github.com/Amsterdam/design-system/issues/1918) when used in combination with our Icon component. 

## How

Changed `baseline` to `center`. Checked what it looked like in the case provided and in our other stories.

![Actiongroup with buttons that start with an icon](https://github.com/user-attachments/assets/8fc96b3a-c4cb-49ac-883e-22a85b828259)

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
