### PR TITLE
fix(Tabs): Do not lose active tab state after rerender

### DIFF
--- a/packages/react/src/Tabs/Tabs.tsx
+++ b/packages/react/src/Tabs/Tabs.tsx
@@ -22,6 +22,7 @@ const TabsRoot = forwardRef(
   ({ activeTab, children, className, onTabChange, ...restProps }: TabsProps, ref: ForwardedRef<HTMLDivElement>) => {
     const [activeTabId, setActiveTabId] = useState<string>()
 
+    // Get all tab ids from TabsButtons on first render
     const allTabIds = useMemo(() => {
       if (!Array.isArray(children)) return []
 
@@ -43,7 +44,7 @@ const TabsRoot = forwardRef(
 
       // If there are no children, return an empty array
       return []
-    }, [children])
+    }, [])
 
     useEffect(() => {
       if (!activeTab) {


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

We received [an issue](https://github.com/Amsterdam/design-system/issues/2008) that the active tab state was lost after a rerender. This fixes that issue. 

## Why

Bugs are bad

## How

`allTabIds` was calculated in a `useMemo` with `children` in its dependency array. The reference to children changes every rerender, so `allTabIds` was calculated every rerender (making `useMemo` kind of useless here). This removes `children` from the dependency array, which means `allTabIds` is only calculated on the first render. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
