### PR TITLE
fix(Icon): Center align SVG

### DIFF
--- a/packages/css/src/components/icon/icon.scss
+++ b/packages/css/src/components/icon/icon.scss
@@ -6,8 +6,9 @@
 .ams-icon {
   --ams-line-height: var(--ams-icon-line-height);
 
+  align-items: center;
   align-self: baseline; // Aligns the icon with text in flex or grid context
-  display: inline-flex; // Stretches the svg in order to align the icon vertically
+  display: inline-flex;
   font-size: var(--ams-icon-font-size);
   line-height: var(--ams-line-height);
 


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Center align SVG in Icon.

## Why

This did not always happen. It worked for Icon in a Button and in Link List, but not in a Pagination link.
We're not sure why, but `align-items: center` fixes the problem and makes the alignment more explicit. 

## How

Adding a CSS rule. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

