### PR TITLE
chore: Use pnpm consistently in workspace scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "update:major": "npm-check-updates --upgrade --workspaces --cooldown 1 && pnpm install",
     "update:minor": "npm-check-updates --target minor --upgrade --workspaces --cooldown 1 && pnpm install",
     "update:patch": "npm-check-updates --target patch --upgrade --workspaces --cooldown 1 && pnpm install",
-    "watch:css": "npm run --workspace packages/css build:watch",
-    "watch:react": "npm run --workspace packages/react build:watch",
-    "watch:storybook": "npm run --workspace storybook start",
-    "watch:tokens": "npm run --workspace packages-proprietary/tokens build:watch"
+    "watch:css": "pnpm --filter @amsterdam/design-system-css run build:watch",
+    "watch:react": "pnpm --filter @amsterdam/design-system-react run build:watch",
+    "watch:storybook": "pnpm --filter @amsterdam/storybook run start",
+    "watch:tokens": "pnpm --filter @amsterdam/design-system-tokens run build:watch"
   },
   "devDependencies": {
     "@eslint/js": "9.39.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint:js": "eslint .",
     "lint:package-json": "npmPkgJsonLint **/package.json",
     "lint:package-lock": "pnpm ls --recursive",
-    "lint-fix": "pnpm run --aggregate-output '/^lint-fix:.+$/' && npm run prettier",
+    "lint-fix": "pnpm run --aggregate-output '/^lint-fix:.+$/' && pnpm run prettier",
     "lint-fix:css": "stylelint --fix '**/*.{css,scss}'",
     "lint-fix:js": "eslint . --fix",
     "plop": "plop",

--- a/packages-proprietary/react-icons/package.json
+++ b/packages-proprietary/react-icons/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && rollup -c",
+    "build": "pnpm run clean && rollup -c",
     "generate": "svgr ../assets/icons && prettier --write src && eslint src --fix"
   },
   "devDependencies": {

--- a/packages-proprietary/tokens/package.json
+++ b/packages-proprietary/tokens/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "clean": "rimraf dist/",
     "build": "node build.js",
-    "build:watch": "chokidar --follow-symlinks --initial --command \"npm run build\" \"src/**/*.tokens.json\""
+    "build:watch": "chokidar --follow-symlinks --initial --command \"pnpm run build\" \"src/**/*.tokens.json\""
   },
   "devDependencies": {
     "change-case": "5.4.4",

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "storybook build --output-dir dist/ --config-dir config/ --quiet && touch dist/.nojekyll",
-    "build:chromatic": "IS_CHROMATIC=true npm run build",
+    "build:chromatic": "IS_CHROMATIC=true pnpm run build",
     "chromatic": "chromatic",
     "clean": "rimraf dist/",
     "lint": "tsc --noEmit --project ./tsconfig.json",


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## What

Replaces the remaining eight `npm run` calls in workspace scripts with `pnpm` equivalents.

Direct swaps (`npm run X` → `pnpm run X`):

- `lint-fix` in the root [package.json](package.json)
- `build:watch` in [packages-proprietary/tokens/package.json](packages-proprietary/tokens/package.json)
- `build:chromatic` in [storybook/package.json](storybook/package.json)
- `build` in [packages-proprietary/react-icons/package.json](packages-proprietary/react-icons/package.json)

Filter rewrites (`npm run --workspace <path> X` → `pnpm --filter <name> run X`), in the root `watch:*` scripts:

- `watch:css`, `watch:react`, `watch:storybook`, `watch:tokens`

## Why

Amsterdam/design-system#2511 adds a "Never use `npm` or `yarn`" rule in `AGENTS.md`. The rule was inaccurate because several workspace scripts still invoked `npm run` internally — flagged by Copilot on [PR #2511](https://github.com/Amsterdam/design-system/pull/2511). Removing those calls makes the AGENTS.md rule truthful and the toolchain consistent.

## How

- Trivial swaps where the command runs a script in the same `package.json`.
- For the four root `watch:*` scripts, `pnpm` has no `--workspace <path>` flag; swapped to `--filter <package-name>` using the names already present in `pnpm-workspace.yaml` and the root `postinstall` filter.
- No lockfile or dependency changes.

## Checklist

- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

Tests, docs, stories, exports, and Chromatic are not applicable — this PR only changes script strings.

## Additional notes

- Risk is minimal: the repo already declares `packageManager: "pnpm@10.33.0"`, and both invocation forms resolve scripts in the same workspace directory.
- The root `engines.npm: "^10"` constraint becomes unused after this PR but is left in place; remove in a follow-up if desired.
- Follows up on a review comment on [PR #2511](https://github.com/Amsterdam/design-system/pull/2511).