### PR TITLE
feat(Description List)!: Rename values for terms column widths

### DIFF
--- a/packages/css/src/components/description-list/description-list.scss
+++ b/packages/css/src/components/description-list/description-list.scss
@@ -36,18 +36,18 @@
     grid-template-columns: auto 1fr;
   }
 
-  .ams-description-list--terms-width-narrow,
-  .ams-description-list--terms-width-narrow .ams-description-list__section {
+  .ams-description-list--narrow,
+  .ams-description-list--narrow .ams-description-list__section {
     grid-template-columns: 1fr 4fr;
   }
 
-  .ams-description-list--terms-width-medium,
-  .ams-description-list--terms-width-medium .ams-description-list__section {
+  .ams-description-list--medium,
+  .ams-description-list--medium .ams-description-list__section {
     grid-template-columns: 1fr 2fr;
   }
 
-  .ams-description-list--terms-width-wide,
-  .ams-description-list--terms-width-wide .ams-description-list__section {
+  .ams-description-list--wide,
+  .ams-description-list--wide .ams-description-list__section {
     grid-template-columns: 1fr 1fr;
   }
 }

--- a/packages/css/src/components/description-list/description-list.scss
+++ b/packages/css/src/components/description-list/description-list.scss
@@ -36,8 +36,8 @@
     grid-template-columns: auto 1fr;
   }
 
-  .ams-description-list--terms-width-small,
-  .ams-description-list--terms-width-small .ams-description-list__section {
+  .ams-description-list--terms-width-narrow,
+  .ams-description-list--terms-width-narrow .ams-description-list__section {
     grid-template-columns: 1fr 4fr;
   }
 
@@ -46,8 +46,8 @@
     grid-template-columns: 1fr 2fr;
   }
 
-  .ams-description-list--terms-width-large,
-  .ams-description-list--terms-width-large .ams-description-list__section {
+  .ams-description-list--terms-width-wide,
+  .ams-description-list--terms-width-wide .ams-description-list__section {
     grid-template-columns: 1fr 1fr;
   }
 }

--- a/packages/css/src/components/description-list/description-list.scss
+++ b/packages/css/src/components/description-list/description-list.scss
@@ -38,17 +38,17 @@
 
   .ams-description-list--narrow,
   .ams-description-list--narrow .ams-description-list__section {
-    grid-template-columns: 1fr 4fr;
+    grid-template-columns: var(--ams-description-list-narrow-grid-template-columns);
   }
 
   .ams-description-list--medium,
   .ams-description-list--medium .ams-description-list__section {
-    grid-template-columns: 1fr 2fr;
+    grid-template-columns: var(--ams-description-list-medium-grid-template-columns);
   }
 
   .ams-description-list--wide,
   .ams-description-list--wide .ams-description-list__section {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: var(--ams-description-list-wide-grid-template-columns);
   }
 }
 

--- a/packages/css/src/components/description-list/description-list.scss
+++ b/packages/css/src/components/description-list/description-list.scss
@@ -36,18 +36,18 @@
     grid-template-columns: auto 1fr;
   }
 
