### PR TITLE
feat(Accordion): Rename `expanded` prop of Section to `defaultExpanded`

### DIFF
--- a/packages/react/src/Accordion/AccordionSection.test.tsx
+++ b/packages/react/src/Accordion/AccordionSection.test.tsx
@@ -5,7 +5,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react'
 import { createRef } from 'react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { Accordion } from './Accordion'
 
@@ -53,7 +53,19 @@ describe('AccordionSection', () => {
     expect(sectionContent).not.toHaveClass('ams-accordion__panel--expanded')
   })
 
-  it('adds --expanded class when expanded prop is true', () => {
+  it('adds --expanded class when defaultExpanded prop is true', () => {
+    const { getByText } = render(
+      <Accordion.Section defaultExpanded label={testLabel}>
+        {testContent}
+      </Accordion.Section>,
+    )
+
+    const sectionContent = getByText(testContent)
+
+    expect(sectionContent).toHaveClass('ams-accordion__panel--expanded')
+  })
+
+  it('still supports the deprecated expanded prop', () => {
     const { getByText } = render(
       <Accordion.Section expanded label={testLabel}>
         {testContent}
@@ -63,6 +75,34 @@ describe('AccordionSection', () => {
     const sectionContent = getByText(testContent)
 
     expect(sectionContent).toHaveClass('ams-accordion__panel--expanded')
+  })
+
+  it('lets defaultExpanded take priority over expanded', () => {
+    const { getByText } = render(
+      <Accordion.Section defaultExpanded={false} expanded label={testLabel}>
+        {testContent}
+      </Accordion.Section>,
+    )
+
+    const sectionContent = getByText(testContent)
+
+    expect(sectionContent).not.toHaveClass('ams-accordion__panel--expanded')
+  })
+
+  it('warns when the deprecated expanded prop is used', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    render(
+      <Accordion.Section expanded label={testLabel}>
+        {testContent}
+      </Accordion.Section>,
+    )
+
+    expect(spy).toHaveBeenCalledWith(
+      'Accordion.Section: The `expanded` prop is deprecated. Use `defaultExpanded` instead.',
+    )
+
+    spy.mockRestore()
   })
 
   it('renders a section HTML tag by default', () => {

--- a/packages/react/src/Accordion/AccordionSection.tsx
+++ b/packages/react/src/Accordion/AccordionSection.tsx
@@ -20,7 +20,7 @@ export type AccordionSectionProps = {
   defaultExpanded?: boolean
   /**
    * Whether the content is displayed initially.
-   * @deprecated Use the `defaultExpanded` prop instead.
+   * @deprecated Use the `defaultExpanded` prop instead. Will be removed on or after 2026-10-17.
    */
   expanded?: boolean
   /** The heading text. */

--- a/packages/react/src/Accordion/AccordionSection.tsx
+++ b/packages/react/src/Accordion/AccordionSection.tsx
@@ -7,7 +7,7 @@ import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 import { ChevronDownIcon } from '@amsterdam/design-system-react-icons'
 import { clsx } from 'clsx'
-import { forwardRef, useContext, useId, useState } from 'react'
+import { forwardRef, useContext, useEffect, useId, useState } from 'react'
 
 import type { IconProps } from '../Icon'
 
@@ -32,12 +32,14 @@ export const AccordionSection = forwardRef(
     { children, className, defaultExpanded, expanded, label, ...restProps }: AccordionSectionProps,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
-    if (expanded !== undefined) {
-      console.warn('Accordion.Section: The `expanded` prop is deprecated. Use `defaultExpanded` instead.')
-    }
-
     const { headingLevel, sectionAs } = useContext(AccordionContext)
     const [isExpanded, setIsExpanded] = useState(defaultExpanded ?? expanded ?? false)
+
+    useEffect(() => {
+      if (expanded !== undefined) {
+        console.warn('Accordion.Section: The `expanded` prop is deprecated. Use `defaultExpanded` instead.')
+      }
+    }, [])
 
     const SectionTag = sectionAs || 'section'
     const id = useId()

--- a/packages/react/src/Accordion/AccordionSection.tsx
+++ b/packages/react/src/Accordion/AccordionSection.tsx
@@ -17,6 +17,11 @@ import { AccordionContext } from './AccordionContext'
 
 export type AccordionSectionProps = {
   /** Whether the content is displayed initially. */
+  defaultExpanded?: boolean
+  /**
+   * Whether the content is displayed initially.
+   * @deprecated Use the `defaultExpanded` prop instead.
+   */
   expanded?: boolean
   /** The heading text. */
   label: string
@@ -24,11 +29,15 @@ export type AccordionSectionProps = {
 
 export const AccordionSection = forwardRef(
   (
-    { children, className, expanded = false, label, ...restProps }: AccordionSectionProps,
+    { children, className, defaultExpanded, expanded, label, ...restProps }: AccordionSectionProps,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
+    if (expanded !== undefined) {
+      console.warn('Accordion.Section: The `expanded` prop is deprecated. Use `defaultExpanded` instead.')
+    }
+
     const { headingLevel, sectionAs } = useContext(AccordionContext)
-    const [isExpanded, setIsExpanded] = useState(expanded)
+    const [isExpanded, setIsExpanded] = useState(defaultExpanded ?? expanded ?? false)
 
     const SectionTag = sectionAs || 'section'
     const id = useId()

--- a/storybook/src/components/Accordion/Accordion.docs.mdx
+++ b/storybook/src/components/Accordion/Accordion.docs.mdx
@@ -32,7 +32,7 @@ Changing the level also changes the visual size of the heading.
 
 ### Expanded by default
 
-If you want the contents of an Accordion Section to appear initially, pass the `expanded` property to the `Accordion.Section` component.
+If you want the contents of an Accordion Section to appear initially, pass the `defaultExpanded` property to the `Accordion.Section` component.
 
 <Canvas of={AccordionStories.ExpandedByDefault} />
 

--- a/storybook/src/components/Accordion/Accordion.stories.tsx
+++ b/storybook/src/components/Accordion/Accordion.stories.tsx
@@ -62,7 +62,7 @@ export const ExpandedByDefault: Story = {
       <Accordion.Section key={1} label={heading1}>
         <Paragraph>{paragraph1}</Paragraph>
       </Accordion.Section>,
-      <Accordion.Section expanded key={2} label={heading2}>
+      <Accordion.Section defaultExpanded key={2} label={heading2}>
         <Paragraph>{paragraph2}</Paragraph>
       </Accordion.Section>,
       <Accordion.Section key={3} label={heading3}>

--- a/storybook/src/components/Accordion/Accordion.test.stories.tsx
+++ b/storybook/src/components/Accordion/Accordion.test.stories.tsx
@@ -68,7 +68,7 @@ export const Test: Story = {
       {renderComponentVariants(Accordion, {
         args,
       })}
-      <Accordion.Section expanded label="Verhuizing doorgeven bij stadsloket">
+      <Accordion.Section defaultExpanded label="Verhuizing doorgeven bij stadsloket">
         <p data-testid="expanded-paragraph">
           Veel Amsterdammers in de bijstand zijn huiverig om te gaan werken. Ze denken dat ze dan minder geld krijgen,
           bijvoorbeeld omdat ze hun toeslagen verliezen. Voor deze mensen ontwikkelen we de ‘garantieknop’. Als mensen


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Rename `expanded` prop to `defaultExpanded` for Accordion Section

## What

- Added `defaultExpanded`, following the React convention for uncontrolled initial-value props (`defaultValue`, `defaultChecked`, etc.).
- The old `expanded` prop is deprecated but still works. It emits a console warning when used. `defaultExpanded` takes priority if both are provided.

## Why

- The `expanded` prop name implied controlled behaviour that the component doesn't actually deliver — it only sets the initial state via `useState`.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Test plan

- [x] Unit tests pass, including new tests for backwards compatibility, prop priority, and the deprecation warning
- [ ] Storybook stories render correctly with the new prop
- [ ] Verify console warning appears when using the old `expanded` prop

## Additional notes

- n/a