### PR TITLE
chore: Don’t use inverse colour in example of orange Breakout

### DIFF
--- a/storybook/src/components/Breakout/Breakout.stories.tsx
+++ b/storybook/src/components/Breakout/Breakout.stories.tsx
@@ -70,10 +70,10 @@ export const VerticalLayout: Story = {
         key={3}
         rowStart={3}
       >
-        <Paragraph className="ams-mb-s" color="inverse">
+        <Paragraph className="ams-mb-s">
           Vertel ons in het evenementenformulier wat u wilt gaan doen. U checkt daarmee of u een vergunning nodig hebt.
         </Paragraph>
-        <Paragraph color="inverse">
+        <Paragraph>
           Daarna vraagt u de vergunning aan in hetzelfde formulier. Of doet u een gratis melding of vooraankondiging.
         </Paragraph>
       </Breakout.Cell>,


### PR DESCRIPTION
We use black text on orange backgrounds, not white.