### PR TITLE
fix: Correct shade of black for interactive contrast colour

### DIFF
--- a/packages-proprietary/tokens/src/brand/ams/color.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/color.tokens.json
@@ -18,7 +18,7 @@
         "yellow": { "value": "#ffe600" }
       },
       "interactive": {
-        "contrast": { "value": "#000000" },
+        "contrast": { "value": "#181818" },
         "default": { "value": "#004699" },
         "disabled": { "value": "#767676" },
         "hover": { "value": "#003677" },

--- a/storybook/config/manager.js
+++ b/storybook/config/manager.js
@@ -18,8 +18,8 @@ addons.setConfig({
     inputBg: '#ffffff',
     inputBorder: '#767676',
     inputBorderRadius: 0,
-    inputTextColor: '#000000',
-    textColor: '#000000',
+    inputTextColor: '#181818',
+    textColor: '#181818',
     textInverseColor: '#ffffff',
   }),
 })


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Replaces a stray #000000 with #181818 in our colour tokens.
Updates two instances in our Storybook config as well.

## Why

We don’t use pure black anymore.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a