### PR TITLE
feat(Dialog): Decrease amount of inside and outside spacing

### DIFF
--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -26,6 +26,16 @@ so do not apply these styles without an `open` attribute. */
 
   @include reset-dialog;
 
+  @media screen and (min-width: $ams-breakpoint-medium) {
+    inline-size: var(--ams-dialog-medium-inline-size);
+    max-block-size: var(--ams-dialog-medium-max-block-size);
+  }
+
+  @media screen and (min-width: $ams-breakpoint-wide) {
+    inline-size: var(--ams-dialog-wide-inline-size);
+    max-block-size: var(--ams-dialog-wide-max-block-size);
+  }
+
   /*
    * The fallback value is for browsers where ::backdrop does not inherit from its originating element.
    * @see https://caniuse.com/mdn-css_selectors_backdrop_inherit_from_originating_element

--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -3,6 +3,8 @@
  * Copyright Gemeente Amsterdam
  */
 
+@use "../../common/breakpoint" as *;
+
 @mixin reset-dialog {
   inset-block: 0;
   padding-block: 0;
@@ -40,6 +42,14 @@ so do not apply these styles without an `open` attribute. */
   justify-content: space-between;
   padding-block: var(--ams-dialog-header-padding-block);
   padding-inline: var(--ams-dialog-header-padding-inline);
+
+  @media screen and (min-width: $ams-breakpoint-medium) {
+    padding-inline: var(--ams-dialog-header-medium-padding-inline);
+  }
+
+  @media screen and (min-width: $ams-breakpoint-wide) {
+    padding-inline: var(--ams-dialog-header-wide-padding-inline);
+  }
 }
 
 .ams-dialog__body {
@@ -47,9 +57,25 @@ so do not apply these styles without an `open` attribute. */
   overscroll-behavior-y: contain;
   padding-block: var(--ams-dialog-body-padding-block);
   padding-inline: var(--ams-dialog-body-padding-inline);
+
+  @media screen and (min-width: $ams-breakpoint-medium) {
+    padding-inline: var(--ams-dialog-body-medium-padding-inline);
+  }
+
+  @media screen and (min-width: $ams-breakpoint-wide) {
+    padding-inline: var(--ams-dialog-body-wide-padding-inline);
+  }
 }
 
 .ams-dialog__footer {
   padding-block: var(--ams-dialog-footer-padding-block);
   padding-inline: var(--ams-dialog-footer-padding-inline);
+
+  @media screen and (min-width: $ams-breakpoint-medium) {
+    padding-inline: var(--ams-dialog-footer-medium-padding-inline);
+  }
+
+  @media screen and (min-width: $ams-breakpoint-wide) {
+    padding-inline: var(--ams-dialog-footer-wide-padding-inline);
+  }
 }

--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -44,10 +44,12 @@ so do not apply these styles without an `open` attribute. */
   padding-inline: var(--ams-dialog-header-padding-inline);
 
   @media screen and (min-width: $ams-breakpoint-medium) {
+    padding-block: var(--ams-dialog-header-medium-padding-block);
     padding-inline: var(--ams-dialog-header-medium-padding-inline);
   }
 
   @media screen and (min-width: $ams-breakpoint-wide) {
+    padding-block: var(--ams-dialog-header-wide-padding-block);
     padding-inline: var(--ams-dialog-header-wide-padding-inline);
   }
 }
@@ -72,10 +74,12 @@ so do not apply these styles without an `open` attribute. */
   padding-inline: var(--ams-dialog-footer-padding-inline);
 
   @media screen and (min-width: $ams-breakpoint-medium) {
+    padding-block: var(--ams-dialog-footer-medium-padding-block);
     padding-inline: var(--ams-dialog-footer-medium-padding-inline);
   }
 
   @media screen and (min-width: $ams-breakpoint-wide) {
+    padding-block: var(--ams-dialog-footer-wide-padding-block);
     padding-inline: var(--ams-dialog-footer-wide-padding-inline);
   }
 }

