### PR TITLE
fix(TextInput, PasswordInput): Restore `size` attribute functionality

### DIFF
--- a/packages/css/src/components/password-input/password-input.scss
+++ b/packages/css/src/components/password-input/password-input.scss
@@ -21,8 +21,8 @@
   font-family: var(--ams-password-input-font-family);
   font-size: var(--ams-password-input-font-size);
   font-weight: var(--ams-password-input-font-weight);
-  inline-size: 100%;
   line-height: var(--ams-password-input-line-height);
+  max-inline-size: 100%;
   outline-offset: var(--ams-password-input-outline-offset);
   padding-block: var(--ams-password-input-padding-block);
   padding-inline: var(--ams-password-input-padding-inline);
@@ -34,6 +34,10 @@
   &:hover {
     box-shadow: var(--ams-password-input-hover-box-shadow);
   }
+}
+
+.ams-password-input:not([size]) {
+  inline-size: 100%;
 }
 
 .ams-password-input::placeholder {

--- a/packages/css/src/components/text-input/text-input.scss
+++ b/packages/css/src/components/text-input/text-input.scss
@@ -21,8 +21,8 @@
   font-family: var(--ams-text-input-font-family);
   font-size: var(--ams-text-input-font-size);
   font-weight: var(--ams-text-input-font-weight);
-  inline-size: 100%;
   line-height: var(--ams-text-input-line-height);
+  max-inline-size: 100%;
   outline-offset: var(--ams-text-input-outline-offset);
   padding-block: var(--ams-text-input-padding-block);
   padding-inline: var(--ams-text-input-padding-inline);
@@ -34,6 +34,10 @@
   &:hover {
     box-shadow: var(--ams-text-input-hover-box-shadow);
   }
+}
+
+.ams-text-input:not([size]) {
+  inline-size: 100%;
 }
 
 .ams-text-input::placeholder {

--- a/storybook/src/components/PasswordInput/PasswordInput.docs.mdx
+++ b/storybook/src/components/PasswordInput/PasswordInput.docs.mdx
@@ -14,6 +14,13 @@ import README from "../../../../packages/css/src/components/password-input/READM
 
 ## Examples
 
+### Size
+
+The size of the input should be appropriate for the information to be entered.
+Use the `size` attribute to set the right size.
+
+<Canvas of={PasswordInputStories.Size} />
+
 ### In a Field
 
 Use a Field to group a Password Input with a Label, description and / or an Error Message.

--- a/storybook/src/components/PasswordInput/PasswordInput.stories.tsx
+++ b/storybook/src/components/PasswordInput/PasswordInput.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
     },
     size: {
       control: { min: 0, type: 'number' },
-      description: 'The size of the input.',
+      description: 'The width, expressed in the average number of characters.',
     },
   },
 } satisfies Meta<typeof PasswordInput>

--- a/storybook/src/components/PasswordInput/PasswordInput.stories.tsx
+++ b/storybook/src/components/PasswordInput/PasswordInput.stories.tsx
@@ -13,10 +13,15 @@ const meta = {
   args: {
     disabled: false,
     invalid: false,
+    size: 0,
   },
   argTypes: {
     disabled: {
       description: 'Prevents interaction. Avoid if possible.',
+    },
+    size: {
+      control: { min: 0, type: 'number' },
+      description: 'The size of the input.',
     },
   },
 } satisfies Meta<typeof PasswordInput>
@@ -26,6 +31,12 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const Size: Story = {
+  args: {
+    size: 10,
+  },
+}
 
 export const InAField: Story = {
   render: (args) => (

--- a/storybook/src/components/TextInput/TextInput.docs.mdx
+++ b/storybook/src/components/TextInput/TextInput.docs.mdx
@@ -69,6 +69,13 @@ Follow the [guidelines for asking for telephone numbers](https://design-system.s
 
 <Canvas of={TextInputStories.PhoneNumber} />
 
+### Size
+
+The size of the input should be appropriate for the information to be entered.
+Use the `size` attribute to set the right size.
+
+<Canvas of={TextInputStories.Size} />
+
 ### Placeholder
 
 This text appears in the field when it is empty. It can give a brief hint about the kind of data to enter.

--- a/storybook/src/components/TextInput/TextInput.stories.tsx
+++ b/storybook/src/components/TextInput/TextInput.stories.tsx
@@ -13,6 +13,7 @@ const meta = {
   args: {
     disabled: false,
     invalid: false,
+    size: 0,
   },
   argTypes: {
     defaultValue: {
@@ -23,6 +24,10 @@ const meta = {
     },
     invalid: {
       description: 'Whether the value fails a validation rule.',
+    },
+    size: {
+      control: { min: 0, type: 'number' },
+      description: 'The size of the input.',
     },
   },
 } satisfies Meta<typeof TextInput>
@@ -51,6 +56,12 @@ export const PhoneNumber: Story = {
   args: {
     defaultValue: '14020',
     type: 'tel',
+  },
+}
+
+export const Size: Story = {
+  args: {
+    size: 10,
   },
 }
 

--- a/storybook/src/components/TextInput/TextInput.stories.tsx
+++ b/storybook/src/components/TextInput/TextInput.stories.tsx
@@ -27,7 +27,7 @@ const meta = {
     },
     size: {
       control: { min: 0, type: 'number' },
-      description: 'The size of the input.',
+      description: 'The width, expressed in the average number of characters.',
     },
   },
 } satisfies Meta<typeof TextInput>


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It restores the `size` attribute functionality, allowing you to set the input's width in `ch`.

## Why

An input's width should be appropriate for the information to be entered.
You can use the `size` prop for this, but we broke that previously.

## How

Only set `inline-size: 100%` if the `size` attribute is not used. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
