### PR TITLE
fix(Image Slider): Improve compatibility across different React versions

### DIFF
--- a/packages/react/src/ImageSlider/ImageSliderItem.tsx
+++ b/packages/react/src/ImageSlider/ImageSliderItem.tsx
@@ -26,7 +26,7 @@ export const ImageSliderItem = forwardRef(
     )
 
     return (
-      <div {...restProps} className={itemClassName} ref={ref} {...(!isInView && { 'aria-hidden': true })}>
+      <div {...restProps} aria-hidden={!isInView ? true : undefined} className={itemClassName} ref={ref}>
         {children}
       </div>
     )

--- a/packages/react/src/ImageSlider/ImageSliderItem.tsx
+++ b/packages/react/src/ImageSlider/ImageSliderItem.tsx
@@ -26,7 +26,7 @@ export const ImageSliderItem = forwardRef(
     )
 
     return (
-      <div {...restProps} className={itemClassName} ref={ref} {...(!isInView && { inert: '' })}>
+      <div {...restProps} className={itemClassName} ref={ref} {...(!isInView && { 'aria-hidden': true })}>
         {children}
       </div>
     )


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What
Replacing the `inert: ''` with `aria-hidden: true`. 

## Why
When using the ADS in a project with React 19 it gives a console error as shown in [this issue](https://github.com/Amsterdam/design-system/issues/2198).

We can't simply assign a boolean value, as the property doesn't accept booleans (in React 18) and doing so would trigger an error.
Since we support multiple versions of React, replacing inert with aria-hidden is necessary.

I have tested if it other images do not appear in the a11y tree and it is not. Just like before with `inert`. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- [Issue](https://github.com/Amsterdam/design-system/issues/2198)
- [Feature branch deploy](https://designsystem.amsterdam/iframe.html?globals=&args=&id=components-media-image-slider--default&viewMode=story)
