### PR TITLE
fix(Column, Row)!: Do not use utility classes

### DIFF
--- a/packages/css/src/components/column/column.scss
+++ b/packages/css/src/components/column/column.scss
@@ -6,7 +6,18 @@
 .ams-column {
   display: flex;
   flex-direction: column;
-  gap: var(--ams-column-gap);
+  gap: var(--ams-column-gap-medium);
+}
+
+@each $size in ("x-small", "small", "large", "x-large") {
+  .ams-column--gap-#{$size} {
+    /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+    gap: var(--ams-column-gap-#{$size});
+  }
+}
+
+.ams-column--gap-none {
+  gap: 0;
 }
 
 .ams-column--align-around {
@@ -39,8 +50,4 @@
 
 .ams-column--align-horizontal-start {
   align-items: flex-start;
-}
-
-.ams-column--gap-none {
-  gap: 0;
 }

--- a/packages/css/src/components/row/row.scss
+++ b/packages/css/src/components/row/row.scss
@@ -5,7 +5,18 @@
 
 .ams-row {
   display: flex;
-  gap: var(--ams-row-gap);
+  gap: var(--ams-row-gap-medium);
+}
+
+@each $size in ("x-small", "small", "large", "x-large") {
+  .ams-row--gap-#{$size} {
+    /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+    gap: var(--ams-row-gap-#{$size});
+  }
+}
+
+.ams-row--gap-none {
+  gap: 0;
 }
 
 .ams-row--wrap {
@@ -46,8 +57,4 @@
 
 .ams-row--align-vertical-start {
   align-items: flex-start;
-}
-
-.ams-row--gap-none {
-  gap: 0;
 }

--- a/packages/react/src/Column/Column.test.tsx
+++ b/packages/react/src/Column/Column.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { createRef } from 'react'
 import { Column, columnGaps } from './Column'
-import { shortSize } from '../common/shortSize'
 import { crossAlignOptionsForColumn, mainAlignOptions } from '../common/types'
 import '@testing-library/jest-dom'
 
@@ -24,16 +23,12 @@ describe('Column', () => {
   })
 
   columnGaps.map((gap) =>
-    it('renders with ‘${gap}’ gap', () => {
+    it(`renders with ‘${gap}’ gap`, () => {
       const { container } = render(<Column gap={gap} />)
 
       const component = container.querySelector(':only-child')
 
-      if (gap === 'none') {
-        expect(component).toHaveClass(`ams-column--gap-none`)
-      } else {
-        expect(component).toHaveClass(`ams-gap-${shortSize[gap]}`)
-      }
+      expect(component).toHaveClass(`ams-column--gap-${gap}`)
     }),
   )
 

--- a/packages/react/src/Column/Column.tsx
+++ b/packages/react/src/Column/Column.tsx
@@ -6,7 +6,6 @@
 import clsx from 'clsx'
 import { forwardRef } from 'react'
 import type { HTMLAttributes, PropsWithChildren } from 'react'
-import { shortSize } from '../common/shortSize'
 import type { CrossAlignForColumn, MainAlign } from '../common/types'
 
 export const columnGaps = ['none', 'x-small', 'small', 'large', 'x-large'] as const
@@ -45,8 +44,7 @@ export const Column = forwardRef(
         'ams-column',
         align && `ams-column--align-${align}`,
         alignHorizontal && `ams-column--align-horizontal-${alignHorizontal}`,
-        gap === 'none' && 'ams-column--gap-none',
-        gap && gap !== 'none' && `ams-gap-${shortSize[gap]}`,
+        gap && `ams-column--gap-${gap}`,
         className,
       )}
       ref={ref}

--- a/packages/react/src/Row/Row.test.tsx
+++ b/packages/react/src/Row/Row.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { createRef } from 'react'
 import { Row, rowGaps } from './Row'
-import { shortSize } from '../common/shortSize'
 import { crossAlignOptions, mainAlignOptions } from '../common/types'
 import '@testing-library/jest-dom'
 
@@ -24,16 +23,12 @@ describe('Row', () => {
   })
 
   rowGaps.map((gap) =>
-    it('renders with ‘${gap}’ gap', () => {
+    it(`renders with ‘${gap}’ gap`, () => {
       const { container } = render(<Row gap={gap} />)
 
       const component = container.querySelector(':only-child')
 
-      if (gap === 'none') {
-        expect(component).toHaveClass(`ams-row--gap-none`)
-      } else {
-        expect(component).toHaveClass(`ams-gap-${shortSize[gap]}`)
-      }
+      expect(component).toHaveClass(`ams-row--gap-${gap}`)
     }),
   )
 

--- a/packages/react/src/Row/Row.tsx
+++ b/packages/react/src/Row/Row.tsx
@@ -6,7 +6,6 @@
 import clsx from 'clsx'
 import { forwardRef } from 'react'
 import type { HTMLAttributes, PropsWithChildren } from 'react'
-import { shortSize } from '../common/shortSize'
 import type { CrossAlign, MainAlign } from '../common/types'
 
 export const rowGaps = ['none', 'x-small', 'small', 'large', 'x-large'] as const
@@ -50,8 +49,7 @@ export const Row = forwardRef(
         'ams-row',
         align && `ams-row--align-${align}`,
         alignVertical && `ams-row--align-vertical-${alignVertical}`,
-        gap === 'none' && 'ams-row--gap-none',
-        gap && gap !== 'none' && `ams-gap-${shortSize[gap]}`,
+        gap && `ams-row--gap-${gap}`,
         wrap && 'ams-row--wrap',
         className,
       )}

--- a/proprietary/tokens/src/components/ams/column.tokens.json
+++ b/proprietary/tokens/src/components/ams/column.tokens.json
@@ -1,7 +1,13 @@
 {
   "ams": {
     "column": {
-      "gap": { "value": "{ams.space.m}" }
+      "gap": {
+        "x-small": { "value": "{ams.space.xs}" },
+        "small": { "value": "{ams.space.s}" },
+        "medium": { "value": "{ams.space.m}" },
+        "large": { "value": "{ams.space.l}" },
+        "x-large": { "value": "{ams.space.xl}" }
+      }
     }
   }
 }

--- a/proprietary/tokens/src/components/ams/row.tokens.json
+++ b/proprietary/tokens/src/components/ams/row.tokens.json
@@ -1,7 +1,13 @@
 {
   "ams": {
     "row": {
-      "gap": { "value": "{ams.space.m}" }
+      "gap": {
+        "x-small": { "value": "{ams.space.xs}" },
+        "small": { "value": "{ams.space.s}" },
+        "medium": { "value": "{ams.space.m}" },
+        "large": { "value": "{ams.space.l}" },
+        "x-large": { "value": "{ams.space.xl}" }
+      }
     }
   }
 }

--- a/storybook/src/components/Column/Column.stories.tsx
+++ b/storybook/src/components/Column/Column.stories.tsx
@@ -72,8 +72,10 @@ export const ImproveSemantics: Story = {
   args: {
     as: 'section',
     children: [
-      <Heading level={3}>Zoekresultaten</Heading>,
-      <Card key={1}>
+      <Heading key={1} level={3}>
+        Zoekresultaten
+      </Heading>,
+      <Card key={2}>
         <Heading level={4}>
           <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>
         </Heading>
@@ -82,7 +84,7 @@ export const ImproveSemantics: Story = {
           in het centrum.
         </Paragraph>
       </Card>,
-      <Card key={2}>
+      <Card key={3}>
         <Heading level={4}>
           <Card.Link href="#">Verlenging proef ophalen afval per boot</Card.Link>
         </Heading>

--- a/storybook/src/components/Row/Row.stories.tsx
+++ b/storybook/src/components/Row/Row.stories.tsx
@@ -84,7 +84,14 @@ export const AlignOpposingTexts: Story = {
   args: {
     align: 'between',
     alignVertical: 'baseline',
-    children: [<Heading level={3}>An example heading</Heading>, <Link href="#">An example link</Link>],
+    children: [
+      <Heading key={1} level={3}>
+        An example heading
+      </Heading>,
+      <Link href="#" key={2}>
+        An example link
+      </Link>,
+    ],
     className: undefined,
     wrap: true,
   },


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It reverts using utility classes for Row and Column. I also fixed some missing key errors in Storybook.

## Why

The utility classes also set `display: grid`, which breaks Row and Column. 

## How

Mostly by reverting the changes in [this commit](https://github.com/Amsterdam/design-system/pull/1940/commits/163973350b0113584a8da6b198057eb6fdbfe916).

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
