### PR TITLE
feat(Aspect Ratio, Gap, Margin)!: Use single dash in utility classes

### DIFF
--- a/packages/css/src/components/aspect-ratio/README.md
+++ b/packages/css/src/components/aspect-ratio/README.md
@@ -9,14 +9,14 @@ Constrains media content to a supported aspect ratio.
 Each available aspect ratio has an associated class name.
 The class can be applied to any component or element.
 
-| Class name               | Example                                                                  |
-| :----------------------- | :----------------------------------------------------------------------- |
-| `ams-aspect-ratio--9-16` | <div className="ams-docs-token-example--space ams-aspect-ratio--9-16" /> |
-| `ams-aspect-ratio--3-4`  | <div className="ams-docs-token-example--space ams-aspect-ratio--3-4" />  |
-| `ams-aspect-ratio--1-1`  | <div className="ams-docs-token-example--space ams-aspect-ratio--1-1" />  |
-| `ams-aspect-ratio--4-3`  | <div className="ams-docs-token-example--space ams-aspect-ratio--4-3" />  |
-| `ams-aspect-ratio--16-9` | <div className="ams-docs-token-example--space ams-aspect-ratio--16-9" /> |
-| `ams-aspect-ratio--16-5` | <div className="ams-docs-token-example--space ams-aspect-ratio--16-5" /> |
+| Class name              | Example                                                                 |
+| :---------------------- | :---------------------------------------------------------------------- |
+| `ams-aspect-ratio-9-16` | <div className="ams-docs-token-example--space ams-aspect-ratio-9-16" /> |
+| `ams-aspect-ratio-3-4`  | <div className="ams-docs-token-example--space ams-aspect-ratio-3-4" />  |
+| `ams-aspect-ratio-1-1`  | <div className="ams-docs-token-example--space ams-aspect-ratio-1-1" />  |
+| `ams-aspect-ratio-4-3`  | <div className="ams-docs-token-example--space ams-aspect-ratio-4-3" />  |
+| `ams-aspect-ratio-16-9` | <div className="ams-docs-token-example--space ams-aspect-ratio-16-9" /> |
+| `ams-aspect-ratio-16-5` | <div className="ams-docs-token-example--space ams-aspect-ratio-16-5" /> |
 
 ## Guidelines
 

--- a/packages/css/src/components/aspect-ratio/aspect-ratio.scss
+++ b/packages/css/src/components/aspect-ratio/aspect-ratio.scss
@@ -7,7 +7,7 @@
   // If you modify this array, you also need to update the
   // aspectRatioOptions in packages/react/src/common/types.ts
   @each $value in ("9-16", "3-4", "1-1", "4-3", "16-9", "16-5") {
-    &--#{$value} {
+    &-#{$value} {
       /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
       aspect-ratio: var(--ams-aspect-ratio-#{$value}) !important;
     }

--- a/packages/css/src/components/gap/README.md
+++ b/packages/css/src/components/gap/README.md
@@ -8,14 +8,14 @@ Adds white space between a set of elements.
 
 All six sizes of [Space](/docs/brand-design-tokens-space--docs) are available for the width or height of the gap.
 
-| Class name    | Example                                                                                    |
-| :------------ | :----------------------------------------------------------------------------------------- |
-| `ams-gap-xs`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-xs);" />  |
-| `ams-gap-sm`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-sm);" />  |
-| `ams-gap-md`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-md);" />  |
-| `ams-gap-lg`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-lg);" />  |
-| `ams-gap-xl`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-xl);" />  |
-| `ams-gap-2xl` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-2xl);" /> |
+| Class name    | Example                                                                                      |
+| :------------ | :------------------------------------------------------------------------------------------- |
+| `ams-gap-xs`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-space-xs);" />  |
+| `ams-gap-sm`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-space-sm);" />  |
+| `ams-gap-md`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-space-md);" />  |
+| `ams-gap-lg`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-space-lg);" />  |
+| `ams-gap-xl`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-space-xl);" />  |
+| `ams-gap-2xl` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-space-2xl);" /> |
 
 ## Guidelines
 

