### PR TITLE
feat(Table): Align Header Cells to the bottom

### DIFF
--- a/packages/css/src/components/table/table.scss
+++ b/packages/css/src/components/table/table.scss
@@ -34,4 +34,8 @@
 
 .ams-table__header-cell {
   font-weight: var(--ams-table-header-cell-font-weight);
+
+  .ams-table__header & {
+    vertical-align: bottom;
+  }
 }


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Aligns the content of Table Header Cells to the bottom, if they are in the Table Header.

Before:
<img width="1240" height="285" alt="1  Table Header align top" src="https://github.com/user-attachments/assets/033f0dbd-5d50-4f74-aff9-8ee6b9242115" />

After:
<img width="1235" height="287" alt="2 Table Header align bottom" src="https://github.com/user-attachments/assets/c2df3ef2-f2bc-4a59-b847-17d7226baf67" />

Note how the Table Header cells in the body (the numbers) are still aligned to the top.

## Why

Keeps the headings closer to their columns if at least one of the Header Cells has multi-line content. Changes nothing otherwise.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a