### PR TITLE
feat: Improve thickness and offset of link underlines

### DIFF
--- a/packages-proprietary/tokens/src/common/ams/links.tokens.json
+++ b/packages-proprietary/tokens/src/common/ams/links.tokens.json
@@ -2,12 +2,12 @@
   "ams": {
     "links": {
       "color": { "value": "{ams.color.interactive.default}" },
-      "text-decoration-thickness": { "value": "{ams.border.width.m}" },
-      "text-underline-offset": { "value": "0.3333em" },
+      "text-decoration-thickness": { "value": "0.075em" },
+      "text-underline-offset": { "value": "5.5px" },
       "hover": {
         "color": { "value": "{ams.color.interactive.hover}" },
-        "text-decoration-thickness": { "value": "{ams.border.width.l}" },
-        "text-underline-offset": { "value": "0.2778em" }
+        "text-decoration-thickness": { "value": "0.1125em" },
+        "text-underline-offset": { "value": "calc(5.5px - 0.0375em)" }
       },
       "subtle": {
         "text-decoration-line": { "value": "none" },

--- a/packages-proprietary/tokens/src/components/ams/checkbox.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/checkbox.tokens.json
@@ -15,7 +15,9 @@
       },
       "hover": {
         "color": { "value": "{ams.color.interactive.hover}" },
-        "text-decoration-thickness": { "value": "{ams.border.width.m}" }
+        "text-decoration-line": { "value": "{ams.links.subtle.hover.text-decoration-line}" },
+        "text-decoration-thickness": { "value": "{ams.links.text-decoration-thickness}" },
+        "text-underline-offset": { "value": "{ams.links.text-underline-offset}" }
       },
       "checked-indicator": {
         "stroke": { "value": "{ams.color.interactive.inverse}" }

--- a/packages-proprietary/tokens/src/components/ams/radio.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/radio.tokens.json
@@ -70,7 +70,9 @@
       },
       "hover": {
         "color": { "value": "{ams.color.interactive.hover}" },
-        "text-decoration-line": { "value": "{ams.links.subtle.hover.text-decoration-line}" }
+        "text-decoration-line": { "value": "{ams.links.subtle.hover.text-decoration-line}" },
+        "text-decoration-thickness": { "value": "{ams.links.text-decoration-thickness}" },
+        "text-underline-offset": { "value": "{ams.links.text-underline-offset}" }
       },
       "icon-container": {
         "block-size": { "value": "calc({ams.radio.font-size} * {ams.radio.line-height})" },

--- a/packages/css/src/components/checkbox/checkbox.scss
+++ b/packages/css/src/components/checkbox/checkbox.scss
@@ -124,9 +124,9 @@
   // Default hover
   &:hover:not(:disabled) + * {
     color: var(--ams-checkbox-hover-color);
-    text-decoration-line: underline;
+    text-decoration-line: var(--ams-checkbox-hover-text-decoration-line);
     text-decoration-thickness: var(--ams-checkbox-hover-text-decoration-thickness);
-    text-underline-offset: 0.375rem;
+    text-underline-offset: var(--ams-checkbox-hover-text-underline-offset);
 
     .ams-checkbox__rectangle {
       @media (forced-colors: none) {

--- a/packages/css/src/components/radio/radio.scss
+++ b/packages/css/src/components/radio/radio.scss
@@ -56,6 +56,8 @@
 .ams-radio__label:hover {
   color: var(--ams-radio-hover-color);
   text-decoration-line: var(--ams-radio-hover-text-decoration-line);
+  text-decoration-thickness: var(--ams-radio-hover-text-decoration-thickness);
+  text-underline-offset: var(--ams-radio-hover-text-underline-offset);
 
   .ams-radio__circle {
     stroke: var(--ams-radio-circle-hover-stroke);


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

- Adjusts the thickness and offset of the underline for links
  - Thickness (this is in ems; expressed in pixels for regular body text)
    - Initial: 2px → 1.5px
    - Hover: 3px → 2.25px
  - Offset
    - Initial: 8px → 5.5px
    - Hover: 6.667px → 4.75px
- Uses the three underline tokens correctly in Checkbox and Radio

## Why

Now that our font sizes have become smaller, the line below links has become too far away from the text. For inline links, it made it appear disconnected. For links spanning multiple lines, like often in cards, the underlines were closer to the next line of text than its own, which looks odd as well.

Our link underlines were 2px thick and offset by 0.333em, which is 8px for 24px text. When hovered, the thickness grew upward to 3px while the offset shrunk to 0.278em, which amounts to 6.66px. (Slightly strange: the sum of both is 10px initially, but 9.66px on hover.)

Even before decreasing the font sizes, I thought the underlines were chunky - too thick and too low. Personally I’d prefer the lines to sit close to the text and have the browser ‘skip ink’ around descenders. However, the team’s conclusion was that the interrupted underline made links appear a bit messy and less in line (ha ha) with our uncomplicated branding.

My first step was to decrease the underline’s width from 2px to 1.5px. Coming close to the thickness of the letterforms, which makes links appear much friendlier already. And our icons use strokes of 1.5px as well.

Using a fraction is not really a problem. Our whole fluid typographic system results in decimals everywhere and the pixel density of most screens is high enough to sharply display half CSS pixels.

I converted the pixel value to ems to sync the line thickness  with the size of text. At our regular font size of 20px, 1.5px is 1.5 ÷ 20 = 0.075em. For a level 2 Heading of 39.1px, the underline would be around 2.9px wide. (As a Heading is extra-bold, that underline is still not quite as thick as the letters in this case, but that’s not necessary either.)

Then, I experimented with the offset of the underline – the distance from the baseline of the text. I wanted to set the line as close as possible to the text, while preventing it to touch the descenders of letters; even the thicker line on hover. The visual optimum seems to be around 5 or 6 pixels. I chose the middle of 5.5, making offset and line 7px tall together. I thought @Bond007 would like that. Converting the offset to rems as well appeared to move the underline farther away from headings than it does for body text. I think the length of the descender in pixels doesn’t differ that much between the two, so we can leave the offset in pixels.

Lastly, the thickness of the underline on hover. Keeping the existing growth ratio of 150% results in a width of 2.25px for regular body text. The offset then decreases to 5.5 - (2.25 - 1.5) = 4.75px. In CSS, we use the ‘calc’ function because the offset is in pixels but the line thickness in ems: calc(5.5px - 0.0375em).

I found that the labels of Checkbox and Radio did not use all tokens correctly; now they do.

Our ‘subtle’ links are using the thickness and offset of non-hovered regular links for their hover state. This is a slight mismatch. As these lines don’t grow, I’m planning to move this underline up a pixel, so that the space between text and underline is the same for subtle links as for regular ones while hovering.

## How

See above.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a