### PR TITLE
feat(Checkbox, Radio): Make the size of controls fluid like text

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/checkbox.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/checkbox.tokens.json
@@ -32,7 +32,7 @@
       },
       "icon-container": {
         "block-size": { "value": "calc({ams.checkbox.font-size} * {ams.checkbox.line-height})" },
-        "inline-size": { "value": "1.5rem" }
+        "inline-size": { "value": "{ams.checkbox.font-size}" }
       },
       "indeterminate-indicator": {
         "stroke": { "value": "{ams.color.interactive.inverse}" }

--- a/packages-proprietary/tokens/src/components/ams/radio.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/radio.tokens.json
@@ -74,7 +74,7 @@
       },
       "icon-container": {
         "block-size": { "value": "calc({ams.radio.font-size} * {ams.radio.line-height})" },
-        "inline-size": { "value": "1.5rem" }
+        "inline-size": { "value": "{ams.radio.font-size}" }
       }
     }
   }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Lets the square shape of Checkbox, and the circle shape of Radio, scale with text. See #2127. Note that this makes the border width slightly less than `2px` on narrow screens.

## Why

They currently have a fixed size, which doesn’t work well with our responsive typography and in Compact Mode.

## How

Use font size tokens for the width of the icon container.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a