### PR TITLE
feat(Link)!: Remove ‘variant’ prop

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/link.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/link.tokens.json
@@ -2,36 +2,17 @@
   "ams": {
     "link": {
       "color": { "value": "{ams.links.color}" },
-      "font-family": { "value": "{ams.typography.font-family}" },
+      "font-family": { "value": "inherit" },
+      "font-size": { "value": "inherit" },
       "font-weight": { "value": "{ams.typography.body-text.font-weight}" },
+      "line-height": { "value": "inherit" },
       "outline-offset": { "value": "{ams.focus.outline-offset}" },
+      "text-decoration-thickness": { "value": "{ams.links.text-decoration-thickness}" },
+      "text-underline-offset": { "value": "{ams.links.text-underline-offset}" },
       "hover": {
-        "color": { "value": "{ams.links.hover.color}" }
-      },
-      "inline": {
-        "text-decoration-thickness": { "value": "{ams.links.text-decoration-thickness}" },
-        "text-underline-offset": { "value": "{ams.links.text-underline-offset}" },
-        "font-family": { "value": "inherit" },
-        "font-size": { "value": "inherit" },
-        "line-height": { "value": "inherit" },
-        "hover": {
-          "text-decoration-thickness": {
-            "value": "{ams.links.hover.text-decoration-thickness}"
-          },
-          "text-underline-offset": { "value": "{ams.links.hover.text-underline-offset}" }
-        }
-      },
-      "standalone": {
-        "font-size": { "value": "{ams.typography.body-text.font-size}" },
-        "line-height": { "value": "{ams.typography.body-text.line-height}" },
-        "text-decoration-thickness": { "value": "{ams.links.text-decoration-thickness}" },
-        "text-underline-offset": { "value": "{ams.links.text-underline-offset}" },
-        "hover": {
-          "text-decoration-thickness": {
-            "value": "{ams.links.hover.text-decoration-thickness}"
-          },
-          "text-underline-offset": { "value": "{ams.links.hover.text-underline-offset}" }
-        }
+        "color": { "value": "{ams.links.hover.color}" },
+        "text-decoration-thickness": { "value": "{ams.links.hover.text-decoration-thickness}" },
+        "text-underline-offset": { "value": "{ams.links.hover.text-underline-offset}" }
       },
       "contrast": {
         "color": { "value": "{ams.links.contrast.color}" },

--- a/packages/css/src/components/link/README.md
+++ b/packages/css/src/components/link/README.md
@@ -7,16 +7,16 @@ It is the lightweight variant for navigation.
 
 ## Guidelines
 
-Use a link in the following cases:
-
-- To navigate to another page within the website or application
-- To navigate to another website (see [External links](#external-links))
-- To navigate to an element on the same page
-- To link to emails or phone numbers (start the link with `mailto:` or `tel:`)
-- Wrap 2 or more consecutive buttons and/or links in an [Action Group](https://designsystem.amsterdam/?path=/docs/components-layout-action-group--docs).
-
-A link is a navigation component.
-Use a button instead of a link when an action is desired.
+- Use a link in the following cases:
+  - To navigate to another page within the website or application
+  - To navigate to another website (see [External links](#external-links))
+  - To navigate to an element on the same page
+  - To link to emails or phone numbers (start the link with `mailto:` or `tel:`)
+  - Wrap 2 or more consecutive buttons and/or links in an [Action Group](https://designsystem.amsterdam/?path=/docs/components-layout-action-group--docs).
+- A link is a navigation component.
+  Use a button instead of a link when an action is desired.
+- An icon can be added to links, positioned after the link.
+- Too many links on the same page may confuse the user.
 
 ### External links
 

--- a/packages/css/src/components/link/link.scss
+++ b/packages/css/src/components/link/link.scss
@@ -9,41 +9,19 @@
 .ams-link {
   color: var(--ams-link-color);
   font-family: var(--ams-link-font-family);
+  font-size: var(--ams-link-font-size);
   font-weight: var(--ams-link-font-weight);
+  line-height: var(--ams-link-line-height);
   outline-offset: var(--ams-link-outline-offset);
+  text-decoration-thickness: var(--ams-link-text-decoration-thickness);
+  text-underline-offset: var(--ams-link-text-underline-offset);
 
   @include text-rendering;
 
   &:hover {
     color: var(--ams-link-hover-color);
-  }
-}
-
-.ams-link--standalone {
-  display: inline-block;
-  font-size: var(--ams-link-standalone-font-size);
-  line-height: var(--ams-link-standalone-line-height);
-  text-decoration-thickness: var(--ams-link-standalone-text-decoration-thickness);
-  text-underline-offset: var(--ams-link-standalone-text-underline-offset);
-
-  @include hyphenation;
-
-  &:hover {
-    text-decoration-thickness: var(--ams-link-standalone-hover-text-decoration-thickness);
-    text-underline-offset: var(--ams-link-standalone-hover-text-underline-offset);
-  }
-}
-
-.ams-link--inline {
-  font-family: var(--ams-link-inline-font-family);
-  font-size: var(--ams-link-inline-font-size);
-  line-height: var(--ams-link-inline-line-height);
-  text-decoration-thickness: var(--ams-link-inline-text-decoration-thickness);
-  text-underline-offset: var(--ams-link-inline-text-underline-offset);
-
-  &:hover {
-    text-decoration-thickness: var(--ams-link-inline-hover-text-decoration-thickness);
-    text-underline-offset: var(--ams-link-inline-hover-text-underline-offset);
+    text-decoration-thickness: var(--ams-link-hover-text-decoration-thickness);
+    text-underline-offset: var(--ams-link-hover-text-underline-offset);
   }
 }
 

--- a/packages/react/src/Link/Link.test.tsx
+++ b/packages/react/src/Link/Link.test.tsx
@@ -15,26 +15,6 @@ describe('Link', () => {
     expect(link).toHaveAttribute('href', '#')
   })
 
-  it('renders standalone variant', () => {
-    const { container } = render(<Link href="#">{linktext}</Link>)
-
-    const link = container.querySelector('a:only-child')
-
-    expect(link).toHaveClass('ams-link')
-  })
-
-  it('renders inline variant', () => {
-    const { container } = render(
-      <Link href="#" variant="inline">
-        {linktext}
-      </Link>,
-    )
-
-    const link = container.querySelector('a:only-child')
-
-    expect(link).toHaveClass('ams-link ams-link--inline')
-  })
-
   it('renders an additional class name', () => {
     const { container } = render(<Link className="large" />)
 

--- a/packages/react/src/Link/Link.tsx
+++ b/packages/react/src/Link/Link.tsx
@@ -7,31 +7,14 @@ import clsx from 'clsx'
 import { forwardRef } from 'react'
 import type { AnchorHTMLAttributes, ForwardedRef } from 'react'
 
-type LinkVariant = 'standalone' | 'inline'
-
 export type LinkProps = {
   /** Changes the text colour for readability on a light or dark background. */
   color?: 'contrast' | 'inverse'
-  /** Whether the link is inline or stands alone. */
-  variant?: LinkVariant
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'placeholder'>
 
 export const Link = forwardRef(
-  (
-    { children, className, color, variant = 'standalone', ...restProps }: LinkProps,
-    ref: ForwardedRef<HTMLAnchorElement>,
-  ) => (
-    <a
-      {...restProps}
-      className={clsx(
-        'ams-link',
-        color && `ams-link--${color}`,
-        variant === 'inline' && 'ams-link--inline',
-        variant === 'standalone' && 'ams-link--standalone',
-        className,
-      )}
-      ref={ref}
-    >
+  ({ children, className, color, ...restProps }: LinkProps, ref: ForwardedRef<HTMLAnchorElement>) => (
+    <a {...restProps} className={clsx('ams-link', color && `ams-link--${color}`, className)} ref={ref}>
       {children}
     </a>
   ),

--- a/storybook/src/components/Alert/Alert.stories.tsx
+++ b/storybook/src/components/Alert/Alert.stories.tsx
@@ -88,10 +88,7 @@ export const WithInlineLink: Story = {
     children: (
       <Paragraph>
         Aangepast op 30 april: de werkzaamheden lopen uit tot ten met 31 juli 2025.{' '}
-        <Link href="#" variant="inline">
-          Lees het nieuwsbericht
-        </Link>{' '}
-        voor meer informatie.
+        <Link href="#">Lees het nieuwsbericht</Link> voor meer informatie.
       </Paragraph>
     ),
     heading: 'De werkzaamheden duren langer',

--- a/storybook/src/components/Link/Link.docs.mdx
+++ b/storybook/src/components/Link/Link.docs.mdx
@@ -14,22 +14,6 @@ import README from "../../../../packages/css/src/components/link/README.md?raw";
 
 ## Examples
 
-### Standalone links
-
-Place standalone links directly after a piece of content.
-Don’t use them in sentences or paragraphs.
-They should never have an associated icon.
-
-<Canvas of={LinkStories.Standalone} />
-
-### Inline links
-
-Use inline links within sentences or paragraphs of text.
-An icon can be added to inline links, positioned after the link.
-Don’t use too many inline links on the same page, as it may confuse the user.
-
-<Canvas of={LinkStories.Inline} />
-
 ### On a coloured background
 
 A Link on a coloured background must set [the correct text colour](?path=/docs/brand-design-tokens-colour--docs#pairing-foreground-with-background-colours) to provide enough contrast.

--- a/storybook/src/components/Link/Link.stories.tsx
+++ b/storybook/src/components/Link/Link.stories.tsx
@@ -38,18 +38,13 @@ const meta = {
 
 export default meta
 
-export const Default: Story = {}
-
-export const Standalone: Story = {}
-
-export const Inline: Story = {
+export const Default: Story = {
   args: {
     children: 'typograaf',
-    variant: 'inline',
   },
   decorators: [
-    (Story) => (
-      <Paragraph>
+    (Story, { args }) => (
+      <Paragraph color={args.color === 'inverse' ? 'inverse' : undefined}>
         Jouw <Story /> biedt mij zulke exquise schreven!
       </Paragraph>
     ),


### PR DESCRIPTION
Use `StandaloneLink` for standaline links instead. `Link` is now for inline use only.

# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Removes the `variant` prop from Link.

## Why

We now have a separate Standalone Link component for the `variant="standalone"`. This would make `inline` the only remaining variant for `Link`, which makes the prop obsolete.

## How

Removed the prop, merged the tokens and the styles, checked all examples, ran the tests.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [X] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a