### PR TITLE
chore(docs): Correct indications of aspect ratio

### DIFF
--- a/packages/css/src/components/screen/README.md
+++ b/packages/css/src/components/screen/README.md
@@ -8,12 +8,12 @@ Manages the maximum width and alignment of the entire website or application.
 
 - This should be the outermost component of your website or application.
 - Within it, combine components such as
-  [Grid](/docs/components-layout-grid--docs),
-  [Header](/docs/components-containers-header--docs),
-  [Footer](/docs/components-containers-footer--docs),
-  [Spotlight](/docs/components-containers-spotlight--docs),
-  [Image Slider](/docs/components-media-image-slider--docs),
-  and Figure.
+  [Grid](https://designsystem.amsterdam/?path=/docs/components-layout-grid--docs),
+  [Header](https://designsystem.amsterdam/?path=/docs/components-containers-header--docs),
+  [Footer](https://designsystem.amsterdam/?path=/docs/components-containers-footer--docs),
+  [Spotlight](https://designsystem.amsterdam/?path=/docs/components-containers-spotlight--docs),
+  [Image Slider](https://designsystem.amsterdam/?path=/docs/components-media-image-slider--docs),
+  and [Figure](https://designsystem.amsterdam/?path=/docs/components-media-figure--docs).
 
 ## Design
 

--- a/storybook/src/components/Grid/Grid.stories.tsx
+++ b/storybook/src/components/Grid/Grid.stories.tsx
@@ -10,6 +10,14 @@ import { Meta, StoryObj } from '@storybook/react'
 const meta = {
   title: 'Components/Layout/Grid',
   component: Grid,
+  args: {
+    style: { minBlockSize: '7rem' },
+  },
+  argTypes: {
+    style: {
+      table: { display: false },
+    },
+  },
   parameters: {
     layout: 'fullscreen',
   },

--- a/storybook/src/components/Grid/Grid.stories.tsx
+++ b/storybook/src/components/Grid/Grid.stories.tsx
@@ -128,7 +128,7 @@ export const VerticalGap: Story = {
 export const SpanColumns: CellStory = {
   ...CellStoryTemplate,
   args: {
-    children: <div className="ams-docs-item" />,
+    className: 'ams-docs-item',
     span: 4,
   },
 }
@@ -136,7 +136,7 @@ export const SpanColumns: CellStory = {
 export const SpanResponsively: CellStory = {
   ...CellStoryTemplate,
   args: {
-    children: <div className="ams-docs-item" />,
+    className: 'ams-docs-item',
     span: { narrow: 4, medium: 6, wide: 8 },
   },
 }
@@ -144,7 +144,7 @@ export const SpanResponsively: CellStory = {
 export const SpanAllColumns: CellStory = {
   ...CellStoryTemplate,
   args: {
-    children: <div className="ams-docs-item" />,
+    className: 'ams-docs-item',
     span: 'all',
   },
 }
@@ -152,7 +152,7 @@ export const SpanAllColumns: CellStory = {
 export const StartPosition: CellStory = {
   ...CellStoryTemplate,
   args: {
-    children: <div className="ams-docs-item" />,
+    className: 'ams-docs-item',
     span: 3,
     start: { narrow: 2, medium: 4, wide: 6 },
   },
@@ -163,9 +163,5 @@ export const ImproveSemantics: CellStory = {
   args: {
     as: 'section',
   },
-  render: ({ as }: GridCellProps) => (
-    <Grid.Cell as={as} span="all">
-      <div className="ams-docs-item" />
-    </Grid.Cell>
-  ),
+  render: ({ as }: GridCellProps) => <Grid.Cell as={as} className="ams-docs-item" span="all" />,
 }

--- a/storybook/src/components/Grid/Grid.stories.tsx
+++ b/storybook/src/components/Grid/Grid.stories.tsx
@@ -10,6 +10,15 @@ import { Meta, StoryObj } from '@storybook/react'
 const meta = {
   title: 'Components/Layout/Grid',
   component: Grid,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof Grid>
+
+export default meta
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const gridMeta = {
   args: {
     gapVertical: undefined /* Keeps this prop at the top of the Controls table. */,
     paddingVertical: 'medium',
@@ -47,12 +56,7 @@ const meta = {
       options: [undefined, 'small', 'medium', 'large'],
     },
   },
-  parameters: {
-    layout: 'fullscreen',
-  },
-} satisfies Meta<typeof Grid>
-
-export default meta
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const cellMeta = {
@@ -67,7 +71,7 @@ const cellMeta = {
   },
 } satisfies Meta<typeof Grid.Cell>
 
-type Story = StoryObj<typeof meta>
+type Story = StoryObj<typeof gridMeta>
 type CellStory = StoryObj<typeof cellMeta>
 
 const BackgroundGrid = () => (

--- a/storybook/src/components/Grid/Grid.stories.tsx
+++ b/storybook/src/components/Grid/Grid.stories.tsx
@@ -14,15 +14,6 @@ const meta = {
     gapVertical: undefined /* Keeps this prop at the top of the Controls table. */,
     paddingVertical: 'medium',
   },
-  parameters: {
-    layout: 'fullscreen',
-  },
-} satisfies Meta<typeof Grid>
-
-export default meta
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const gridMeta = {
   argTypes: {
     className: {
       table: { disable: true },
@@ -56,7 +47,12 @@ const gridMeta = {
       options: [undefined, 'small', 'medium', 'large'],
     },
   },
-}
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof Grid>
+
+export default meta
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const cellMeta = {
@@ -71,7 +67,7 @@ const cellMeta = {
   },
 } satisfies Meta<typeof Grid.Cell>
 
-type Story = StoryObj<typeof gridMeta>
+type Story = StoryObj<typeof meta>
 type CellStory = StoryObj<typeof cellMeta>
 
 const BackgroundGrid = () => (

--- a/storybook/src/components/Grid/Grid.stories.tsx
+++ b/storybook/src/components/Grid/Grid.stories.tsx
@@ -11,12 +11,8 @@ const meta = {
   title: 'Components/Layout/Grid',
   component: Grid,
   args: {
-    style: { minBlockSize: '7rem' },
-  },
-  argTypes: {
-    style: {
-      table: { display: false },
-    },
+    gapVertical: undefined /* Keeps this prop at the top of the Controls table. */,
+    paddingVertical: 'medium',
   },
   parameters: {
     layout: 'fullscreen',
@@ -27,10 +23,6 @@ export default meta
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const gridMeta = {
-  args: {
-    gapVertical: undefined /* Keeps this prop at the top of the Controls table. */,
-    paddingVertical: 'medium',
-  },
   argTypes: {
     className: {
       table: { disable: true },

--- a/storybook/src/components/Screen/Screen.docs.mdx
+++ b/storybook/src/components/Screen/Screen.docs.mdx
@@ -10,7 +10,8 @@ import README from "../../../../packages/css/src/components/screen/README.md?raw
 
 ## Example
 
-There’s not much too see in the example – on a wide screen, or when zooming out, you’ll notice that width of the pink indicator is limited by the maximum width of the Screen component.
+There’s not much to see in the example.
+On a wide screen, or when zooming out, you’ll notice that the width of the pink box gets limited by the maximum width of the Screen component.
 
 <Primary />
 

--- a/storybook/src/components/Screen/Screen.docs.mdx
+++ b/storybook/src/components/Screen/Screen.docs.mdx
@@ -8,12 +8,25 @@ import README from "../../../../packages/css/src/components/screen/README.md?raw
 
 <Markdown>{README}</Markdown>
 
+## Example
+
+There’s not much too see in the example – on a wide screen, or when zooming out, you’ll notice that width of the pink indicator is limited by the maximum width of the Screen component.
+
 <Primary />
 
 <Controls />
 
-## Examples
+## Structure
 
-### Extra wide
+The outer containers of your website will look like this:
 
-<Canvas of={ScreenStories.ExtraWide} />
+```jsx
+<Screen>
+  <Header />
+  <Grid />
+  <Spotlight />
+  <Grid />
+  <Figure />
+  <Footer />
+</Screen>
+```

--- a/storybook/src/components/Screen/Screen.stories.tsx
+++ b/storybook/src/components/Screen/Screen.stories.tsx
@@ -19,12 +19,12 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
-  args: { children: <div className="ams-docs-item">Ik pas in het scherm.</div> },
+  args: { children: <div className="ams-docs-item" /> },
 }
 
 export const ExtraWide: Story = {
   args: {
-    children: <div className="ams-docs-item">Ik pas in een extra breed scherm.</div>,
+    children: <div className="ams-docs-item" />,
     maxWidth: 'x-wide',
   },
 }

--- a/storybook/src/components/Screen/Screen.stories.tsx
+++ b/storybook/src/components/Screen/Screen.stories.tsx
@@ -21,10 +21,3 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: { children: <div className="ams-docs-item" /> },
 }
-
-export const ExtraWide: Story = {
-  args: {
-    children: <div className="ams-docs-item" />,
-    maxWidth: 'x-wide',
-  },
-}

--- a/storybook/src/components/Screen/Screen.stories.tsx
+++ b/storybook/src/components/Screen/Screen.stories.tsx
@@ -9,6 +9,14 @@ import { Meta, StoryObj } from '@storybook/react'
 const meta = {
   title: 'Components/Layout/Screen',
   component: Screen,
+  args: {
+    className: 'ams-docs-screen',
+  },
+  argTypes: {
+    className: {
+      table: { disable: true },
+    },
+  },
   parameters: {
     layout: 'fullscreen',
   },

--- a/storybook/src/styles/docs.css
+++ b/storybook/src/styles/docs.css
@@ -158,6 +158,10 @@
     min-block-size: 3rem;
   }
 
+  .ams-docs-screen > & {
+    block-size: 3rem;
+  }
+
   .ams-docs-grid + .ams-grid > & {
     min-block-size: 3rem;
   }

--- a/storybook/src/styles/docs.css
+++ b/storybook/src/styles/docs.css
@@ -81,12 +81,6 @@
 }
 
 .ams-docs-column,
-.ams-docs-grid,
-.ams-docs-row {
-  border-inline: thin solid var(--ams-docs-grey);
-}
-
-.ams-docs-column,
 .ams-docs-row {
   background: repeating-linear-gradient(
     135deg,
@@ -95,6 +89,7 @@
     white 0.5rem,
     white 1rem
   );
+  border: thin solid var(--ams-docs-grey);
 }
 
 .ams-docs-column {
@@ -108,6 +103,7 @@
 
 .ams-docs-grid {
   block-size: 100vh;
+  border-inline: thin solid var(--ams-docs-grey);
   inset-block: 0;
   inset-inline: 0;
   position: absolute;

--- a/storybook/src/styles/docs.css
+++ b/storybook/src/styles/docs.css
@@ -97,10 +97,6 @@
   min-block-size: 16rem;
 }
 
-.ams-docs-row {
-  min-block-size: 6rem;
-}
-
 .ams-docs-grid {
   block-size: 100vh;
   border-inline: thin solid var(--ams-docs-grey);
@@ -139,16 +135,12 @@
 
 .ams-docs-item {
   background-color: var(--ams-docs-pink);
+  block-size: 3rem;
   border: thin dashed var(--ams-docs-grey);
-  font-family: "Amsterdam Sans", sans-serif;
-  font-size: var(--ams-paragraph-small-font-size);
-  line-height: var(--ams-paragraph-small-line-height);
-  padding-block: 1.5rem;
-  text-align: center;
 
   .ams-docs-row > & {
-    flex-basis: 8rem;
-    padding-inline: 1.5rem;
+    inline-size: 8rem;
+    min-block-size: 3rem;
   }
 
   .ams-docs-column > & {

--- a/storybook/src/styles/docs.css
+++ b/storybook/src/styles/docs.css
@@ -157,6 +157,10 @@
     inline-size: 8rem;
     min-block-size: 3rem;
   }
+
+  .ams-docs-grid + .ams-grid > & {
+    min-block-size: 3rem;
+  }
 }
 
 .ams-docs-item--highlight {

--- a/storybook/src/styles/docs.css
+++ b/storybook/src/styles/docs.css
@@ -80,15 +80,15 @@
   display: contents;
 }
 
-.ams-docs-container,
 .ams-docs-column,
+.ams-docs-container,
 .ams-docs-item,
 .ams-docs-row {
   box-sizing: border-box;
 }
 
-.ams-docs-container,
 .ams-docs-column,
+.ams-docs-container,
 .ams-docs-row {
   background: repeating-linear-gradient(
     135deg,
@@ -103,6 +103,11 @@
 .ams-docs-column {
   max-inline-size: 16rem;
   min-block-size: 16rem;
+}
+
+.ams-docs-container {
+  padding-block: var(--ams-space-m);
+  padding-inline: var(--ams-space-m);
 }
 
 .ams-docs-row {
@@ -121,11 +126,6 @@
     block-size: 100%;
   }
   /* stylelint-enable selector-max-id */
-}
-
-.ams-docs-container {
-  padding-block: var(--ams-space-m);
-  padding-inline: var(--ams-space-m);
 }
 
 .ams-docs-grid__cell {

--- a/storybook/src/styles/docs.css
+++ b/storybook/src/styles/docs.css
@@ -80,6 +80,14 @@
   display: contents;
 }
 
+.ams-docs-container,
+.ams-docs-column,
+.ams-docs-item,
+.ams-docs-row {
+  box-sizing: border-box;
+}
+
+.ams-docs-container,
 .ams-docs-column,
 .ams-docs-row {
   background: repeating-linear-gradient(
@@ -97,6 +105,10 @@
   min-block-size: 16rem;
 }
 
+.ams-docs-row {
+  min-block-size: 6rem;
+}
+
 .ams-docs-grid {
   block-size: 100vh;
   border-inline: thin solid var(--ams-docs-grey);
@@ -109,6 +121,11 @@
     block-size: 100%;
   }
   /* stylelint-enable selector-max-id */
+}
+
+.ams-docs-container {
+  padding-block: var(--ams-space-m);
+  padding-inline: var(--ams-space-m);
 }
 
 .ams-docs-grid__cell {
@@ -127,24 +144,18 @@
   }
 }
 
-.ams-docs-aspect-ratio {
-  min-block-size: initial;
-  padding-block: var(--ams-space-m);
-  padding-inline: var(--ams-space-m);
-}
-
 .ams-docs-item {
   background-color: var(--ams-docs-pink);
-  block-size: 3rem;
   border: thin dashed var(--ams-docs-grey);
+
+  .ams-docs-column > & {
+    block-size: 3rem;
+    min-inline-size: 3rem;
+  }
 
   .ams-docs-row > & {
     inline-size: 8rem;
     min-block-size: 3rem;
-  }
-
-  .ams-docs-column > & {
-    min-inline-size: 3rem;
   }
 }
 

--- a/storybook/src/utils/AspectRatio/AspectRatio.stories.tsx
+++ b/storybook/src/utils/AspectRatio/AspectRatio.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
   },
   render: ({ aspectRatio }) => (
     <div className="ams-docs-column ams-docs-aspect-ratio">
-      <div className={clsx('ams-docs-item', generateAspectRatioClass(aspectRatio))}></div>
+      <div className={clsx('ams-docs-item', generateAspectRatioClass(aspectRatio))} />
     </div>
   ),
 } satisfies Meta<typeof AspectRatio>

--- a/storybook/src/utils/AspectRatio/AspectRatio.stories.tsx
+++ b/storybook/src/utils/AspectRatio/AspectRatio.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
     },
   },
   render: ({ aspectRatio }) => (
-    <div className="ams-docs-column ams-docs-aspect-ratio">
+    <div className="ams-docs-container" style={{ maxInlineSize: '24rem' }}>
       <div className={clsx('ams-docs-item', generateAspectRatioClass(aspectRatio))} />
     </div>
   ),


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Removes padding from our `ams-docs-item` class that we use in Storybook to show a pink box. The padding got added to our aspect ratio examples too, distorting their actual aspect ratio.

The padding was needed for examples where the docs item contained text. We have had quite a few of those, but only two instances were left in the examples for Screen, that weren’t so strong anyway.

So we can decide not to use text in a docs item anymore. I removed typography and updated the Screen examples to restore some of the message that the removed text had.

I also made the sizing of docs item more consistent: just inline size and block size, no more padding and flex basis in the mix.

We use the docs item in Aspect Ratio, Column, Grid, Row and Screen, and I’ve tested the visual appearance of all variations.

## Why

To resolve a visual bug in Aspect Ratio and to simplify how we use this docs item.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a