### PR TITLE
feat(Breadcrumb): Enlarge hit area for links

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/breadcrumb.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/breadcrumb.tokens.json
@@ -15,7 +15,11 @@
       },
       "link": {
         "color": { "value": "{ams.links.color}" },
+        "margin-block": { "value": "calc(var(--ams-space-xs) * -1)" },
+        "margin-inline": { "value": "calc(var(--ams-space-xs) * -1)" },
         "outline-offset": { "value": "{ams.focus.outline-offset}" },
+        "padding-block": { "value": "var(--ams-space-xs)" },
+        "padding-inline": { "value": "var(--ams-space-xs)" },
         "text-decoration-line": { "value": "{ams.links.subtle.text-decoration-line}" },
         "text-decoration-thickness": { "value": "{ams.links.text-decoration-thickness}" },
         "text-underline-offset": { "value": "{ams.links.text-underline-offset}" },

--- a/packages/css/src/components/breadcrumb/breadcrumb.scss
+++ b/packages/css/src/components/breadcrumb/breadcrumb.scss
@@ -44,7 +44,11 @@
 
 .ams-breadcrumb__link {
   color: var(--ams-breadcrumb-link-color);
+  margin-block: var(--ams-breadcrumb-link-margin-block);
+  margin-inline: var(--ams-breadcrumb-link-margin-inline);
   outline-offset: var(--ams-breadcrumb-link-outline-offset);
+  padding-block: var(--ams-breadcrumb-link-padding-block);
+  padding-inline: var(--ams-breadcrumb-link-padding-inline);
   text-decoration-line: var(--ams-breadcrumb-link-text-decoration-line);
   text-decoration-thickness: var(--ams-breadcrumb-link-text-decoration-thickness);
   text-underline-offset: var(--ams-breadcrumb-link-text-underline-offset);


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

This makes it easier to hit the links in our breadcrumbs.

## Why

Easy is good.

## How

Both the items and links in a Breadcrumb have `display: inline` for natural text wrapping. Consequently, the hit area of links doesn’t span their entire line height so it becomes more difficult to hit them with a pointer or finger. I’ve added some padding to all sides, compensated with an equal negative margin. On desktop, this increases the height of the links from 26 to 38 pixels. Still not WCAG AAA, but better. A large padding would make links overlap each other.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a
