### PR TITLE
fix(Page Header): Remove heading and image from navigation section

### DIFF
--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -15,19 +15,17 @@ import { PageHeaderMenuLink } from './PageHeaderMenuLink'
 import useIsAfterBreakpoint from '../common/useIsAfterBreakpoint'
 
 const LogoLinkContent = ({
-  ariaHidden,
   brandName,
   logoAccessibleName,
   logoBrand,
 }: {
-  ariaHidden?: boolean
   brandName?: string
   logoAccessibleName?: string
   logoBrand: LogoBrand
 }) => (
   <>
     <span className={clsx(logoBrand === 'amsterdam' && Boolean(brandName) && 'ams-page-header__logo-container')}>
-      <Logo aria-hidden={ariaHidden} aria-label={logoAccessibleName} brand={logoBrand} />
+      <Logo aria-label={logoAccessibleName} brand={logoBrand} />
     </span>
     {brandName && (
       <span aria-hidden="true" className="ams-page-header__brand-name">
@@ -105,8 +103,8 @@ const PageHeaderRoot = forwardRef(
             </h2>
 
             {/* The logo link section is recreated here, to make sure the header menu wraps at the right spot */}
-            <div className="ams-page-header__logo-link ams-page-header__logo-link--hidden" hidden>
-              <LogoLinkContent ariaHidden brandName={brandName} logoBrand={logoBrand} />
+            <div aria-hidden className="ams-page-header__logo-link ams-page-header__logo-link--hidden" hidden>
+              <LogoLinkContent brandName={brandName} logoBrand={logoBrand} />
             </div>
 
             <ul className="ams-page-header__menu">


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It removes the `h2` and the image in the navigation section from the a11y tree.

## Why

Headings before the page `h1` are technically allowed, but they add noise for screen readers. The text in the `h2` is used to label the `nav`, so it is still used. I didn't change the tag, because using an `h2` is still useful when the CSS doesn't load. See [this comment by Robbert NLDS](https://datalab-amsterdam.slack.com/archives/C01DAT4TRPF/p1748003310697089) for more info.

The image in the nav section was exposed to the a11y tree by accident. Previously, we removed all SVGs from the a11y tree, but we later changed that for the Logo. It should be hidden in the nav section though. 

## How

Added `aria-hidden` to the `h2`. Added `aria-hidden` and `hidden` to the image, to make sure it's hidden both from screen readers and visually when the CSS does not load. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Provide links to any related issues or discussions.
- Add a link to the specific story in the feature branch deploy.
- Mention any areas where additional review or feedback is needed.
