### PR TITLE
poc: Add current mega menu to example pages

### DIFF
--- a/storybook/src/pages/public/common/AppHeader.tsx
+++ b/storybook/src/pages/public/common/AppHeader.tsx
@@ -5,7 +5,7 @@
 
 import { Grid, Heading, LinkList, PageHeader } from '@amsterdam/design-system-react'
 
-import { megaMenuLinks, pageHeaderMenuLinks } from './menu'
+import { megaMenuLinkLists, pageHeaderMenuLinks } from './menu'
 
 export const AppHeader = () => (
   <PageHeader
@@ -34,18 +34,22 @@ export const AppHeader = () => (
             ))}
         </LinkList>
       </PageHeader.GridCellNarrowWindowOnly>
-      <Grid.Cell span="all">
+      <Grid.Cell span="all" style={{ marginBlockEnd: 'calc(var(--ams-space-xl) * -1)' }}>
         <Heading className="ams-mb-s" level={2}>
           Alle onderwerpen
         </Heading>
-        <LinkList>
-          {megaMenuLinks.map((label) => (
-            <LinkList.Link href="#" key={label}>
-              {label}
-            </LinkList.Link>
-          ))}
-        </LinkList>
       </Grid.Cell>
+      {megaMenuLinkLists.map((list, index) => (
+        <Grid.Cell key={index} span={4}>
+          <LinkList>
+            {list.map((label) => (
+              <LinkList.Link href="#" key={label}>
+                {label}
+              </LinkList.Link>
+            ))}
+          </LinkList>
+        </Grid.Cell>
+      ))}
     </Grid>
   </PageHeader>
 )

--- a/storybook/src/pages/public/common/menu.ts
+++ b/storybook/src/pages/public/common/menu.ts
@@ -29,4 +29,39 @@ export const pageHeaderMenuLinks: PageHeaderMenuLink[] = [
 
 type MegaMenuLink = string
 
-export const megaMenuLinks: MegaMenuLink[] = ['Afval', 'Bestuur en organisatie', 'Gemeentebelastingen', '…']
+export const megaMenuLinkLists: MegaMenuLink[][] = [
+  [
+    'Afval',
+    'Belastingen',
+    'Bestuur en organisatie',
+    'Bouw- en verkeersprojecten',
+    'Burgerzaken',
+    'Jeugdhulp',
+    'Leefomgeving',
+    'Ondernemen',
+    'Onderwijs',
+    'Parkeren',
+  ],
+  [
+    'Sport',
+    'Stadsdelen',
+    'Subsidies',
+    'Vergunningen en ontheffingen',
+    'Verkeer en vervoer',
+    'Verkiezingen',
+    'Werk aan de weg',
+    'Werk en inkomen',
+    'Wonen, bouwen en verbouwen',
+    'Zorg en ondersteuning',
+  ],
+  [
+    'Nieuws',
+    'Nieuwsbrieven',
+    'Bijeenkomsten en activiteiten',
+    'Social media, krant en tv',
+    'Evenementen en herdenkingen',
+    'Bekendmakingen',
+    'Vacatures',
+    'Contact',
+  ],
+]


### PR DESCRIPTION
Proof of concept to design with a filled mega menu. Options taken from the current home page.

Example: [Article Page (full screen)](https://designsystem.amsterdam/demo-mega-menu-complete/iframe.html?globals=&args=&id=pages-public-article-page--default&viewMode=story)