### PR TITLE
chore: Always publish Storybook on merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,6 @@ jobs:
       # The logic below handles the Storybook deploy:
       - name: Build Storybook
         run: pnpm --filter=storybook build
-        if: ${{ steps.release.outputs.releases_created == 'true' }}
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8 # v4.7.3
@@ -69,4 +68,3 @@ jobs:
           # feature branch directories are prefixed with demo-*
           # these are excluded from this action's default clean
           clean-exclude: demo-*
-        if: ${{ steps.release.outputs.releases_created == 'true' }}


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It removes a check for an existing release in order to publish Storybook.

## Why

We want to publish our Storybook even when there aren't any releases. Changes to documentation should be able to be published without requiring a release of a package.

## How

Removing 2 checks. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
