### PR TITLE
fix(Switch): Remove phantom whitespace below

### DIFF
--- a/packages/css/src/components/switch/switch.scss
+++ b/packages/css/src/components/switch/switch.scss
@@ -25,6 +25,7 @@
   inline-size: var(--ams-switch-inline-size);
   outline-offset: var(--ams-switch-outline-offset);
   transition: background-color 0.2s ease-in-out;
+  vertical-align: middle;
 }
 
 .ams-switch__label::before {


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Removes phantom whitespace below a Switch.

## Why

It’s unintentional and may introduce layout issues.

## How

By adding the good old `vertical-align: middle` to `.ams-switch__label`.

Our robot friends explain:

> `vertical-align: middle` fixes the phantom whitespace because `.ams-switch__label` is `inline-block` by default, and its baseline aligns with the baseline of surrounding inline content. The pseudo-element inside is a block, but the label itself sits on the baseline, leaving extra space below (for descenders).
>
> By setting `vertical-align: middle`, the label aligns to the middle of the line box, removing the extra space below and making the switch height match the visual content. This centers the label (and its pseudo-element) vertically relative to the parent, eliminating the unwanted whitespace.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [ ] Add or update unit tests
- [ ] Add or update documentation
- [ ] Add or update stories
- [ ] Add or update exports in index.\* files
- [ ] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Provide links to any related issues or discussions.
- Add a link to the specific story in the feature branch deploy.
- Mention any areas where additional review or feedback is needed.
