### PR TITLE
chore: Shorten placeholder in Search Field examples

### DIFF
--- a/storybook/src/components/Overlap/Overlap.stories.tsx
+++ b/storybook/src/components/Overlap/Overlap.stories.tsx
@@ -30,7 +30,7 @@ export const Default: Story = {
       <Grid key={2} style={{ alignSelf: 'center' }}>
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 8 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           <SearchField onSubmit={(e) => e.preventDefault()}>
-            <SearchField.Input label="Zoeken" placeholder="Wat kunnen we voor u vinden?" />
+            <SearchField.Input label="Zoeken" placeholder="Zoeken…" />
             <SearchField.Button />
           </SearchField>
         </Grid.Cell>

--- a/storybook/src/components/SearchField/SearchField.stories.tsx
+++ b/storybook/src/components/SearchField/SearchField.stories.tsx
@@ -52,7 +52,7 @@ export const Default: Story = {}
 
 export const WithPlaceholder: Story = {
   args: {
-    placeholder: 'Wat kunnen we voor u vinden?',
+    placeholder: 'Zoeken…',
   },
 }
 


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Replaces the ‘Wat kunnen we voor u vinden?’ placeholder in our examples for Search Field with ‘Zoeken…’.

## Why

Because it doesn’t fit the input in narrow windows.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- See comment