### PR TITLE
fix: Use correct underline width for Standalone Link with icon

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/standalone-link.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/standalone-link.tokens.json
@@ -32,7 +32,8 @@
       "with-icon": {
         "text-decoration-line": { "value": "{ams.links.subtle.text-decoration-line}" },
         "hover": {
-          "text-decoration-line": { "value": "{ams.links.subtle.hover.text-decoration-line}" }
+          "text-decoration-line": { "value": "{ams.links.subtle.hover.text-decoration-line}" },
+          "text-decoration-thickness": { "value": "{ams.links.text-decoration-thickness}" }
         }
       }
     }

--- a/packages/css/src/components/standalone-link/standalone-link.scss
+++ b/packages/css/src/components/standalone-link/standalone-link.scss
@@ -49,5 +49,6 @@
 
   &:hover {
     text-decoration-line: var(--ams-standalone-link-with-icon-hover-text-decoration-line);
+    text-decoration-thickness: var(--ams-standalone-link-with-icon-hover-text-decoration-thickness);
   }
 }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Changes the underline of a hovered Standalone Link with an icon from 2px to 3px.

## Why

It’s a bug, found my @dlnr. A Standalone Link with an icon is a ‘subtle’ link. This group has no underline initially, and a 2px underline on hover.

The variant of a Standalone Link with an icon inherited the hover underline border with for the variant without an icon, which is 3px because it must grow from the initial 2px.

## How

Add a token for the hover of a Standalone Link with an icon that overrides the hover of a Standalone Link without one.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a