### PR TITLE
chore: Add PR workflows for bundle size and coverage reports

### DIFF
--- a/.github/workflows/pr-bundle-size.yml
+++ b/.github/workflows/pr-bundle-size.yml
@@ -30,5 +30,5 @@ jobs:
         with:
           build-script: build
           install-script: pnpm install --frozen-lockfile --ignore-scripts
-          pattern: "{packages/react/dist/index*.js,packages/css/dist/index.css,packages-proprietary/tokens/dist/{index,compact}.{mjs,css,json}}"
+          pattern: "{packages/react/dist/index!(*.cjs).js,packages/css/dist/index.css,packages-proprietary/tokens/dist/!(*.theme).css}"
           strip-hash: "\\b\\w{8}\\."

--- a/.github/workflows/pr-bundle-size.yml
+++ b/.github/workflows/pr-bundle-size.yml
@@ -1,0 +1,34 @@
+name: Bundle size report
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  compressed-size:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          cache: pnpm
+          node-version-file: .nvmrc
+
+      - name: Report bundle size
+        uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2.9.1
+        with:
+          build-script: build
+          install-script: pnpm install --frozen-lockfile --ignore-scripts
+          pattern: "{packages/react/dist/index*.js,packages/css/dist/index.css,packages-proprietary/tokens/dist/{index,compact}.{mjs,css,json}}"
+          strip-hash: "\\b\\w{8}\\."

--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -1,0 +1,42 @@
+name: Coverage report
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  coverage:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          cache: pnpm
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build icons package
+        run: pnpm --filter @amsterdam/design-system-react-icons build
+
+      - name: Run tests with coverage
+        run: pnpm --filter @amsterdam/design-system-react test
+
+      - name: Report coverage
+        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2.11.2
+        with:
+          json-summary-path: packages/react/coverage/coverage-summary.json
+          name: React components
+          threshold-icons: '{"0": "🔴", "90": "🟠", "95": "🟢"}'

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     coverage: {
       exclude: ['**/index.ts'],
       provider: 'v8',
+      reporter: ['text', 'json-summary'],
     },
     environment: 'jsdom',
     exclude: ['**/dist/**', '**/node_modules/**'],


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Add PR workflows for bundle size and coverage reports

## What

- Add a bundle size comparison workflow that posts a PR comment showing size changes across the React, CSS, and tokens packages
- Add a test coverage workflow that posts a PR comment with coverage metrics for the React package
- Add json-summary to the Vitest coverage reporters so the coverage action can read the output

## Bundle size workflow details
- Tracks only meaningful entry points: `index*.js` for React, `index.css` for CSS, and `{index,compact}.{mjs,css,json}` for tokens — keeping the PR comment concise
- Uses `--ignore-scripts` on install to skip the postinstall build, so the monorepo is only built once
- Skips fork PRs, which cannot write PR comments due to GitHub token restrictions

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- See #2559 for iterations