### PR TITLE
feat(Grid): Allow cells to span multiple rows

### DIFF
--- a/packages/css/src/components/grid/_mixins.scss
+++ b/packages/css/src/components/grid/_mixins.scss
@@ -116,3 +116,21 @@
     grid-column-start: $i;
   }
 }
+
+// Cell row span
+
+@mixin ams-grid__cell--row-span($i) {
+  grid-row: span $i;
+}
+
+@mixin ams-grid__cell--row-span-medium($i) {
+  @media (min-width: $ams-breakpoint-medium) {
+    grid-row: span $i;
+  }
+}
+
+@mixin ams-grid__cell--row-span-wide($i) {
+  @media (min-width: $ams-breakpoint-wide) {
+    grid-row: span $i;
+  }
+}

--- a/packages/css/src/components/grid/grid.scss
+++ b/packages/css/src/components/grid/grid.scss
@@ -7,6 +7,7 @@
 @use "mixins" as *;
 
 $ams-grid-column-count: 12;
+$ams-grid-row-span-max: 4;
 
 .ams-grid {
   @include ams-grid;
@@ -115,6 +116,30 @@ $ams-grid-column-count: 12;
 
     .ams-grid__cell--start-#{$i}-wide {
       @include ams-grid__cell--start-wide($i);
+    }
+  }
+}
+
+// Cell row span
+
+@for $i from 1 through $ams-grid-row-span-max {
+  .ams-grid__cell--row-span-#{$i} {
+    @include ams-grid__cell--row-span($i);
+  }
+}
+
+@media (min-width: $ams-breakpoint-medium) {
+  @for $i from 1 through $ams-grid-row-span-max {
+    .ams-grid__cell--row-span-#{$i}-medium {
+      @include ams-grid__cell--row-span-medium($i);
+    }
+  }
+}
+
+@media (min-width: $ams-breakpoint-wide) {
+  @for $i from 1 through $ams-grid-row-span-max {
+    .ams-grid__cell--row-span-#{$i}-wide {
+      @include ams-grid__cell--row-span-wide($i);
     }
   }
 }

--- a/packages/react/src/Grid/Grid.tsx
+++ b/packages/react/src/Grid/Grid.tsx
@@ -18,6 +18,9 @@ export type GridColumnNumbers = {
   wide: GridColumnNumber
 }
 
+export type GridRowNumber = 1 | 2 | 3 | 4
+export type GridRowNumbers = { narrow: GridRowNumber; medium: GridRowNumber; wide: GridRowNumber }
+
 export const gridGaps = ['none', 'large', '2x-large'] as const
 export type GridGap = (typeof gridGaps)[number]
 

--- a/packages/react/src/Grid/GridCell.test.tsx
+++ b/packages/react/src/Grid/GridCell.test.tsx
@@ -115,6 +115,32 @@ describe('GridCell', () => {
     )
   })
 
