### PR TITLE
feat(Page): Allow components to query the width of Page to change their appearance

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/page.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/page.tokens.json
@@ -5,6 +5,12 @@
         "$value": "{ams.color.background.body}",
         "$type": "color"
       },
+      "container-name": {
+        "$value": "ams-page"
+      },
+      "container-type": {
+        "$value": "inline-size"
+      },
       "max-inline-size": {
         "$value": {
           "value": 90,

--- a/packages/css/src/components/page/README.md
+++ b/packages/css/src/components/page/README.md
@@ -6,6 +6,11 @@ Contains the entire website.
 
 The Page component wraps the [Page Header](https://designsystem.amsterdam/?path=/docs/components-containers-page-header--docs),
 [Page Footer](https://designsystem.amsterdam/?path=/docs/components-containers-page-footer--docs), and the main content in between.
-As a root layout component, it must be used for all websites for the City of Amsterdam.
 It is centered horizontally and sets a maximum width of 90 rems (usually 1.440 pixels).
 With a Menu, that becomes 120 rems (1.920 pixels).
+
+## Guidelines
+
+- As a root layout component, it must be used for all websites for the City of Amsterdam.
+- Components can adapt their appearance to the width of a container component and ultimately the Page component through a [CSS container query](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Containment/Container_queries).
+- Because Page spans the entire width of the page, it effectively allows components to adapt their appearance to the width of the viewport by using container queries instead of [CSS media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Media_queries).

--- a/packages/css/src/components/page/README.md
+++ b/packages/css/src/components/page/README.md
@@ -13,4 +13,4 @@ With a Menu, that becomes 120 rems (1.920 pixels).
 
 - As a root layout component, it must be used for all websites for the City of Amsterdam.
 - Components can adapt their appearance to the width of a container component and ultimately the Page component through a [CSS container query](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Containment/Container_queries).
-- Because Page spans the entire width of the page, it effectively allows components to adapt their appearance to the width of the viewport by using container queries instead of [CSS media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Media_queries).
+- Because Page is the top-level layout container, it allows components to adapt their appearance to the Page component’s available inline size by using container queries instead of [CSS media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Media_queries). This matches the viewport width only until the Page reaches its configured maximum width.

--- a/packages/css/src/components/page/page.scss
+++ b/packages/css/src/components/page/page.scss
@@ -5,6 +5,8 @@
 
 .ams-page {
   background-color: var(--ams-page-background-color);
+  container-name: var(--ams-page-container-name);
+  container-type: var(--ams-page-container-type);
   margin-inline: auto;
   max-inline-size: var(--ams-page-max-inline-size);
   min-block-size: 100vh; /* Fallback for browsers that do not support dvh */

--- a/storybook/src/components/Page/Page.docs.mdx
+++ b/storybook/src/components/Page/Page.docs.mdx
@@ -12,13 +12,13 @@ import { DesignTokensTable } from "../../_components/DesignTokensTable/DesignTok
 
 <Markdown>{README}</Markdown>
 
-See the [Home Page](/story/pages-public-home-page--default) template for public websites for a full-page example.
-
 <Primary />
 
 <Controls />
 
 ## Examples
+
+See the [Home Page](/story/pages-public-home-page--default) template for public websites for a full-page example.
 
 ### With menu
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Let Page act as a container query context

## What

Turns the Page component into a [CSS container query](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Containment/Container_queries) context, so components inside a page can adapt their layout to its inline size using `@container [ams-page] (…)` instead of `@media` queries against the viewport.

- Two new design tokens on `page`:
  - `container-name` (default `ams-page`)
  - `container-type` (default `inline-size`)
- `.ams-page` now sets `container-name` and `container-type` from those tokens.
- Documents the new capability in the Page README and tidies the Storybook docs page so the Home Page template link sits under *Examples* rather than above *Primary*.

## Why

Page is the root layout component of every City of Amsterdam website and, by definition, spans the full width of the viewport. By declaring it as a containment context, consumers get a single, stable query name (`ams-page`) to express "respond to the width of the browser window" without reaching for media queries. This keeps responsive behaviour consistent with the pattern already introduced on Grid Cell, and lets child components choose the right containment context for their situation (cell-level or page-level) without changing the querying mechanism.

Part of DES-1761, where Description List uses container queries to switch between stacked and column layouts based on the space it actually has.

## How

- Added `container-name` and `container-type` entries under `page` in `packages-proprietary/tokens/src/components/ams/page.tokens.json`.
- Declared `container-name: var(--ams-page-container-name)` and `container-type: var(--ams-page-container-type)` on `.ams-page` in `packages/css/src/components/page/page.scss`.
- Restructured the Page README: introduced a *Guidelines* section, kept the existing "root layout component" rule as a bullet, and added two bullets explaining container queries and the Page-as-viewport-proxy pattern.
- Moved the Home Page template link from the top of `Page.docs.mdx` into the *Examples* section, where it belongs.
- No React, markup, or API changes. The change is purely additive CSS and tokens; existing pages gain a containment context but their visual layout is unaffected.

## Checklist

- [x] Add or update unit tests (see Additional notes)
- [x] Add or update documentation
- [x] Add or update stories (see Additional notes)
- [x] Add or update exports in index.* files
- [ ] Verify visual regression tests pass (comment `/chromatic test` for a new test run)
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Related ticket: DES-1761.
- Companion to `feat/DES-1761-grid-cell-as-containment-context`: Grid Cell provides the cell-scoped `ams-grid-cell` context, this PR provides the page-scoped `ams-page` context. Neither depends on the other — they can land in any order.
- Related to #2539 that allows a Description List to use this containment context.
- No visual changes are expected. It would still be good to sanity-check Chromatic for the Page stories.
- No Story added at this time, because we do not have any components that do container queries yet and adding a custom component is too cumbersome.
- No unit or visual regression tests have been added. We should consider adding media and container query test capability to our Chromatic visual regression tests.