### PR TITLE
feat(Tabs): Allow preventing Tabs from switching to different panel

### DIFF
--- a/packages/react/src/Tabs/TabsButton.test.tsx
+++ b/packages/react/src/Tabs/TabsButton.test.tsx
@@ -4,9 +4,11 @@
  */
 
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createRef } from 'react'
 import { TabsButton } from './TabsButton'
 import '@testing-library/jest-dom'
+import { TabsContext } from './TabsContext'
 
 describe('Tabs button', () => {
   it('renders', () => {
@@ -55,6 +57,24 @@ describe('Tabs button', () => {
     const component = screen.getByRole('tab')
 
     expect(component).toHaveAttribute('aria-controls', 'one')
+  })
+
+  it('does not call updateTab if event.preventDefault is invoked', async () => {
+    const user = userEvent.setup()
+    const mockUpdateTab = jest.fn()
+
+    render(
+      <TabsContext.Provider value={{ updateTab: mockUpdateTab }}>
+        <TabsButton aria-controls="one" onClick={(event) => event.preventDefault()}>
+          Label
+        </TabsButton>
+      </TabsContext.Provider>,
+    )
+
+    const button = screen.getByRole('tab', { name: 'Label' })
+    await user.click(button)
+
+    expect(mockUpdateTab).not.toHaveBeenCalled()
   })
 
   it('supports ForwardRef in React', () => {

--- a/packages/react/src/Tabs/TabsButton.tsx
+++ b/packages/react/src/Tabs/TabsButton.tsx
@@ -22,6 +22,10 @@ export const TabsButton = forwardRef(
 
     const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
       onClick?.(event)
+
+      // Allow preventDefault to stop the tab from updating
+      if (event.defaultPrevented) return
+
       startTransition(() => {
         updateTab(ariaControls)
       })

--- a/storybook/src/components/Tabs/Tabs.docs.mdx
+++ b/storybook/src/components/Tabs/Tabs.docs.mdx
@@ -26,3 +26,22 @@ Another tab’s panel can be displayed initially as well.
 The Tab Buttons list and the content within the active Tab Panel will scroll horizontally when their width exceeds the available space.
 
 <Canvas of={TabsStories.WithWideContent} />
+
+### Prevent tabs from changing
+
+The Tab Button `onChange` prop can be used with `event.preventDefault` to stop tabs from changing when clicked.
+This is helpful to keep users from switching tabs until specific conditions are met.
+
+You can use this click handler for example:
+
+```jsx
+const handleClick = (event) => {
+  // eslint-disable-next-line no-alert
+  const confirmLeave = window.confirm("You have unsaved changes. Do you want to leave?");
+  if (!confirmLeave) {
+    event.preventDefault();
+  }
+};
+```
+
+<Canvas of={TabsStories.PreventTabsFromChanging} />

--- a/storybook/src/components/Tabs/Tabs.stories.tsx
+++ b/storybook/src/components/Tabs/Tabs.stories.tsx
@@ -128,3 +128,37 @@ export const WithWideContent: Story = {
     ],
   },
 }
+
+const tabsContentWithoutSlowPanel = tabsContent.filter(({ label }) => label !== 'Documenten')
+
+export const PreventTabsFromChanging: Story = {
+  args: {
+    children: [
+      <Tabs.List key="tabsList">
+        {tabsContentWithoutSlowPanel.map(({ label }) => (
+          <Tabs.Button
+            aria-controls={label}
+            key={label}
+            onClick={(e) => {
+              // eslint-disable-next-line no-alert
+              const confirmLeave = window.confirm('You have unsaved changes. Do you want to leave?')
+              if (!confirmLeave) {
+                e.preventDefault()
+              }
+            }}
+          >
+            {label}
+          </Tabs.Button>
+        ))}
+      </Tabs.List>,
+      tabsContentWithoutSlowPanel.map(({ body, label }) => (
+        <Tabs.Panel id={label} key={label}>
+          <Heading className="ams-mb-xs" level={3}>
+            {label}
+          </Heading>
+          <Paragraph>{body}</Paragraph>
+        </Tabs.Panel>
+      )),
+    ],
+  },
+}


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Allows users to prevent Tabs from switching to different panel.

## Why

This was requested in [this issue](https://github.com/Amsterdam/design-system/issues/1948). It's helpful to keep users from switching tabs if that means they lose form data for example.

## How

Do not fire `updateTab` if `event.defaultPrevented` is true.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