-  .ams-description-list--terms-width-sm,
-  .ams-description-list--terms-width-sm .ams-description-list__section {
+  .ams-description-list--terms-width-small,
+  .ams-description-list--terms-width-small .ams-description-list__section {
     grid-template-columns: 1fr 4fr;
   }
 
-  .ams-description-list--terms-width-md,
-  .ams-description-list--terms-width-md .ams-description-list__section {
+  .ams-description-list--terms-width-medium,
+  .ams-description-list--terms-width-medium .ams-description-list__section {
     grid-template-columns: 1fr 2fr;
   }
 
-  .ams-description-list--terms-width-lg,
-  .ams-description-list--terms-width-lg .ams-description-list__section {
+  .ams-description-list--terms-width-large,
+  .ams-description-list--terms-width-large .ams-description-list__section {
     grid-template-columns: 1fr 1fr;
   }
 }

--- a/packages/react/src/DescriptionList/DescriptionList.tsx
+++ b/packages/react/src/DescriptionList/DescriptionList.tsx
@@ -30,7 +30,7 @@ const DescriptionListRoot = forwardRef(
       className={clsx(
         'ams-description-list',
         color && `ams-description-list--${color}`,
-        termsWidth && `ams-description-list--terms-width-${termsWidth}`,
+        termsWidth && `ams-description-list--${termsWidth}`,
         className,
       )}
       ref={ref}

--- a/packages/react/src/DescriptionList/DescriptionList.tsx
+++ b/packages/react/src/DescriptionList/DescriptionList.tsx
@@ -10,7 +10,7 @@ import { DescriptionListDescription } from './DescriptionListDescription'
 import { DescriptionListSection } from './DescriptionListSection'
 import { DescriptionListTerm } from './DescriptionListTerm'
 
-export const descriptionListTermsWidths = ['small', 'medium', 'large'] as const
+export const descriptionListTermsWidths = ['narrow', 'medium', 'wide'] as const
 type DescriptionListTermsWidth = (typeof descriptionListTermsWidths)[number]
 
 export type DescriptionListProps = {

--- a/packages/react/src/DescriptionList/DescriptionList.tsx
+++ b/packages/react/src/DescriptionList/DescriptionList.tsx
@@ -10,7 +10,7 @@ import { DescriptionListDescription } from './DescriptionListDescription'
 import { DescriptionListSection } from './DescriptionListSection'
 import { DescriptionListTerm } from './DescriptionListTerm'
 
-export const descriptionListTermsWidths = ['sm', 'md', 'lg'] as const
+export const descriptionListTermsWidths = ['small', 'medium', 'large'] as const
 type DescriptionListTermsWidth = (typeof descriptionListTermsWidths)[number]
 
 export type DescriptionListProps = {

--- a/proprietary/tokens/src/components/ams/description-list.tokens.json
+++ b/proprietary/tokens/src/components/ams/description-list.tokens.json
@@ -16,6 +16,15 @@
       "description": {
         "font-weight": { "value": "{ams.typography.body-text.font-weight}" },
         "padding-inline-start": { "value": "{ams.space.lg}" }
+      },
+      "narrow": {
+        "grid-template-columns": { "value": "1fr 4fr" }
+      },
+      "medium": {
+        "grid-template-columns": { "value": "1fr 2fr" }
+      },
+      "wide": {
+        "grid-template-columns": { "value": "1fr 1fr" }
       }
     }
   }

--- a/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Link, Paragraph, UnorderedList } from '@amsterdam/design-system-react'
+import { descriptionListTermsWidths } from '@amsterdam/design-system-react/dist/DescriptionList/DescriptionList'
 import { DescriptionList } from '@amsterdam/design-system-react/src'
 import { Meta, StoryObj } from '@storybook/react'
 
@@ -37,7 +38,7 @@ const meta = {
         labels: { lg: 'large', md: 'medium', sm: 'small', undefined: 'auto' },
         type: 'radio',
       },
-      options: [undefined, 'sm', 'md', 'lg'],
+      options: [undefined, ...descriptionListTermsWidths],
     },
   },
 } satisfies Meta<typeof DescriptionList>
@@ -76,7 +77,7 @@ export const MultipleTerms: Story = {
       <DescriptionList.Term key={4}>Geboortedatum</DescriptionList.Term>,
       <DescriptionList.Description key={5}>De datum waarop een persoon is geboren</DescriptionList.Description>,
     ],
-    termsWidth: 'md',
+    termsWidth: 'medium',
   },
 }
 

--- a/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -35,7 +35,7 @@ const meta = {
     },
     termsWidth: {
       control: {
-        labels: { lg: 'large', md: 'medium', sm: 'small', undefined: 'auto' },
+        labels: { undefined: 'auto' },
         type: 'radio',
       },
       options: [undefined, ...descriptionListTermsWidths],


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Changes the prop values of Description List’s `termsWidth` like so:
- `sm` → `narrow`
- `md` → `medium`
- `lg` → `wide`

I also added tokens for the various `grid-template-columns` in our stylesheet.

## Why

1. We don’t want to abbreviate values in component tokens and props.
2. Narrow and wide are better options for a column indicating width.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a