### PR TITLE
feat(Checkbox, Radio): Allow passing a custom ID

### DIFF
--- a/packages/react/src/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/Checkbox/Checkbox.test.tsx
@@ -174,6 +174,22 @@ describe('Checkbox', () => {
     expect(handleChange).toHaveBeenCalled()
   })
 
+  it('can use a custom id', () => {
+    const handleChange = jest.fn()
+
+    const { container } = render(<Checkbox id="test-id" onChange={handleChange} />)
+
+    const input = screen.getByRole('checkbox')
+
+    expect(input).toHaveAttribute('id', 'test-id')
+
+    const label = container.querySelector('label')
+
+    label?.click()
+
+    expect(handleChange).toHaveBeenCalled()
+  })
+
   it('shows a custom icon', () => {
     const { container } = render(<Checkbox icon={<StarIcon className="test-class" />} />)
 

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -22,10 +22,10 @@ export type CheckboxProps = {
  */
 export const Checkbox = forwardRef(
   (
-    { children, className, icon, indeterminate, invalid, ...restProps }: CheckboxProps,
+    { children, className, icon, id, indeterminate, invalid, ...restProps }: CheckboxProps,
     ref: ForwardedRef<HTMLInputElement>,
   ) => {
-    const id = useId()
+    const inputId = id || useId()
     const innerRef = useRef<HTMLInputElement>(null)
 
     // use a passed ref if it's there, otherwise use innerRef
@@ -46,11 +46,11 @@ export const Checkbox = forwardRef(
           {...restProps}
           aria-invalid={invalid || undefined}
           className="ams-checkbox__input"
-          id={id}
+          id={inputId}
           ref={innerRef}
           type="checkbox"
         />
-        <label className="ams-checkbox__label" htmlFor={id}>
+        <label className="ams-checkbox__label" htmlFor={inputId}>
           <span className="ams-checkbox__icon-container">{icon ?? <CheckboxIcon />}</span>
           {children}
         </label>

--- a/packages/react/src/Radio/Radio.test.tsx
+++ b/packages/react/src/Radio/Radio.test.tsx
@@ -160,6 +160,22 @@ describe('Radio', () => {
     expect(handleChange).toHaveBeenCalled()
   })
 
+  it('can use a custom id', () => {
+    const handleChange = jest.fn()
+
+    const { container } = render(<Radio id="test-id" onChange={handleChange} />)
+
+    const input = screen.getByRole('radio')
+
+    expect(input).toHaveAttribute('id', 'test-id')
+
+    const label = container.querySelector('label')
+
+    label?.click()
+
+    expect(handleChange).toHaveBeenCalled()
+  })
+
   it('shows a custom icon', () => {
     const { container } = render(<Radio icon={<StarIcon className="test-class" />} />)
 

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -19,8 +19,8 @@ export type RadioProps = {
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-forms-radio--docs Radio docs at Amsterdam Design System}
  */
 export const Radio = forwardRef(
-  ({ children, className, icon, invalid, ...restProps }: RadioProps, ref: ForwardedRef<HTMLInputElement>) => {
-    const id = useId()
+  ({ children, className, icon, id, invalid, ...restProps }: RadioProps, ref: ForwardedRef<HTMLInputElement>) => {
+    const inputId = id || useId()
 
     return (
       // This div is here because NVDA doesn't match the input to the label
@@ -30,11 +30,11 @@ export const Radio = forwardRef(
           {...restProps}
           aria-invalid={invalid || undefined}
           className="ams-radio__input"
-          id={id}
+          id={inputId}
           ref={ref}
           type="radio"
         />
-        <label className="ams-radio__label" htmlFor={id}>
+        <label className="ams-radio__label" htmlFor={inputId}>
           <span className="ams-radio__icon-container">{icon ?? <RadioIcon />}</span>
           {children}
         </label>

--- a/storybook/src/components/Checkbox/Checkbox.stories.tsx
+++ b/storybook/src/components/Checkbox/Checkbox.stories.tsx
@@ -16,6 +16,7 @@ const meta = {
     checked: false,
     children: 'Checkbox label',
     disabled: false,
+    id: '',
     indeterminate: false,
     invalid: false,
   },
@@ -29,6 +30,9 @@ const meta = {
     },
     disabled: {
       description: 'Prevents interaction. Avoid if possible.',
+    },
+    id: {
+      description: 'The id of the input element. If not provided, a unique id will be generated.',
     },
     onChange: {
       action: 'clicked',

--- a/storybook/src/components/Radio/Radio.stories.tsx
+++ b/storybook/src/components/Radio/Radio.stories.tsx
@@ -16,6 +16,7 @@ const meta = {
     checked: false,
     children: 'Radio label',
     disabled: false,
+    id: '',
     invalid: false,
   },
   argTypes: {
@@ -31,6 +32,9 @@ const meta = {
     },
     icon: {
       table: { disable: true },
+    },
+    id: {
+      description: 'The id of the input element. If not provided, a unique id will be generated.',
     },
     invalid: {
       description: 'Whether the value fails a validation rule.',


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It allows passing a custom ID to Radio and Checkbox, which replaces the generated one. 

## Why

We need to be able to [link to the first Radio or Checkbox of a FieldSet in the Invalid Form Alert component](https://design-system.service.gov.uk/components/error-summary/#linking-from-the-error-summary-to-each-answer). That wasn't possible yet. 

## How

You can pass an ID which gets preference over the generated ID. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

