### PR TITLE
chore: Add react-icons and assets to bundle size reports

### DIFF
--- a/.github/workflows/pr-bundle-size.yml
+++ b/.github/workflows/pr-bundle-size.yml
@@ -31,10 +31,6 @@ jobs:
           tar -czf packages-proprietary/temp/assets-fonts.tar.gz -C packages-proprietary/assets font
           tar -czf packages-proprietary/temp/assets-others.tar.gz -C packages-proprietary/assets app-icons favicon icons logo manifest *.svg *.png *.jpg *.jpeg *.gif *.webp *.avif *.ico 2>/dev/null || true
 
-      - name: Clean up asset aggregates
-        if: always()
-        run: rm -rf packages-proprietary/temp/
-
       - name: Report bundle size
         uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2.9.1
         with:
@@ -42,3 +38,7 @@ jobs:
           install-script: pnpm install --frozen-lockfile --ignore-scripts
           pattern: "{packages/react/dist/index!(*.cjs).js,packages/css/dist/index.css,packages-proprietary/tokens/dist/!(*.theme).css,packages-proprietary/react-icons/dist/index.esm.js,packages-proprietary/temp/assets-fonts.tar.gz,packages-proprietary/temp/assets-others.tar.gz}"
           strip-hash: "\\b\\w{8}\\."
+
+      - name: Clean up asset aggregates
+        if: always()
+        run: rm -rf packages-proprietary/temp/

--- a/.github/workflows/pr-bundle-size.yml
+++ b/.github/workflows/pr-bundle-size.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Clean up asset aggregates
         if: always()
-        run: rm -rf packages-proprietary/temp/
+        run: rm -f packages-proprietary/temp/assets-fonts.tar.gz packages-proprietary/temp/assets-others.tar.gz

--- a/.github/workflows/pr-bundle-size.yml
+++ b/.github/workflows/pr-bundle-size.yml
@@ -27,14 +27,18 @@ jobs:
 
       - name: Create asset aggregates
         run: |
-          mkdir -p packages-proprietary/assets-sizes
-          tar -czf packages-proprietary/assets-sizes/fonts.tar.gz -C packages-proprietary/assets font
-          tar -czf packages-proprietary/assets-sizes/assets-other.tar.gz -C packages-proprietary/assets app-icons favicon icons logo manifest *.svg *.png *.jpg *.jpeg *.gif *.webp *.avif *.ico 2>/dev/null || true
+          mkdir -p packages-proprietary/temp
+          tar -czf packages-proprietary/temp/assets-fonts.tar.gz -C packages-proprietary/assets font
+          tar -czf packages-proprietary/temp/assets-others.tar.gz -C packages-proprietary/assets app-icons favicon icons logo manifest *.svg *.png *.jpg *.jpeg *.gif *.webp *.avif *.ico 2>/dev/null || true
+
+      - name: Clean up asset aggregates
+        if: always()
+        run: rm -rf packages-proprietary/temp/
 
       - name: Report bundle size
         uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2.9.1
         with:
           build-script: build
           install-script: pnpm install --frozen-lockfile --ignore-scripts
-          pattern: "{packages/react/dist/index!(*.cjs).js,packages/css/dist/index.css,packages-proprietary/tokens/dist/!(*.theme).css,packages-proprietary/react-icons/dist/index.esm.js,packages-proprietary/assets-sizes/fonts.tar.gz,packages-proprietary/assets-sizes/assets-other.tar.gz}"
+          pattern: "{packages/react/dist/index!(*.cjs).js,packages/css/dist/index.css,packages-proprietary/tokens/dist/!(*.theme).css,packages-proprietary/react-icons/dist/index.esm.js,packages-proprietary/temp/assets-fonts.tar.gz,packages-proprietary/temp/assets-others.tar.gz}"
           strip-hash: "\\b\\w{8}\\."

--- a/.github/workflows/pr-bundle-size.yml
+++ b/.github/workflows/pr-bundle-size.yml
@@ -25,10 +25,16 @@ jobs:
           cache: pnpm
           node-version-file: .nvmrc
 
+      - name: Create asset aggregates
+        run: |
+          mkdir -p packages-proprietary/assets-sizes
+          tar -czf packages-proprietary/assets-sizes/fonts.tar.gz -C packages-proprietary/assets font
+          tar -czf packages-proprietary/assets-sizes/assets-other.tar.gz -C packages-proprietary/assets app-icons favicon icons logo manifest *.svg *.png *.jpg *.jpeg *.gif *.webp *.avif *.ico 2>/dev/null || true
+
       - name: Report bundle size
         uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2.9.1
         with:
           build-script: build
           install-script: pnpm install --frozen-lockfile --ignore-scripts
