### PR TITLE
fix: Use correct styling for disabled and / or invalid inputs

### DIFF
--- a/packages/css/src/components/date-input/date-input.scss
+++ b/packages/css/src/components/date-input/date-input.scss
@@ -76,7 +76,7 @@
 }
 
 .ams-date-input:not(:disabled):invalid,
-.ams-date-input[aria-invalid="true"]:not(:disabled) {
+.ams-date-input:not(:disabled)[aria-invalid="true"] {
   border-color: var(--ams-date-input-invalid-border-color);
 }
 
@@ -85,7 +85,7 @@
 }
 
 .ams-date-input:not(:disabled):invalid:hover,
-.ams-date-input[aria-invalid="true"]:not(:disabled):hover {
+.ams-date-input:not(:disabled)[aria-invalid="true"]:hover {
   border-color: var(--ams-date-input-invalid-hover-border-color);
   box-shadow: var(--ams-date-input-invalid-hover-box-shadow);
 }

--- a/packages/css/src/components/date-input/date-input.scss
+++ b/packages/css/src/components/date-input/date-input.scss
@@ -75,16 +75,17 @@
   visibility: visible;
 }
 
-.ams-date-input:invalid,
-.ams-date-input[aria-invalid="true"] {
+.ams-date-input:not(:disabled):invalid,
+.ams-date-input[aria-invalid="true"]:not(:disabled) {
   border-color: var(--ams-date-input-invalid-border-color);
-
-  &:hover {
-    border-color: var(--ams-date-input-invalid-hover-border-color);
-    box-shadow: var(--ams-date-input-invalid-hover-box-shadow);
-  }
 }
 
 .ams-date-input:not(:disabled):hover {
   box-shadow: var(--ams-date-input-hover-box-shadow);
+}
+
+.ams-date-input:not(:disabled):invalid:hover,
+.ams-date-input[aria-invalid="true"]:not(:disabled):hover {
+  border-color: var(--ams-date-input-invalid-hover-border-color);
+  box-shadow: var(--ams-date-input-invalid-hover-box-shadow);
 }

--- a/packages/css/src/components/password-input/password-input.scss
+++ b/packages/css/src/components/password-input/password-input.scss
@@ -48,7 +48,7 @@
 }
 
 .ams-password-input:not(:disabled):invalid,
-.ams-password-input[aria-invalid="true"]:not(:disabled) {
+.ams-password-input:not(:disabled)[aria-invalid="true"] {
   border-color: var(--ams-password-input-invalid-border-color);
 }
 
@@ -57,7 +57,7 @@
 }
 
 .ams-password-input:not(:disabled):invalid:hover,
-.ams-password-input[aria-invalid="true"]:not(:disabled):hover {
+.ams-password-input:not(:disabled)[aria-invalid="true"]:hover {
   border-color: var(--ams-password-input-invalid-hover-border-color);
   box-shadow: var(--ams-password-input-invalid-hover-box-shadow);
 }

--- a/packages/css/src/components/password-input/password-input.scss
+++ b/packages/css/src/components/password-input/password-input.scss
@@ -47,16 +47,17 @@
   cursor: var(--ams-password-input-disabled-cursor);
 }
 
-.ams-password-input:invalid,
-.ams-password-input[aria-invalid="true"] {
+.ams-password-input:not(:disabled):invalid,
+.ams-password-input[aria-invalid="true"]:not(:disabled) {
   border-color: var(--ams-password-input-invalid-border-color);
-
-  &:hover {
-    border-color: var(--ams-password-input-invalid-hover-border-color);
-    box-shadow: var(--ams-password-input-invalid-hover-box-shadow);
-  }
 }
 
 .ams-password-input:not(:disabled):hover {
   box-shadow: var(--ams-password-input-hover-box-shadow);
+}
+
+.ams-password-input:not(:disabled):invalid:hover,
+.ams-password-input[aria-invalid="true"]:not(:disabled):hover {
+  border-color: var(--ams-password-input-invalid-hover-border-color);
+  box-shadow: var(--ams-password-input-invalid-hover-box-shadow);
 }

--- a/packages/css/src/components/password-input/password-input.scss
+++ b/packages/css/src/components/password-input/password-input.scss
@@ -37,9 +37,14 @@
   inline-size: 100%;
 }
 
