### PR TITLE
feat: Balance text wrapping in all kinds of Headings

### DIFF
--- a/packages/css/src/components/accordion/accordion.scss
+++ b/packages/css/src/components/accordion/accordion.scss
@@ -44,6 +44,7 @@
   padding-block: var(--ams-accordion-button-padding-block);
   padding-inline: var(--ams-accordion-button-padding-inline);
   text-align: start;
+  text-wrap: var(--ams-accordion-button-text-wrap);
 
   @include reset-button;
 

--- a/packages/css/src/components/field-set/field-set.scss
+++ b/packages/css/src/components/field-set/field-set.scss
@@ -30,11 +30,9 @@
   padding-inline: 0;
 
   + * {
-    clear: both; // Reset the applied float for the legend’s first sibling
+    clear: both; // [2]
   }
 }
-
-// [1] This combination allows the fieldset border to go around the legend, instead of through it.
 
 .ams-field-set__legend {
   color: var(--ams-field-set-legend-color);
@@ -42,11 +40,14 @@
   font-size: var(--ams-field-set-legend-font-size);
   font-weight: var(--ams-field-set-legend-font-weight);
   line-height: var(--ams-field-set-legend-line-height);
-  margin-block-end: var(
-    --ams-field-set-legend-margin-block-end
-  ); /* Because of a bug in Chrome we can’t use display grid or flex for this gap */
+  margin-block-end: var(--ams-field-set-legend-margin-block-end); // [3]
+  text-wrap: var(--ams-field-set-legend-text-wrap);
 
   @include hyphenation;
   @include text-rendering;
   @include reset-legend;
 }
+
+// [1] This combination allows the fieldset border to go around the legend, instead of through it.
+// [2] Reset the applied float for the legend’s first sibling.
+// [3] We can’t use grid or flex display and a gap because of a bug in Chrome.

--- a/packages/css/src/components/header/header.scss
+++ b/packages/css/src/components/header/header.scss
@@ -49,6 +49,7 @@
   font-size: var(--ams-header-brand-name-font-size);
   font-weight: var(--ams-header-brand-name-font-weight);
   line-height: 1.35;
