### PR TITLE
chore(docs): Add missing space in Link List docs

### DIFF
--- a/storybook/src/components/LinkList/LinkList.docs.mdx
+++ b/storybook/src/components/LinkList/LinkList.docs.mdx
@@ -38,7 +38,8 @@ Any attributes and the `ref` are passed on to the `<a>` element.
 
 ### On a coloured background
 
-A Link on a coloured background must set [the correct text colour](?path=/docs/brand-design-tokens-colour--docs#pairing-foreground-with-background-colours) to provide enough contrast. We have lighter and darker background colours, and links behave differently on each.
+A Link on a coloured background must set [the correct text colour](?path=/docs/brand-design-tokens-colour--docs#pairing-foreground-with-background-colours) to provide enough contrast.
+We have lighter and darker background colours, and links behave differently on each.
 
 #### Contrast colour
 


### PR DESCRIPTION
# Describe the pull request

This is a trivial change to fix a typo: a missing space between two sentences in the Link List documentation.

## What

Add space between two sentences.

## Why

There's a typo and we can't have that.

## How

By pressing the space bar on a keyboard.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update documentation
- [x] Add or update stories
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Provide links to any related issues or discussions.
- Add a link to the specific story in the feature branch deploy.
- Mention any areas where additional review or feedback is needed.
