### PR TITLE
feat: Use DTCG shadow format for shadow tokens

### DIFF
--- a/packages-proprietary/tokens/package.json
+++ b/packages-proprietary/tokens/package.json
@@ -30,6 +30,6 @@
   "devDependencies": {
     "change-case": "5.4.4",
     "chokidar-cli": "3.0.0",
-    "style-dictionary": "5.3.3"
+    "style-dictionary": "5.4.0"
   }
 }

--- a/packages-proprietary/tokens/src/brand/ams/border.compact.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/border.compact.tokens.json
@@ -37,6 +37,26 @@
           "$extensions": {
             "nl.amsterdam.type": "borderWidth"
           }
+        },
+        "negative": {
+          "m": {
+            "$value": {
+              "value": -0.0625,
+              "unit": "rem"
+            },
+            "$extensions": {
+              "nl.amsterdam.type": "borderWidth"
+            }
+          },
+          "xl": {
+            "$value": {
+              "value": -0.1875,
+              "unit": "rem"
+            },
+            "$extensions": {
+              "nl.amsterdam.type": "borderWidth"
+            }
+          }
         }
       }
     }

--- a/packages-proprietary/tokens/src/brand/ams/border.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/border.tokens.json
@@ -37,6 +37,26 @@
           "$extensions": {
             "nl.amsterdam.type": "borderWidth"
           }
+        },
+        "negative": {
+          "m": {
+            "$value": {
+              "value": -0.125,
+              "unit": "rem"
+            },
+            "$extensions": {
+              "nl.amsterdam.type": "borderWidth"
+            }
+          },
+          "xl": {
+            "$value": {
+              "value": -0.25,
+              "unit": "rem"
+            },
+            "$extensions": {
+              "nl.amsterdam.type": "borderWidth"
+            }
+          }
         }
       }
     }

--- a/packages-proprietary/tokens/src/components/ams/file-input.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/file-input.tokens.json
@@ -144,6 +144,7 @@
         },
         "hover": {
           "box-shadow": {
+            "$type": "shadow",
             "$value": "{ams.button.secondary.hover.box-shadow}"
           },
           "color": {

--- a/packages-proprietary/tokens/src/components/ams/select.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/select.tokens.json
@@ -86,6 +86,7 @@
       },
       "hover": {
         "box-shadow": {
+          "$type": "shadow",
           "$value": "{ams.inputs.hover.box-shadow}"
         },
         "background-image": {
@@ -103,6 +104,7 @@
             "$type": "color"
           },
           "box-shadow": {
+            "$type": "shadow",
             "$value": "{ams.inputs.invalid.hover.box-shadow}"
           }
         }

--- a/packages-proprietary/tokens/src/components/ams/switch.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/switch.tokens.json
@@ -43,7 +43,23 @@
         },
         "hover": {
           "box-shadow": {
-            "$value": "0 0 0 {ams.border.width.m} {ams.switch.thumb.hover.color}"
+            "$type": "shadow",
+            "$value": {
+              "offsetX": {
+                "value": 0,
+                "unit": "rem"
+              },
+              "offsetY": {
+                "value": 0,
+                "unit": "rem"
+              },
+              "blur": {
+                "value": 0,
+                "unit": "rem"
+              },
+              "spread": "{ams.border.width.m}",
+              "color": "{ams.switch.thumb.hover.color}"
+            }
           },
           "color": {
             "$value": "{ams.color.interactive.hover}",

--- a/packages-proprietary/tokens/src/components/ams/tabs.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/tabs.tokens.json
@@ -17,7 +17,7 @@
               "value": 0,
               "unit": "rem"
             },
-            "offsetY": "calc({ams.border.width.m} * -1)",
+            "offsetY": "{ams.border.width.negative.m}",
             "blur": {
               "value": 0,
               "unit": "rem"
@@ -88,7 +88,7 @@
                 "value": 0,
                 "unit": "rem"
               },
-              "offsetY": "calc({ams.border.width.m} * -1)",
+              "offsetY": "{ams.border.width.negative.m}",
               "blur": {
                 "value": 0,
                 "unit": "rem"
@@ -114,7 +114,7 @@
                 "value": 0,
                 "unit": "rem"
               },
-              "offsetY": "calc({ams.border.width.xl} * -1)",
+              "offsetY": "{ams.border.width.negative.xl}",
               "blur": {
                 "value": 0,
                 "unit": "rem"

--- a/packages-proprietary/tokens/src/components/ams/text-input.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/text-input.tokens.json
@@ -77,6 +77,7 @@
       },
       "hover": {
         "box-shadow": {
+          "$type": "shadow",
           "$value": "{ams.inputs.hover.box-shadow}"
         }
       },
@@ -91,6 +92,7 @@
             "$type": "color"
           },
           "box-shadow": {
+            "$type": "shadow",
             "$value": "{ams.inputs.invalid.hover.box-shadow}"
           }
         }