+@mixin reset-placeholder {
+  opacity: 100%; // Reset lower opacity set by Firefox
+}
+
 .ams-password-input::placeholder {
   color: var(--ams-password-input-placeholder-color);
-  opacity: 100%; // This resets the lower opacity set by Firefox
+
+  @include reset-placeholder;
 }
 
 .ams-password-input:disabled {

--- a/packages/css/src/components/search-field/search-field.scss
+++ b/packages/css/src/components/search-field/search-field.scss
@@ -37,28 +37,29 @@
   @include text-rendering;
   @include reset-input;
 
-  &:hover {
-    box-shadow: var(--ams-search-field-input-hover-box-shadow);
-  }
-
   &:focus {
     z-index: 1; // Make sure the focus outline isn’t cut off by the adjacent button
-  }
-}
-
-.ams-search-field__input:invalid,
-.ams-search-field__input[aria-invalid="true"] {
-  border-color: var(--ams-search-field-input-invalid-border-color);
-
-  &:hover {
-    border-color: var(--ams-search-field-input-invalid-hover-border-color);
-    box-shadow: var(--ams-search-field-input-invalid-hover-box-shadow);
   }
 }
 
 .ams-search-field__input::placeholder {
   color: var(--ams-search-field-input-placeholder-color);
   opacity: 100%; // This resets the lower opacity set by Firefox
+}
+
+.ams-search-field__input:not(:disabled):invalid,
+.ams-search-field__input[aria-invalid="true"]:not(:disabled) {
+  border-color: var(--ams-search-field-input-invalid-border-color);
+}
+
+.ams-search-field__input:not(:disabled):hover {
+  box-shadow: var(--ams-search-field-input-hover-box-shadow);
+}
+
+.ams-search-field__input:not(:disabled):invalid:hover,
+.ams-search-field__input[aria-invalid="true"]:not(:disabled):hover {
+  border-color: var(--ams-search-field-input-invalid-hover-border-color);
+  box-shadow: var(--ams-search-field-input-invalid-hover-box-shadow);
 }
 
 .ams-search-field__input::-webkit-search-cancel-button {

--- a/packages/css/src/components/search-field/search-field.scss
+++ b/packages/css/src/components/search-field/search-field.scss
@@ -42,9 +42,12 @@
   }
 }
 
+@mixin reset-placeholder {
+  opacity: 100%; // Reset lower opacity set by Firefox
+}
+
 .ams-search-field__input::placeholder {
   color: var(--ams-search-field-input-placeholder-color);
-  opacity: 100%; // This resets the lower opacity set by Firefox
 }
 
 .ams-search-field__input:not(:disabled):invalid,

--- a/packages/css/src/components/search-field/search-field.scss
+++ b/packages/css/src/components/search-field/search-field.scss
@@ -48,7 +48,7 @@
 }
 
 .ams-search-field__input:not(:disabled):invalid,
-.ams-search-field__input[aria-invalid="true"]:not(:disabled) {
+.ams-search-field__input:not(:disabled)[aria-invalid="true"] {
   border-color: var(--ams-search-field-input-invalid-border-color);
 }
 
@@ -57,7 +57,7 @@
 }
 
 .ams-search-field__input:not(:disabled):invalid:hover,
-.ams-search-field__input[aria-invalid="true"]:not(:disabled):hover {
+.ams-search-field__input:not(:disabled)[aria-invalid="true"]:hover {
   border-color: var(--ams-search-field-input-invalid-hover-border-color);
   box-shadow: var(--ams-search-field-input-invalid-hover-box-shadow);
 }

--- a/packages/css/src/components/select/select.scss
+++ b/packages/css/src/components/select/select.scss
@@ -37,10 +37,10 @@
 .ams-select:disabled {
   color: var(--ams-select-disabled-color);
   cursor: var(--ams-select-disabled-cursor);
-}
 
-.ams-select:disabled:not([multiple]) {
-  background-image: var(--ams-select-disabled-background-image);
+  &:not([multiple]) {
+    background-image: var(--ams-select-disabled-background-image);
+  }
 }
 
 .ams-select:not(:disabled):invalid,

--- a/packages/css/src/components/select/select.scss
+++ b/packages/css/src/components/select/select.scss
@@ -44,17 +44,20 @@
 }
 
 .ams-select:not(:disabled):invalid,
-.ams-select[aria-invalid="true"]:not(:disabled) {
+.ams-select:not(:disabled)[aria-invalid="true"] {
   border-color: var(--ams-select-invalid-border-color);
 }
 
 .ams-select:not(:disabled):hover {
-  background-image: var(--ams-select-hover-background-image);
   box-shadow: var(--ams-select-hover-box-shadow);
+
+  &:not([multiple]) {
+    background-image: var(--ams-select-hover-background-image);
+  }
 }
 
 .ams-select:not(:disabled):invalid:hover,
-.ams-select[aria-invalid="true"]:not(:disabled):hover {
+.ams-select:not(:disabled)[aria-invalid="true"]:hover {
   border-color: var(--ams-select-invalid-hover-border-color);
   box-shadow: var(--ams-select-invalid-hover-box-shadow);
 }

--- a/packages/css/src/components/select/select.scss
+++ b/packages/css/src/components/select/select.scss
@@ -34,33 +34,29 @@
   }
 }
 