+  text-wrap: var(--ams-header-brand-name-text-wrap);
 }
 
 .ams-header__navigation {

--- a/packages/css/src/components/heading/heading.scss
+++ b/packages/css/src/components/heading/heading.scss
@@ -17,6 +17,7 @@
   color: var(--ams-heading-color);
   font-family: var(--ams-heading-font-family);
   font-weight: var(--ams-heading-font-weight);
+  text-wrap: var(--ams-heading-text-wrap);
 
   @include hyphenation;
   @include text-rendering;

--- a/packages/css/src/components/label/label.scss
+++ b/packages/css/src/components/label/label.scss
@@ -12,6 +12,7 @@
   font-size: var(--ams-label-font-size);
   font-weight: var(--ams-label-font-weight);
   line-height: var(--ams-label-line-height);
+  text-wrap: var(--ams-label-text-wrap);
 
   @include hyphenation;
   @include text-rendering;

--- a/packages/css/src/components/page-heading/page-heading.scss
+++ b/packages/css/src/components/page-heading/page-heading.scss
@@ -19,6 +19,7 @@
   font-size: var(--ams-page-heading-font-size);
   font-weight: var(--ams-page-heading-font-weight);
   line-height: var(--ams-page-heading-line-height);
+  text-wrap: var(--ams-page-heading-text-wrap);
 
   @include hyphenation;
   @include text-rendering;

--- a/packages/css/src/components/top-task-link/top-task-link.scss
+++ b/packages/css/src/components/top-task-link/top-task-link.scss
@@ -28,6 +28,7 @@
   text-decoration-line: var(--ams-top-task-link-label-text-decoration-line);
   text-decoration-thickness: var(--ams-top-task-link-label-text-decoration-thickness);
   text-underline-offset: var(--ams-top-task-link-label-text-underline-offset);
+  text-wrap: var(--ams-top-task-link-label-text-wrap);
 }
 
 .ams-top-task-link:hover .ams-top-task-link__label {

--- a/proprietary/tokens/src/brand/ams/typography.tokens.json
+++ b/proprietary/tokens/src/brand/ams/typography.tokens.json
@@ -25,6 +25,7 @@
       },
       "heading": {
         "font-weight": { "value": "800" },
+        "text-wrap": { "value": "balance" },
         "0": {
           "font-size": { "value": "clamp(2.4316rem, calc(1.8951rem + 2.6826vw), 4.5776rem)" },
           "line-height": { "value": "1.1386" }

--- a/proprietary/tokens/src/components/ams/accordion.tokens.json
+++ b/proprietary/tokens/src/components/ams/accordion.tokens.json
@@ -13,6 +13,7 @@
         "outline-offset": { "value": "{ams.focus.outline-offset}" },
         "padding-block": { "value": "{ams.space.s}" },
         "padding-inline": { "value": "0" },
+        "text-wrap": { "value": "{ams.typography.heading.text-wrap}" },
         "hover": {
           "color": { "value": "{ams.color.interactive.hover}" }
         }

--- a/proprietary/tokens/src/components/ams/field-set.tokens.json
+++ b/proprietary/tokens/src/components/ams/field-set.tokens.json
@@ -11,7 +11,8 @@
         "font-size": { "value": "{ams.typography.heading.4.font-size}" },
         "font-weight": { "value": "{ams.typography.heading.font-weight}" },
         "line-height": { "value": "{ams.typography.heading.4.line-height}" },
-        "margin-block-end": { "value": "{ams.space.m}" }
+        "margin-block-end": { "value": "{ams.space.m}" },
+        "text-wrap": { "value": "{ams.typography.heading.text-wrap}" }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/header.tokens.json
+++ b/proprietary/tokens/src/components/ams/header.tokens.json
@@ -14,7 +14,8 @@
       "brand-name": {
         "color": { "value": "{ams.color.text.default}" },
         "font-size": { "value": "{ams.typography.heading.4.font-size}" },
-        "font-weight": { "value": "{ams.typography.heading.font-weight}" }
+        "font-weight": { "value": "{ams.typography.heading.font-weight}" },
+        "text-wrap": { "value": "{ams.typography.heading.text-wrap}" }
       },
       "mega-menu": {
         "button": {

--- a/proprietary/tokens/src/components/ams/heading.tokens.json
+++ b/proprietary/tokens/src/components/ams/heading.tokens.json
@@ -4,6 +4,7 @@
       "color": { "value": "{ams.color.text.default}" },
       "font-family": { "value": "{ams.typography.font-family}" },
       "font-weight": { "value": "{ams.typography.heading.font-weight}" },
+      "text-wrap": { "value": "{ams.typography.heading.text-wrap}" },
       "inverse": {
         "color": { "value": "{ams.color.text.inverse}" }
       },

--- a/proprietary/tokens/src/components/ams/label.tokens.json
+++ b/proprietary/tokens/src/components/ams/label.tokens.json
@@ -5,7 +5,8 @@
       "font-family": { "value": "{ams.typography.font-family}" },
       "font-size": { "value": "{ams.typography.heading.4.font-size}" },
       "font-weight": { "value": "{ams.typography.heading.font-weight}" },
-      "line-height": { "value": "{ams.typography.heading.4.line-height}" }
+      "line-height": { "value": "{ams.typography.heading.4.line-height}" },
+      "text-wrap": { "value": "{ams.typography.heading.text-wrap}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/ams/page-heading.tokens.json
+++ b/proprietary/tokens/src/components/ams/page-heading.tokens.json
@@ -8,7 +8,8 @@
       "line-height": { "value": "{ams.typography.heading.0.line-height}" },
       "inverse": {
         "color": { "value": "{ams.color.text.inverse}" }
-      }
+      },
+      "text-wrap": { "value": "{ams.typography.heading.text-wrap}" }
     }
   }
 }

--- a/proprietary/tokens/src/components/ams/top-task-link.tokens.json
+++ b/proprietary/tokens/src/components/ams/top-task-link.tokens.json
@@ -18,6 +18,7 @@
         "text-decoration-line": { "value": "{ams.links.subtle.text-decoration-line}" },
         "text-decoration-thickness": { "value": "{ams.links.text-decoration-thickness}" },
         "text-underline-offset": { "value": "{ams.links.text-underline-offset}" },
+        "text-wrap": { "value": "{ams.typography.heading.text-wrap}" },
         "hover": {
           "color": { "value": "{ams.links.hover.color}" },
           "text-decoration-line": { "value": "{ams.links.subtle.hover.text-decoration-line}" }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Balances the length of multiple lines in Headings.

## Why

To make them easier to read and visually more pleasing.

## How

Created a brand token for `text-wrap` and applied it to all heading-like components. I looked for components that use `ams.typography.heading.*` tokens already.

To see the difference, comparing the ‘All sizes’ example of Heading between this branch and the live site is a good start. Check the page templates as well: Home Page, Article Page, Form Page.

- [All heading sizes on production](https://designsystem.amsterdam/demo-DES-1192-link-color-on-background/?path=/story/components-text-heading--sizes), without balanced text wrapping
- All heading sizes on this branch, with balanced text wrapping

Notice how the first example makes the first line(s) of text as long as possible, making its last line often (much) shorter. In the second example, the browser gives each line of text a similar length.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- I skipped the Table of Contents; there’s a bunch of unused tokens there that I will delete in a separate PR.