### PR TITLE
fix(Grid): Set correct horizontal padding in Compact Mode

### DIFF
--- a/packages-proprietary/tokens/CONTRIBUTING.md
+++ b/packages-proprietary/tokens/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+<!-- @license CC0-1.0 -->
+
+# Contributing to the tokens package
+
+See the [repository-wide contributing guidelines](../../CONTRIBUTING.md) for general instructions.
+The notes below apply specifically to design tokens.
+
+## Compact Mode and responsive overrides
+
+Components may expose separate tokens for responsive variants, such as `vi-medium` and `vi-wide` for the Grid.
+These are applied at breakpoints in the component stylesheet and override the base token.
+
+When you add or change a token in a `*.compact.tokens.json` file, check whether the component stylesheet also applies a responsive variant of that token at larger breakpoints.
+If it does, override every responsive variant in the compact file as well.
+Otherwise, the compact value only applies below the first breakpoint, and the component silently reverts to the default token at larger viewports.
+
+For example, the Grid mixin sets `padding-inline` from `--ams-grid-padding-inline`, then overrides it with `--ams-grid-vi-medium-padding-inline` and `--ams-grid-vi-wide-padding-inline` at the medium and wide breakpoints.
+Compact Mode must override all three, not just the base.

--- a/packages-proprietary/tokens/src/components/ams/grid.compact.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/grid.compact.tokens.json
@@ -2,10 +2,28 @@
   "ams": {
     "grid": {
       "padding-inline": {
-        "$value": "{ams.space.xl}",
+        "$value": "{ams.space.m}",
         "$extensions": {
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
+        }
+      },
+      "vi-medium": {
+        "padding-inline": {
+          "$value": "{ams.space.l}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        }
+      },
+      "vi-wide": {
+        "padding-inline": {
+          "$value": "{ams.space.xl}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
         }
       },
       "cell": {


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Set correct horizontal padding on Grid in Compact Mode

## What

1. Fixes a bug in our Grid tokens, where Compact Mode didn’t override the default (spacious) tokens for horizontal padding on the Grid at the medium and wide viewports.
The intent was to make `padding-inline` smaller in Compact Mode, but the value was overridden by the `ams.grid.vi-medium.padding-inline` and `ams.grid.vi-wide.padding-inline` tokens at breakpoints, so the compact override only held below the first breakpoint.
2. Applies the same ‘stairs’ of values to the compact grid padding (m → l → xl) as spacious already had (l → xl → 2xl), so padding now scales with viewport width in both modes.
3. Adds a short `CONTRIBUTING.md` to the tokens package documenting the pitfall, so future contributors override responsive variants together with their base token.

## Why

Compact Mode is supposed to produce tighter spacing than the default at every viewport.

At the wide breakpoint, the Grid was rendering with the default `2xl` inline padding instead of the compact value, breaking that promise.

The underlying cause is a foot-gun in the split between tokens and stylesheet: a base token can be overridden in a `*.compact.tokens.json` file, but the stylesheet picks up the `vi-medium` / `vi-wide` variants at breakpoints, and those weren’t overridden in the compact file.

Fixing this silently is not enough — the same trap exists for any other responsive token the Grid (or a future component) might add, so we also document it.

## How

1. In `grid.compact.tokens.json`, add overrides for `ams.grid.vi-medium.padding-inline` (`l`) and `ams.grid.vi-wide.padding-inline` (`xl`), and change the base `ams.grid.padding-inline` to `m`.
Result: Compact Mode padding scales `m → l → xl` across narrow, medium, and wide.
2. Add `packages-proprietary/tokens/CONTRIBUTING.md` with a short section explaining that when a component stylesheet applies responsive variants at breakpoints, every compact override must cover all variants — otherwise the compact value silently reverts at larger viewports.
Uses this bug as the worked example.
3. No changes to the default (non-compact) tokens or to the Grid mixin: the fix is fully contained in the compact token file plus docs.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests — n/a, no behaviour change in code
- [x] Add or update documentation — added `CONTRIBUTING.md` in the tokens package
- [x] Add or update stories — the existing `BackgroundInCompactMode` story already exercises Compact Mode at every breakpoint
- [x] Add or update exports in index.\* files — n/a, tokens only
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Responsive `column-gap` and `row-gap` experiments that were previously in-flight here have been moved to a separate feature branch and will land independently.
- Chromatic should flag the Grid stories in Compact Mode across the narrow, medium, and wide viewports — please confirm the inline padding now steps through `m`, `l`, `xl`.