### PR TITLE
feat(Card)!: Replace gap with block-end margins in Card

### DIFF
--- a/packages/css/src/components/card/card.scss
+++ b/packages/css/src/components/card/card.scss
@@ -5,7 +5,6 @@
 
 .ams-card {
   display: grid;
-  gap: var(--ams-card-gap);
   outline-offset: var(--ams-card-outline-offset);
   position: relative; // Allows stretching the card link below.
   touch-action: manipulation;
@@ -16,12 +15,24 @@
     outline-style: auto;
     outline-width: 0.0625rem;
   }
+
+  & > .ams-heading:has(+ *) {
+    margin-block-end: var(--ams-space-s);
+  }
+
+  & > .ams-image:has(+ *) {
+    margin-block-end: var(--ams-space-s);
+  }
 }
 
 .ams-card__heading-group {
   display: flex;
   flex-direction: column-reverse;
   gap: var(--ams-card-heading-group-gap);
+
+  &:has(+ *) {
+    margin-block-end: var(--ams-space-s);
+  }
 }
 
 .ams-card__link {

--- a/storybook/src/components/Card/Card.stories.tsx
+++ b/storybook/src/components/Card/Card.stories.tsx
@@ -3,7 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { Heading, Image, Paragraph } from '@amsterdam/design-system-react'
+import { Column, Heading, Image, Paragraph } from '@amsterdam/design-system-react'
 import { Card } from '@amsterdam/design-system-react/src'
 import { Meta, StoryObj } from '@storybook/react'
 import { exampleTopTask } from '../shared/exampleContent'
@@ -68,12 +68,12 @@ export const WithImage: Story = {
           <Card.Link href="/">Nederlands eerste houten woonwijk komt in Zuidoost</Card.Link>
         </Heading>
       </Card.HeadingGroup>,
-      <Paragraph key={3}>
-        We bouwen een levendige, groene en duurzame woonbuurt tussen de Gooiseweg en het Nelson Mandelapark.
-      </Paragraph>,
-      <Paragraph key={4} size="small">
-        {today}
-      </Paragraph>,
+      <Column gap="small" key={3}>
+        <Paragraph>
+          We bouwen een levendige, groene en duurzame woonbuurt tussen de Gooiseweg en het Nelson Mandelapark.
+        </Paragraph>
+        <Paragraph size="small">{today}</Paragraph>
+      </Column>,
     ],
   },
 }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

In Cards, replace blanket gaps with margins at the end of the block (i.e. `margin-bottom`) it's common and direct child elements such as the Card Heading (Group) or a Card Image.

## Why

We want to leave it up to the developer to decide on what vertical spacing to use in the body of the Card, but give some standard spacing on some of the common Card children.

## How

Remove `gap` from `.ams-card` and add `margin-block-end` to the aforementioned children via `.has(+ *)` selectors.

Also update stories to make multiple children in the body look as much as possible as before.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Should we add documentation on how to deal with vertical spacing in the Card? Such as possible overrides or using a layout component like Column?
- Add a link to the specific story in the feature branch deploy.
