### PR TITLE
chore: Fix plop template for test stories

### DIFF
--- a/plop-templates/storybook.test.stories.tsx.hbs
+++ b/plop-templates/storybook.test.stories.tsx.hbs
@@ -3,10 +3,11 @@
  * Copyright Gemeente Amsterdam
  */
 
-import type { {{pascalCase name}} } from '@amsterdam/design-system-react/src'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { getVariants } from '../../utils/getVariants'
+import { {{pascalCase name}} } from '@amsterdam/design-system-react/src'
+
+import { renderComponentVariants } from '../../_common/renderComponentVariants'
 import { default as {{camelCase name}}Meta } from './{{pascalCase name}}.stories'
 
 const meta = {
@@ -19,6 +20,6 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
-  render: (args) => getVariants({{pascalCase name}}, { args }),
+  render: (args) => renderComponentVariants({{pascalCase name}}, { args }),
   tags: ['!dev', '!autodocs'],
 }


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Uses the latest name of `renderComponentVariants`.

## Why

I found out it was incorrect when scaffoldig a new component.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

There will still be an error when committing the pure output of the scaffolding:

```bash
/Volumes/Code/amsterdam/design-system/design-system/packages/react/src/index.ts
  8:1  error  Expected "./Accordion" to come before "./Combobox"  perfectionist/sort-exports
```

Not sure if we can do something about it. Running `npm lint-fix` will not update the order of imports in the CSS package. It does update that of the React package, but takes the `/* Append here */` comment along with it. Not in scope of this PR, not a big problem either.