+  it('renders no class name for an undefined value for rowSpan', () => {
+    const { container } = render(<Grid.Cell />)
+
+    const elementWithRowSpanClass = container.querySelector('[class*="ams-grid__cell--row-span"]')
+
+    expect(elementWithRowSpanClass).not.toBeInTheDocument()
+  })
+
+  it('renders a class name for a single number value for rowSpan', () => {
+    const { container } = render(<Grid.Cell rowSpan={2} />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('ams-grid__cell--row-span-2')
+  })
+
+  it('renders class names for an object value for rowSpan', () => {
+    const { container } = render(<Grid.Cell rowSpan={{ narrow: 1, medium: 3, wide: 4 }} />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass(
+      'ams-grid__cell--row-span-1 ams-grid__cell--row-span-3-medium ams-grid__cell--row-span-4-wide',
+    )
+  })
+
   it('renders the correct class name for the “all” value of span', () => {
     const { container } = render(<Grid.Cell span="all" />)
 

--- a/packages/react/src/Grid/GridCell.tsx
+++ b/packages/react/src/Grid/GridCell.tsx
@@ -8,7 +8,7 @@ import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { clsx } from 'clsx'
 import { forwardRef } from 'react'
 
-import type { GridColumnNumber, GridColumnNumbers } from './Grid'
+import type { GridColumnNumber, GridColumnNumbers, GridRowNumber, GridRowNumbers } from './Grid'
 
 import { gridCellClasses } from './gridCellClasses'
 
@@ -43,12 +43,14 @@ export type GridCellProps = {
   appearance?: GridCellAppearance
   /** The HTML tag to use. */
   as?: GridCellTag
+  /** The amount of grid rows the cell spans. */
+  rowSpan?: GridRowNumber | GridRowNumbers
 } & PropsWithChildren<HTMLAttributes<HTMLElement>> &
   (GridCellSpanAllProp | GridCellSpanAndStartProps)
 
 export const GridCell = forwardRef(
   (
-    { appearance, as: Tag = 'div', children, className, span, start, ...restProps }: GridCellProps,
+    { appearance, as: Tag = 'div', children, className, rowSpan, span, start, ...restProps }: GridCellProps,
     ref: ForwardedRef<any>,
   ) => (
     <Tag
@@ -56,7 +58,7 @@ export const GridCell = forwardRef(
       className={clsx(
         'ams-grid__cell',
         appearance && `ams-grid__cell--${appearance}`,
-        gridCellClasses(span, start),
+        gridCellClasses(span, start, rowSpan),
         className,
       )}
       ref={ref}

--- a/packages/react/src/Grid/gridCellClasses.ts
+++ b/packages/react/src/Grid/gridCellClasses.ts
@@ -16,7 +16,12 @@ export const addGridClass = (prefix: string, value?: GridColumnNumber | GridColu
   return []
 }
 
-export const gridCellClasses = (colSpan?: GridCellProps['span'], colStart?: GridCellProps['start']): string[] => [
+export const gridCellClasses = (
+  colSpan?: GridCellProps['span'],
+  colStart?: GridCellProps['start'],
+  rowSpan?: GridCellProps['rowSpan'],
+): string[] => [
   ...addGridClass('ams-grid__cell--span-', colSpan),
   ...addGridClass('ams-grid__cell--start-', colStart),
+  ...addGridClass('ams-grid__cell--row-span-', rowSpan),
 ]

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -52,12 +52,14 @@ Use the `span` prop to make a cell span more columns.
 ### Span rows
 
 The `rowSpan` prop makes a Cell span multiple rows.
+It only supports the values `1`, `2`, `3`, and `4`.
+If you use `rowSpan` responsively, each of the `narrow`, `medium`, and `wide` values must also be between `1` and `4`.
 
 <Canvas of={GridStories.SpanRows} />
 
 ### Span responsively
 
-You can make the number of columns a cell spans depend on the window width.
+The number of columns or rows that a cell covers can vary with the window width.
 Use the `span` or `rowSpan` prop with 3 values for narrow, medium, and wide windows.
 E.g. `span={{ narrow: 4, medium: 5, wide: 7 }}` makes the cell span all 4 columns on narrow windows, 5 of the 8 on medium windows, and 7 of the 12 on wide windows.
 
@@ -71,7 +73,7 @@ To stretch the cell to all columns of the grid – whether that are 4, 8, or 12 
 
 ### Start position
 
-Each cell automatically starts in the next available column in the grid.
+Each cell automatically starts in the next available position in the grid.
 Adjust the starting position of a cell with the `start` prop.
 This way, you can align cells in multiple rows or center a cell horizontally.
 It can also skip a column for more white space between cells.

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -49,10 +49,16 @@ Use the `span` prop to make a cell span more columns.
 
 <Canvas of={GridStories.SpanColumns} />
 
+### Span rows
+
+The `rowSpan` prop makes a Cell span multiple rows.
+
+<Canvas of={GridStories.SpanRows} />
+
 ### Span responsively
 
 You can make the number of columns a cell spans depend on the window width.
-Use the `span` prop with 3 values for narrow, medium, and wide windows.
+Use the `span` or `rowSpan` prop with 3 values for narrow, medium, and wide windows.
 E.g. `span={{ narrow: 4, medium: 5, wide: 7 }}` makes the cell span all 4 columns on narrow windows, 5 of the 8 on medium windows, and 7 of the 12 on wide windows.
 
 <Canvas of={GridStories.SpanResponsively} />
@@ -65,7 +71,7 @@ To stretch the cell to all columns of the grid – whether that are 4, 8, or 12 
 
 ### Start position
 
-Each cell automatically starts in the next available position in the grid.
+Each cell automatically starts in the next available column in the grid.
 Adjust the starting position of a cell with the `start` prop.
 This way, you can align cells in multiple rows or center a cell horizontally.
 It can also skip a column for more white space between cells.

--- a/storybook/src/components/Grid/Grid.stories.tsx
+++ b/storybook/src/components/Grid/Grid.stories.tsx
@@ -96,6 +96,17 @@ export const SpanColumns: CellStory = {
   },
 }
 
+export const SpanRows: Story = {
+  ...StoryTemplate,
+  args: {
+    children: [
+      <Grid.Cell className="_ams-item" key={1} rowSpan={2} span={2} />,
+      <Grid.Cell className="_ams-item" key={2} span={{ narrow: 2, medium: 6, wide: 10 }} />,
+      <Grid.Cell className="_ams-item" key={3} span={{ narrow: 2, medium: 6, wide: 10 }} />,
+    ],
+  },
+}
+
 export const SpanResponsively: CellStory = {
   ...CellStoryTemplate,
   args: {


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Allows cells to span multiple rows

## Why

PR #2534 shows a common layout for internal websites, where a vertical Tab Navigation must sit next to a horizontal Tab Navigation and another (set of) Grid Cell(s).

## How

Add a prop and CSS, just like the existing column span.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Breakout already has a `rowSpan` prop, and `rowStart` as well. We might want to deprecate those and use these classes of Grid instead, but we can do that in a separate task. Also, we’re not sure yet that Grid needs `rowStart`.