### PR TITLE
feat(Storybook): Add Navigation Page example with two-level Tab Navigation

### DIFF
--- a/storybook/src/components/TabNavigation/TabNavigation.docs.mdx
+++ b/storybook/src/components/TabNavigation/TabNavigation.docs.mdx
@@ -47,6 +47,11 @@ The links scroll horizontally when their width exceeds the available space.
 
 <Canvas of={TabNavigationStories.WithManyLinks} />
 
+### Full page template
+
+One or two Tab Navigations can be used for large internal websites.
+[Here’s a template for that.](/story/pages-internal-navigation-page--default)
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/pages/internal/NavigationPage/NavigationPage.docs.mdx
+++ b/storybook/src/pages/internal/NavigationPage/NavigationPage.docs.mdx
@@ -15,9 +15,9 @@ import * as NavigationPageStories from "./NavigationPage.stories";
 
 Use this template when content is organised into main sections that each have subsections.
 
-The first level of navigation is provided by the [Menu](/docs/components-navigation-menu--docs) component.
-A vertical [Tab Navigation](/docs/components-navigation-tab-navigation--docs) on the left shows the main sections, each with an icon.
-A horizontal Tab Navigation across the top shows the sub-items for the active section.
+The main navigation is provided by the [Menu](/docs/components-navigation-menu--docs) component.
+Within the body of the page, a vertical [Tab Navigation](/docs/components-navigation-tab-navigation--docs) shows its main sections, each with an icon.
+A second, horizontal Tab Navigation across the top shows the sub-items for the active section.
 
 Clicking a main section selects it, updates the sub-navigation, and resets its scroll position to the start.
 Each link has an `href` with a slug-based path, making the pattern suitable for both server-rendered pages and single-page applications.

--- a/storybook/src/pages/internal/NavigationPage/NavigationPage.docs.mdx
+++ b/storybook/src/pages/internal/NavigationPage/NavigationPage.docs.mdx
@@ -1,0 +1,29 @@
+{/* @license CC0-1.0 */}
+
+import { Meta } from "@storybook/addon-docs/blocks";
+import { StatusBadge } from "../../../_components/StatusBadge/StatusBadge";
+import * as NavigationPageStories from "./NavigationPage.stories";
+
+<Meta of={NavigationPageStories} />
+
+<StatusBadge
+  description="Stacking two Tab Navigations on small screens is not ideal. The mobile design is being explored."
+  status="experimental"
+/>
+
+# Navigation page
+
+Use this template when content is organised into main sections that each have subsections.
+
+The first level of navigation is provided by the [Menu](/docs/components-navigation-menu--docs) component.
+A vertical [Tab Navigation](/docs/components-navigation-tab-navigation--docs) on the left shows the main sections, each with an icon.
+A horizontal Tab Navigation across the top shows the sub-items for the active section.
+
+Clicking a main section selects it, updates the sub-navigation, and resets its scroll position to the start.
+Each link has an `href` with a slug-based path, making the pattern suitable for both server-rendered pages and single-page applications.
+
+This template works best with 3–7 main sections.
+Too few make the vertical Tab Navigation redundant; too many make it hard to scan.
+
+On narrow screens both Tab Navigations stack vertically.
+This is a known limitation, and the mobile design is being further explored.