-          pattern: "{packages/react/dist/index!(*.cjs).js,packages/css/dist/index.css,packages-proprietary/tokens/dist/!(*.theme).css,packages-proprietary/react-icons/dist/index.esm.js,packages-proprietary/assets/font/**/*,packages-proprietary/assets/**/*.{svg,png,jpg,jpeg,gif,webp,avif,ico}}"
+          pattern: "{packages/react/dist/index!(*.cjs).js,packages/css/dist/index.css,packages-proprietary/tokens/dist/!(*.theme).css,packages-proprietary/react-icons/dist/index.esm.js,packages-proprietary/assets-sizes/fonts.tar.gz,packages-proprietary/assets-sizes/assets-other.tar.gz}"
           strip-hash: "\\b\\w{8}\\."

--- a/.github/workflows/pr-bundle-size.yml
+++ b/.github/workflows/pr-bundle-size.yml
@@ -30,5 +30,5 @@ jobs:
         with:
           build-script: build
           install-script: pnpm install --frozen-lockfile --ignore-scripts
-          pattern: "{packages/react/dist/index!(*.cjs).js,packages/css/dist/index.css,packages-proprietary/tokens/dist/!(*.theme).css,packages-proprietary/react-icons/dist/index.esm.js,packages-proprietary/assets/font/**/*,packages-proprietary/assets/!(font)/**/*}"
+          pattern: "{packages/react/dist/index!(*.cjs).js,packages/css/dist/index.css,packages-proprietary/tokens/dist/!(*.theme).css,packages-proprietary/react-icons/dist/index.esm.js,packages-proprietary/assets/font/**/*,packages-proprietary/assets/**/*.{svg,png,jpg,jpeg,gif,webp,avif,ico}}"
           strip-hash: "\\b\\w{8}\\."

--- a/.github/workflows/pr-bundle-size.yml
+++ b/.github/workflows/pr-bundle-size.yml
@@ -30,5 +30,5 @@ jobs:
         with:
           build-script: build
           install-script: pnpm install --frozen-lockfile --ignore-scripts
-          pattern: "{packages/react/dist/index!(*.cjs).js,packages/css/dist/index.css,packages-proprietary/tokens/dist/!(*.theme).css}"
+          pattern: "{packages/react/dist/index!(*.cjs).js,packages/css/dist/index.css,packages-proprietary/tokens/dist/!(*.theme).css,packages-proprietary/react-icons/dist/index.esm.js,packages-proprietary/assets/**/*}"
           strip-hash: "\\b\\w{8}\\."

--- a/.github/workflows/pr-bundle-size.yml
+++ b/.github/workflows/pr-bundle-size.yml
@@ -30,5 +30,5 @@ jobs:
         with:
           build-script: build
           install-script: pnpm install --frozen-lockfile --ignore-scripts
-          pattern: "{packages/react/dist/index!(*.cjs).js,packages/css/dist/index.css,packages-proprietary/tokens/dist/!(*.theme).css,packages-proprietary/react-icons/dist/index.esm.js,packages-proprietary/assets/**/*}"
+          pattern: "{packages/react/dist/index!(*.cjs).js,packages/css/dist/index.css,packages-proprietary/tokens/dist/!(*.theme).css,packages-proprietary/react-icons/dist/index.esm.js,packages-proprietary/assets/font/**/*,packages-proprietary/assets/!(font)/**/*}"
           strip-hash: "\\b\\w{8}\\."


### PR DESCRIPTION
## Summary

Adds monitoring of package sizes to the PR bundle size report workflow:
- **react-icons ESM variant** (~52 KB gzipped) - Provides visibility into this substantial bundle to catch size regressions
- **Assets fonts** - Aggregated tar archive of all fonts from packages-proprietary/assets/font/
- **Assets other** - Aggregated tar archive of all other assets (icons, logos, images) from packages-proprietary/assets/

## Implementation

The workflow:
1. Creates tar.gz archives of asset categories to provide clean aggregated size reports
2. Measures only the two tar files instead of listing hundreds of individual asset files
3. Reports clean bundle size comparisons on each PR
4. Cleans up temporary archives after reporting

## Bundle Size Impact

The report now tracks:
- `packages/react/dist/index.esm.js` (main package)
- `packages/css/dist/index.css` (styles)
- `packages-proprietary/tokens/dist/index.css` (design tokens)
- `packages-proprietary/react-icons/dist/index.esm.js` (icons bundle)
- `packages-proprietary/temp/assets-fonts.tar.gz` (fonts total)
- `packages-proprietary/temp/assets-others.tar.gz` (other assets total)