### PR TITLE
feat(Ordered List, Unordered List): Visually group nested list with parent item

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/ordered-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/ordered-list.tokens.json
@@ -28,7 +28,7 @@
       "ordered-list": {
         "gap": { "value": "{ams.space.s}" },
         "list-style-type": { "value": "lower-alpha" },
-        "padding-block-end": { "value": "0" },
+        "padding-block-end": { "value": "{ams.space.s}" },
         "padding-block-start": { "value": "{ams.space.s}" },
         "item": {
           "margin-inline-start": {

--- a/packages-proprietary/tokens/src/components/ams/unordered-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/unordered-list.tokens.json
@@ -28,7 +28,7 @@
       "unordered-list": {
         "gap": { "value": "{ams.space.s}" },
         "list-style-type": { "value": "'\\2013'" },
-        "padding-block-end": { "value": "0" },
+        "padding-block-end": { "value": "{ams.space.s}" },
         "padding-block-start": { "value": "{ams.space.s}" },
         "item": {
           "margin-inline-start": {

--- a/packages/css/src/components/ordered-list/ordered-list.scss
+++ b/packages/css/src/components/ordered-list/ordered-list.scss
@@ -45,14 +45,19 @@
   line-height: var(--ams-ordered-list-small-line-height);
 }
 
-:is(.ams-ordered-list, .ams-unordered-list) .ams-ordered-list {
-  gap: var(--ams-ordered-list-ordered-list-gap);
-  list-style-type: var(--ams-ordered-list-ordered-list-list-style-type);
-  padding-block-end: var(--ams-ordered-list-ordered-list-padding-block-end);
-  padding-block-start: var(--ams-ordered-list-ordered-list-padding-block-start);
+:is(.ams-ordered-list, .ams-unordered-list) {
+  .ams-ordered-list {
+    gap: var(--ams-ordered-list-ordered-list-gap);
+    list-style-type: var(--ams-ordered-list-ordered-list-list-style-type);
+    padding-block-start: var(--ams-ordered-list-ordered-list-padding-block-start);
 
-  .ams-ordered-list__item {
-    margin-inline-start: var(--ams-ordered-list-ordered-list-item-margin-inline-start);
-    padding-inline-start: var(--ams-ordered-list-ordered-list-item-padding-inline-start);
+    .ams-ordered-list__item {
+      margin-inline-start: var(--ams-ordered-list-ordered-list-item-margin-inline-start);
+      padding-inline-start: var(--ams-ordered-list-ordered-list-item-padding-inline-start);
+    }
+  }
+
+  > :not(:last-child) > .ams-ordered-list {
+    padding-block-end: var(--ams-ordered-list-ordered-list-padding-block-end);
   }
 }

--- a/packages/css/src/components/unordered-list/unordered-list.scss
+++ b/packages/css/src/components/unordered-list/unordered-list.scss
@@ -45,14 +45,19 @@
   line-height: var(--ams-unordered-list-small-line-height);
 }
 
-:is(.ams-ordered-list, .ams-unordered-list) .ams-unordered-list {
-  gap: var(--ams-unordered-list-unordered-list-gap);
-  list-style-type: var(--ams-unordered-list-unordered-list-list-style-type);
-  padding-block-end: var(--ams-unordered-list-unordered-list-padding-block-end);
-  padding-block-start: var(--ams-unordered-list-unordered-list-padding-block-start);
+:is(.ams-ordered-list, .ams-unordered-list) {
+  .ams-unordered-list {
+    gap: var(--ams-unordered-list-unordered-list-gap);
+    list-style-type: var(--ams-unordered-list-unordered-list-list-style-type);
+    padding-block-start: var(--ams-unordered-list-unordered-list-padding-block-start);
 
-  .ams-unordered-list__item {
-    margin-inline-start: var(--ams-unordered-list-unordered-list-item-margin-inline-start);
-    padding-inline-start: var(--ams-unordered-list-unordered-list-item-padding-inline-start);
+    .ams-unordered-list__item {
+      margin-inline-start: var(--ams-unordered-list-unordered-list-item-margin-inline-start);
+      padding-inline-start: var(--ams-unordered-list-unordered-list-item-padding-inline-start);
+    }
+  }
+
+  > :not(:last-child) > .ams-unordered-list {
+    padding-block-end: var(--ams-unordered-list-unordered-list-padding-block-end);
   }
 }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Adds a bit of whitespace below a nested list, unless it is in the last item of its parent.

## Why

To better indicate that the nested list belongs to its parent and not the next sibling of its parent.

## How

- I’ve used child combinators and ‘not last child’ in CSS. This might fail with invisble nodes. The `:has` selector might help but isn’t widely supported yet.
- I’ve omitted the `li` type selector on purpose. The element in between should be one, but if it’s something else, we still want this effect. And it prevents increasing specificity.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a