### PR TITLE
feat(Field Set): Make space below legend smaller

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/field-set.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/field-set.tokens.json
@@ -11,7 +11,7 @@
         "font-size": { "value": "{ams.typography.heading.3.font-size}" },
         "font-weight": { "value": "{ams.typography.heading.font-weight}" },
         "line-height": { "value": "{ams.typography.heading.3.line-height}" },
-        "margin-block-end": { "value": "{ams.space.m}" },
+        "margin-block-end": { "value": "{ams.space.s}" },
         "text-wrap": { "value": "{ams.typography.heading.text-wrap}" }
       }
     }


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It makes the space below the legend in a Field Set smaller.

## Why

The `gap` in a Field was already small, but we set a medium space below the legend in a Field Set. This was a little inconsistent, and looked off with the smaller font sizes we now use.

## How

Change `m` to `s`.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
