### PR TITLE
feat(Page Header): Add vertical space around collapsible menu

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/page-header.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/page-header.tokens.json
@@ -24,6 +24,7 @@
         "text-wrap": { "value": "{ams.typography.heading.text-wrap}" }
       },
       "mega-menu": {
+        "padding-block": { "value": "{ams.space.xl}" },
         "button": {
           "cursor": { "value": "{ams.cursor.interactive}" },
           "label": {

--- a/packages/css/src/components/page-header/README.md
+++ b/packages/css/src/components/page-header/README.md
@@ -8,16 +8,16 @@ Includes the name of the application if it is not the general website.
 ## Design
 
 - The Page Header includes the logo of the City or the organization, the site title (except for the general website), and a menu with links to commonly used pages.
-- An optional 'Menu' button opens a collapsible menu, which has room for more links.
+- An optional ‘Menu’ button opens a collapsible menu, which has room for more links.
 - On narrow windows, links can move from the inline menu to the collapsible one.
 - For websites with a brand name that feature the standard Amsterdam logo, only the emblem is shown on narrow screens.
 
 ## Guidelines
 
 - The Page Header must be used on all websites and applications for the City of Amsterdam.
-- The Page Header is important because it conveys our corporate identity and is the first thing people see.
-  Using it consistently helps users recognize and trust the website.
-- The Page Header is the same on every page of the application, although full-screen pages may hide it, e.g. a video or a map.
+  It’s often the first thing people perceive.
+  As it conveys our corporate identity, using it consistently helps users recognize and trust the website.
+- The Page Header should be the same on every page, although full-screen pages may hide it, e.g. a video or a map.
 - The inline menu can contain a maximum of 5 items.
   The last two will often be ‘Search’ and ‘Menu’.
 - Labels should be short to help the inline menu fit on a single line whenever possible.

--- a/packages/css/src/components/page-header/README.md
+++ b/packages/css/src/components/page-header/README.md
@@ -5,20 +5,23 @@
 Displays the City’s logo at the top of every page, and optionally a navigation menu.
 Includes the name of the application if it is not the general website.
 
+## Design
+
+- The Page Header includes the logo of the City or the organization, the site title (except for the general website), and a menu with links to commonly used pages.
+- An optional 'Menu' button opens a collapsible menu, which has room for more links.
+- On narrow windows, links can move from the inline menu to the collapsible one.
+- For websites with a brand name that feature the standard Amsterdam logo, only the emblem is shown on narrow screens.
+
 ## Guidelines
 
 - The Page Header must be used on all websites and applications for the City of Amsterdam.
-- It includes the logo of the City or the organization, the site title (except for the general website), and a menu with links to commonly used pages.
 - The Page Header is important because it conveys our corporate identity and is the first thing people see.
   Using it consistently helps users recognize and trust the website.
 - The Page Header is the same on every page of the application, although full-screen pages may hide it, e.g. a video or a map.
 - The inline menu can contain a maximum of 5 items.
   The last two will often be ‘Search’ and ‘Menu’.
-- The 'Menu' button opens a collapsible menu, which has room for more links.
-- On narrow windows, links can move from the inline menu to the collapsible one.
 - Labels should be short to help the inline menu fit on a single line whenever possible.
 - An icon can be added to the end of a link to make its destination easier to guess.
-- For websites with a brand name that feature the standard Amsterdam logo, only the emblem is shown on narrow screens.
 
 ## References
 

--- a/packages/css/src/components/page-header/README.md
+++ b/packages/css/src/components/page-header/README.md
@@ -22,6 +22,10 @@ Includes the name of the application if it is not the general website.
   The last two will often be ‘Search’ and ‘Menu’.
 - Labels should be short to help the inline menu fit on a single line whenever possible.
 - An icon can be added to the end of a link to make its destination easier to guess.
+- Wrap the collapsible menu in a [Grid](/docs/components-layout-grid--docs).
+  Don’t set its padding props – Page Header adds the correct space above and below.
+- If the collapsible menu contains a list that spans multiple columns, make sure not to split the items over multiple Link Lists.
+  This will confuse users of assistive software.
 
 ## References
 

--- a/packages/css/src/components/page-header/page-header.scss
+++ b/packages/css/src/components/page-header/page-header.scss
@@ -217,6 +217,7 @@
 
 .ams-page-header__mega-menu {
   inline-size: 100%;
+  padding-block: var(--ams-page-header-mega-menu-padding-block);
   pointer-events: auto; // Set pointer events back to auto to allow the mega menu to be activated
 
   // Remove inline padding from Grids that are used in the mega menu.

--- a/storybook/src/components/Header/PageHeader.stories.tsx
+++ b/storybook/src/components/Header/PageHeader.stories.tsx
@@ -10,6 +10,9 @@ import { Meta, StoryObj } from '@storybook/react'
 const meta = {
   title: 'Components/Containers/Page Header',
   component: PageHeader,
+  parameters: {
+    layout: 'fullscreen',
+  },
 } satisfies Meta<typeof PageHeader>
 
 export default meta

--- a/storybook/src/components/Header/PageHeader.stories.tsx
+++ b/storybook/src/components/Header/PageHeader.stories.tsx
@@ -42,7 +42,7 @@ export const Default: Story = {
   args: {
     brandName: 'Data Amsterdam',
     children: (
-      <Grid paddingBottom="large">
+      <Grid>
         <PageHeader.GridCellNarrowWindowOnly span="all">
           <LinkList>
             <LinkList.Link href="#" lang="en">
@@ -102,7 +102,7 @@ export const Default: Story = {
 export const WithMovingLinks: Story = {
   args: {
     children: (
-      <Grid gapVertical="small" paddingBottom="large">
+      <Grid>
         <PageHeader.GridCellNarrowWindowOnly span="all">
           <LinkList>
             <LinkList.Link href="#" lang="en">

--- a/storybook/src/components/PageFooter/PageFooter.stories.tsx
+++ b/storybook/src/components/PageFooter/PageFooter.stories.tsx
@@ -19,6 +19,9 @@ import { Meta, StoryObj } from '@storybook/react'
 const meta = {
   title: 'Components/Containers/Page Footer',
   component: PageFooter,
+  parameters: {
+    layout: 'fullscreen',
+  },
 } satisfies Meta<typeof PageFooter>
 
 export default meta

--- a/storybook/src/pages/amsterdam/common/AppHeader.tsx
+++ b/storybook/src/pages/amsterdam/common/AppHeader.tsx
@@ -9,7 +9,7 @@ export const AppHeader = () => (
       </PageHeader.MenuLink>
     ))}
   >
-    <Grid paddingBottom="large" paddingTop="small">
+    <Grid>
       <PageHeader.GridCellNarrowWindowOnly span="all">
         <LinkList>
           {pageHeaderMenuLinks


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

1. Adds XL vertical space at the top and bottom of the mega menu container.
2. Updates our examples to indicate a Grid child no longer needs to set padding.
3. Separates describing design choices from prescribing guidelines in the docs.
4. Explains how to use a Grid in the collapsible menu.

## Why

1. Otherwise, all our uses would need to configure this whitespace themselves.
2. To update our examples for the change to the Page Header component.
3. To clarify.
4. To help people lay out the collapsible menu and to prevent accessibility problems.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a