### PR TITLE
fix(Image): Set inline size to 100%

### DIFF
--- a/packages/css/src/components/image/image.scss
+++ b/packages/css/src/components/image/image.scss
@@ -7,8 +7,7 @@
   aspect-ratio: var(--ams-image-aspect-ratio);
   block-size: auto; /* [1] */
   font-style: italic; /* [3] */
-  inline-size: fit-content;
-  max-inline-size: 100%; /* [1] */
+  inline-size: 100%; /* [1] */
   object-fit: cover; /* [4] */
   vertical-align: middle; /* [2] */
 }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It sets the Image inline size to 100%.

## Why

Using `fit-content` [caused issues](https://gemeente-amsterdam.atlassian.net/browse/DES-1277) when using multiple images for different screen widths and resizing. It also caused layout shifts, because the content size of an image that hasn't loaded yet is 0.

## How

Change `inline-size` to 100% and removing `max-inline-size`. I've tested this in our prototypes, where both issues did not occur any more. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Provide links to any related issues or discussions.
- Add a link to the specific story in the feature branch deploy.
- Mention any areas where additional review or feedback is needed.
