### PR TITLE
chore: Remove obsolete imports

### DIFF
--- a/storybook/src/brand/design-tokens/colour.docs.mdx
+++ b/storybook/src/brand/design-tokens/colour.docs.mdx
@@ -1,6 +1,5 @@
 {/* @license CC0-1.0 */}
 
-import tokens from "@amsterdam/design-system-tokens/dist/index.json";
 import { Meta } from "@storybook/addon-docs/blocks";
 import { ColorPalette } from "../../docs/components/ColorPalette";
 import { InlineColorSample } from "../../styles/InlineColorSample";

--- a/storybook/src/brand/design-tokens/typography.docs.mdx
+++ b/storybook/src/brand/design-tokens/typography.docs.mdx
@@ -1,6 +1,6 @@
 {/* @license CC0-1.0 */}
 
-import { Meta, Typeset } from "@storybook/addon-docs/blocks";
+import { Meta } from "@storybook/addon-docs/blocks";
 import { FontDesignToken } from "../../styles/FontDesignToken";
 
 <Meta title="Brand/Design Tokens/Typography" />

--- a/storybook/src/components/PageHeading/PageHeading.docs.mdx
+++ b/storybook/src/components/PageHeading/PageHeading.docs.mdx
@@ -1,6 +1,6 @@
 {/* @license CC0-1.0 */}
 
-import { Canvas, Controls, Markdown, Meta, Primary } from "@storybook/addon-docs/blocks";
+import { Markdown, Meta, Primary } from "@storybook/addon-docs/blocks";
 import * as PageHeadingStories from "./PageHeading.stories.tsx";
 import README from "../../../../packages/css/src/components/page-heading/README.md?raw";
 import { StatusBadge } from "../../docs/components/StatusBadge";


### PR DESCRIPTION
Some plugin of my IDE found some unused imports in .mdx files. This removes them.