### PR TITLE
chore(docs): Fix tuple type for icon sizes prop

### DIFF
--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -10,7 +10,6 @@ import type { ForwardedRef, HTMLAttributes } from 'react'
 import { Icon } from '../Icon'
 
 export const avatarColors = ['azure', 'green', 'lime', 'magenta', 'orange', 'yellow'] as const
-
 type AvatarColor = (typeof avatarColors)[number]
 
 type AvatarContentProps = {

--- a/packages/react/src/Badge/Badge.tsx
+++ b/packages/react/src/Badge/Badge.tsx
@@ -8,7 +8,6 @@ import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes } from 'react'
 
 export const badgeColors = ['azure', 'lime', 'magenta', 'orange', 'purple', 'red', 'yellow'] as const
-
 type BadgeColor = (typeof badgeColors)[number]
 
 export type BadgeProps = {

--- a/packages/react/src/DateInput/DateInput.tsx
+++ b/packages/react/src/DateInput/DateInput.tsx
@@ -8,7 +8,6 @@ import { forwardRef } from 'react'
 import type { ForwardedRef, InputHTMLAttributes } from 'react'
 
 export const dateInputTypes = ['date', 'datetime-local'] as const
-
 type DateInputType = (typeof dateInputTypes)[number]
 
 export type DateInputProps = {

--- a/packages/react/src/Icon/Icon.tsx
+++ b/packages/react/src/Icon/Icon.tsx
@@ -9,7 +9,7 @@ import clsx from 'clsx'
 import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes, ReactNode } from 'react'
 
-export const iconSizes = ['small', 'large', 'heading-3', 'heading-4', 'heading-5', 'heading-6']
+export const iconSizes = ['small', 'large', 'heading-3', 'heading-4', 'heading-5', 'heading-6'] as const
 
 type IconSize = (typeof iconSizes)[number]
 

--- a/packages/react/src/Icon/Icon.tsx
+++ b/packages/react/src/Icon/Icon.tsx
@@ -10,7 +10,6 @@ import { forwardRef } from 'react'
 import type { ForwardedRef, HTMLAttributes, ReactNode } from 'react'
 
 export const iconSizes = ['small', 'large', 'heading-3', 'heading-4', 'heading-5', 'heading-6'] as const
-
 type IconSize = (typeof iconSizes)[number]
 
 export type IconProps = {

--- a/packages/react/src/TextInput/TextInput.tsx
+++ b/packages/react/src/TextInput/TextInput.tsx
@@ -8,7 +8,6 @@ import { forwardRef } from 'react'
 import type { ForwardedRef, InputHTMLAttributes } from 'react'
 
 export const textInputTypes = ['email', 'tel', 'text', 'url'] as const
-
 type TextInputType = (typeof textInputTypes)[number]
 
 export type TextInputProps = {


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

We forgot the `as const` piece for the icon sizes array that defines the related prop.

## Why

Restoring it lets TypeScript treat the array as a tuple with literal types instead of just an array of strings. This improves type checking and displays each of the options in the Storybook Controls.

When checking all the instances, I found some of them have an empty line between them, while most don’t. I deleted these.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a