### PR TITLE
fix: Add type attribute defaulting to button to buttons

### DIFF
--- a/packages/react/src/IconButton/IconButton.tsx
+++ b/packages/react/src/IconButton/IconButton.tsx
@@ -23,13 +23,14 @@ export type IconButtonProps = {
 
 export const IconButton = forwardRef(
   (
-    { className, color, label, size, svg = CloseIcon, ...restProps }: IconButtonProps,
+    { className, color, label, size, svg = CloseIcon, type, ...restProps }: IconButtonProps,
     ref: ForwardedRef<HTMLButtonElement>,
   ) => (
     <button
       {...restProps}
       className={clsx('ams-icon-button', color && `ams-icon-button--${color}`, className)}
       ref={ref}
+      type={type || 'button'}
     >
       <span className="ams-visually-hidden">{label}</span>
       <Icon size={size} square svg={svg} />

--- a/packages/react/src/ImageSlider/ImageSlider.tsx
+++ b/packages/react/src/ImageSlider/ImageSlider.tsx
@@ -13,7 +13,7 @@ import { ImageSliderScroller } from './ImageSliderScroller'
 import { ImageSliderThumbnails } from './ImageSliderThumbnails'
 import { Image, ImageProps } from '../Image/Image'
 
-export type ImageSliderImageProps = ImageProps
+export type ImageSliderImageProps = ImageProps & Partial<HTMLButtonElement>
 
 export type ImageSliderProps = {
   /** Display buttons to navigate to the previous or next image. */

--- a/packages/react/src/ImageSlider/ImageSliderThumbnails.tsx
+++ b/packages/react/src/ImageSlider/ImageSliderThumbnails.tsx
@@ -46,7 +46,7 @@ export const ImageSliderThumbnails = forwardRef(
 
     const renderThumbnails = useMemo(
       () =>
-        thumbnails.map(({ alt, aspectRatio, src }, index) => (
+        thumbnails.map(({ alt, aspectRatio, src, type }, index) => (
           <button
             aria-label={`${imageLabel} ${index + 1}: ${alt}`}
             aria-posinset={index + 1}
@@ -62,6 +62,7 @@ export const ImageSliderThumbnails = forwardRef(
             role="tab"
             style={{ backgroundImage: `url(${src})` }}
             tabIndex={currentSlideId === index ? 0 : -1}
+            type={type || 'button'}
           />
         )),
       [currentSlideId, goToSlideId, imageLabel, thumbnails],

--- a/packages/react/src/Tabs/TabsButton.tsx
+++ b/packages/react/src/Tabs/TabsButton.tsx
@@ -14,7 +14,10 @@ export type TabsButtonProps = {
 } & PropsWithChildren<ButtonHTMLAttributes<HTMLButtonElement>>
 
 export const TabsButton = forwardRef(
-  ({ children, className, onClick, tab, ...restProps }: TabsButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
+  (
+    { children, className, onClick, tab, type, ...restProps }: TabsButtonProps,
+    ref: ForwardedRef<HTMLButtonElement>,
+  ) => {
     const { activeTabId, tabsId, updateTab } = useContext(TabsContext)
 
     const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
@@ -35,6 +38,7 @@ export const TabsButton = forwardRef(
         ref={ref}
         role="tab"
         tabIndex={activeTabId === tab ? 0 : -1}
+        type={type || 'button'}
       >
         <span aria-hidden="true" className="ams-tabs__button-label-hidden">
           {children}


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Add the `type` attribute to all `button` elements with a default value of `button`.

## Why

All buttons should that trigger some kind of non-standard functionality should be of type "button" by default. Exceptions are buttons in forms that have native submit or reset actions.

## How

- Add the `type` attribute to all `button` elements with a default value of `button`.
- Change component interfaces to handle this.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Provide links to any related issues or discussions.
- Add a link to the specific story in the feature branch deploy.
- Mention any areas where additional review or feedback is needed.
