### PR TITLE
poc: Implement ChatAmsterdam home page with design system

### DIFF
--- a/packages/react/src/SearchField/SearchFieldButton.tsx
+++ b/packages/react/src/SearchField/SearchFieldButton.tsx
@@ -12,11 +12,14 @@ import type { ButtonProps } from '../Button'
 
 import { Button } from '../Button'
 
-type SearchFieldButtonProps = Omit<ButtonProps, 'icon' | 'iconBefore' | 'iconOnly' | 'variant'>
+type SearchFieldButtonProps = Omit<ButtonProps, 'iconBefore' | 'iconOnly' | 'variant'>
 
 export const SearchFieldButton = forwardRef(
-  ({ children = 'Zoeken', ...restProps }: SearchFieldButtonProps, ref: ForwardedRef<HTMLButtonElement>) => (
-    <Button {...restProps} icon={SearchIcon} iconOnly ref={ref} type="submit">
+  (
+    { children = 'Zoeken', icon = SearchIcon, ...restProps }: SearchFieldButtonProps,
+    ref: ForwardedRef<HTMLButtonElement>,
+  ) => (
+    <Button {...restProps} icon={icon} iconOnly ref={ref} type="submit">
       {children}
     </Button>
   ),

--- a/storybook/src/pages/internal/ChatAmsterdam/ChatAmsterdam.docs.mdx
+++ b/storybook/src/pages/internal/ChatAmsterdam/ChatAmsterdam.docs.mdx
@@ -1,0 +1,10 @@
+{/* @license CC0-1.0 */}
+
+import { Meta } from "@storybook/addon-docs/blocks";
+import * as ChatAmsterdamStories from "./ChatAmsterdam.stories.tsx";
+
+<Meta of={ChatAmsterdamStories} />
+
+# Chat Amsterdam
+
+Proof of concept replicating [ChatAmsterdam](https://chat.amsterdam.nl/).

--- a/storybook/src/pages/internal/ChatAmsterdam/ChatAmsterdam.stories.tsx
+++ b/storybook/src/pages/internal/ChatAmsterdam/ChatAmsterdam.stories.tsx
@@ -1,0 +1,19 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { commonMeta } from '../common/config'
+import { ChatAmsterdam } from './ChatAmsterdam'
+
+const meta = {
+  ...commonMeta,
+  title: 'Pages/Internal/Chat Amsterdam',
+  component: ChatAmsterdam,
+} satisfies Meta<typeof ChatAmsterdam>
+
+export default meta
+
+export const Default: StoryObj = {}

--- a/storybook/src/pages/internal/ChatAmsterdam/ChatAmsterdam.tsx
+++ b/storybook/src/pages/internal/ChatAmsterdam/ChatAmsterdam.tsx
@@ -1,0 +1,71 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { Grid, Heading, Paragraph, Row, SearchField } from '@amsterdam/design-system-react'
+import {
+  ArrowUpIcon,
+  DocumentIcon,
+  DocumentWithPencilIcon,
+  LightBulbIcon,
+  QuestionMarkCircleIcon,
+} from '@amsterdam/design-system-react-icons'
+
+import { Layout } from './Layout'
+import { TileButton } from './TileButton'
+
+export const ChatAmsterdam = () => (
+  <Layout>
+    <Grid paddingVertical="large">
+      <Grid.Cell
+        span={{ narrow: 3, medium: 5, wide: 7 }}
+        start={{ narrow: 1, medium: 2, wide: 3 }}
+        style={{ display: 'flex' }}
+      >
+        <div>
+          <Heading className="ams-mb-l" level={1}>
+            Goedenavond,
+            <br />
+            <span className="ams-heading--2" style={{ fontWeight: 'normal' }}>
+              waar kan ik je mee helpen?
+            </span>
+          </Heading>
+          <Row className="ams-row--tile-buttons">
+            <TileButton icon={DocumentIcon} label="Bevraag een tekst" />
+            <TileButton icon={QuestionMarkCircleIcon} label="Maak een samenvatting" />
+            <TileButton icon={DocumentWithPencilIcon} label="Verbeter een tekst" />
+            <TileButton icon={LightBulbIcon} label="Herschrijf een tekst in heldere taal" />
+          </Row>
+        </div>
+      </Grid.Cell>
+      <Grid.Cell
+        span={{ narrow: 4, medium: 5, wide: 7 }}
+        start={{ narrow: 1, medium: 2, wide: 3 }}
+        style={{ alignContent: 'end' }}
+      >
+        <div>
+          <Paragraph className="ams-mb-xl">
+            Hoewel gemeentelijke organisaties de afgelopen jaren aanzienlijke stappen hebben gezet in het digitaliseren
+            van hun dienstverlening, blijft de vraag in hoeverre deze transformatie daadwerkelijk aansluit op de
+            diepere, vaak impliciet aanwezige verwachtingen van burgers onderwerp van voortdurende discussie. Dit komt
+            mede doordat digitale interacties niet alleen afhankelijk zijn van de technische infrastructuur of de
+            toegankelijkheid van afzonderlijke systemen, maar in toenemende mate worden bepaald door de samenhang van
+            processen, de begrijpelijkheid van informatie en de mate waarin gebruikers zich herkennen in de logica die
+            de dienstverlenende organisatie hanteert. Hierdoor ontstaat een spanningsveld waarin enerzijds wordt
+            gestreefd naar efficiencywinst, schaalbaarheid en uniforme uitvoeringsstandaarden, terwijl anderzijds de
+            diversiteit aan gebruikersbehoeften en de variabiliteit van individuele gebruikssituaties een veel
+            genuanceerdere benadering vereisen.
+          </Paragraph>
+          <SearchField className="ams-mb-m">
+            <SearchField.Input placeholder="Of stel een andere vraag" />
+            <SearchField.Button icon={ArrowUpIcon} />
+          </SearchField>
+          <Paragraph size="small" style={{ color: 'var(--ams-color-text-secondary)', textAlign: 'center' }}>
+            ChatAmsterdam is een AI-systeem en kan dus fouten maken. Controleer altijd de antwoorden.
+          </Paragraph>
+        </div>
+      </Grid.Cell>
+    </Grid>
+  </Layout>
+)

--- a/storybook/src/pages/internal/ChatAmsterdam/Layout.tsx
+++ b/storybook/src/pages/internal/ChatAmsterdam/Layout.tsx
@@ -1,0 +1,52 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { HTMLAttributes, PropsWithChildren } from 'react'
+
+import { Heading, PageFooter, PageHeader, SkipLink } from '@amsterdam/design-system-react'
+import { LogOutIcon } from '@amsterdam/design-system-react-icons'
+
+import { MenuWithItems } from './MenuWithItems'
+
+type LayoutProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
+
+export const Layout = ({ children }: LayoutProps) => (
+  <>
+    <SkipLink className="ams-page__area--skip-link" href="#inhoud">
+      Direct naar inhoud
+    </SkipLink>
+    <PageHeader
+      brandName="ChatAmsterdam"
+      className="ams-page__area--header"
+      logoLink="/"
+      logoLinkTitle="Naar de homepage van ChatAmsterdam"
+      menuItems={
+        <PageHeader.MenuLink fixed href="#" icon={LogOutIcon} key="logOut">
+          Uitloggen
+        </PageHeader.MenuLink>
+      }
+      noMenuButtonOnWideWindow
+    >
+      <MenuWithItems />
+    </PageHeader>
+    <MenuWithItems className="ams-page__area--menu" inWideWindow />
+    <main className="ams-page__area--body" id="inhoud" style={{ display: 'flex' }}>
+      {children}
+    </main>
+    <PageFooter
+      className="ams-page__area--footer"
+      style={{ borderBlockStart: 'var(--ams-border-width-l) solid var(--ams-color-interactive)' }}
+    >
+      <Heading className="ams-visually-hidden" level={2}>
+        Over deze website
+      </Heading>
+      <PageFooter.Menu style={{ paddingBlock: 'var(--ams-space-s)' }}>
+        <PageFooter.MenuLink href="#">E-learning</PageFooter.MenuLink>
+        <PageFooter.MenuLink href="#">Privacyverklaring</PageFooter.MenuLink>
+        <PageFooter.MenuLink href="#">Gebruikersvoorwaarden</PageFooter.MenuLink>
+      </PageFooter.Menu>
+    </PageFooter>
+  </>
+)

--- a/storybook/src/pages/internal/ChatAmsterdam/MenuWithItems.tsx
+++ b/storybook/src/pages/internal/ChatAmsterdam/MenuWithItems.tsx
@@ -1,0 +1,38 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { MenuLinkProps, MenuProps } from '@amsterdam/design-system-react'
+
+import { Menu } from '@amsterdam/design-system-react'
+import { PlusCircleFillIcon, QuestionMarkCircleFillIcon } from '@amsterdam/design-system-react-icons'
+
+type MenuItem = {
+  href: string
+  icon: MenuLinkProps['icon']
+  text: string
+}
+
+const menuItems: MenuItem[] = [
+  {
+    href: '#',
+    icon: <PlusCircleFillIcon />,
+    text: 'Nieuwe chat',
+  },
+  {
+    href: '#',
+    icon: <QuestionMarkCircleFillIcon />,
+    text: 'Veelgestelde vragen',
+  },
+]
+
+export const MenuWithItems = (props: MenuProps) => (
+  <Menu {...props}>
+    {menuItems.map(({ href, icon, text }) => (
+      <Menu.Link href={href} icon={icon} key={text}>
+        {text}
+      </Menu.Link>
+    ))}
+  </Menu>
+)

--- a/storybook/src/pages/internal/ChatAmsterdam/TileButton.tsx
+++ b/storybook/src/pages/internal/ChatAmsterdam/TileButton.tsx
@@ -1,0 +1,29 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { IconProps } from '@amsterdam/design-system-react'
+
+import './tile-button.css'
+
+import type { ButtonHTMLAttributes, ForwardedRef } from 'react'
+
+import { Icon } from '@amsterdam/design-system-react'
+import { forwardRef } from 'react'
+
+type TileButtonProps = {
+  icon: IconProps['svg']
+  label: string
+} & ButtonHTMLAttributes<HTMLButtonElement>
+
+export const TileButton = forwardRef(
+  ({ icon, label, ...restProps }: TileButtonProps, ref: ForwardedRef<HTMLButtonElement>) => (
+    <button className="ams-tile-button" ref={ref} type="button" {...restProps}>
+      <Icon size="heading-2" svg={icon} />
+      <span>{label}</span>
+    </button>
+  ),
+)
+
+TileButton.displayName = 'TileButton'

--- a/storybook/src/pages/internal/ChatAmsterdam/tile-button.css
+++ b/storybook/src/pages/internal/ChatAmsterdam/tile-button.css
@@ -1,0 +1,64 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+.ams-tile-button {
+  --ams-icon-line-height: var(--ams-button-line-height);
+
+  background-color: var(--ams-color-background);
+  border-color: var(--ams-color-interactive);
+  border-style: var(--ams-button-border-style);
+  border-width: var(--ams-border-width-l);
+  color: var(--ams-color-interactive);
+  cursor: var(--ams-button-cursor);
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  font-family: var(--ams-button-font-family);
+  font-size: var(--ams-typography-body-text-large-font-size);
+  font-weight: var(--ams-button-font-weight);
+  gap: var(--ams-button-gap);
+  justify-content: start;
+  line-height: var(--ams-typography-body-text-large-line-height);
+  margin-block: 0;
+  margin-inline: 0;
+  outline-offset: var(--ams-button-outline-offset);
+  padding-block: var(--ams-button-padding-block);
+  padding-inline: var(--ams-button-padding-inline);
+  text-align: start;
+  touch-action: manipulation;
+
+  &:disabled,
+  &[aria-disabled="true"] {
+    cursor: var(--ams-button-disabled-cursor);
+  }
+
+  &:hover:not(:disabled, [aria-disabled="true"]) {
+    background-color: #e4effa;
+  }
+}
+
+.ams-row--tile-buttons {
+  flex-direction: column;
+
+  @media screen and (width >= 36.5rem) {
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    > * {
+      min-inline-size: 13.4rem;
+    }
+  }
+
+  @media screen and (width >= 72.5rem) {
+    > * {
+      aspect-ratio: var(--ams-aspect-ratio-4-3);
+      min-inline-size: initial;
+    }
+  }
+}
+
+body {
+  background-color: #e4effa;
+}

--- a/storybook/src/pages/internal/HomePage/HomePage.docs.mdx
+++ b/storybook/src/pages/internal/HomePage/HomePage.docs.mdx
@@ -1,9 +1,9 @@
 {/* @license CC0-1.0 */}
 
 import { Meta } from "@storybook/addon-docs/blocks";
-import * as HomeStories from "./HomePage.stories.tsx";
+import * as HomePageStories from "./HomePage.stories.tsx";
 
-<Meta of={HomeStories} />
+<Meta of={HomePageStories} />
 
 # Home page
 

--- a/storybook/src/pages/internal/HomePage/HomePage.tsx
+++ b/storybook/src/pages/internal/HomePage/HomePage.tsx
@@ -5,37 +5,41 @@
 
 import { Grid, Heading } from '@amsterdam/design-system-react'
 
+import { Layout } from '../common/Layout'
+
 export const HomePage = () => (
-  <Grid paddingBottom="x-large" paddingTop="large">
-    <Grid.Cell span="all">
-      <Heading level={1}>Titel van de pagina</Heading>
-    </Grid.Cell>
-    <Grid.Cell span={{ narrow: 4, medium: 5, wide: 8 }}>
-      <div style={{ backgroundColor: '#e8e8e8', height: '12rem' }} />
-    </Grid.Cell>
-    <Grid.Cell span={{ narrow: 1, medium: 3, wide: 4 }}>
-      <div style={{ backgroundColor: '#e8e8e8', height: '10rem' }} />
-    </Grid.Cell>
-    <Grid.Cell span={{ narrow: 3, medium: 3, wide: 3 }}>
-      <div style={{ backgroundColor: '#e8e8e8', height: '8rem' }} />
-    </Grid.Cell>
-    <Grid.Cell span={{ narrow: 4, medium: 5, wide: 9 }}>
-      <div style={{ backgroundColor: '#e8e8e8', height: '12rem' }} />
-    </Grid.Cell>
-    <Grid.Cell span={{ narrow: 2, medium: 3, wide: 6 }}>
-      <div style={{ backgroundColor: '#e8e8e8', height: '8rem' }} />
-    </Grid.Cell>
-    <Grid.Cell span={{ narrow: 2, medium: 3, wide: 6 }}>
-      <div style={{ backgroundColor: '#e8e8e8', height: '8rem' }} />
-    </Grid.Cell>
-    <Grid.Cell span={{ narrow: 3, medium: 2, wide: 4 }}>
-      <div style={{ backgroundColor: '#e8e8e8', height: '6rem' }} />
-    </Grid.Cell>
-    <Grid.Cell span={{ narrow: 1, medium: 4, wide: 4 }}>
-      <div style={{ backgroundColor: '#e8e8e8', height: '8rem' }} />
-    </Grid.Cell>
-    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
-      <div style={{ backgroundColor: '#e8e8e8', height: '6rem' }} />
-    </Grid.Cell>
-  </Grid>
+  <Layout>
+    <Grid paddingBottom="x-large" paddingTop="large">
+      <Grid.Cell span="all">
+        <Heading level={1}>Titel van de pagina</Heading>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 5, wide: 8 }}>
+        <div style={{ backgroundColor: '#e8e8e8', height: '12rem' }} />
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 1, medium: 3, wide: 4 }}>
+        <div style={{ backgroundColor: '#e8e8e8', height: '10rem' }} />
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 3, medium: 3, wide: 3 }}>
+        <div style={{ backgroundColor: '#e8e8e8', height: '8rem' }} />
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 5, wide: 9 }}>
+        <div style={{ backgroundColor: '#e8e8e8', height: '12rem' }} />
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 2, medium: 3, wide: 6 }}>
+        <div style={{ backgroundColor: '#e8e8e8', height: '8rem' }} />
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 2, medium: 3, wide: 6 }}>
+        <div style={{ backgroundColor: '#e8e8e8', height: '8rem' }} />
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 3, medium: 2, wide: 4 }}>
+        <div style={{ backgroundColor: '#e8e8e8', height: '6rem' }} />
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 1, medium: 4, wide: 4 }}>
+        <div style={{ backgroundColor: '#e8e8e8', height: '8rem' }} />
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
+        <div style={{ backgroundColor: '#e8e8e8', height: '6rem' }} />
+      </Grid.Cell>
+    </Grid>
+  </Layout>
 )

--- a/storybook/src/pages/internal/common/config.tsx
+++ b/storybook/src/pages/internal/common/config.tsx
@@ -5,16 +5,7 @@
 
 import type { Meta } from '@storybook/react-vite'
 
-import { Layout } from './Layout'
-
 export const commonMeta = {
-  decorators: [
-    (Story) => (
-      <Layout>
-        <Story />
-      </Layout>
-    ),
-  ],
   parameters: {
     layout: 'fullscreen',
     themes: { themeOverride: 'Compact' },


### PR DESCRIPTION
The design for ChatAmsterdam largely follows the design system and adds some custom elements and patterns. Unfortunately, the implementation uses nothing of the code libraries.

This poc shows how much of the homepage can be built using the design system correctly. It’s a very small project that took about two hours. It slightly changes some of the interaction, adds a basic ‘tile button’ but skips the behaviour of the text input and doesn’t offer any functionality.