--- a/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
@@ -1,0 +1,113 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { MouseEvent } from 'react'
+
+import { Breadcrumb, Grid, Heading, TabNavigation } from '@amsterdam/design-system-react'
+import { useRef, useState } from 'react'
+
+import { commonMeta } from '../common/config'
+import { menuItems } from './menuItems'
+
+const meta = {
+  ...commonMeta,
+  title: 'Pages/Internal/Navigation Page',
+  render: () => {
+    const [currentMenuSlug, setCurrentMenuSlug] = useState(menuItems[0].slug)
+    const [currentSubMenuSlug, setCurrentSubMenuSlug] = useState(menuItems[0].subMenuItems[0].slug)
+
+    const subMenuListRef = useRef<HTMLUListElement>(null)
+
+    const currentMenu = menuItems.find(({ slug }) => slug === currentMenuSlug) ?? menuItems[0]
+    const subMenuItems = currentMenu.subMenuItems
+    const currentSubMenu = subMenuItems.find(({ slug }) => slug === currentSubMenuSlug) ?? subMenuItems[0]
+
+    const handleMenuItemClick = (event: MouseEvent<HTMLAnchorElement>, menuSlug: string) => {
+      event.preventDefault()
+      setCurrentMenuSlug(menuSlug)
+
+      const menu = menuItems.find((item) => item.slug === menuSlug) ?? menuItems[0]
+
+      setCurrentSubMenuSlug(menu.subMenuItems[0].slug)
+      subMenuListRef.current?.scrollTo({ left: 0 })
+    }
+
+    const handleSubMenuItemClick = (event: MouseEvent<HTMLAnchorElement>, subMenuSlug: string) => {
+      event.preventDefault()
+      setCurrentSubMenuSlug(subMenuSlug)
+    }
+
+    return (
+      <Grid paddingVertical="x-large">
+        <Grid.Cell appearance="transparent" span="all">
+          <Breadcrumb>
+            <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+            <Breadcrumb.Link href="#">Projecten</Breadcrumb.Link>
+          </Breadcrumb>
+          <Heading level={1}>Naam van het project</Heading>
+        </Grid.Cell>
+        <Grid.Cell appearance="flush" rowSpan={2} span={{ narrow: 4, medium: 2, wide: 2 }}>
+          <TabNavigation accessibleName="Navigatie voor dit project" orientation="vertical">
+            <TabNavigation.List>
+              {menuItems.map(({ icon, label, slug }) => (
+                <TabNavigation.Link
+                  aria-current={currentMenuSlug === slug ? 'page' : undefined}
+                  href={`/projecten/42/${slug}`}
+                  icon={icon}
+                  key={slug}
+                  onClick={(e) => handleMenuItemClick(e, slug)}
+                >
+                  {label}
+                </TabNavigation.Link>
+              ))}
+            </TabNavigation.List>
+          </TabNavigation>
+        </Grid.Cell>
+        <Grid.Cell
+          appearance="flush"
+          span={{ narrow: 4, medium: 6, wide: 10 }}
+          start={{ narrow: 1, medium: 3, wide: 3 }}
+        >
+          <TabNavigation accessibleName="Subnavigatie voor dit project">
+            <TabNavigation.List ref={subMenuListRef}>
+              {subMenuItems.map(({ label, slug }) => (
+                <TabNavigation.Link
+                  aria-current={currentSubMenuSlug === slug ? 'page' : undefined}
+                  href={`/projecten/42/${currentMenuSlug}/${slug}`}
+                  key={slug}
+                  onClick={(e) => handleSubMenuItemClick(e, slug)}
+                >
+                  {label}
+                </TabNavigation.Link>
+              ))}
+            </TabNavigation.List>
+          </TabNavigation>
+        </Grid.Cell>
+        <Grid.Cell
+          span={{ narrow: 4, medium: 6, wide: 7 }}
+          start={{ narrow: 1, medium: 3, wide: 3 }}
+          style={{ blockSize: `${currentSubMenu.cellHeights[0]}vb` }}
+        >
+          <Heading className="ams-mb-s" level={2}>
+            {currentMenu.label}
+          </Heading>
+          <Heading className="ams-mb-m" level={3}>
+            {currentSubMenu.label}
+          </Heading>
+        </Grid.Cell>
+        <Grid.Cell
+          span={{ narrow: 4, medium: 4, wide: 3 }}
+          start={{ narrow: 1, medium: 3, wide: 10 }}
+          style={{ blockSize: `${currentSubMenu.cellHeights[1]}vb` }}
+        />
+      </Grid>
+    )
+  },
+} satisfies Meta
+
+export default meta
+
+export const Default: StoryObj = {}

