### PR TITLE
feat(Page Footer)!: Automatically render visually hidden heading before menu

### DIFF
--- a/packages/css/src/components/page-footer/README.md
+++ b/packages/css/src/components/page-footer/README.md
@@ -7,20 +7,23 @@ Provides service information at the bottom of every page.
 ## Guidelines
 
 - The Page Footer must be used on all websites for the City of Amsterdam.
-- It must be the same on every page.
-- It usually consists of two sections: a full-width blue `PageFooter.Spotlight` and a `PageFooter.Menu` below it.
-- A Page Footer containing only a `PageFooter.Menu` can be sufficient for internal websites.
-- Set [the inverse colour](?path=/docs/brand-design-tokens-colour--docs#pairing-foreground-with-background-colours) on all text and links in the Spotlight area.
+- It must be the same on every page of the website.
+
+### Content
+
+- This section is required for public websites, but not for internal ones.
+  It offers space for various practical links:
+  - The first column focuses on contact information.
+    Make it specific and tailor it to the website or page.
+  - The second column contains links to other relevant sources.
+  - The third column refers to newsletters, events, social media, etc.
+- Set [the inverse colour](?path=/docs/brand-design-tokens-colour--docs#pairing-foreground-with-background-colours) on all text and links in this area.
 - If the Page Footer contains [Headings](https://designsystem.amsterdam/?path=/docs/components-text-heading--docs), give them level 2 and a size of ‘level-3’.
   A visually hidden heading to group them is not necessary – the footer’s landmark provides enough guidance.
 
-## Content
+### Menu
 
-The top section offers space for various practical links:
-
-1. The first column focuses on contact information.
-   The information is as specific as possible and tailored to the respective website or page (e.g., including a chat option if available).
-1. The second column contains links to relevant (online) sites or sources.
-1. The third column refers to newsletters, events, social media, etc.
-
-The menu is for links to privacy policies, cookie statements, and other information about the website itself.
+- The menu is for links to privacy policies, cookie statements, and other information about the website itself.
+- It includes a visually hidden heading to provide structural context for screen reader users.
+  The default heading text is ‘Over deze website’.
+  Customize it when the menu serves a different purpose, or the interface language is not Dutch.

--- a/packages/react/src/PageFooter/PageFooterMenu.test.tsx
+++ b/packages/react/src/PageFooter/PageFooterMenu.test.tsx
@@ -20,21 +20,51 @@ describe('Page Footer Menu', () => {
       </PageFooter.Menu>,
     )
 
-    const component = screen.getByRole('list')
+    const menu = screen.getByRole('list')
 
-    const children = screen.getAllByRole('listitem')
+    const items = screen.getAllByRole('listitem')
 
-    expect(component).toBeInTheDocument()
-    expect(component).toBeVisible()
-    expect(children).toHaveLength(2)
+    expect(menu).toBeInTheDocument()
+    expect(menu).toBeVisible()
+    expect(items).toHaveLength(2)
   })
 
   it('renders a design system BEM class name', () => {
     render(<PageFooter.Menu />)
 
-    const component = screen.getByRole('list')
+    const menu = screen.getByRole('list')
 
-    expect(component).toHaveClass('ams-page-footer__menu')
+    expect(menu).toHaveClass('ams-page-footer__menu')
+  })
+
+  it('renders an extra class name', () => {
+    render(<PageFooter.Menu className="intro" />)
+
+    const menu = screen.getByRole('list')
+
+    expect(menu).toHaveClass('ams-page-footer__menu intro')
+  })
+
+  it('renders a visually hidden heading with a default text', () => {
+    render(<PageFooter.Menu />)
+
+    const heading = screen.getByRole('heading', {
+      name: 'Over deze website',
+    })
+
+    expect(heading).toBeInTheDocument()
+    expect(heading.tagName).toBe('H2')
+  })
+
+  it('renders a visually hidden heading with a custom text or heading level', () => {
+    render(<PageFooter.Menu heading="Meer informatie" headingLevel={4} />)
+
+    const heading = screen.getByRole('heading', {
+      name: 'Meer informatie',
+    })
+
+    expect(heading).toBeInTheDocument()
+    expect(heading.tagName).toBe('H4')
   })
 
   it('is able to pass a React ref', () => {
@@ -48,16 +78,8 @@ describe('Page Footer Menu', () => {
       </PageFooter.Menu>,
     )
 
-    const component = screen.getByRole('list')
+    const menu = screen.getByRole('list')
 
-    expect(ref.current).toBe(component)
-  })
-
-  it('renders an extra class name', () => {
-    render(<PageFooter.Menu className="intro" />)
-
-    const component = screen.getByRole('list')
-
-    expect(component).toHaveClass('ams-page-footer__menu intro')
+    expect(ref.current).toBe(menu)
   })
 })

--- a/packages/react/src/PageFooter/PageFooterMenu.tsx
+++ b/packages/react/src/PageFooter/PageFooterMenu.tsx
@@ -8,14 +8,40 @@ import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { clsx } from 'clsx'
 import { forwardRef } from 'react'
 
-export type PageFooterMenuProps = PropsWithChildren<HTMLAttributes<HTMLUListElement>>
+import type { HeadingProps } from '../Heading'
+
+import { getHeadingTag } from '../Heading/getHeadingTag'
+
+export type PageFooterMenuProps = {
+  /**
+   * Describes the menu for users of assistive technology.
+   * The heading gets visually hidden – sighted users can infer the meaning of the menu from its appearance.
+   * @default Over deze website
+   */
+  heading?: string
+  /**
+   * The hierarchical level of the Footer Menu’s Heading within the document.
+   * The default value is 2. This will almost always be correct – but verify this yourself.
+   */
+  headingLevel?: HeadingProps['level']
+} & PropsWithChildren<HTMLAttributes<HTMLUListElement>>
 
 export const PageFooterMenu = forwardRef(
-  ({ children, className, ...restProps }: PageFooterMenuProps, ref: ForwardedRef<HTMLUListElement>) => (
-    <ul {...restProps} className={clsx('ams-page-footer__menu', className)} ref={ref}>
-      {children}
-    </ul>
-  ),
+  (
+    { children, className, heading = 'Over deze website', headingLevel = 2, ...restProps }: PageFooterMenuProps,
+    ref: ForwardedRef<HTMLUListElement>,
+  ) => {
+    const HeadingTag = getHeadingTag(headingLevel)
+
+    return (
+      <>
+        <HeadingTag className="ams-visually-hidden">{heading}</HeadingTag>
+        <ul {...restProps} className={clsx('ams-page-footer__menu', className)} ref={ref}>
+          {children}
+        </ul>
+      </>
+    )
+  },
 )
 
 PageFooterMenu.displayName = 'PageFooter.Menu'

--- a/storybook/src/components/Page/Page.stories.tsx
+++ b/storybook/src/components/Page/Page.stories.tsx
@@ -50,9 +50,6 @@ export const Default: Story = {
         <PageBody />
       </main>,
       <PageFooter key="footer">
-        <Heading className="ams-visually-hidden" level={2}>
-          Over deze website
-        </Heading>
         <PageFooter.Spotlight>
           <Grid paddingVertical="x-large">
             <Grid.Cell span="all">
@@ -98,9 +95,6 @@ export const WithMenu: Story = {
         {children}
       </main>
       <PageFooter className="ams-page__area--footer">
-        <Heading className="ams-visually-hidden" level={2}>
-          Over deze website
-        </Heading>
         <PageFooter.Menu>
           <PageFooter.MenuLink href="/">Page Footer Menu</PageFooter.MenuLink>
         </PageFooter.Menu>

--- a/storybook/src/components/PageFooter/PageFooter.docs.mdx
+++ b/storybook/src/components/PageFooter/PageFooter.docs.mdx
@@ -18,3 +18,10 @@ The Page Footer for a specific website can be a bit different.
 Here’s an example for the ‘Onderzoek en Statistiek’ department.
 
 <Canvas of={PageFooterStories.OnderzoekEnStatistiek} />
+
+### Custom menu heading
+
+For an English website, update the visually hidden heading to ‘Support links’.
+If your website is in Dutch, but the default heading of ‘Over deze website’ doesn’t reflect the content of the menu, choose a different heading as well.
+
+<Canvas of={PageFooterStories.CustomMenuHeading} />

--- a/storybook/src/components/PageFooter/PageFooter.stories.tsx
+++ b/storybook/src/components/PageFooter/PageFooter.stories.tsx
@@ -98,10 +98,7 @@ export const Default: Story = {
           </Grid.Cell>
         </Grid>
       </PageFooter.Spotlight>,
-      <Heading className="ams-visually-hidden" key={2} level={2}>
-        Over deze website
-      </Heading>,
-      <PageFooter.Menu key={3}>
+      <PageFooter.Menu key={2}>
         <PageFooter.MenuLink href="#">Over deze site</PageFooter.MenuLink>
         <PageFooter.MenuLink href="#">Privacy</PageFooter.MenuLink>
         <PageFooter.MenuLink href="#">Cookies op deze site</PageFooter.MenuLink>
@@ -175,13 +172,23 @@ export const OnderzoekEnStatistiek: Story = {
           </Grid.Cell>
         </Grid>
       </PageFooter.Spotlight>,
-      <Heading className="ams-visually-hidden" key={2} level={2}>
-        Over deze website
-      </Heading>,
-      <PageFooter.Menu key={3}>
+      <PageFooter.Menu key={2}>
         <PageFooter.MenuLink href="#">Privacy</PageFooter.MenuLink>
         <PageFooter.MenuLink href="#">Toegankelijkheid</PageFooter.MenuLink>
       </PageFooter.Menu>,
     ],
+  },
+}
+
+export const CustomMenuHeading: Story = {
+  args: {
+    children: (
+      <PageFooter.Menu heading="Support links">
+        <PageFooter.MenuLink href="#">About this website</PageFooter.MenuLink>
+        <PageFooter.MenuLink href="#">Privacy</PageFooter.MenuLink>
+        <PageFooter.MenuLink href="#">Cookies</PageFooter.MenuLink>
+        <PageFooter.MenuLink href="#">Web archive</PageFooter.MenuLink>
+      </PageFooter.Menu>
+    ),
   },
 }

--- a/storybook/src/pages/internal/common/Layout.tsx
+++ b/storybook/src/pages/internal/common/Layout.tsx
@@ -5,7 +5,7 @@
 
 import type { HTMLAttributes, PropsWithChildren } from 'react'
 
-import { Heading, PageFooter, PageHeader, SkipLink } from '@amsterdam/design-system-react'
+import { PageFooter, PageHeader, SkipLink } from '@amsterdam/design-system-react'
 
 import { MenuWithItems } from './MenuWithItems'
 
@@ -29,9 +29,6 @@ export const Layout = ({ children }: LayoutProps) => (
       {children}
     </main>
     <PageFooter className="ams-page__area--footer">
-      <Heading className="ams-visually-hidden" level={2}>
-        Over deze website
-      </Heading>
       <PageFooter.Menu>
         <PageFooter.MenuLink href="#">E-mail je vraag of feedback</PageFooter.MenuLink>
         <PageFooter.MenuLink href="#">Bekijk help en uitleg</PageFooter.MenuLink>

--- a/storybook/src/pages/public/FormFlow/components/FormFooter.tsx
+++ b/storybook/src/pages/public/FormFlow/components/FormFooter.tsx
@@ -24,9 +24,6 @@ export const FormFooter = () => (
         </Grid.Cell>
       </Grid>
     </PageFooter.Spotlight>
-    <Heading className="ams-visually-hidden" level={2}>
-      Over deze website
-    </Heading>
     <PageFooter.Menu>
       <PageFooter.MenuLink href="#">Over deze site</PageFooter.MenuLink>
       <PageFooter.MenuLink href="#">Privacy</PageFooter.MenuLink>


### PR DESCRIPTION
This is a copy of #2320. We merged that into a release branch because we didn’t want its breaking change to get in our way. This PR merges its squashed commit into develop.