### PR TITLE
chore: Remove localhost from link in ‘getting started’ docs

### DIFF
--- a/storybook/src/docs/developer-guide/getting-started.docs.mdx
+++ b/storybook/src/docs/developer-guide/getting-started.docs.mdx
@@ -33,7 +33,7 @@ export default App
 
 ## Compact Mode
 
-If you use [Compact Mode](http://localhost:6006/?path=/docs/docs-developer-guide-modes--docs#compact-mode),
+If you use [Compact Mode](/docs/docs-developer-guide-modes--docs#compact-mode),
 import the stylesheets in this order – the compact tokens override the spacious ones.
 
 {/* prettier-ignore */}


### PR DESCRIPTION
Fixes #2393