### PR TITLE
fix(Storybook): work around Story rendering bug in Firefox 140 ESR

### DIFF
--- a/storybook/config/main.ts
+++ b/storybook/config/main.ts
@@ -38,18 +38,6 @@ const config: StorybookConfig = {
     options: {},
   },
 
-  // TODO: remove this temporary workaround for Storybook's rendering of stories in Firefox 140 (ESR) when a fix has been released.
-  // Bug reports for Storybook: https://github.com/storybookjs/storybook/issues/33743, https://github.com/storybookjs/storybook/issues/33769
-  // Implemented workaround: https://github.com/storybookjs/storybook/issues/33769#issuecomment-3929210792
-  managerHead: (head) => `
-    ${head}
-    <style>
-      main[aria-labelledby="main-preview-heading"] > div {
-        place-content: stretch;
-      }
-    </style>
-  `,
-
   staticDirs: ['../../packages-proprietary/assets'],
   stories: ['../src/**/*.docs.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
 

--- a/storybook/config/main.ts
+++ b/storybook/config/main.ts
@@ -38,6 +38,18 @@ const config: StorybookConfig = {
     options: {},
   },
 
+  // TODO: remove this temporary workaround for Storybook's rendering of stories in Firefox 140 (ESR) when a fix has been released.
+  // Bug reports for Storybook: https://github.com/storybookjs/storybook/issues/33743, https://github.com/storybookjs/storybook/issues/33769
+  // Implemented workaround: https://github.com/storybookjs/storybook/issues/33769#issuecomment-3929210792
+  managerHead: (head) => `
+    ${head}
+    <style>
+      main[aria-labelledby="main-preview-heading"] > div {
+        place-content: stretch;
+      }
+    </style>
+  `,
+
   staticDirs: ['../../packages-proprietary/assets'],
   stories: ['../src/**/*.docs.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
 

--- a/storybook/config/manager-head.html
+++ b/storybook/config/manager-head.html
@@ -1,4 +1,13 @@
 <style>
+
+  /* TODO: remove this temporary workaround for Storybook's rendering of stories in Firefox 140 (ESR) when a fix has been released.
+   * Bug reports for Storybook: https://github.com/storybookjs/storybook/issues/33743, https://github.com/storybookjs/storybook/issues/33769
+   * Implemented workaround: https://github.com/storybookjs/storybook/issues/33769#issuecomment-3929210792
+   */
+  main[aria-labelledby="main-preview-heading"] > div {
+    place-content: stretch;
+  }
+
   /* Looks like we can’t configure our custom theme to keep the background of controls light in dark mode. */
   #panel-tab-content,
   input {


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Work around Storybook story rendering bug in Firefox 140 ESR

## What

Injects a small CSS override via Storybook's `managerHead` in [`storybook/config/main.ts`](storybook/config/main.ts) that sets `place-content: stretch` on the preview's `main > div`, restoring correct story rendering in Firefox 140 ESR.

## Why

Firefox 140 (ESR) triggers a layout bug in Storybook where stories fail to render correctly in the preview iframe. Tracked upstream in:

- storybookjs/storybook#33743
- storybookjs/storybook#33769

Since 140 is the current ESR line and many developers can only use this version of Firefox on their managed laptops a local workaround is needed until upstream ships a fix.

## How

Applied the community workaround from [storybookjs/storybook#33769 (comment)](https://github.com/storybookjs/storybook/issues/33769#issuecomment-3929210792): extend Storybook's `managerHead` with a `<style>` block targeting `main[aria-labelledby="main-preview-heading"] > div` and setting `place-content: stretch`. A `TODO` comment links the upstream issues so this can be removed once Storybook releases a fix.

This PR targets `main` directly as a hotfix (not `develop`).

## Checklist

- [x] Add or update unit tests — n/a, config-only workaround
- [x] Add or update documentation — n/a
- [x] Add or update stories — n/a
- [x] Add or update exports in index.\* files — n/a
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- Jira: DES-1798
- Remove the workaround once an upstream fix for storybookjs/storybook#33743 / storybookjs/storybook#33769 is released (I've subscribed to both issues).
- Worth a quick sanity check in both Firefox 140 ESR and a current stable Firefox to confirm the override is harmless where the bug isn't present.
