### PR TITLE
fix(Tabs)!: Remove unnecessary token, reuse color value

### DIFF
--- a/packages/css/src/components/tabs/tabs.scss
+++ b/packages/css/src/components/tabs/tabs.scss
@@ -49,14 +49,16 @@
     }
   }
 
+  &:hover:not([disabled]) {
+    color: var(--ams-tabs-button-hover-color);
+  }
+
   &:hover:not([aria-selected="true"], [disabled]) {
     box-shadow: var(--ams-tabs-button-hover-box-shadow);
-    color: var(--ams-tabs-button-hover-color);
   }
 
   &[aria-selected="true"] {
     box-shadow: var(--ams-tabs-button-selected-box-shadow);
-    color: var(--ams-tabs-button-selected-color);
     font-weight: var(--ams-tabs-button-selected-font-weight);
 
     @media (forced-colors: active) {

--- a/proprietary/tokens/src/components/ams/tabs.tokens.json
+++ b/proprietary/tokens/src/components/ams/tabs.tokens.json
@@ -17,11 +17,10 @@
         "padding-inline": { "value": "{ams.space.md}" },
         "hover": {
           "color": { "value": "{ams.color.interactive.hover}" },
-          "box-shadow": { "value": "inset 0 calc({ams.border.width.md} * -1) {ams.color.interactive.hover}" }
+          "box-shadow": { "value": "inset 0 calc({ams.border.width.md} * -1)" }
         },
         "selected": {
-          "box-shadow": { "value": "inset 0 calc({ams.border.width.xl} * -1) {ams.color.interactive.default}" },
-          "color": { "value": "{ams.color.interactive.default}" },
+          "box-shadow": { "value": "inset 0 calc({ams.border.width.xl} * -1)" },
           "font-weight": { "value": "{ams.typography.body-text.bold.font-weight}" }
         },
         "disabled": {


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Removes an unnecessary token. `ams.tabs.button.selected.color` has the same value as `ams.tabs.button.color`.
While doing that, I saw that a selected button had the same color on hover as default, so I fixed that as well. 

## Why

Cleanup, and reusing `color` for the `box-shadow` makes it easier to maintain. 

## How

Removing `color` from the selected button, and reusing color for the `box-shadow`.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Breaking for the tokens package, because we're removing a token. 
