### PR TITLE
chore(dev-deps): Update rollup-plugin-node-externals to v8.0.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -67,7 +67,7 @@
     "rollup": "4.39.0",
     "rollup-plugin-dts": "6.2.1",
     "rollup-plugin-filesize": "10.0.0",
-    "rollup-plugin-node-externals": "7.1.3",
+    "rollup-plugin-node-externals": "8.0.0",
     "rollup-plugin-node-polyfills": "0.2.1",
     "rollup-plugin-peer-deps-external": "2.2.4",
     "rollup-plugin-typescript2": "0.36.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,8 +274,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0
       rollup-plugin-node-externals:
-        specifier: 7.1.3
-        version: 7.1.3(rollup@4.39.0)
+        specifier: 8.0.0
+        version: 8.0.0(rollup@4.39.0)
       rollup-plugin-node-polyfills:
         specifier: 0.2.1
         version: 0.2.1
@@ -6103,11 +6103,11 @@ packages:
     resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
 
-  rollup-plugin-node-externals@7.1.3:
-    resolution: {integrity: sha512-RM+7tJAejAoRsCf93TptTSdqUhRA8S78DleihMiu54Kac+uLkd9VIegLPhGnaW3ehZTXh56+R301mFH6j2A7vw==}
+  rollup-plugin-node-externals@8.0.0:
+    resolution: {integrity: sha512-2HIOpWsWn5DqBoYl6iCAmB4kd5GoGbF68PR4xKR1YBPvywiqjtYvDEjHFodyqRL51iAMDITP074Zxs0OKs6F+g==}
     engines: {node: '>= 21 || ^20.6.0 || ^18.19.0'}
     peerDependencies:
-      rollup: ^3.0.0 || ^4.0.0
+      rollup: ^4.0.0
 
   rollup-plugin-node-polyfills@0.2.1:
     resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
@@ -14093,7 +14093,7 @@ snapshots:
       magic-string: 0.25.9
       rollup-pluginutils: 2.8.2
 
-  rollup-plugin-node-externals@7.1.3(rollup@4.39.0):
+  rollup-plugin-node-externals@8.0.0(rollup@4.39.0):
     dependencies:
       rollup: 4.39.0
 


### PR DESCRIPTION
I checked if we had major upgrades available, and this was the only one besides React 19, and it’s not breaking for us.