### PR TITLE
feat(Page Footer): Use regular text size instead of small

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/page-footer.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/page-footer.tokens.json
@@ -15,9 +15,9 @@
         "link": {
           "color": { "value": "{ams.links.color}" },
           "font-family": { "value": "{ams.typography.font-family}" },
-          "font-size": { "value": "{ams.typography.body-text.small.font-size}" },
+          "font-size": { "value": "{ams.typography.body-text.font-size}" },
           "font-weight": { "value": "{ams.typography.body-text.font-weight}" },
-          "line-height": { "value": "{ams.typography.body-text.small.line-height}" },
+          "line-height": { "value": "{ams.typography.body-text.line-height}" },
           "outline-offset": { "value": "{ams.focus.outline-offset}" },
           "text-decoration-line": { "value": "{ams.links.subtle.text-decoration-line}" },
           "text-decoration-thickness": { "value": "{ams.links.text-decoration-thickness}" },

--- a/storybook/src/components/PageFooter/PageFooter.stories.tsx
+++ b/storybook/src/components/PageFooter/PageFooter.stories.tsx
@@ -3,16 +3,17 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { Grid, Heading, LinkList, Paragraph } from '@amsterdam/design-system-react'
+import { Grid, Heading, LinkList, Paragraph, StandaloneLink } from '@amsterdam/design-system-react'
 import { PageFooter } from '@amsterdam/design-system-react/src'
 import {
-  CameraIcon,
+  ChevronForwardIcon,
   ClockIcon,
   FacebookIcon,
+  InstagramIcon,
   LinkedinIcon,
   MailIcon,
+  MastodonIcon,
   PhoneIcon,
-  XIcon,
 } from '@amsterdam/design-system-react-icons'
 import { Meta, StoryObj } from '@storybook/react'
 
@@ -25,11 +26,18 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-const socialPlatforms = [
-  { icon: XIcon, name: 'X' },
-  { icon: FacebookIcon, name: 'Facebook' },
-  { icon: LinkedinIcon, name: 'Linkedin' },
-  { icon: CameraIcon, name: 'Instagram' },
+type FollowLink = {
+  icon?: Function
+  text: string
+}
+
+const followLinks: FollowLink[] = [
+  { text: 'De Amsterdam App' },
+  { text: 'Nieuwsbrieven' },
+  { icon: FacebookIcon, text: 'Facebook' },
+  { icon: InstagramIcon, text: 'Instagram' },
+  { icon: LinkedinIcon, text: 'LinkedIn' },
+  { icon: MastodonIcon, text: 'Mastodon' },
 ]
 
 export const Default: Story = {
@@ -39,60 +47,53 @@ export const Default: Story = {
         <Grid paddingVertical="x-large">
           <Grid.Cell span={4}>
             <Heading className="ams-mb-s" color="inverse" level={2} size="level-4">
-              Meer weten
-            </Heading>
-            <LinkList>
-              {['Veel gestelde vragen', 'Over ons', 'Werken bij', 'Kalender', 'Uit in Amsterdam', 'Bronnen'].map(
-                (label, index) => (
-                  <LinkList.Link color="inverse" href="#" key={index}>
-                    {label}
-                  </LinkList.Link>
-                ),
-              )}
-            </LinkList>
-          </Grid.Cell>
-          <Grid.Cell span={4} start={{ narrow: 1, medium: 5, wide: 5 }}>
-            <Heading className="ams-mb-s" color="inverse" level={2} size="level-4">
               Contact
             </Heading>
-            <Paragraph className="ams-mb-m" color="inverse">
-              Hebt u een vraag en kunt u het antwoord niet vinden op deze website? Neem dan contact met ons op.
-            </Paragraph>
-            <LinkList>
-              <LinkList.Link color="inverse" href="mailto:redactie@amsterdam.nl" icon={MailIcon}>
-                E-mail
+            <LinkList className="ams-mb-xl">
+              <LinkList.Link color="inverse" href="#" icon={MailIcon}>
+                Contactformulier
               </LinkList.Link>
-              <LinkList.Link color="inverse" href="tel:+3114020" icon={PhoneIcon}>
+              <LinkList.Link color="inverse" href="#" icon={PhoneIcon}>
                 14 020
               </LinkList.Link>
               <LinkList.Link color="inverse" href="#" icon={ClockIcon}>
-                Contactgegevens en openingstijden
+                Adressen en openingstijden
               </LinkList.Link>
+            </LinkList>
+            <Heading className="ams-mb-s" color="inverse" level={2} size="level-4">
+              Vacatures
+            </Heading>
+            <StandaloneLink color="inverse" href="#" icon={ChevronForwardIcon}>
+              Werken bij Amsterdam
+            </StandaloneLink>
+          </Grid.Cell>
+          <Grid.Cell span={4} start={{ narrow: 1, medium: 5, wide: 5 }}>
+            <Heading className="ams-mb-s" color="inverse" level={2} size="level-4">
+              Volg ons
+            </Heading>
+            <LinkList>
+              {followLinks.map(({ icon, text }) => (
+                <LinkList.Link color="inverse" href="#" icon={icon} key={text}>
+                  {text}
+                </LinkList.Link>
+              ))}
             </LinkList>
           </Grid.Cell>
           <Grid.Cell span={4} start={{ narrow: 1, medium: 1, wide: 9 }}>
-            <div className="ams-mb-xl">
-              <Heading className="ams-mb-s" color="inverse" level={2} size="level-4">
-                Nieuwsbrief
-              </Heading>
-              <LinkList>
-                <LinkList.Link color="inverse" href="#">
-                  Inschrijven
-                </LinkList.Link>
-              </LinkList>
-            </div>
-            <div>
-              <Heading className="ams-mb-s" color="inverse" level={2} size="level-4">
-                Volg ons
-              </Heading>
-              <LinkList>
-                {socialPlatforms.map(({ icon, name }) => (
-                  <LinkList.Link color="inverse" href="#" icon={icon} key={name}>
-                    {name}
-                  </LinkList.Link>
-                ))}
-              </LinkList>
-            </div>
+            <Heading className="ams-mb-s" color="inverse" level={2} size="level-4">
+              Doen in de stad
+            </Heading>
+            <LinkList>
+              <LinkList.Link color="inverse" href="#">
+                Bijeenkomsten en activiteiten
+              </LinkList.Link>
+              <LinkList.Link color="inverse" href="#">
+                Uit in Amsterdam
+              </LinkList.Link>
+              <LinkList.Link color="inverse" href="#">
+                Amsterdam 750 jaar
+              </LinkList.Link>
+            </LinkList>
           </Grid.Cell>
         </Grid>
       </PageFooter.Spotlight>,
@@ -102,7 +103,8 @@ export const Default: Story = {
       <PageFooter.Menu key={3}>
         <PageFooter.MenuLink href="#">Over deze site</PageFooter.MenuLink>
         <PageFooter.MenuLink href="#">Privacy</PageFooter.MenuLink>
-        <PageFooter.MenuLink href="#">Cookies</PageFooter.MenuLink>
+        <PageFooter.MenuLink href="#">Cookies op deze site</PageFooter.MenuLink>
+        <PageFooter.MenuLink href="#">Webarchief</PageFooter.MenuLink>
       </PageFooter.Menu>,
     ],
   },
@@ -159,6 +161,9 @@ export const OnderzoekEnStatistiek: Story = {
               <LinkList.Link color="inverse" href="#">
                 Veelgestelde vragen
               </LinkList.Link>
+              <LinkList.Link color="inverse" href="#">
+                Termen en categorieën
+              </LinkList.Link>
               <LinkList.Link color="inverse" href="#" rel="external">
                 Nieuwsbrief
               </LinkList.Link>
@@ -173,9 +178,8 @@ export const OnderzoekEnStatistiek: Story = {
         Over deze website
       </Heading>,
       <PageFooter.Menu key={3}>
-        <PageFooter.MenuLink href="#">Over deze site</PageFooter.MenuLink>
         <PageFooter.MenuLink href="#">Privacy</PageFooter.MenuLink>
-        <PageFooter.MenuLink href="#">Cookies</PageFooter.MenuLink>
+        <PageFooter.MenuLink href="#">Toegankelijkheid</PageFooter.MenuLink>
       </PageFooter.Menu>,
     ],
   },

--- a/storybook/src/components/PageFooter/PageFooter.stories.tsx
+++ b/storybook/src/components/PageFooter/PageFooter.stories.tsx
@@ -44,7 +44,7 @@ export const Default: Story = {
             <LinkList>
               {['Veel gestelde vragen', 'Over ons', 'Werken bij', 'Kalender', 'Uit in Amsterdam', 'Bronnen'].map(
                 (label, index) => (
-                  <LinkList.Link color="inverse" href="#" key={index} size="small">
+                  <LinkList.Link color="inverse" href="#" key={index}>
                     {label}
                   </LinkList.Link>
                 ),
@@ -55,17 +55,17 @@ export const Default: Story = {
             <Heading className="ams-mb-s" color="inverse" level={2} size="level-4">
               Contact
             </Heading>
-            <Paragraph className="ams-mb-m" color="inverse" size="small">
+            <Paragraph className="ams-mb-m" color="inverse">
               Hebt u een vraag en kunt u het antwoord niet vinden op deze website? Neem dan contact met ons op.
             </Paragraph>
             <LinkList>
-              <LinkList.Link color="inverse" href="mailto:redactie@amsterdam.nl" icon={MailIcon} size="small">
+              <LinkList.Link color="inverse" href="mailto:redactie@amsterdam.nl" icon={MailIcon}>
                 E-mail
               </LinkList.Link>
-              <LinkList.Link color="inverse" href="tel:+3114020" icon={PhoneIcon} size="small">
+              <LinkList.Link color="inverse" href="tel:+3114020" icon={PhoneIcon}>
                 14 020
               </LinkList.Link>
-              <LinkList.Link color="inverse" href="#" icon={ClockIcon} size="small">
+              <LinkList.Link color="inverse" href="#" icon={ClockIcon}>
                 Contactgegevens en openingstijden
               </LinkList.Link>
             </LinkList>
@@ -76,7 +76,7 @@ export const Default: Story = {
                 Nieuwsbrief
               </Heading>
               <LinkList>
-                <LinkList.Link color="inverse" href="#" size="small">
+                <LinkList.Link color="inverse" href="#">
                   Inschrijven
                 </LinkList.Link>
               </LinkList>
@@ -87,7 +87,7 @@ export const Default: Story = {
               </Heading>
               <LinkList>
                 {socialPlatforms.map(({ icon, name }) => (
-                  <LinkList.Link color="inverse" href="#" icon={icon} key={name} size="small">
+                  <LinkList.Link color="inverse" href="#" icon={icon} key={name}>
                     {name}
                   </LinkList.Link>
                 ))}
@@ -117,14 +117,14 @@ export const OnderzoekEnStatistiek: Story = {
             <Heading className="ams-mb-s" color="inverse" level={2} size="level-4">
               Contact
             </Heading>
-            <Paragraph className="ams-mb-m" color="inverse" size="small">
+            <Paragraph className="ams-mb-m" color="inverse">
               Heeft u een vraag en kunt u het antwoord niet vinden op deze site? Neem dan contact met ons op.
             </Paragraph>
             <LinkList>
-              <LinkList.Link color="inverse" href="mailto:redactie.os@amsterdam.nl" icon={MailIcon} size="small">
+              <LinkList.Link color="inverse" href="mailto:redactie.os@amsterdam.nl" icon={MailIcon}>
                 E-mail
               </LinkList.Link>
-              <LinkList.Link color="inverse" href="tel:+31202510333" icon={PhoneIcon} size="small">
+              <LinkList.Link color="inverse" href="tel:+31202510333" icon={PhoneIcon}>
                 020 251 0333
               </LinkList.Link>
             </LinkList>
@@ -133,17 +133,17 @@ export const OnderzoekEnStatistiek: Story = {
             <Heading className="ams-mb-s" color="inverse" level={2} size="level-4">
               Panels en enquêtes
             </Heading>
-            <Paragraph className="ams-mb-m" color="inverse" size="small">
+            <Paragraph className="ams-mb-m" color="inverse">
               Bent u uitgenodigd om mee te doen aan onderzoek of heeft u vragen over het panel of stadspaspanel?
             </Paragraph>
             <LinkList>
-              <LinkList.Link color="inverse" href="#" rel="external" size="small">
+              <LinkList.Link color="inverse" href="#" rel="external">
                 Meedoen aan onderzoek
               </LinkList.Link>
-              <LinkList.Link color="inverse" href="#" rel="external" size="small">
+              <LinkList.Link color="inverse" href="#" rel="external">
                 Panel Amsterdam
               </LinkList.Link>
-              <LinkList.Link color="inverse" href="#" rel="external" size="small">
+              <LinkList.Link color="inverse" href="#" rel="external">
                 Stadspaspanel Amsterdam
               </LinkList.Link>
             </LinkList>
@@ -153,16 +153,16 @@ export const OnderzoekEnStatistiek: Story = {
               Onderzoek en Statistiek
             </Heading>
             <LinkList>
-              <LinkList.Link color="inverse" href="#" size="small">
+              <LinkList.Link color="inverse" href="#">
                 Over Onderzoek en Statistiek
               </LinkList.Link>
-              <LinkList.Link color="inverse" href="#" size="small">
+              <LinkList.Link color="inverse" href="#">
                 Veelgestelde vragen
               </LinkList.Link>
-              <LinkList.Link color="inverse" href="#" rel="external" size="small">
+              <LinkList.Link color="inverse" href="#" rel="external">
                 Nieuwsbrief
               </LinkList.Link>
-              <LinkList.Link color="inverse" href="#" size="small">
+              <LinkList.Link color="inverse" href="#">
                 Vacatures
               </LinkList.Link>
             </LinkList>


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Uses regular text size for the Page Footer component.
Changes the example content to what’s currently published in production.

Compare: [old](https://designsystem.amsterdam/iframe.html?globals=&args=&id=pages-amsterdam-nl-home-page--default&viewMode=story) vs [new](https://designsystem.amsterdam/iframe.html?globals=&args=&id=pages-amsterdam-nl-home-page--default&viewMode=story)

## Why

Because these texts and lists are regularly important pieces of content; they don’t deserve to look less so.
They also appear more visally balanced near their Headings, and less off from body text just above the footer.

## How

Changed token values.
Updated two examples.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Discussed and agreed with @Bondt007 earlier today. (Tested visually with the updated text sizes fo https://github.com/Amsterdam/design-system/pull/2119.)
