### PR TITLE
fix(Storybook): Include React component sources in tsconfig for docgen

### DIFF
--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -15,5 +15,5 @@
     "src/**/*.ts",
     "src/**/*.tsx"
   ],
-  "exclude": ["**/node_modules/*"]
+  "exclude": ["**/node_modules/*", "../**/*.test.ts", "../**/*.test.tsx"]
 }

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -5,6 +5,13 @@
     "skipLibCheck": true
   },
   "extends": "../tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx", "config/**/*.ts", "config/**/*.tsx"],
+  "include": [
+    "../packages/react/src/**/*.ts",
+    "../packages/react/src/**/*.tsx",
+    "config/**/*.ts",
+    "config/**/*.tsx",
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
   "exclude": ["**/node_modules/*"]
 }

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -8,6 +8,8 @@
   "include": [
     "../packages/react/src/**/*.ts",
     "../packages/react/src/**/*.tsx",
+    "../packages-proprietary/react-icons/src/**/*.ts",
+    "../packages-proprietary/react-icons/src/**/*.tsx",
     "config/**/*.ts",
     "config/**/*.tsx",
     "src/**/*.ts",


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Add the React and React Icons package source files to the Storybook tsconfig's `include` array so the docgen plugin recognises them as project files.

Exclude test files so they don't cause type errors from missing Vitest types.

## Why

The upgrade of `@joshwooding/vite-plugin-react-docgen-typescript` from 0.6.4 to 0.7.0 (part of the Vite 8 upgrade) introduced a stricter check in its transform hook.

In addition to glob matching, the plugin now verifies that each file is part of the active TypeScript project by checking the tsconfig's parsed file list.

The Storybook tsconfig only included files in its own `src/` and `config/` directories, so component files in `packages/react/src/` and `packages-proprietary/react-icons/src/` were skipped with "not included in the active TypeScript project" warnings.

Including the broader source globs also pulled in `.test.ts` and `.test.tsx` files, which use Vitest matchers not available in the Storybook TypeScript context, causing lint errors.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a