--- a/packages-proprietary/tokens/src/components/ams/time-input.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/time-input.tokens.json
@@ -89,6 +89,7 @@
       },
       "hover": {
         "box-shadow": {
+          "$type": "shadow",
           "$value": "{ams.inputs.hover.box-shadow}"
         },
         "calendar-picker-indicator": {
@@ -114,6 +115,7 @@
             "$type": "color"
           },
           "box-shadow": {
+            "$type": "shadow",
             "$value": "{ams.inputs.invalid.hover.box-shadow}"
           }
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
       vite:
         specifier: 8.0.2
         version: 8.0.2(@types/node@25.3.3)(esbuild@0.27.4)(sass@1.98.0)(terser@5.37.0)(yaml@2.8.2)
+      vitest:
+        specifier: 4.1.1
+        version: 4.1.1(@types/node@25.3.3)(@vitest/browser-playwright@4.1.1)(jsdom@26.1.0)(vite@8.0.2(@types/node@25.3.3)(esbuild@0.27.4)(sass@1.98.0)(terser@5.37.0)(yaml@2.8.2))
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       style-dictionary:
-        specifier: 5.3.3
-        version: 5.3.3(tslib@2.8.1)
+        specifier: 5.4.0
+        version: 5.4.0(tslib@2.8.1)
 
   packages/css:
     dependencies:
@@ -5275,8 +5275,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  style-dictionary@5.3.3:
-    resolution: {integrity: sha512-NSeYkVYttoko/TPiH82F6EewyL3eDEVQPLnh8ofRgA0EG5kYEkcMhu5/Wqkfpfpyq1tlPP1t1yePnBZm11sA/Q==}
+  style-dictionary@5.4.0:
+    resolution: {integrity: sha512-6BzO0DV19t6KUEXYfvHJ73d3y8bBDcd0wNLfoZRX817obJ8YX5Vev8Xh3+k9601tHE8qRJ/586iLt0byuY2THw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -11696,7 +11696,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  style-dictionary@5.3.3(tslib@2.8.1):
+  style-dictionary@5.4.0(tslib@2.8.1):
     dependencies:
       '@bundled-es-modules/deepmerge': 4.3.1
       '@bundled-es-modules/glob': 13.0.6

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -18,6 +18,7 @@
     "chromatic": "chromatic",
     "clean": "rimraf dist/",
     "lint": "tsc --noEmit --project ./tsconfig.json",
+    "test": "vitest run",
     "start": "storybook dev --config-dir config/ --port 6006"
   },
   "dependencies": {
@@ -46,7 +47,8 @@
     "remark-gfm": "4.0.1",
     "storybook": "10.3.3",
     "storybook-addon-pseudo-states": "10.3.3",
-    "vite": "8.0.2"
+    "vite": "8.0.2",
+    "vitest": "4.1.1"
   },
   "overrides": {
     "storybook": {

--- a/storybook/src/_common/formatTokenValue.test.ts
+++ b/storybook/src/_common/formatTokenValue.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { formatTokenValue } from './formatTokenValue'
+
+describe('formatTokenValue', () => {
+  it('returns a literal value unchanged', () => {
+    expect(formatTokenValue('2px')).toBe('2px')
+  })
+
+  it('returns an empty string unchanged', () => {
+    expect(formatTokenValue('')).toBe('')
+  })
+
+  it('converts a single token reference to a CSS custom property', () => {
+    expect(formatTokenValue('{ams.border.width.s}')).toBe('var(--ams-border-width-s)')
+  })
+
+  it('converts dots in the reference to hyphens', () => {
+    expect(formatTokenValue('{ams.color.highlight.orange}')).toBe('var(--ams-color-highlight-orange)')
+  })
+
+  it('converts multiple token references in a single string', () => {
+    expect(formatTokenValue('inset 0rem {ams.border.width.m} 0rem 0rem {ams.color.separator}')).toBe(
+      'inset 0rem var(--ams-border-width-m) 0rem 0rem var(--ams-color-separator)',
+    )
+  })
+
+  it('leaves literal parts untouched when mixed with references', () => {
+    expect(formatTokenValue('0 0 0 {ams.border.width.negative.m} hotpink')).toBe(
+      '0 0 0 var(--ams-border-width-negative-m) hotpink',
+    )
+  })
+})

--- a/storybook/src/_common/formatTokenValue.ts
+++ b/storybook/src/_common/formatTokenValue.ts
@@ -11,15 +11,15 @@
  * @returns String with all token references replaced by CSS custom properties
  *
  * @example
- * formatTokenValue("{border.width.sm}")                           // "var(--border-width-sm)"
- * formatTokenValue("{spacing.md}")                                // "var(--spacing-md)"
+ * formatTokenValue("{border.width.sm}")                          // "var(--border-width-sm)"
+ * formatTokenValue("{spacing.md}")                               // "var(--spacing-md)"
  * formatTokenValue("2px")                                        // "2px"
  * formatTokenValue("inset 0rem {border.width.m} 0rem {color.x}") // "inset 0rem var(--border-width-m) 0rem var(--color-x)"
  */
-export function formatTokenValue<Type = string>(value: string): Type {
+export function formatTokenValue<T = string>(value: string): T {
   if (value.includes('{')) {
-    return value.replace(/\{([^}]+)\}/g, (_, ref: string) => `var(--${ref.replace(/\./g, '-')})`) as unknown as Type
+    return value.replace(/\{([^}]+)\}/g, (_, ref: string) => `var(--${ref.replace(/\./g, '-')})`) as unknown as T
   }
 
-  return value as unknown as Type
+  return value as unknown as T
 }

--- a/storybook/src/_common/formatTokenValue.ts
+++ b/storybook/src/_common/formatTokenValue.ts
@@ -4,21 +4,21 @@
  */
 
 /**
- * Converts a design token reference to a CSS custom property.
+ * Converts design token references in a string to CSS custom properties.
+ * Supports both single references and strings containing multiple references.
  *
- * @param value - A token value that may be a variable reference (e.g., "{spacing.md}") or a literal value (e.g., "2px")
- * @returns CSS custom property if value is a variable reference, otherwise the original value
+ * @param value - A token value that may contain variable references (e.g., "{spacing.md}") or be a literal value (e.g., "2px")
+ * @returns String with all token references replaced by CSS custom properties
  *
  * @example
- * formatTokenValue("{border.width.sm}") // "var(--border-width-sm)"
- * formatTokenValue("{spacing.md}")      // "var(--spacing-md)"
- * formatTokenValue("2px")               // "2px"
- * formatTokenValue("1rem")              // "1rem"
+ * formatTokenValue("{border.width.sm}")                           // "var(--border-width-sm)"
+ * formatTokenValue("{spacing.md}")                                // "var(--spacing-md)"
+ * formatTokenValue("2px")                                        // "2px"
+ * formatTokenValue("inset 0rem {border.width.m} 0rem {color.x}") // "inset 0rem var(--border-width-m) 0rem var(--color-x)"
  */
 export function formatTokenValue<Type = string>(value: string): Type {
   if (value.includes('{')) {
-    const cssVar = value.replace(/[{}]/g, '').replace(/\./g, '-')
-    return `var(--${cssVar})` as unknown as Type
+    return value.replace(/\{([^}]+)\}/g, (_, ref: string) => `var(--${ref.replace(/\./g, '-')})`) as unknown as Type
   }
 
   return value as unknown as Type

--- a/storybook/src/_components/BorderSample/BorderSample.tsx
+++ b/storybook/src/_components/BorderSample/BorderSample.tsx
@@ -17,18 +17,24 @@ type BorderSampleProps = {
   width?: string
 } & HTMLAttributes<HTMLDivElement>
 
-export const BorderSample = ({ className, lineStyle, style, width, ...restProps }: BorderSampleProps) => (
-  <div
-    {...restProps}
-    className={clsx('_ams-border-sample', 'sb-unstyled', className)}
-    style={{
-      ...style,
-      // Typed as a closed keyword union, not string, so the generic cast is required
-      borderInlineStartStyle:
-        lineStyle !== undefined
-          ? formatTokenValue<CSSProperties['borderInlineStartStyle']>(lineStyle)
-          : style?.borderInlineStartStyle,
-      borderInlineStartWidth: width !== undefined ? formatTokenValue(width) : style?.borderInlineStartWidth,
-    }}
-  />
-)
+export const BorderSample = ({ className, lineStyle, style, width, ...restProps }: BorderSampleProps) => {
+  if (width?.startsWith('-')) {
+    return null
+  }
+
+  return (
+    <div
+      {...restProps}
+      className={clsx('_ams-border-sample', 'sb-unstyled', className)}
+      style={{
+        ...style,
+        // Typed as a closed keyword union, not string, so the generic cast is required
+        borderInlineStartStyle:
+          lineStyle !== undefined
+            ? formatTokenValue<CSSProperties['borderInlineStartStyle']>(lineStyle)
+            : style?.borderInlineStartStyle,
+        borderInlineStartWidth: width !== undefined ? formatTokenValue(width) : style?.borderInlineStartWidth,
+      }}
+    />
+  )
+}

--- a/storybook/src/_components/DesignTokensTable/DesignTokensTable.tsx
+++ b/storybook/src/_components/DesignTokensTable/DesignTokensTable.tsx
@@ -10,6 +10,19 @@ import { clsx } from 'clsx'
 
 import { DesignTokensTableRow } from './DesignTokensTableRow'
 
+/** A dimension expressed as a number and a CSS unit. */
+type DimensionValue = { unit: string; value: number }
+
+/** The composite value of a shadow token. */
+type ShadowValue = {
+  blur: DimensionValue | string
+  color: string
+  inset?: boolean
+  offsetX: DimensionValue | string
+  offsetY: DimensionValue | string
+  spread: DimensionValue | string
+}
+
 /** A single design token node as produced by Style Dictionary (W3C DTCG format). */
 type Token = {
   $extensions?: {
@@ -17,7 +30,7 @@ type Token = {
     'nl.amsterdam.type'?: string
   }
   $type?: string
-  $value: string | { unit: string; value: number }
+  $value: DimensionValue | ShadowValue | string
 }
 
 /** A nested tree of design tokens, where leaf nodes are `Token` objects. */
@@ -36,6 +49,28 @@ type TokenEntry = {
 const isTokenValue = (value: unknown): value is Token =>
   typeof value === 'object' && value !== null && '$value' in value
 
+/** Type guard that checks whether a value is a dimension object (i.e. has `value` and `unit` keys). */
+const isDimensionValue = (value: unknown): value is DimensionValue =>
+  typeof value === 'object' && value !== null && 'value' in value && 'unit' in value
+
+/** Formats a dimension-or-reference sub-property into a display string. */
+const formatSubValue = (subValue: DimensionValue | string): string =>
+  isDimensionValue(subValue) ? `${subValue.value}${subValue.unit}` : subValue
+
+/** Formats a shadow value object into a CSS-like display string. */
+const formatShadowValue = (shadow: ShadowValue): string => {
+  const parts = [
+    ...(shadow.inset ? ['inset'] : []),
+    formatSubValue(shadow.offsetX),
+    formatSubValue(shadow.offsetY),
+    formatSubValue(shadow.blur),
+    formatSubValue(shadow.spread),
+    shadow.color,
+  ]
+
+  return parts.join(' ')
+}
+
 /**
  * Recursively flattens a nested token tree into a list of `TokenEntry` objects.
  * Composite values (e.g. `{ value, unit }`) are normalised into a single string (e.g. `'1rem'`).
@@ -51,20 +86,23 @@ const flattenTokens = (tokens: Tokens, scope: string[] = []): TokenEntry[] =>
     // Case 1: It is a valid token
     if (isTokenValue(node)) {
       const { $extensions, $type, $value } = node
+      const type = $extensions?.['nl.amsterdam.subtype'] ?? $type ?? $extensions?.['nl.amsterdam.type']
 
       // Combine unit and value into a single string e.g. "1rem"
       let normalizedValue = ''
 
       if (typeof $value === 'string') {
         normalizedValue = $value
-      } else if (typeof $value === 'object' && $value !== null && 'value' in $value && 'unit' in $value) {
+      } else if (isDimensionValue($value)) {
         normalizedValue = `${$value.value}${$value.unit}`
+      } else if (type === 'shadow' && typeof $value === 'object') {
+        normalizedValue = formatShadowValue($value as ShadowValue)
       }
 
       return [
         {
           path: `--${currentPath.join('-')}`,
-          type: $extensions?.['nl.amsterdam.subtype'] ?? $type ?? $extensions?.['nl.amsterdam.type'],
+          type,
           value: normalizedValue,
         },
       ]

--- a/storybook/src/_components/DesignTokensTable/DesignTokensTableRow.tsx
+++ b/storybook/src/_components/DesignTokensTable/DesignTokensTableRow.tsx
@@ -6,6 +6,7 @@
 import { BorderSample } from '../BorderSample/BorderSample'
 import { Code } from '../Code/Code'
 import { ColorSample } from '../ColorSample/ColorSample'
+import { ShadowSample } from '../ShadowSample/ShadowSample'
 import { SpaceSample } from '../SpaceSample/SpaceSample'
 import { TypographySample } from '../TypographySample/TypographySample'
 
@@ -38,6 +39,7 @@ export const DesignTokensTableRow = ({ name, type, value }: DesignTokensTableRow
       {type === 'fontSize' && <TypographySample fontSize={value} />}
       {type === 'fontWeight' && <TypographySample fontWeight={value} />}
       {type === 'lineHeight' && <TypographySample lineHeight={value} />}
+      {type === 'shadow' && <ShadowSample value={value} />}
       {type === 'space' && <SpaceSample value={value} />}
     </td>
   </tr>

--- a/storybook/src/_components/ShadowSample/ShadowSample.test.stories.tsx
+++ b/storybook/src/_components/ShadowSample/ShadowSample.test.stories.tsx
@@ -1,0 +1,27 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { ShadowSample } from './ShadowSample'
+
+const meta = {
+  title: 'Components/Docs/Shadow Sample',
+} satisfies Meta<typeof ShadowSample>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Test: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--ams-space-l)' }}>
+      <ShadowSample value="0 0 0 0.125rem hotpink" />
+      <ShadowSample value="inset 0 -0.125rem 0 0 rebeccapurple" />
+      <ShadowSample value="4px 4px 8px 0 rgba(0,0,0,0.25)" />
+    </div>
+  ),
+  tags: ['!dev', '!autodocs'],
+}

--- a/storybook/src/_components/ShadowSample/ShadowSample.tsx
+++ b/storybook/src/_components/ShadowSample/ShadowSample.tsx
@@ -8,17 +8,15 @@ import type { HTMLAttributes } from 'react'
 
 import { clsx } from 'clsx'
 
+import { formatTokenValue } from '../../_common/formatTokenValue'
+
 type ShadowSampleProps = {
   /** A box-shadow token value, either a CSS value or containing token references. */
   value: string
 } & HTMLAttributes<HTMLDivElement>
 
-/** Replaces all `{token.reference}` occurrences in a string with `var(--token-reference)`. */
-const formatShadowValue = (value: string): string =>
-  value.replace(/\{([^}]+)\}/g, (_, ref: string) => `var(--${ref.replace(/\./g, '-')})`)
-
 export const ShadowSample = ({ className, style, value, ...restProps }: ShadowSampleProps) => {
-  const formattedValue = formatShadowValue(value)
+  const formattedValue = formatTokenValue(value)
 
   return (
     <div

--- a/storybook/src/_components/ShadowSample/ShadowSample.tsx
+++ b/storybook/src/_components/ShadowSample/ShadowSample.tsx
@@ -1,0 +1,30 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import './shadow-sample.css'
+import type { HTMLAttributes } from 'react'
+
+import { clsx } from 'clsx'
+
+type ShadowSampleProps = {
+  /** A box-shadow token value, either a CSS value or containing token references. */
+  value: string
+} & HTMLAttributes<HTMLDivElement>
+
+/** Replaces all `{token.reference}` occurrences in a string with `var(--token-reference)`. */
+const formatShadowValue = (value: string): string =>
+  value.replace(/\{([^}]+)\}/g, (_, ref: string) => `var(--${ref.replace(/\./g, '-')})`)
+
+export const ShadowSample = ({ className, style, value, ...restProps }: ShadowSampleProps) => {
+  const formattedValue = formatShadowValue(value)
+
+  return (
+    <div
+      {...restProps}
+      className={clsx('_ams-shadow-sample', 'sb-unstyled', className)}
+      style={{ ...style, boxShadow: formattedValue }}
+    />
+  )
+}

--- a/storybook/src/_components/ShadowSample/shadow-sample.css
+++ b/storybook/src/_components/ShadowSample/shadow-sample.css
@@ -1,0 +1,10 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+._ams-shadow-sample {
+  background-color: white;
+  block-size: 1rem;
+  inline-size: 2rem;
+}

--- a/storybook/src/brand/design-tokens/border.docs.mdx
+++ b/storybook/src/brand/design-tokens/border.docs.mdx
@@ -23,6 +23,8 @@ We use a limited set of border widths for consistency.
 The default border is 2 pixels thick.
 One thinner and two thicker options are available.
 
+Some values have a negative equivalent for borders that are drawn inside elements, using a negative offset for a box shadow.
+
 <DesignTokensTable tokens={tokensSpacious} />
 
 ### Compact Mode

--- a/storybook/vitest.config.ts
+++ b/storybook/vitest.config.ts
@@ -1,0 +1,12 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Use DTCG shadow format for shadow tokens

## What

- Update Style Dictionary to 5.4.0.
- Add negative border-width tokens (`ams.border.width.negative.m` and `ams.border.width.negative.xl`) in both default and compact variants.
- Convert shadow tokens in tabs and switch to the DTCG shadow object format.
- Replace `calc()` expressions in shadow `offsetY` values with references to the new negative tokens.
- Add missing `"$type": "shadow"` to box-shadow tokens in text-input, select, time-input, and file-input.
- Display shadow token values and a visual preview in the `DesignTokensTable`.

## Why

- Style Dictionary 5.4 enforces DTCG dimension types for shadow sub-properties, so `calc()` expressions can no longer be used for negation.
- Several box-shadow alias tokens were also inconsistently missing the `"$type": "shadow"` annotation.

## How

- Added dedicated negative border-width tokens to avoid `calc()` in shadow values.
- Converted shadow token values from shorthand strings to DTCG shadow objects with `offsetX`, `offsetY`, `blur`, `spread`, and `color` properties.
- Created a `ShadowSample` component and extended `DesignTokensTable` to serialize and visualise shadow tokens.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Related to DES-1735.
