### PR TITLE
chore: Add linter to help check that we only use Baseline widely available JavaScript

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import markdown from '@eslint/markdown'
 import tsParser from '@typescript-eslint/parser'
 import tsPlugin from '@typescript-eslint/eslint-plugin'
 import eslintConfigPrettier from 'eslint-config-prettier'
+import baselineJs from 'eslint-plugin-baseline-js'
 import importPlugin from 'eslint-plugin-import'
 import jest from 'eslint-plugin-jest'
 import * as mdx from 'eslint-plugin-mdx'
@@ -76,6 +77,7 @@ export default tseslint.config(
     files: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'],
     plugins: {
       '@typescript-eslint': tsPlugin,
+      'baseline-js': baselineJs,
       import: importPlugin,
       jest,
       perfectionist,
@@ -160,6 +162,12 @@ export default tseslint.config(
         },
       ],
       yoda: 'error',
+
+      // Baseline JS
+      'baseline-js/use-baseline': [
+        'error',
+        { available: 'widely', includeWebApis: { preset: 'type-aware' }, includeJsBuiltins: { preset: 'type-aware' } },
+      ],
 
       // Import
       'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@typescript-eslint/parser": "8.46.0",
     "eslint": "9.37.0",
     "eslint-config-prettier": "10.1.8",
+    "eslint-plugin-baseline-js": "0.3.0",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jest": "29.0.1",
     "eslint-plugin-mdx": "3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       eslint-config-prettier:
         specifier: 10.1.8
         version: 10.1.8(eslint@9.37.0)
+      eslint-plugin-baseline-js:
+        specifier: 0.3.0
+        version: 0.3.0(eslint@9.37.0)
       eslint-plugin-import:
         specifier: 2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0)(typescript@5.9.3))(eslint@9.37.0)
@@ -3709,6 +3712,18 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
+  eslint-plugin-baseline-js@0.3.0:
+    resolution: {integrity: sha512-1IwvYn5tJo8bHLifY5VTbf5CM1x14MLYg2ma4c5d5qf2kXyIYPo0/E77dkr6fSao6NoodiTEsooAoOzsm/V5cQ==}
+    engines: {node: '>=20.19.0 <22 || >=22.12.0'}
+    peerDependencies:
+      eslint: '>=8.57.0 <10'
+
+  eslint-plugin-es-x@9.1.0:
+    resolution: {integrity: sha512-vqKpuEsJeqFxhcJgHxyeI9sYw4o6DJ8jdT+mA4+HOszIXXbIqoW5dx4PgA5pW6/IoVBYQAk5o8ZW9EtlcXBiOQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      eslint: '>=9.29.0'
+
   eslint-plugin-import@2.32.0:
     resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
     engines: {node: '>=4'}
@@ -3760,6 +3775,12 @@ packages:
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-type-tracer@0.4.1:
+    resolution: {integrity: sha512-7kDovYNNitAxahP/qQ9UrHssUk8d6V5Y9MQaDiHPKsJrk1g6STDqVHjJPu8ycn1+qE4D0jwQRN7waRrxrX9k+Q==}
+    engines: {node: ^18 || >=20}
+    peerDependencies:
+      eslint: '>=8'
 
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
@@ -10806,6 +10827,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-plugin-baseline-js@0.3.0(eslint@9.37.0):
+    dependencies:
+      eslint: 9.37.0
+      eslint-plugin-es-x: 9.1.0(eslint@9.37.0)
+
+  eslint-plugin-es-x@9.1.0(eslint@9.37.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0)
+      '@eslint-community/regexpp': 4.12.1
+      eslint: 9.37.0
+      eslint-type-tracer: 0.4.1(eslint@9.37.0)
+
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0)(typescript@5.9.3))(eslint@9.37.0):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -10909,6 +10942,11 @@ snapshots:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
+
+  eslint-type-tracer@0.4.1(eslint@9.37.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0)
+      eslint: 9.37.0
 
   eslint-visitor-keys@3.4.3: {}
 


### PR DESCRIPTION
# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

It adds a linter to help check that we only use Baseline widely available JavaScript.

## Why

We want to adhere to the Baseline standard.

## How

Add a plugin and run ESLint. There weren't any issues to fix.
We use ES2020 JavaScript, so we're pretty cautious already. 

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