--- a/packages/css/src/components/gap/README.md
+++ b/packages/css/src/components/gap/README.md
@@ -8,14 +8,14 @@ Adds white space between a set of elements.
 
 All six sizes of [Space](/docs/brand-design-tokens-space--docs) are available for the width or height of the gap.
 
-| Class name     | Example                                                                                    |
-| :------------- | :----------------------------------------------------------------------------------------- |
-| `ams-gap--xs`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-xs);" />  |
-| `ams-gap--sm`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-sm);" />  |
-| `ams-gap--md`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-md);" />  |
-| `ams-gap--lg`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-lg);" />  |
-| `ams-gap--xl`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-xl);" />  |
-| `ams-gap--2xl` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-2xl);" /> |
+| Class name    | Example                                                                                    |
+| :------------ | :----------------------------------------------------------------------------------------- |
+| `ams-gap-xs`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-xs);" />  |
+| `ams-gap-sm`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-sm);" />  |
+| `ams-gap-md`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-md);" />  |
+| `ams-gap-lg`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-lg);" />  |
+| `ams-gap-xl`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-xl);" />  |
+| `ams-gap-2xl` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-gap-2xl);" /> |
 
 ## Guidelines
 

--- a/packages/css/src/components/gap/gap.scss
+++ b/packages/css/src/components/gap/gap.scss
@@ -6,13 +6,13 @@
 @use "sass:map";
 @use "../../common/size" as *;
 
-[class|="ams-gap-"] {
+[class|="ams-gap"] {
   display: grid !important;
 }
 
 @each $size in map.keys($ams-sizes) {
   @if $size != "no" {
-    .ams-gap--#{$size} {
+    .ams-gap-#{$size} {
       /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
       gap: var(--ams-space-#{$size}) !important;
     }

--- a/packages/css/src/components/margin/README.md
+++ b/packages/css/src/components/margin/README.md
@@ -8,14 +8,14 @@ Adds white space below a single element.
 
 All six sizes of [Space](/docs/brand-design-tokens-space--docs) are available for the height of the bottom margin.
 
-| Class name    | Example                                                                                       |
-| :------------ | :-------------------------------------------------------------------------------------------- |
-| `ams-mb--xs`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-xs);" />  |
-| `ams-mb--sm`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-sm);" />  |
-| `ams-mb--md`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-md);" />  |
-| `ams-mb--lg`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-lg);" />  |
-| `ams-mb--xl`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-xl);" />  |
-| `ams-mb--2xl` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-2xl);" /> |
+| Class name   | Example                                                                                       |
+| :----------- | :-------------------------------------------------------------------------------------------- |
+| `ams-mb-xs`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-xs);" />  |
+| `ams-mb-sm`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-sm);" />  |
+| `ams-mb-md`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-md);" />  |
+| `ams-mb-lg`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-lg);" />  |
+| `ams-mb-xl`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-xl);" />  |
+| `ams-mb-2xl` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-2xl);" /> |
 
 ## Guidelines
 

--- a/packages/css/src/components/margin/README.md
+++ b/packages/css/src/components/margin/README.md
@@ -8,14 +8,14 @@ Adds white space below a single element.
 
 All six sizes of [Space](/docs/brand-design-tokens-space--docs) are available for the height of the bottom margin.
 
-| Class name   | Example                                                                                       |
-| :----------- | :-------------------------------------------------------------------------------------------- |
-| `ams-mb-xs`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-xs);" />  |
-| `ams-mb-sm`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-sm);" />  |
-| `ams-mb-md`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-md);" />  |
-| `ams-mb-lg`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-lg);" />  |
-| `ams-mb-xl`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-xl);" />  |
-| `ams-mb-2xl` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-margin-2xl);" /> |
+| Class name   | Example                                                                                      |
+| :----------- | :------------------------------------------------------------------------------------------- |
+| `ams-mb-xs`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-space-xs);" />  |
+| `ams-mb-sm`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-space-sm);" />  |
+| `ams-mb-md`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-space-md);" />  |
+| `ams-mb-lg`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-space-lg);" />  |
+| `ams-mb-xl`  | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-space-xl);" />  |
+| `ams-mb-2xl` | <div className="ams-docs-token-example--space" style="inline-size: var(--ams-space-2xl);" /> |
 
 ## Guidelines
 

