### PR TITLE
fix(Gap): Make sure grid display is always set

### DIFF
--- a/packages/css/src/components/gap/gap.scss
+++ b/packages/css/src/components/gap/gap.scss
@@ -3,15 +3,12 @@
  * Copyright Gemeente Amsterdam
  */
 
-[class|="ams-gap"] {
-  display: grid !important;
-}
-
 // If you modify this list, you must also update the object in
 // packages/react/src/common/shortSize.ts
 // Note that we don’t offer a 2xl gap on purpose.
 @each $size in ("xs", "s", "m", "l", "xl") {
   .ams-gap-#{$size} {
+    display: grid !important;
     /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
     gap: var(--ams-space-#{$size}) !important;
   }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Replaces an attribute selector shaped `[attr|=value]`.

## Why

Because we expected it to select `<div class="foo ams-gap">`, but it doesn’t. This utility class should always work, irrespective of other classes on the element. 

Changing it to `[class*="ams-gap-"]` is an option, but maybe we should just add `display: grid` to five possible class names rather than trying to be smart.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a