-.ams-select:invalid,
-.ams-select[aria-invalid="true"] {
-  border-color: var(--ams-select-invalid-border-color);
-}
-
 .ams-select:disabled {
   color: var(--ams-select-disabled-color);
   cursor: var(--ams-select-disabled-cursor);
-
-  &:not([multiple]) {
-    background-image: var(--ams-select-disabled-background-image);
-
-    /* stylelint-disable no-descending-specificity */
-    &:hover {
-      background-image: var(--ams-select-hover-background-image);
-    }
-  }
 }
 
-.ams-select:invalid:hover,
-.ams-select[aria-invalid="true"]:hover {
-  border-color: var(--ams-select-invalid-hover-border-color);
-  box-shadow: var(--ams-select-invalid-hover-box-shadow);
+.ams-select:disabled:not([multiple]) {
+  background-image: var(--ams-select-disabled-background-image);
+}
+
+.ams-select:not(:disabled):invalid,
+.ams-select[aria-invalid="true"]:not(:disabled) {
+  border-color: var(--ams-select-invalid-border-color);
 }
 
 .ams-select:not(:disabled):hover {
+  background-image: var(--ams-select-hover-background-image);
   box-shadow: var(--ams-select-hover-box-shadow);
+}
+
+.ams-select:not(:disabled):invalid:hover,
+.ams-select[aria-invalid="true"]:not(:disabled):hover {
+  border-color: var(--ams-select-invalid-hover-border-color);
+  box-shadow: var(--ams-select-invalid-hover-box-shadow);
 }
 
 .ams-select__option:disabled {

--- a/packages/css/src/components/text-area/text-area.scss
+++ b/packages/css/src/components/text-area/text-area.scss
@@ -35,9 +35,14 @@
   @include reset-textarea;
 }
 
+@mixin reset-placeholder {
+  opacity: 100%; // Reset lower opacity set by Firefox
+}
+
 .ams-text-area::placeholder {
   color: var(--ams-text-area-placeholder-color);
-  opacity: 100%; // This resets the lower opacity set by Firefox
+
+  @include reset-placeholder;
 }
 
 .ams-text-area:disabled {

--- a/packages/css/src/components/text-area/text-area.scss
+++ b/packages/css/src/components/text-area/text-area.scss
@@ -45,18 +45,19 @@
   cursor: var(--ams-text-area-disabled-cursor);
 }
 
-.ams-text-area:invalid,
-.ams-text-area[aria-invalid="true"] {
+.ams-text-area:not(:disabled):invalid,
+.ams-text-area[aria-invalid="true"]:not(:disabled) {
   border-color: var(--ams-text-area-invalid-border-color);
-
-  &:hover {
-    border-color: var(--ams-text-area-invalid-hover-border-color);
-    box-shadow: var(--ams-text-area-invalid-hover-box-shadow);
-  }
 }
 
 .ams-text-area:not(:disabled):hover {
   box-shadow: var(--ams-text-area-hover-box-shadow);
+}
+
+.ams-text-area:not(:disabled):invalid:hover,
+.ams-text-area[aria-invalid="true"]:not(:disabled):hover {
+  border-color: var(--ams-text-area-invalid-hover-border-color);
+  box-shadow: var(--ams-text-area-invalid-hover-box-shadow);
 }
 
 .ams-text-area--resize-none {

--- a/packages/css/src/components/text-area/text-area.scss
+++ b/packages/css/src/components/text-area/text-area.scss
@@ -46,7 +46,7 @@
 }
 
 .ams-text-area:not(:disabled):invalid,
-.ams-text-area[aria-invalid="true"]:not(:disabled) {
+.ams-text-area:not(:disabled)[aria-invalid="true"] {
   border-color: var(--ams-text-area-invalid-border-color);
 }
 
@@ -55,7 +55,7 @@
 }
 
 .ams-text-area:not(:disabled):invalid:hover,
-.ams-text-area[aria-invalid="true"]:not(:disabled):hover {
+.ams-text-area:not(:disabled)[aria-invalid="true"]:hover {
   border-color: var(--ams-text-area-invalid-hover-border-color);
   box-shadow: var(--ams-text-area-invalid-hover-box-shadow);
 }

--- a/packages/css/src/components/text-input/text-input.scss
+++ b/packages/css/src/components/text-input/text-input.scss
@@ -37,9 +37,14 @@
   inline-size: 100%;
 }
 
+@mixin reset-placeholder {
+  opacity: 100%; // Reset lower opacity set by Firefox
+}
+
 .ams-text-input::placeholder {
   color: var(--ams-text-input-placeholder-color);
-  opacity: 100%; // This resets the lower opacity set by Firefox
+
+  @include reset-placeholder;
 }
 
 .ams-text-input:disabled {

--- a/packages/css/src/components/text-input/text-input.scss
+++ b/packages/css/src/components/text-input/text-input.scss
@@ -48,7 +48,7 @@
 }
 
 .ams-text-input:not(:disabled):invalid,
-.ams-text-input[aria-invalid="true"]:not(:disabled) {
+.ams-text-input:not(:disabled)[aria-invalid="true"] {
   border-color: var(--ams-text-input-invalid-border-color);
 }
 
@@ -57,7 +57,7 @@
 }
 
 .ams-text-input:not(:disabled):invalid:hover,
-.ams-text-input[aria-invalid="true"]:not(:disabled):hover {
+.ams-text-input:not(:disabled)[aria-invalid="true"]:hover {
   border-color: var(--ams-text-input-invalid-hover-border-color);
   box-shadow: var(--ams-text-input-invalid-hover-box-shadow);
 }

--- a/packages/css/src/components/text-input/text-input.scss
+++ b/packages/css/src/components/text-input/text-input.scss
@@ -47,16 +47,17 @@
   cursor: var(--ams-text-input-disabled-cursor);
 }
 
-.ams-text-input:invalid,
-.ams-text-input[aria-invalid="true"] {
+.ams-text-input:not(:disabled):invalid,
+.ams-text-input[aria-invalid="true"]:not(:disabled) {
   border-color: var(--ams-text-input-invalid-border-color);
-
-  &:hover {
-    border-color: var(--ams-text-input-invalid-hover-border-color);
-    box-shadow: var(--ams-text-input-invalid-hover-box-shadow);
-  }
 }
 
 .ams-text-input:not(:disabled):hover {
   box-shadow: var(--ams-text-input-hover-box-shadow);
+}
+
+.ams-text-input:not(:disabled):invalid:hover,
+.ams-text-input[aria-invalid="true"]:not(:disabled):hover {
+  border-color: var(--ams-text-input-invalid-hover-border-color);
+  box-shadow: var(--ams-text-input-invalid-hover-box-shadow);
 }

--- a/packages/css/src/components/time-input/time-input.scss
+++ b/packages/css/src/components/time-input/time-input.scss
@@ -73,7 +73,7 @@
 }
 
 .ams-time-input:not(:disabled):invalid,
-.ams-time-input[aria-invalid="true"]:not(:disabled) {
+.ams-time-input:not(:disabled)[aria-invalid="true"] {
   border-color: var(--ams-time-input-invalid-border-color);
 }
 
@@ -82,7 +82,7 @@
 }
 
 .ams-time-input:not(:disabled):invalid:hover,
-.ams-time-input[aria-invalid="true"]:not(:disabled):hover {
+.ams-time-input:not(:disabled)[aria-invalid="true"]:hover {
   border-color: var(--ams-time-input-invalid-hover-border-color);
   box-shadow: var(--ams-time-input-invalid-hover-box-shadow);
 }

--- a/packages/css/src/components/time-input/time-input.scss
+++ b/packages/css/src/components/time-input/time-input.scss
@@ -72,16 +72,17 @@
   visibility: visible;
 }
 
-.ams-time-input:invalid,
-.ams-time-input[aria-invalid="true"] {
+.ams-time-input:not(:disabled):invalid,
+.ams-time-input[aria-invalid="true"]:not(:disabled) {
   border-color: var(--ams-time-input-invalid-border-color);
-
-  &:hover {
-    border-color: var(--ams-time-input-invalid-hover-border-color);
-    box-shadow: var(--ams-time-input-invalid-hover-box-shadow);
-  }
 }
 
 .ams-time-input:not(:disabled):hover {
   box-shadow: var(--ams-time-input-hover-box-shadow);
+}
+
+.ams-time-input:not(:disabled):invalid:hover,
+.ams-time-input[aria-invalid="true"]:not(:disabled):hover {
+  border-color: var(--ams-time-input-invalid-hover-border-color);
+  box-shadow: var(--ams-time-input-invalid-hover-box-shadow);
 }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It fixes 2 visual bugs:

- The invalid hover styling had a black inset box shadow for several inputs, instead of a dark red one
- The invalid styling 'beat' the disabled styling, which is not what we want

## Why

Bugs are bad

## How

Got rid of some of the nesting, and added `:not(:disabled)` in several spots

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