--- a/packages/css/src/components/margin/margin.scss
+++ b/packages/css/src/components/margin/margin.scss
@@ -8,7 +8,7 @@
 
 @each $size in map.keys($ams-sizes) {
   @if $size != "no" {
-    .ams-mb--#{$size} {
+    .ams-mb-#{$size} {
       /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
       margin-block-end: var(--ams-space-#{$size}) !important;
     }

--- a/packages/react/src/Image/generateAspectRatioClass.ts
+++ b/packages/react/src/Image/generateAspectRatioClass.ts
@@ -1,2 +1,2 @@
 export const generateAspectRatioClass = (aspectRatio?: string) =>
-  aspectRatio && `ams-aspect-ratio--${aspectRatio.replace(':', '-')}`
+  aspectRatio && `ams-aspect-ratio-${aspectRatio.replace(':', '-')}`

--- a/storybook/src/components/Breakout/Breakout.stories.tsx
+++ b/storybook/src/components/Breakout/Breakout.stories.tsx
@@ -68,7 +68,7 @@ export const VerticalLayout: Story = {
         key={3}
         rowStart={3}
       >
-        <Paragraph className="ams-mb--sm" color="inverse">
+        <Paragraph className="ams-mb-sm" color="inverse">
           Vertel ons in het evenementenformulier wat u wilt gaan doen. U checkt daarmee of u een vergunning nodig hebt.
         </Paragraph>
         <Paragraph color="inverse">

--- a/storybook/src/components/Checkbox/Checkbox.stories.tsx
+++ b/storybook/src/components/Checkbox/Checkbox.stories.tsx
@@ -80,11 +80,11 @@ export const InAFieldSet: Story = {
       invalid={invalid}
       legend="Waar gaat uw melding over?"
     >
-      <Paragraph className="ams-mb--sm" id="description1" size="small">
+      <Paragraph className="ams-mb-sm" id="description1" size="small">
         De laatstgenoemde melding.
       </Paragraph>
       {invalid && (
-        <ErrorMessage className="ams-mb--sm" id="error1">
+        <ErrorMessage className="ams-mb-sm" id="error1">
           Geef aan waar uw laatstgenoemde melding over gaat.
         </ErrorMessage>
       )}
@@ -131,11 +131,11 @@ export const InAFieldSetWithValidation: Story = {
       invalid={invalid}
       legend="Waar gaat uw melding over?"
     >
-      <Paragraph className="ams-mb--sm" id="description2" size="small">
+      <Paragraph className="ams-mb-sm" id="description2" size="small">
         De laatstgenoemde melding.
       </Paragraph>
       {invalid && (
-        <ErrorMessage className="ams-mb--sm" id="error2">
+        <ErrorMessage className="ams-mb-sm" id="error2">
           Geef aan waar uw laatstgenoemde melding over gaat.
         </ErrorMessage>
       )}

--- a/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -85,7 +85,7 @@ export const RichDescription: Story = {
     <DescriptionList {...args}>
       <DescriptionList.Term key={1}>Amsterdam Light Festival</DescriptionList.Term>
       <DescriptionList.Description key={2}>
-        <Paragraph className="ams-mb--sm" color={args.color}>
+        <Paragraph className="ams-mb-sm" color={args.color}>
           Een jaarlijks evenement waarbij kunstenaars van over de hele wereld hun{' '}
           <strong>creatieve lichtinstallaties</strong> tonen. De kunstwerken zijn verspreid over de stad en zijn zowel
           vanaf het water als vanaf de kant te bewonderen.

--- a/storybook/src/components/Dialog/Dialog.docs.mdx
+++ b/storybook/src/components/Dialog/Dialog.docs.mdx
@@ -32,7 +32,7 @@ At the same time, this will position the buttons outside the `form` element.
 Create an `id` for the form and add it to the submit Button’s `form` attribute to connect the two.
 
 If the Action Group must be in the `form`, implement the whitespace and scrolling behaviour as well.
-Add a medium bottom margin (`ams-mb--md`) to the element before it.
+Add a medium bottom margin (`ams-mb-md`) to the element before it.
 Make sure the content of the form scrolls if necessary, while the Action Group is visible at the bottom at all times.
 
 The form returns the `value` of the submit Button, which allows inferring which Button the user clicked.

--- a/storybook/src/components/FieldSet/FieldSet.stories.tsx
+++ b/storybook/src/components/FieldSet/FieldSet.stories.tsx
@@ -41,7 +41,7 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   render: ({ hint, invalid, legend, optional }) => (
     <FieldSet hint={hint} invalid={invalid} legend={legend} optional={optional}>
-      <Field className="ams-mb--sm">
+      <Field className="ams-mb-sm">
         <Label htmlFor="input-a1">Voornaam</Label>
         {invalid && <ErrorMessage id="error-a1">Vul uw voornaam in.</ErrorMessage>}
         <TextInput
@@ -68,10 +68,10 @@ export const Default: Story = {
 export const WithDescription: Story = {
   render: (args) => (
     <FieldSet aria-describedby="description-b" invalid={args.invalid} legend={args.legend}>
-      <Paragraph className="ams-mb--sm" id="description-b" size="small">
+      <Paragraph className="ams-mb-sm" id="description-b" size="small">
         Vul uw naam in zoals in uw paspoort staat.
       </Paragraph>
-      <Field className="ams-mb--sm">
+      <Field className="ams-mb-sm">
         <Label htmlFor="input-b1">Voornaam</Label>
         {args.invalid && <ErrorMessage id="error-b1">Vul uw voornaam in.</ErrorMessage>}
         <TextInput
@@ -99,7 +99,7 @@ export const WithHint: Story = {
   args: { hint: 'verplicht', optional: false },
   render: ({ hint, invalid, legend, optional }) => (
     <FieldSet hint={hint} invalid={invalid} legend={legend} optional={optional}>
-      <Field className="ams-mb--sm">
+      <Field className="ams-mb-sm">
         <Label htmlFor="input-b3">Voornaam</Label>
         {invalid && <ErrorMessage id="error-b3">Vul uw voornaam in.</ErrorMessage>}
         <TextInput
@@ -127,10 +127,10 @@ export const WithValidation: Story = {
   args: { invalid: true },
   render: (args) => (
     <FieldSet aria-describedby="description-c" invalid={args.invalid} legend={args.legend}>
-      <Paragraph className="ams-mb--sm" id="description-c" size="small">
+      <Paragraph className="ams-mb-sm" id="description-c" size="small">
         Vul uw naam in zoals in uw paspoort staat.
       </Paragraph>
-      <Field className="ams-mb--sm">
+      <Field className="ams-mb-sm">
         <Label htmlFor="input-c1">Voornaam</Label>
         {args.invalid && <ErrorMessage id="error-c1">Vul uw voornaam in.</ErrorMessage>}
         <TextInput
@@ -166,11 +166,11 @@ export const RadioGroup: Story = {
       legend={args.legend}
       role="radiogroup"
     >
-      <Paragraph className="ams-mb--sm" id="description-d" size="small">
+      <Paragraph className="ams-mb-sm" id="description-d" size="small">
         De laatstgenoemde melding.
       </Paragraph>
       {args.invalid && (
-        <ErrorMessage className="ams-mb--sm" id="error-d">
+        <ErrorMessage className="ams-mb-sm" id="error-d">
           Geef aan waar uw laatstgenoemde melding over gaat.
         </ErrorMessage>
       )}
@@ -205,11 +205,11 @@ export const RadioGroupWithValidation: Story = {
       legend={args.legend}
       role="radiogroup"
     >
-      <Paragraph className="ams-mb--sm" id="description-e" size="small">
+      <Paragraph className="ams-mb-sm" id="description-e" size="small">
         De laatstgenoemde melding.
       </Paragraph>
       {args.invalid && (
-        <ErrorMessage className="ams-mb--sm" id="error-e">
+        <ErrorMessage className="ams-mb-sm" id="error-e">
           Geef aan waar uw laatstgenoemde melding over gaat.
         </ErrorMessage>
       )}
@@ -242,11 +242,11 @@ export const CheckboxGroup: Story = {
       invalid={args.invalid}
       legend={args.legend}
     >
-      <Paragraph className="ams-mb--sm" id="description-f" size="small">
+      <Paragraph className="ams-mb-sm" id="description-f" size="small">
         De laatstgenoemde melding.
       </Paragraph>
       {args.invalid && (
-        <ErrorMessage className="ams-mb--sm" id="error-f">
+        <ErrorMessage className="ams-mb-sm" id="error-f">
           Geef aan waar uw melding over gaat.
         </ErrorMessage>
       )}
@@ -280,11 +280,11 @@ export const CheckboxGroupWithValidation: Story = {
       invalid={args.invalid}
       legend={args.legend}
     >
-      <Paragraph className="ams-mb--sm" id="description-g" size="small">
+      <Paragraph className="ams-mb-sm" id="description-g" size="small">
         De laatstgenoemde melding.
       </Paragraph>
       {args.invalid && (
-        <ErrorMessage className="ams-mb--sm" id="error-g">
+        <ErrorMessage className="ams-mb-sm" id="error-g">
           Geef aan waar uw melding over gaat.
         </ErrorMessage>
       )}

--- a/storybook/src/components/Footer/Footer.stories.tsx
+++ b/storybook/src/components/Footer/Footer.stories.tsx
@@ -38,7 +38,7 @@ export const Default: Story = {
       <Footer.Spotlight key="footer-spotlight">
         <Grid paddingVertical="medium">
           <Grid.Cell span={4}>
-            <Heading className="ams-mb--sm" color="inverse" level={2} size="level-4">
+            <Heading className="ams-mb-sm" color="inverse" level={2} size="level-4">
               Meer weten
             </Heading>
             <LinkList>
@@ -52,10 +52,10 @@ export const Default: Story = {
             </LinkList>
           </Grid.Cell>
           <Grid.Cell span={4} start={{ narrow: 1, medium: 5, wide: 5 }}>
-            <Heading className="ams-mb--sm" color="inverse" level={2} size="level-4">
+            <Heading className="ams-mb-sm" color="inverse" level={2} size="level-4">
               Contact
             </Heading>
-            <Paragraph className="ams-mb--md" color="inverse" size="small">
+            <Paragraph className="ams-mb-md" color="inverse" size="small">
               Hebt u een vraag en kunt u het antwoord niet vinden op deze website? Neem dan contact met ons op.
             </Paragraph>
             <LinkList>
@@ -71,8 +71,8 @@ export const Default: Story = {
             </LinkList>
           </Grid.Cell>
           <Grid.Cell span={4} start={{ narrow: 1, medium: 1, wide: 9 }}>
-            <div className="ams-mb--xl">
-              <Heading className="ams-mb--sm" color="inverse" level={2} size="level-4">
+            <div className="ams-mb-xl">
+              <Heading className="ams-mb-sm" color="inverse" level={2} size="level-4">
                 Nieuwsbrief
               </Heading>
               <LinkList>
@@ -82,7 +82,7 @@ export const Default: Story = {
               </LinkList>
             </div>
             <div>
-              <Heading className="ams-mb--sm" color="inverse" level={2} size="level-4">
+              <Heading className="ams-mb-sm" color="inverse" level={2} size="level-4">
                 Volg ons
               </Heading>
               <LinkList>
@@ -114,10 +114,10 @@ export const OnderzoekEnStatistiek: Story = {
       <Footer.Spotlight key="footer-spotlight">
         <Grid paddingVertical="medium">
           <Grid.Cell span={3}>
-            <Heading className="ams-mb--sm" color="inverse" level={2} size="level-4">
+            <Heading className="ams-mb-sm" color="inverse" level={2} size="level-4">
               Contact
             </Heading>
-            <Paragraph className="ams-mb--md" color="inverse" size="small">
+            <Paragraph className="ams-mb-md" color="inverse" size="small">
               Heeft u een vraag en kunt u het antwoord niet vinden op deze site? Neem dan contact met ons op.
             </Paragraph>
             <LinkList>
@@ -130,10 +130,10 @@ export const OnderzoekEnStatistiek: Story = {
             </LinkList>
           </Grid.Cell>
           <Grid.Cell span={3} start={{ narrow: 1, medium: 5, wide: 5 }}>
-            <Heading className="ams-mb--sm" color="inverse" level={2} size="level-4">
+            <Heading className="ams-mb-sm" color="inverse" level={2} size="level-4">
               Panels en enquêtes
             </Heading>
-            <Paragraph className="ams-mb--md" color="inverse" size="small">
+            <Paragraph className="ams-mb-md" color="inverse" size="small">
               Bent u uitgenodigd om mee te doen aan onderzoek of heeft u vragen over het panel of stadspaspanel?
             </Paragraph>
             <LinkList>
@@ -149,7 +149,7 @@ export const OnderzoekEnStatistiek: Story = {
             </LinkList>
           </Grid.Cell>
           <Grid.Cell span={3} start={{ narrow: 1, medium: 1, wide: 9 }}>
-            <Heading className="ams-mb--sm" color="inverse" level={2} size="level-4">
+            <Heading className="ams-mb-sm" color="inverse" level={2} size="level-4">
               Onderzoek en Statistiek
             </Heading>
             <LinkList>

--- a/storybook/src/components/Header/Header.stories.tsx
+++ b/storybook/src/components/Header/Header.stories.tsx
@@ -48,7 +48,7 @@ export const Default: Story = {
           </LinkList>
         </Header.GridCellNarrowWindowOnly>
         <Grid.Cell span={4}>
-          <Heading className="ams-mb--sm" level={3}>
+          <Heading className="ams-mb-sm" level={3}>
             Onderdelen
           </Heading>
           <LinkList>
@@ -60,7 +60,7 @@ export const Default: Story = {
           </LinkList>
         </Grid.Cell>
         <Grid.Cell span={4}>
-          <Heading className="ams-mb--sm" level={3}>
+          <Heading className="ams-mb-sm" level={3}>
             Over ons
           </Heading>
           <LinkList>
@@ -72,7 +72,7 @@ export const Default: Story = {
           </LinkList>
         </Grid.Cell>
         <Grid.Cell span={4}>
-          <Heading className="ams-mb--sm" level={3}>
+          <Heading className="ams-mb-sm" level={3}>
             Help
           </Heading>
           <LinkList>
@@ -136,7 +136,7 @@ export const WithoutMenuButtonOnWideWindow: Story = {
   args: {
     brandName: 'Aan de Amsterdamse grachten',
     children: (
-      <LinkList className="ams-mb--lg">
+      <LinkList className="ams-mb-lg">
         {WithoutMenuButtonOnWideWindowStoryLinks.map(({ href, label }) => (
           <LinkList.Link href={href} key={label}>
             {label}

--- a/storybook/src/components/Radio/Radio.stories.tsx
+++ b/storybook/src/components/Radio/Radio.stories.tsx
@@ -76,11 +76,11 @@ export const InAFieldSet: Story = {
       legend="Waar gaat uw melding over?"
       role="radiogroup"
     >
-      <Paragraph className="ams-mb--sm" id="description1" size="small">
+      <Paragraph className="ams-mb-sm" id="description1" size="small">
         De laatstgenoemde melding.
       </Paragraph>
       {invalid && (
-        <ErrorMessage className="ams-mb--sm" id="error1">
+        <ErrorMessage className="ams-mb-sm" id="error1">
           Geef aan waar uw laatstgenoemde melding over gaat.
         </ErrorMessage>
       )}
@@ -124,11 +124,11 @@ export const InAFieldSetWithValidation: Story = {
       legend="Waar gaat uw melding over?"
       role="radiogroup"
     >
-      <Paragraph className="ams-mb--sm" id="description2" size="small">
+      <Paragraph className="ams-mb-sm" id="description2" size="small">
         De laatstgenoemde melding.
       </Paragraph>
       {invalid && (
-        <ErrorMessage className="ams-mb--sm" id="error2">
+        <ErrorMessage className="ams-mb-sm" id="error2">
           Geef aan waar uw laatstgenoemde melding over gaat.
         </ErrorMessage>
       )}

--- a/storybook/src/components/Tabs/Tabs.stories.tsx
+++ b/storybook/src/components/Tabs/Tabs.stories.tsx
@@ -52,7 +52,7 @@ const defaultTabs = [
   </Tabs.List>,
   tabsContent.map(({ body, label }) => (
     <Tabs.Panel key={label} tab={label}>
-      <Heading className="ams-mb--xs" level={3}>
+      <Heading className="ams-mb-xs" level={3}>
         {label}
       </Heading>
       <Paragraph>{body}</Paragraph>

--- a/storybook/src/pages/amsterdam/ArticlePage/ArticleBody.tsx
+++ b/storybook/src/pages/amsterdam/ArticlePage/ArticleBody.tsx
@@ -16,7 +16,7 @@ export const ArticleBody = ({ lead, paragraph1, spotlightHeading, spotlightLinkL
   <>
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Paragraph className="ams-mb--md" size="large">
+        <Paragraph className="ams-mb-md" size="large">
           {lead}
         </Paragraph>
         <Paragraph>{paragraph1}</Paragraph>
@@ -58,7 +58,7 @@ export const ArticleBody = ({ lead, paragraph1, spotlightHeading, spotlightLinkL
       <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Column>
           <section>
-            <Heading className="ams-mb--xs" level={2}>
+            <Heading className="ams-mb-xs" level={2}>
               Wanneer bezorgen we
             </Heading>
             <Paragraph>
@@ -67,7 +67,7 @@ export const ArticleBody = ({ lead, paragraph1, spotlightHeading, spotlightLinkL
             </Paragraph>
           </section>
           <section>
-            <Heading className="ams-mb--xs" level={2}>
+            <Heading className="ams-mb-xs" level={2}>
               Tekenen voor ontvangst
             </Heading>
             <Paragraph>
@@ -77,7 +77,7 @@ export const ArticleBody = ({ lead, paragraph1, spotlightHeading, spotlightLinkL
             </Paragraph>
           </section>
           <section>
-            <Heading className="ams-mb--xs" level={2}>
+            <Heading className="ams-mb-xs" level={2}>
               Bezorgen met waarde-transport
             </Heading>
             <Paragraph>
@@ -89,7 +89,7 @@ export const ArticleBody = ({ lead, paragraph1, spotlightHeading, spotlightLinkL
             </Paragraph>
           </section>
           <section>
-            <Heading className="ams-mb--xs" level={2}>
+            <Heading className="ams-mb-xs" level={2}>
               Wanneer kan bezorgen niet?
             </Heading>
             <UnorderedList>
@@ -102,7 +102,7 @@ export const ArticleBody = ({ lead, paragraph1, spotlightHeading, spotlightLinkL
             </UnorderedList>
           </section>
           <section>
-            <Heading className="ams-mb--xs" level={2}>
+            <Heading className="ams-mb-xs" level={2}>
               Meer weten
             </Heading>
             <LinkList>

--- a/storybook/src/pages/amsterdam/ArticlePage/ArticleHeader.tsx
+++ b/storybook/src/pages/amsterdam/ArticlePage/ArticleHeader.tsx
@@ -7,7 +7,7 @@ export const ArticleHeader = ({ heading, imageSrc }: ArticleHeaderProps) => (
   <header>
     <Grid paddingBottom="medium">
       <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading className="ams-mb--sm" level={1}>
+        <Heading className="ams-mb-sm" level={1}>
           {heading}
         </Heading>
         <Paragraph size="small">7 juni 2024</Paragraph>

--- a/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
+++ b/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
@@ -30,7 +30,7 @@ export const FormPage = () => {
         <Heading className="ams-mb--md" level={1}>
           Contact
         </Heading>
-        <form className="ams-gap--md" id="main" onSubmit={(e) => e.preventDefault()}>
+        <form className="ams-gap-md" id="main" onSubmit={(e) => e.preventDefault()}>
           <Field>
             <Label htmlFor="body">Wat wilt u aan de gemeente vragen?</Label>
             <Paragraph id="bodyDescription" size="small">

--- a/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
+++ b/storybook/src/pages/amsterdam/FormPage/FormPage.tsx
@@ -27,7 +27,7 @@ export const FormPage = () => {
         <Breadcrumb>
           <Breadcrumb.Link>Home</Breadcrumb.Link>
         </Breadcrumb>
-        <Heading className="ams-mb--md" level={1}>
+        <Heading className="ams-mb-md" level={1}>
           Contact
         </Heading>
         <form className="ams-gap-md" id="main" onSubmit={(e) => e.preventDefault()}>

--- a/storybook/src/pages/amsterdam/HomePage/HomeSpotlight.tsx
+++ b/storybook/src/pages/amsterdam/HomePage/HomeSpotlight.tsx
@@ -4,10 +4,10 @@ export const HomeSpotlight = () => (
   <Spotlight>
     <Grid paddingVertical="medium">
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-        <Heading className="ams-mb--xs" color="inverse" level={1} size="level-2">
+        <Heading className="ams-mb-xs" color="inverse" level={1} size="level-2">
           Ontheffing of vergunning
         </Heading>
-        <Paragraph className="ams-mb--sm" color="inverse">
+        <Paragraph className="ams-mb-sm" color="inverse">
           Check welke ontheffing of vergunning u nodig heeft. Bijvoorbeeld een RVV, TVM, objectvergunning,{' '}
           nachtwerkontheffing, e-RVV, e-TVM of filmmelding. Dat regult u allemaal met 1 formulier.
         </Paragraph>
@@ -16,10 +16,10 @@ export const HomeSpotlight = () => (
         </Link>
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-        <Heading className="ams-mb--xs" color="inverse" level={1} size="level-2">
+        <Heading className="ams-mb-xs" color="inverse" level={1} size="level-2">
           Werkzaamheden
         </Heading>
-        <Paragraph className="ams-mb--sm" color="inverse">
+        <Paragraph className="ams-mb-sm" color="inverse">
           Lees waar en wanneer we werken aan nieuwbouw, groot onderhoud, herinrichting van straten en wegen, aanpak van
           parken of ontwikkeling van hele gebieden.
         </Paragraph>

--- a/storybook/src/pages/amsterdam/common/AppHeader.tsx
+++ b/storybook/src/pages/amsterdam/common/AppHeader.tsx
@@ -22,7 +22,7 @@ export const AppHeader = () => (
         </LinkList>
       </Header.GridCellNarrowWindowOnly>
       <Grid.Cell span="all">
-        <Heading className="ams-mb--sm" level={3}>
+        <Heading className="ams-mb-sm" level={3}>
           Alle onderwerpen
         </Heading>
         <div className="ams-mega-menu__columns">

--- a/storybook/src/utils/Gap/Gap.stories.tsx
+++ b/storybook/src/utils/Gap/Gap.stories.tsx
@@ -9,7 +9,7 @@ import { Gap } from './Gap'
 import type { GapProps } from './Gap'
 
 const render = ({ size }: GapProps) => (
-  <div className={`ams-gap--${size}`}>
+  <div className={`ams-gap-${size}`}>
     <Paragraph>These paragraphs are separated by a gap.</Paragraph>
     <Paragraph>These paragraphs are separated by a gap.</Paragraph>
     <Paragraph>These paragraphs are separated by a gap.</Paragraph>

--- a/storybook/src/utils/Margin/Margin.stories.tsx
+++ b/storybook/src/utils/Margin/Margin.stories.tsx
@@ -10,7 +10,7 @@ import { Margin } from './Margin'
 
 const render = ({ size }: MarginProps) => (
   <>
-    <Heading className={`ams-mb--${size}`} level={2}>
+    <Heading className={`ams-mb-${size}`} level={2}>
       This heading has a bottom margin
     </Heading>
     <Paragraph>It introduces white space between the heading and this paragraph below.</Paragraph>


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

This removes one of the double dashes in the class names `ams-aspect-ratio-*`, `ams-gap-*` and `ams-mb-*`.

It also fixes the display of the examples for gap and margin; they were still using tokens that we removed in #1910.

## Why

We concluded BEM doesn’t apply to utility classes.

## How

I think you know how.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a