### PR TITLE
poc: Use Storybook’s backgrounds feature for relevant stories

### DIFF
--- a/storybook/config/main.ts
+++ b/storybook/config/main.ts
@@ -26,6 +26,9 @@ const config: StorybookConfig = {
   docs: {
     autodocs: true,
   },
+  features: {
+    backgroundsStoryGlobals: true,
+  },
   framework: {
     name: '@storybook/react-vite',
     options: {},

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -85,7 +85,6 @@ export const parameters = {
     grid: {
       disable: true,
     },
-    options: {},
   },
   controls: {
     sort: 'alpha', // Sorts controls in the Controls addon

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -7,8 +7,8 @@ import '../src/styles/overrides.css'
 import { Page } from '@amsterdam/design-system-react'
 import { withThemeByClassName } from '@storybook/addon-themes'
 import type { StoryContext, StoryFn } from '@storybook/react'
-import { viewports } from './viewports'
 import clsx from 'clsx'
+import { viewports } from './viewports'
 
 export const argTypes = {
   children: {
@@ -16,19 +16,61 @@ export const argTypes = {
   },
 }
 
+export const backgroundColourOptionsLight = {
+  lime: { name: 'lime', value: '#BED200' },
+  orange: { name: 'orange', value: '#FF9100' },
+  white: { name: 'white', value: '#FFFFFF' },
+  yellow: { name: 'yellow', value: '#FFE600' },
+}
+export const backgroundColourOptionsDark = {
+  azure: { name: 'azure', value: '#009DE6' },
+  blue: { name: 'blue', value: '#004699' },
+  green: { name: 'green', value: '#00A03C' },
+  magenta: { name: 'magenta', value: '#E50082' },
+  purple: { name: 'purple', value: '#A00078' },
+}
+export const backgroundColourOptions = {
+  ...backgroundColourOptionsLight,
+  ...backgroundColourOptionsDark,
+}
+
+export const backgroundToForeground = {
+  azure: 'inverse',
+  blue: 'inverse',
+  green: 'inverse',
+  lime: 'contrast',
+  magenta: 'inverse',
+  orange: 'contrast',
+  purple: 'inverse',
+  white: 'contrast',
+  yellow: 'contrast',
+}
+export type backgroundToForegroundKey = keyof typeof backgroundToForeground
+export const getForegroundColor = (backgroundColor: backgroundToForegroundKey) => {
+  return backgroundToForeground[backgroundColor] || 'contrast'
+}
+
 // Wrap in Page, set language to Dutch for Canvas and Stories
 export const decorators = [
-  (Story: StoryFn, { args }: StoryContext) => (
-    <Page
-      className={clsx({
-        'ams-docs-dark-background': args['color'] === 'inverse',
-        'ams-docs-light-background': args['color'] === 'contrast',
-      })}
-      lang="nl"
-    >
-      <Story />
-    </Page>
-  ),
+  (Story: StoryFn, storyContext: StoryContext) => {
+    const {
+      globals: { backgrounds },
+    } = storyContext
+
+    const color = backgroundToForeground[backgrounds.value as backgroundToForegroundKey]
+
+    return (
+      <Page
+        className={clsx({
+          'ams-docs-dark-background': color === 'inverse',
+          'ams-docs-light-background': color === 'contrast',
+        })}
+        lang="nl"
+      >
+        <Story />
+      </Page>
+    )
+  },
   withThemeByClassName({
     defaultTheme: 'Spacious',
     themes: {
@@ -43,17 +85,7 @@ export const parameters = {
     grid: {
       disable: true,
     },
-    options: {
-      white: { name: 'white', value: '#FFFFFF' },
-      azure: { name: 'azure', value: '#009DE6' },
-      blue: { name: 'blue', value: '#004699' },
-      green: { name: 'green', value: '#00A03C' },
-      lime: { name: 'lime', value: '#BED200' },
-      magenta: { name: 'magenta', value: '#E50082' },
-      orange: { name: 'orange', value: '#FF9100' },
-      purple: { name: 'purple', value: '#A00078' },
-      yellow: { name: 'yellow', value: '#FFE600' },
-    },
+    options: {},
   },
   controls: {
     sort: 'alpha', // Sorts controls in the Controls addon
@@ -87,5 +119,5 @@ export const parameters = {
 }
 
 export const initialGlobals = {
-  backgrounds: { value: 'light' },
+  backgrounds: { value: 'white' },
 }

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -7,8 +7,8 @@ import '../src/styles/overrides.css'
 import { Page } from '@amsterdam/design-system-react'
 import { withThemeByClassName } from '@storybook/addon-themes'
 import type { StoryContext, StoryFn } from '@storybook/react'
-import clsx from 'clsx'
 import { viewports } from './viewports'
+import clsx from 'clsx'
 
 export const argTypes = {
   children: {
@@ -40,9 +40,19 @@ export const decorators = [
 
 export const parameters = {
   backgrounds: {
-    disable: true,
     grid: {
       disable: true,
+    },
+    options: {
+      white: { name: 'white', value: '#FFFFFF' },
+      azure: { name: 'azure', value: '#009DE6' },
+      blue: { name: 'blue', value: '#004699' },
+      green: { name: 'green', value: '#00A03C' },
+      lime: { name: 'lime', value: '#BED200' },
+      magenta: { name: 'magenta', value: '#E50082' },
+      orange: { name: 'orange', value: '#FF9100' },
+      purple: { name: 'purple', value: '#A00078' },
+      yellow: { name: 'yellow', value: '#FFE600' },
     },
   },
   controls: {
@@ -74,4 +84,8 @@ export const parameters = {
   viewport: {
     viewports,
   },
+}
+
+export const initialGlobals = {
+  backgrounds: { value: 'light' },
 }

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -57,7 +57,7 @@ export const decorators = [
       globals: { backgrounds },
     } = storyContext
 
-    const color = backgroundToForeground[backgrounds.value as backgroundToForegroundKey]
+    const color = getForegroundColor(backgrounds.value)
 
     return (
       <Page

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -31,6 +31,7 @@
     "@mdx-js/react": "3.1.0",
     "@storybook/addon-a11y": "8.6.14",
     "@storybook/addon-actions": "8.6.14",
+    "@storybook/addon-backgrounds": "8.6.14",
     "@storybook/addon-docs": "8.6.14",
     "@storybook/addon-essentials": "8.6.14",
     "@storybook/addon-interactions": "8.6.14",

--- a/storybook/src/components/LinkList/LinkList.stories.tsx
+++ b/storybook/src/components/LinkList/LinkList.stories.tsx
@@ -123,6 +123,11 @@ export const ContrastColour: LinkStory = {
     ...LinkStoryTemplate.args,
     color: 'contrast',
   },
+  globals: {
+    backgrounds: {
+      value: 'yellow',
+    },
+  },
 }
 
 export const InverseColour: LinkStory = {
@@ -130,5 +135,10 @@ export const InverseColour: LinkStory = {
   args: {
     ...LinkStoryTemplate.args,
     color: 'inverse',
+  },
+  globals: {
+    backgrounds: {
+      value: 'blue',
+    },
   },
 }

--- a/storybook/src/components/LinkList/LinkList.stories.tsx
+++ b/storybook/src/components/LinkList/LinkList.stories.tsx
@@ -3,9 +3,15 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { LinkList } from '@amsterdam/design-system-react/src'
+import { LinkList, LinkListLinkProps } from '@amsterdam/design-system-react/src'
 import * as Icons from '@amsterdam/design-system-react-icons'
 import { Meta, StoryObj } from '@storybook/react'
+import {
+  backgroundColourOptions,
+  backgroundColourOptionsDark,
+  backgroundColourOptionsLight,
+  getForegroundColor,
+} from '../../../config/preview'
 import { exampleLinkList } from '../shared/exampleContent'
 
 const linkList = exampleLinkList()
@@ -66,17 +72,42 @@ const LinkStoryTemplate: LinkStory = {
     },
   },
   decorators: [
-    (Story) => (
-      <LinkList>
-        <Story />
-      </LinkList>
-    ),
+    (Story, StoryContext) => {
+      console.log(StoryContext)
+
+      return (
+        <LinkList>
+          <Story />
+        </LinkList>
+      )
+    },
   ],
   render: ({ children, ...args }) => <LinkList.Link {...args}>{children}</LinkList.Link>,
 }
 
 export const Default: Story = {
   ...StoryTemplate,
+  parameters: {
+    backgrounds: {
+      options: backgroundColourOptions,
+    },
+  },
+  render: (args, { globals: { backgrounds } }) => {
+    return (
+      <LinkList {...args}>
+        {Array.isArray(args.children) &&
+          args.children.map((link, index) => {
+            const color = getForegroundColor(backgrounds.value) as LinkListLinkProps['color']
+
+            return (
+              <LinkList.Link {...link.props} color={color} key={index}>
+                {link.props.children}
+              </LinkList.Link>
+            )
+          })}
+      </LinkList>
+    )
+  },
 }
 
 export const CustomIcons: Story = {
@@ -124,8 +155,11 @@ export const ContrastColour: LinkStory = {
     color: 'contrast',
   },
   globals: {
+    backgrounds: { value: 'yellow' },
+  },
+  parameters: {
     backgrounds: {
-      value: 'yellow',
+      options: { yellow: backgroundColourOptionsLight.yellow },
     },
   },
 }
@@ -137,8 +171,11 @@ export const InverseColour: LinkStory = {
     color: 'inverse',
   },
   globals: {
+    backgrounds: { value: 'blue' },
+  },
+  parameters: {
     backgrounds: {
-      value: 'blue',
+      options: { blue: backgroundColourOptionsDark.blue },
     },
   },
 }

--- a/storybook/src/components/LinkList/LinkList.stories.tsx
+++ b/storybook/src/components/LinkList/LinkList.stories.tsx
@@ -72,15 +72,11 @@ const LinkStoryTemplate: LinkStory = {
     },
   },
   decorators: [
-    (Story, StoryContext) => {
-      console.log(StoryContext)
-
-      return (
-        <LinkList>
-          <Story />
-        </LinkList>
-      )
-    },
+    (Story) => (
+      <LinkList>
+        <Story />
+      </LinkList>
+    ),
   ],
   render: ({ children, ...args }) => <LinkList.Link {...args}>{children}</LinkList.Link>,
 }

--- a/storybook/src/components/Paragraph/Paragraph.stories.tsx
+++ b/storybook/src/components/Paragraph/Paragraph.stories.tsx
@@ -3,9 +3,10 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { Icon, Paragraph, Row } from '@amsterdam/design-system-react/src'
+import { Icon, Paragraph, ParagraphProps, Row } from '@amsterdam/design-system-react/src'
 import { MailIcon } from '@amsterdam/design-system-react-icons'
 import { Meta, StoryObj } from '@storybook/react'
+import { backgroundColourOptions, backgroundColourOptionsDark, getForegroundColor } from '../../../config/preview'
 import { exampleParagraph } from '../shared/exampleContent'
 
 const paragraph = exampleParagraph()
@@ -42,7 +43,19 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  parameters: {
+    backgrounds: {
+      options: backgroundColourOptions,
+      value: 'blue',
+    },
+  },
+  render: (args, { globals: { backgrounds } }) => {
+    args['color'] = getForegroundColor(backgrounds.value) as ParagraphProps['color']
+
+    return <Paragraph {...args}>{args.children}</Paragraph>
+  },
+}
 
 export const LargeText: Story = {
   args: {
@@ -59,6 +72,17 @@ export const SmallText: Story = {
 export const InverseColour: Story = {
   args: {
     color: 'inverse',
+  },
+  parameters: {
+    backgrounds: {
+      options: backgroundColourOptionsDark,
+      value: 'blue',
+    },
+  },
+  render: (args, { globals: { backgrounds } }) => {
+    args['color'] = getForegroundColor(backgrounds.value) as ParagraphProps['color']
+
+    return <Paragraph {...args}>{args.children}</Paragraph>
   },
 }
 

--- a/storybook/src/components/Paragraph/Paragraph.stories.tsx
+++ b/storybook/src/components/Paragraph/Paragraph.stories.tsx
@@ -47,7 +47,6 @@ export const Default: Story = {
   parameters: {
     backgrounds: {
       options: backgroundColourOptions,
-      value: 'blue',
     },
   },
   render: (args, { globals: { backgrounds } }) => {
@@ -73,16 +72,13 @@ export const InverseColour: Story = {
   args: {
     color: 'inverse',
   },
+  globals: {
+    backgrounds: { value: 'blue' },
+  },
   parameters: {
     backgrounds: {
-      options: backgroundColourOptionsDark,
-      value: 'blue',
+      options: { blue: backgroundColourOptionsDark.blue },
     },
-  },
-  render: (args, { globals: { backgrounds } }) => {
-    args['color'] = getForegroundColor(backgrounds.value) as ParagraphProps['color']
-
-    return <Paragraph {...args}>{args.children}</Paragraph>
   },
 }
 

--- a/storybook/src/styles/docs.css
+++ b/storybook/src/styles/docs.css
@@ -62,7 +62,15 @@
   background-color: #ffe600; /* Yellow */
 }
 
+.ams-docs-light-background .ams-page {
+  background-color: #ffe600; /* Yellow */
+}
+
 .ams-docs-dark-background {
+  background-color: #004699; /* Dark blue */
+}
+
+.ams-docs-dark-background .ams-page {
   background-color: #004699; /* Dark blue */
 }
 

--- a/storybook/src/styles/docs.css
+++ b/storybook/src/styles/docs.css
@@ -51,27 +51,11 @@
 
 .ams-docs-dark-background,
 .ams-docs-light-background {
+  background-color: transparent;
   margin-block: -1rem;
   margin-inline: -1rem;
   padding-block: 1rem;
   padding-inline: 1rem;
-}
-
-/* Do not change the order of these two selectors. They ensure the dark background wins if both are set, which is in line with the implementation of the React-component. */
-.ams-docs-light-background {
-  background-color: #ffe600; /* Yellow */
-}
-
-.ams-docs-light-background .ams-page {
-  background-color: #ffe600; /* Yellow */
-}
-
-.ams-docs-dark-background {
-  background-color: #004699; /* Dark blue */
-}
-
-.ams-docs-dark-background .ams-page {
-  background-color: #004699; /* Dark blue */
 }
 
 .ams-docs-column,


### PR DESCRIPTION
## What

We tried removing our custom approach to give stories a light or dark background colour in favour of the backgrounds feature that Storybook offers.

## Why

To have less customisations and make it easier to use background colours in our examples.

## How

We didn’t succeed – it proved difficult to trigger the `color` prop to change, as our components require on coloured backgrounds. Creating this PR for possible later retries.
