### PR TITLE
feat(Ordered List, Unordered List): Use small gap between items instead of medium

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/ordered-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/ordered-list.tokens.json
@@ -5,7 +5,7 @@
       "font-family": { "value": "{ams.typography.font-family}" },
       "font-size": { "value": "{ams.typography.body-text.font-size}" },
       "font-weight": { "value": "{ams.typography.body-text.font-weight}" },
-      "gap": { "value": "{ams.space.m}" },
+      "gap": { "value": "{ams.space.s}" },
       "line-height": { "value": "{ams.typography.body-text.line-height}" },
       "list-style-type": { "value": "decimal" },
       "small": {

--- a/packages-proprietary/tokens/src/components/ams/unordered-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/unordered-list.tokens.json
@@ -5,7 +5,7 @@
       "font-family": { "value": "{ams.typography.font-family}" },
       "font-size": { "value": "{ams.typography.body-text.font-size}" },
       "font-weight": { "value": "{ams.typography.body-text.font-weight}" },
-      "gap": { "value": "{ams.space.m}" },
+      "gap": { "value": "{ams.space.s}" },
       "line-height": { "value": "{ams.typography.body-text.line-height}" },
       "list-style-type": { "value": "'\\2022'" },
       "inverse": {


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Sets a small gap between items of an Ordered or Unordered List, instead of a medium one.

## Why

The gap was too large. It had been designed as such to accommodate list items with several lines of content, but they occur less in practice and list items with short content suffer.

The gap between Link List Items is small as well.

We might consider two variations of lists to support both longer and shorter content. We could also instruct to use a Paragraph for long content in a List Item, and add the extra whitespace to that.

## How

Changed token values.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a