### PR TITLE
fix(PageHeader): Remove restprops from menu button

### DIFF
--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -101,7 +101,6 @@ const PageHeaderRoot = forwardRef(
                   )}
                 >
                   <button
-                    {...restProps}
                     aria-controls="ams-page-header-mega-menu"
                     aria-expanded={open}
                     className="ams-page-header__mega-menu-button"


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It removes passing `restprops` to the menu button.

## Why

A user mentioned this was a problem. It was probably a copy-paste mistake, the menu button shouldn't receive the `restprops`. 

## How

Delete a line

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