--- a/storybook/src/pages/internal/NavigationPage/menuItems.tsx
+++ b/storybook/src/pages/internal/NavigationPage/menuItems.tsx
@@ -23,7 +23,7 @@ type MenuItem = {
 }
 
 type SubMenuItem = {
-  // These random heights in `vb` simulate content variation in the two Grid Cells.
+  // These random heights in `vb` (viewport block size) simulate content variation in the two Grid Cells on every page.
   cellHeights: [number, number]
   label: string
   slug: string

--- a/storybook/src/pages/internal/NavigationPage/menuItems.tsx
+++ b/storybook/src/pages/internal/NavigationPage/menuItems.tsx
@@ -1,0 +1,116 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { IconProps } from '@amsterdam/design-system-react'
+
+import {
+  CalendarIcon,
+  DocumentIcon,
+  EuroIcon,
+  GridIcon,
+  MapMarkerIcon,
+  MegaphoneIcon,
+  PersonsIcon,
+} from '@amsterdam/design-system-react-icons'
+
+type MenuItem = {
+  icon: IconProps['svg']
+  label: string
+  slug: string
+  subMenuItems: Array<SubMenuItem>
+}
+
+type SubMenuItem = {
+  // These random heights in `vb` simulate content variation in the two Grid Cells.
+  cellHeights: [number, number]
+  label: string
+  slug: string
+}
+
+export const menuItems: Array<MenuItem> = [
+  {
+    icon: GridIcon,
+    label: 'Overzicht',
+    slug: 'overzicht',
+    subMenuItems: [
+      { cellHeights: [64, 48], label: 'Samenvatting', slug: 'samenvatting' },
+      { cellHeights: [72, 40], label: 'Status', slug: 'status' },
+      { cellHeights: [56, 64], label: 'Kenmerken', slug: 'kenmerken' },
+      { cellHeights: [80, 32], label: 'Tijdlijn', slug: 'tijdlijn' },
+      { cellHeights: [48, 56], label: 'Gerelateerde projecten', slug: 'gerelateerde-projecten' },
+    ],
+  },
+  {
+    icon: CalendarIcon,
+    label: 'Planning',
+    slug: 'planning',
+    subMenuItems: [
+      { cellHeights: [88, 44], label: 'Fasering', slug: 'fasering' },
+      { cellHeights: [52, 72], label: 'Mijlpalen', slug: 'mijlpalen' },
+      { cellHeights: [40, 88], label: 'Omleidingen', slug: 'omleidingen' },
+      { cellHeights: [76, 36], label: 'Afsluitingen', slug: 'afsluitingen' },
+      { cellHeights: [60, 52], label: 'Werkzaamheden', slug: 'werkzaamheden' },
+    ],
+  },
+  {
+    icon: MapMarkerIcon,
+    label: 'Locatie',
+    slug: 'locatie',
+    subMenuItems: [
+      { cellHeights: [96, 40], label: 'Kaart', slug: 'kaart' },
+      { cellHeights: [44, 80], label: 'Werkgebied', slug: 'werkgebied' },
+      { cellHeights: [68, 56], label: 'Bereikbaarheid', slug: 'bereikbaarheid' },
+      { cellHeights: [56, 68], label: 'Omliggende projecten', slug: 'omliggende-projecten' },
+    ],
+  },
+  {
+    icon: DocumentIcon,
+    label: 'Documenten',
+    slug: 'documenten',
+    subMenuItems: [
+      { cellHeights: [48, 92], label: 'Vergunningen', slug: 'vergunningen' },
+      { cellHeights: [84, 36], label: 'Tekeningen', slug: 'tekeningen' },
+      { cellHeights: [60, 60], label: 'Rapporten', slug: 'rapporten' },
+      { cellHeights: [36, 76], label: 'Besluiten', slug: 'besluiten' },
+      { cellHeights: [72, 48], label: 'Overeenkomsten', slug: 'overeenkomsten' },
+    ],
+  },
+  {
+    icon: EuroIcon,
+    label: 'Financiën',
+    slug: 'financien',
+    subMenuItems: [
+      { cellHeights: [76, 52], label: 'Begroting', slug: 'begroting' },
+      { cellHeights: [44, 84], label: 'Besteding', slug: 'besteding' },
+      { cellHeights: [92, 40], label: 'Prognose', slug: 'prognose' },
+      { cellHeights: [56, 68], label: 'Facturen', slug: 'facturen' },
+      { cellHeights: [64, 44], label: 'Subsidies', slug: 'subsidies' },
+    ],
+  },
+  {
+    icon: PersonsIcon,
+    label: 'Betrokkenen',
+    slug: 'betrokkenen',
+    subMenuItems: [
+      { cellHeights: [40, 96], label: 'Opdrachtgever', slug: 'opdrachtgever' },
+      { cellHeights: [68, 52], label: 'Aannemer', slug: 'aannemer' },
+      { cellHeights: [84, 36], label: 'Toezicht', slug: 'toezicht' },
+      { cellHeights: [52, 72], label: 'Stakeholders', slug: 'stakeholders' },
+      { cellHeights: [60, 60], label: 'Contactpersonen', slug: 'contactpersonen' },
+    ],
+  },
+  {
+    icon: MegaphoneIcon,
+    label: 'Communicatie',
+    slug: 'communicatie',
+    subMenuItems: [
+      { cellHeights: [72, 44], label: 'Bewonersberichten', slug: 'bewonersberichten' },
+      { cellHeights: [48, 80], label: 'Omgevingsmelding', slug: 'omgevingsmelding' },
+      { cellHeights: [88, 32], label: 'Klachten en meldingen', slug: 'klachten-en-meldingen' },
+      { cellHeights: [36, 64], label: 'Persberichten', slug: 'persberichten' },
+      { cellHeights: [56, 56], label: 'Nieuwsbrieven', slug: 'nieuwsbrieven' },
+    ],
+  },
+]


### PR DESCRIPTION
# Describe the pull request

## Link

- [Story](https://designsystem.amsterdam/?path=/story/pages-internal-navigation-page--default)
- [Full screen](https://designsystem.amsterdam/iframe.html?id=pages-internal-navigation-page--default&viewMode=story)

## What

Adds a Navigation Page example to the internal Storybook pages demonstrating two levels of Tab Navigation: a vertical sidebar for main sections and a horizontal bar for sub-items.

## Why

There was no example showing how to combine vertical and horizontal Tab Navigation instances on a single page.
This pattern is common in internal applications with large data sets spread across multiple sections.

## How

- A `menuItems` data file defines 7 main sections (Overzicht, Planning, Locatie, Documenten, Financiën, Betrokkenen, Communicatie) with slugs and descriptive icons, each containing 4–5 sub-items with their own slugs.
- The story manages active menu and sub-menu state through slugs and uses them as `href` values.
- Switching a main section resets the horizontal sub-navigation scroll position to the start.
- Each sub-item has `cellHeights` to simulate varying page layouts after navigation.
- A short docs page introduces the pattern.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [[as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11)](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- This is a Storybook-only change; no component source code is modified.
- This PR is on top of #2552. Rebase onto develop before merging.