--- a/proprietary/tokens/src/components/ams/dialog.tokens.json
+++ b/proprietary/tokens/src/components/ams/dialog.tokens.json
@@ -13,15 +13,32 @@
       "header": {
         "gap": { "value": "{ams.space.m}" },
         "padding-block": { "value": "{ams.space.xl} 0" },
-        "padding-inline": { "value": "{ams.space.2xl}" }
+        "padding-inline": { "value": "{ams.space.l}" },
+        "medium": {
+          "padding-inline": { "value": "{ams.space.xl}" }
+        },
+        "wide": {
+          "padding-inline": { "value": "{ams.space.xl}" }
+        }
       },
       "body": {
         "padding-block": { "value": "0" },
-        "padding-inline": { "value": "{ams.space.2xl}" }
+        "padding-inline": { "value": "{ams.space.l}" },
+        "medium": {
+          "padding-inline": { "value": "{ams.space.xl}" }
+        },
+        "wide": {
+          "padding-inline": { "value": "{ams.space.xl}" }
+        }
       },
       "footer": {
-        "padding-block": { "value": "0 {ams.space.xl}" },
-        "padding-inline": { "value": "{ams.space.2xl}" }
+        "padding-inline": { "value": "{ams.space.l}" },
+        "medium": {
+          "padding-inline": { "value": "{ams.space.xl}" }
+        },
+        "wide": {
+          "padding-inline": { "value": "{ams.space.xl}" }
+        }
       }
     }
   }

--- a/proprietary/tokens/src/components/ams/dialog.tokens.json
+++ b/proprietary/tokens/src/components/ams/dialog.tokens.json
@@ -12,12 +12,14 @@
       },
       "header": {
         "gap": { "value": "{ams.space.m}" },
-        "padding-block": { "value": "{ams.space.xl} 0" },
+        "padding-block": { "value": "{ams.space.l} 0" },
         "padding-inline": { "value": "{ams.space.l}" },
         "medium": {
+          "padding-block": { "value": "{ams.space.xl} 0" },
           "padding-inline": { "value": "{ams.space.xl}" }
         },
         "wide": {
+          "padding-block": { "value": "{ams.space.xl} 0" },
           "padding-inline": { "value": "{ams.space.xl}" }
         }
       },
@@ -32,11 +34,14 @@
         }
       },
       "footer": {
+        "padding-block": { "value": "0 {ams.space.l}" },
         "padding-inline": { "value": "{ams.space.l}" },
         "medium": {
+          "padding-block": { "value": "0 {ams.space.xl}" },
           "padding-inline": { "value": "{ams.space.xl}" }
         },
         "wide": {
+          "padding-block": { "value": "0 {ams.space.xl}" },
           "padding-inline": { "value": "{ams.space.xl}" }
         }
       }

--- a/proprietary/tokens/src/components/ams/dialog.tokens.json
+++ b/proprietary/tokens/src/components/ams/dialog.tokens.json
@@ -4,9 +4,17 @@
       "background-color": { "value": "{ams.color.background}" },
       "border": { "value": "{ams.border.width.m} solid {ams.dialog.background-color}" },
       "gap": { "value": "{ams.space.m}" },
-      "inline-size": { "value": "calc(100% - 2 * {ams.space.xl})" },
-      "max-block-size": { "value": "calc(100dvh - 2 * {ams.space.xl})" },
+      "inline-size": { "value": "calc(100% - 2 * {ams.space.l})" },
+      "max-block-size": { "value": "calc(100dvh - 2 * {ams.space.l})" },
       "max-inline-size": { "value": "48rem" },
+      "medium": {
+        "inline-size": { "value": "calc(100% - 2 * {ams.space.xl})" },
+        "max-block-size": { "value": "calc(100dvh - 2 * {ams.space.xl})" }
+      },
+      "wide": {
+        "inline-size": { "value": "calc(100% - 2 * {ams.space.xl})" },
+        "max-block-size": { "value": "calc(100dvh - 2 * {ams.space.xl})" }
+      },
       "backdrop": {
         "background-color": { "value": "rgb(24 24 24 / 62.5%)" }
       },


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Decreases all whitespace inside and outside a Dialog to:
- `large` on narrow windows
- `x-large` on medium and  wide windows

Previously, for all window sizes:
- Horizontal padding was `x-large`
- Vertical padding was `large`
- Horizontal and vertical margins were `x-large`

## Why

1. To save space on small screens
2. To make whitespace at the corners square; rectangular space seemed to misalign the title and buttons.

## How

Add tokens and apply them with breakpoints.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Can we use a margin on `dialog` instead of subtracting space from the maximum width and height? This would simplify both tokens and styles. It does break our rule that components don’t manage their outer whitespace – but that’s to prevent collapsing or duplication margins, both of which won’t happen with a Dialog.
- We should updated these spacing values in Figma, too.