### PR TITLE
fix(Field Set): Don’t grow beyond container width for wide inputs or textareas

### DIFF
--- a/packages/css/src/components/field-set/field-set.scss
+++ b/packages/css/src/components/field-set/field-set.scss
@@ -11,6 +11,7 @@
   @include reset-fieldset;
 
   break-inside: avoid;
+  min-inline-size: 0; // Prevent growing to fit children with an intrinsic width (e.g. input[size], textarea[cols]).
 }
 
 // Default margin between all direct children of Field Set

--- a/storybook/src/components/PasswordInput/PasswordInput.docs.mdx
+++ b/storybook/src/components/PasswordInput/PasswordInput.docs.mdx
@@ -20,8 +20,9 @@ import { DesignTokensTable } from "../../_components/DesignTokensTable/DesignTok
 
 ### Size
 
-The size of the input should be appropriate for the information to be entered.
-Use the `size` attribute to set the right size.
+Match the width of the input to the expected length of its content.
+Use the `size` attribute for this.
+The input won’t grow beyond the width of its container.
 
 <Canvas of={PasswordInputStories.Size} />
 

--- a/storybook/src/components/TextInput/TextInput.docs.mdx
+++ b/storybook/src/components/TextInput/TextInput.docs.mdx
@@ -100,13 +100,14 @@ We follow the advice against using `type="number"` by [NL Design System](https:/
 
 ### Size
 
-Make the width of the input appropriate for the information to be entered.
+Match the width of the input to the expected length of its content.
 Use the `size` attribute for this.
+The input won’t grow beyond the width of its container.
 
-Avoid making it too narrow – ensure the user has enough space to operate comfortably.
-This also gives browsers or extensions an opportunity to add an icon or button at the end.
+Avoid sizes that feel cramped: the user needs room to type and review comfortably.
+Extra space also leaves room for icons or buttons that browsers and extensions may add.
 
-We suggest a size of 15 for a phone number, 30 for an e-mail address, 40 for a web address, and 7 for a postal code.
+As a rule of thumb: 7 for a postal code, 15 for a phone number, 30 for an email address, and 40 for a web address.
 
 <Canvas of={TextInputStories.Size} />
 

--- a/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
@@ -6,7 +6,17 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { MouseEvent } from 'react'
 
-import { Breadcrumb, Grid, Heading, TabNavigation } from '@amsterdam/design-system-react'
+import {
+  Breadcrumb,
+  Field,
+  FieldSet,
+  Grid,
+  Heading,
+  Label,
+  Select,
+  TabNavigation,
+  TextInput,
+} from '@amsterdam/design-system-react'
 import { useRef, useState } from 'react'
 
 import { commonMeta } from '../common/config'
@@ -97,6 +107,24 @@ const meta = {
           <Heading className="ams-mb-m" level={3}>
             {currentSubMenu.label}
           </Heading>
+          <FieldSet legend="Test Inline size">
+            <Field>
+              <Label htmlFor="input1">Wat is uw Voornaam?</Label>
+              <TextInput id="input1" size={32} />
+            </Field>
+            <Field>
+              <Label htmlFor="input2">Wat is uw achternaam?</Label>
+              <TextInput id="input2" size={64} />
+            </Field>
+            <Field>
+              <Label htmlFor="input3">Hoe mogen wij u aanspreken?</Label>
+              <Select id="input3">
+                <Select.Option value="heer">De heer</Select.Option>
+                <Select.Option value="mevrouw">Mevrouw</Select.Option>
+                <Select.Option value="anders">Anders</Select.Option>
+              </Select>
+            </Field>
+          </FieldSet>
         </Grid.Cell>
         <Grid.Cell
           span={{ narrow: 4, medium: 4, wide: 3 }}

--- a/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
@@ -6,17 +6,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { MouseEvent } from 'react'
 
-import {
-  Breadcrumb,
-  Field,
-  FieldSet,
-  Grid,
-  Heading,
-  Label,
-  Select,
-  TabNavigation,
-  TextInput,
-} from '@amsterdam/design-system-react'
+import { Breadcrumb, Grid, Heading, TabNavigation } from '@amsterdam/design-system-react'
 import { useRef, useState } from 'react'
 
 import { commonMeta } from '../common/config'
@@ -107,24 +97,6 @@ const meta = {
           <Heading className="ams-mb-m" level={3}>
             {currentSubMenu.label}
           </Heading>
-          <FieldSet legend="Test Inline size">
-            <Field>
-              <Label htmlFor="input1">Wat is uw Voornaam?</Label>
-              <TextInput id="input1" size={32} />
-            </Field>
-            <Field>
-              <Label htmlFor="input2">Wat is uw achternaam?</Label>
-              <TextInput id="input2" size={64} />
-            </Field>
-            <Field>
-              <Label htmlFor="input3">Hoe mogen wij u aanspreken?</Label>
-              <Select id="input3">
-                <Select.Option value="heer">De heer</Select.Option>
-                <Select.Option value="mevrouw">Mevrouw</Select.Option>
-                <Select.Option value="anders">Anders</Select.Option>
-              </Select>
-            </Field>
-          </FieldSet>
         </Grid.Cell>
         <Grid.Cell
           span={{ narrow: 4, medium: 4, wide: 3 }}


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Don’t grow beyond container width for wide inputs or textareas

## What

Adds `min-inline-size: 0` to `.ams-field-set` so it no longer grows to accommodate children with an intrinsic width (inputs with a `size` attribute, textareas with `cols`).

Also clarifies the Size documentation for Text Input and Password Input to note that the input won’t grow beyond the width of its container.

This was reported in #2580.

## Why

The native `<fieldset>` element has a UA style that effectively sets `min-inline-size: min-content`, so it refuses to shrink below the intrinsic size of its children. When a `TextInput` with a `size` attribute is placed inside a `FieldSet`, the fieldset expands to fit the input and overflows its containing grid cell. Swapping the fieldset for a `<div>` sidesteps the quirk but drops the semantics.

`max-inline-size: 100%` on the input can’t help here: the containing block (the fieldset) has already grown, so 100% equals the expanded width.

## How

One-line CSS fix in `field-set.scss` with an inline comment explaining the UA quirk. The input’s existing `max-inline-size: 100%` then clamps correctly, because the fieldset now tracks its container's width.

Clarified documentation on the `size` attribute for Text Input and Password Input.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a