### PR TITLE
fix(Accordion, Tabs): Only allow keyboard focus on relevant buttons

### DIFF
--- a/packages/react/src/Accordion/Accordion.test.tsx
+++ b/packages/react/src/Accordion/Accordion.test.tsx
@@ -1,8 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createRef } from 'react'
 import { Accordion } from './Accordion'
 import '@testing-library/jest-dom'
-import { KeyboardKeys } from '../common/useKeyboardFocus'
 
 describe('Accordion', () => {
   it('renders an accordion', () => {
@@ -22,8 +22,10 @@ describe('Accordion', () => {
     expect(accordion).toHaveClass('test')
   })
 
-  it('sets focus on Accordion buttons when using arrow keys', () => {
-    const { container } = render(
+  it('sets focus on Accordion buttons when using arrow keys', async () => {
+    const user = userEvent.setup()
+
+    render(
       <Accordion headingLevel={1}>
         <Accordion.Section label="one" />
         <Accordion.Section label="two" />
@@ -31,24 +33,23 @@ describe('Accordion', () => {
       </Accordion>,
     )
 
-    const firstChild = container.firstChild as HTMLElement
     const firstButton = screen.getByRole('button', { name: 'one' })
     const thirdButton = screen.getByRole('button', { name: 'three' })
 
-    fireEvent.keyDown(firstChild, {
-      key: KeyboardKeys.ArrowDown,
-    })
+    await user.click(firstButton)
 
     expect(firstButton).toHaveFocus()
 
-    Array.from(Array(2).keys()).forEach(() => {
-      fireEvent.keyDown(firstChild, {
-        key: KeyboardKeys.ArrowDown,
-      })
-    })
+    // Click the down arrow key twice
+    await user.keyboard('{ArrowDown}')
+    await user.keyboard('{ArrowDown}')
 
     expect(thirdButton).toHaveFocus()
     expect(firstButton).not.toHaveFocus()
+
+    await user.keyboard('{ArrowDown}')
+
+    expect(firstButton).toHaveFocus()
   })
 
   it('supports ForwardRef in React', () => {

--- a/packages/react/src/Accordion/Accordion.test.tsx
+++ b/packages/react/src/Accordion/Accordion.test.tsx
@@ -1,7 +1,8 @@
-import { render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { createRef } from 'react'
 import { Accordion } from './Accordion'
 import '@testing-library/jest-dom'
+import { KeyboardKeys } from '../common/useKeyboardFocus'
 
 describe('Accordion', () => {
   it('renders an accordion', () => {
@@ -19,6 +20,35 @@ describe('Accordion', () => {
     const accordion = container.querySelector('.ams-accordion')
 
     expect(accordion).toHaveClass('test')
+  })
+
+  it('sets focus on Accordion buttons when using arrow keys', () => {
+    const { container } = render(
+      <Accordion headingLevel={1}>
+        <Accordion.Section label="one" />
+        <Accordion.Section label="two" />
+        <Accordion.Section label="three" />
+      </Accordion>,
+    )
+
+    const firstChild = container.firstChild as HTMLElement
+    const firstButton = screen.getByRole('button', { name: 'one' })
+    const thirdButton = screen.getByRole('button', { name: 'three' })
+
+    fireEvent.keyDown(firstChild, {
+      key: KeyboardKeys.ArrowDown,
+    })
+
+    expect(firstButton).toHaveFocus()
+
+    Array.from(Array(2).keys()).forEach(() => {
+      fireEvent.keyDown(firstChild, {
+        key: KeyboardKeys.ArrowDown,
+      })
+    })
+
+    expect(thirdButton).toHaveFocus()
+    expect(firstButton).not.toHaveFocus()
   })
 
   it('supports ForwardRef in React', () => {

--- a/packages/react/src/Accordion/Accordion.tsx
+++ b/packages/react/src/Accordion/Accordion.tsx
@@ -29,7 +29,10 @@ const AccordionRoot = forwardRef(
     // use a passed ref if it's there, otherwise use innerRef
     useImperativeHandle(ref, () => innerRef.current as HTMLDivElement)
 
-    const { keyDown } = useKeyboardFocus(innerRef, { rotating: true })
+    const { keyDown } = useKeyboardFocus(innerRef, {
+      focusableElements: ['.ams-accordion__button:not([disabled])'],
+      rotating: true,
+    })
 
     return (
       <AccordionContext.Provider value={{ headingLevel: headingLevel, sectionAs: sectionAs }}>

--- a/packages/react/src/Tabs/Tabs.test.tsx
+++ b/packages/react/src/Tabs/Tabs.test.tsx
@@ -163,4 +163,39 @@ describe('Tabs', () => {
     expect(lastTab).toHaveAttribute('tabindex', '-1')
     expect(screen.getByRole('tabpanel')).toHaveTextContent('Content 1')
   })
+
+  it('sets focus on Tabs buttons when using arrow keys', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Tabs>
+        <Tabs.List>
+          <Tabs.Button tab="one">Tab 1</Tabs.Button>
+          <Tabs.Button tab="two">Tab 2</Tabs.Button>
+          <Tabs.Button tab="three">Tab 3</Tabs.Button>
+        </Tabs.List>
+        <Tabs.Panel tab="one" />
+        <Tabs.Panel tab="two" />
+        <Tabs.Panel tab="three" />
+      </Tabs>,
+    )
+
+    const firstButton = screen.getByRole('tab', { name: 'Tab 1' })
+    const thirdButton = screen.getByRole('tab', { name: 'Tab 3' })
+
+    await user.click(firstButton)
+
+    expect(firstButton).toHaveFocus()
+
+    // Click the right arrow key twice
+    await user.keyboard('{ArrowRight}')
+    await user.keyboard('{ArrowRight}')
+
+    expect(thirdButton).toHaveFocus()
+    expect(firstButton).not.toHaveFocus()
+
+    await user.keyboard('{ArrowRight}')
+
+    expect(firstButton).toHaveFocus()
+  })
 })

--- a/packages/react/src/Tabs/TabsList.tsx
+++ b/packages/react/src/Tabs/TabsList.tsx
@@ -18,7 +18,7 @@ export const TabsList = forwardRef(
     useImperativeHandle(ref, () => innerRef.current as HTMLDivElement)
 
     const { keyDown } = useKeyboardFocus(innerRef, {
-      focusableElements: ['button[role="tab"]'],
+      focusableElements: ['.ams-tabs__button:not([disabled])'],
       horizontally: true,
       rotating: true,
     })


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It removes disabled buttons from the Tabs focusable elements selector, and it adds a specific selector for Accordion. It also adds unit tests to Accordion and Tabs to check if this functionality keeps working.

## Why

When adding a disabled Tabs button, the keyboard focus could not pass it. When adding a regular button to an Accordion Section, it would erroneously receive focus when using the arrow keys. 

## How

Using the class name as selectors, and adding `:not([disabled])`

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
