### PR TITLE
feat(Dialog): Allow composing a Dialog with header, body and footer

### DIFF
--- a/packages/css/src/components/dialog/README.md
+++ b/packages/css/src/components/dialog/README.md
@@ -10,6 +10,8 @@ A popup window in which the user must perform an action to proceed.
 - Use a dialog for short and non-frequent tasks.
   Consider using the main flow for regular tasks.
 - Wrap multiple buttons in an [Action Group](https://designsystem.amsterdam/?path=/docs/components-layout-action-group--docs).
+- Compose the Dialog from `Dialog.Header`, `Dialog.Body`, and `Dialog.Footer` sub-components.
+  Wire `aria-labelledby` on the root `Dialog` to the `id` of the heading inside `Dialog.Header`.
 - To open the Dialog, use `Dialog.open(dialogId)` from the React package.
 - To close it, either call the `Dialog.close` function or add a `<form>` as in the ‘confirmation’ example.
 - Dialog is a [query container](/docs/utilities-css-query-container--docs) for inline size, so that elements in it can adapt their appearance to the width of the dialog.

--- a/packages/css/src/components/dialog/README.md
+++ b/packages/css/src/components/dialog/README.md
@@ -7,26 +7,11 @@ A popup window in which the user must perform an action to proceed.
 ## Guidelines
 
 - Use dialogs sparingly because they interrupt the user’s workflow.
-- Use a dialog for short and non-frequent tasks.
-  Consider using the main flow for regular tasks.
+  They can be useful for short, essential, non-frequent tasks.
+  Consider just using the main flow for regular tasks.
+- Compose the Dialog from its Header, Body, and Footer subcomponents.
+- Wire `aria-labelledby` on the root Dialog to the `id` of the [Heading](/docs/components-text-heading--docs) in Dialog Header.
 - Wrap multiple buttons in an [Action Group](https://designsystem.amsterdam/?path=/docs/components-layout-action-group--docs).
-- Compose the Dialog from `Dialog.Header`, `Dialog.Body`, and `Dialog.Footer` sub-components.
-  Wire `aria-labelledby` on the root `Dialog` to the `id` of the heading inside `Dialog.Header`.
 - To open the Dialog, use `Dialog.open(dialogId)` from the React package.
-- To close it, either call the `Dialog.close` function or add a `<form>` as in the ‘confirmation’ example.
+- To close it, either call the `Dialog.close` function, or add a `<form>` like in the ‘Confirmation’ example.
 - Dialog is a [query container](/docs/utilities-css-query-container--docs) for inline size, so that elements in it can adapt their appearance to the width of the dialog.
-
-## Keyboard support
-
-| key         | function                                                         |
-| :---------- | :--------------------------------------------------------------- |
-| Tab         | Moves focus to the next focusable element inside the dialog.     |
-| Shift + Tab | Moves focus to the previous focusable element inside the dialog. |
-| Escape      | Closes the dialog.                                               |
-
-## References
-
-- [HTMLDialogElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement)
-- [Return value](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/returnValue)
-- [Modal & Nonmodal Dialogs: When (& When Not) to Use Them](https://www.nngroup.com/articles/modal-nonmodal-dialog/)
-- [Patterns](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)

--- a/packages/react/src/Dialog/Dialog.test.tsx
+++ b/packages/react/src/Dialog/Dialog.test.tsx
@@ -7,11 +7,19 @@ import type { MouseEvent } from 'react'
 
 import { render, screen } from '@testing-library/react'
 import { createRef } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { Dialog } from './Dialog'
 
 describe('Dialog', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('renders', () => {
     render(<Dialog heading="Test heading" open />)
 
@@ -167,5 +175,140 @@ describe('Dialog', () => {
     expect(component).toHaveAttribute('aria-hidden', 'false')
     expect(component).toHaveAttribute('id', 'id')
     expect(component).toHaveAttribute('data-test', 'data-test')
+  })
+
+  describe('composable API', () => {
+    it('renders children directly without a built-in header or body wrapper', () => {
+      const { container } = render(
+        <Dialog aria-labelledby="label" open>
+          <Dialog.Header>
+            <h1 id="label">Composable</h1>
+          </Dialog.Header>
+          <Dialog.Body>Body content</Dialog.Body>
+        </Dialog>,
+      )
+
+      const dialog = screen.getByRole('dialog')
+      const headers = container.querySelectorAll('header.ams-dialog__header')
+      const bodies = container.querySelectorAll('div.ams-dialog__body')
+
+      expect(dialog).toHaveAttribute('aria-labelledby', 'label')
+      expect(headers).toHaveLength(1)
+      expect(bodies).toHaveLength(1)
+    })
+
+    it('renders Dialog.Header, Dialog.Body, and Dialog.Footer with the right BEM classes', () => {
+      render(
+        <Dialog aria-labelledby="label" open>
+          <Dialog.Header>
+            <h1 id="label">Heading</h1>
+          </Dialog.Header>
+          <Dialog.Body>Body</Dialog.Body>
+          <Dialog.Footer>
+            <button>OK</button>
+          </Dialog.Footer>
+        </Dialog>,
+      )
+
+      expect(screen.getByRole('banner')).toHaveClass('ams-dialog__header')
+      expect(screen.getByRole('contentinfo')).toHaveClass('ams-dialog__footer')
+      expect(screen.getByText('Body').closest('div')).toHaveClass('ams-dialog__body')
+    })
+
+    it('renders Dialog.CloseButton with a default Sluiten label', () => {
+      render(
+        <Dialog aria-labelledby="label" open>
+          <Dialog.Header>
+            <h1 id="label">Heading</h1>
+            <Dialog.CloseButton />
+          </Dialog.Header>
+        </Dialog>,
+      )
+
+      expect(screen.getByRole('button', { name: 'Sluiten' })).toBeInTheDocument()
+    })
+
+    it('does not warn when only the composable API is used', () => {
+      const warnSpy = vi.spyOn(console, 'warn')
+
+      render(
+        <Dialog aria-labelledby="label" open>
+          <Dialog.Header>
+            <h1 id="label">Heading</h1>
+          </Dialog.Header>
+        </Dialog>,
+      )
+
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deprecation warnings', () => {
+    it('warns when the heading prop is used', () => {
+      const warnSpy = vi.spyOn(console, 'warn')
+
+      render(<Dialog heading="Test heading" open />)
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('`heading` prop is deprecated'))
+    })
+
+    it('warns when the footer prop is used', () => {
+      const warnSpy = vi.spyOn(console, 'warn')
+
+      render(<Dialog footer={<button>OK</button>} heading="Test heading" open />)
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('`footer` prop is deprecated'))
+    })
+
+    it('warns when the closeButtonLabel prop is used', () => {
+      const warnSpy = vi.spyOn(console, 'warn')
+
+      render(<Dialog closeButtonLabel="Close" heading="Test heading" open />)
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('`closeButtonLabel` prop is deprecated'))
+    })
+
+    it('warns when the composable API is used without an accessible name', () => {
+      const warnSpy = vi.spyOn(console, 'warn')
+
+      render(
+        <Dialog open>
+          <Dialog.Header>
+            <h1>Heading</h1>
+          </Dialog.Header>
+        </Dialog>,
+      )
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('provide an accessible name'))
+    })
+
+    it('does not warn about the accessible name when aria-label is provided', () => {
+      const warnSpy = vi.spyOn(console, 'warn')
+
+      render(
+        <Dialog aria-label="Heading" open>
+          <Dialog.Header>
+            <h1>Heading</h1>
+          </Dialog.Header>
+        </Dialog>,
+      )
+
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('provide an accessible name'))
+    })
+  })
+
+  describe('mixed legacy and composable usage', () => {
+    it('renders only the body wrapper from heading; footer prop still works alongside', () => {
+      const { container } = render(
+        <Dialog footer={<button>Legacy footer</button>} heading="Legacy heading" open>
+          <p>Content</p>
+        </Dialog>,
+      )
+
+      // Legacy heading triggers built-in header AND body wrapper
+      expect(container.querySelectorAll('div.ams-dialog__body')).toHaveLength(1)
+      // Legacy footer prop renders its own footer
+      expect(screen.getByRole('contentinfo')).toHaveTextContent('Legacy footer')
+    })
   })
 })

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -3,43 +3,72 @@
  * Copyright Gemeente Amsterdam
  */
 
-import type { DialogHTMLAttributes, ForwardedRef, MouseEvent, PropsWithChildren, ReactNode } from 'react'
+import type { DialogHTMLAttributes, ForwardedRef, PropsWithChildren, ReactNode } from 'react'
 
 import { clsx } from 'clsx'
-import { forwardRef } from 'react'
+import { forwardRef, useEffect } from 'react'
 
 import { Heading } from '../Heading'
 import { IconButton } from '../IconButton'
+import { closeDialog, openDialog } from './dialogActions'
+import { DialogBody } from './DialogBody'
+import { DialogCloseButton } from './DialogCloseButton'
+import { DialogFooter } from './DialogFooter'
+import { DialogHeader } from './DialogHeader'
 
 export type DialogProps = {
-  /** The label for the button that dismisses the Dialog. */
+  /**
+   * The label for the button that dismisses the Dialog.
+   * @deprecated Render `<Dialog.CloseButton label="…">` (or your own button) inside `<Dialog.Header>` instead. Will be removed on or after 2026-11-06.
+   */
   readonly closeButtonLabel?: string
-  /** Content for the footer, often one Button or an Action Group containing more of them. */
+  /**
+   * Content for the footer, often one Button or an Action Group containing more of them.
+   * @deprecated Use `<Dialog.Footer>` instead. Will be removed on or after 2026-11-06.
+   */
   readonly footer?: ReactNode
-  /** The text for the Heading. */
-  readonly heading: string
+  /**
+   * The text for the Heading.
+   * @deprecated Use `<Dialog.Header>` with a `<Heading>` child instead. Will be removed on or after 2026-11-06.
+   */
+  readonly heading?: string
 } & Readonly<PropsWithChildren<DialogHTMLAttributes<HTMLDialogElement>>>
 
-const closeDialog = (event: MouseEvent<HTMLButtonElement>) => event.currentTarget.closest('dialog')?.close()
-const openDialog = (id: string) => (document.querySelector(id) as HTMLDialogElement)?.showModal()
+const DialogRoot = forwardRef((props: DialogProps, ref: ForwardedRef<HTMLDialogElement>) => {
+  const { children, className, closeButtonLabel = 'Sluiten', footer, heading, ...restProps } = props
 
-const DialogRoot = forwardRef(
-  (
-    { children, className, closeButtonLabel = 'Sluiten', footer, heading, ...restProps }: DialogProps,
-    ref: ForwardedRef<HTMLDialogElement>,
-  ) => (
+  useEffect(() => {
+    if (heading !== undefined) {
+      console.warn('Dialog: the `heading` prop is deprecated. Use `<Dialog.Header>` with a `<Heading>` child instead.')
+    }
+    if (footer !== undefined) {
+      console.warn('Dialog: the `footer` prop is deprecated. Use `<Dialog.Footer>` instead.')
+    }
+    if (props.closeButtonLabel !== undefined) {
+      console.warn('Dialog: the `closeButtonLabel` prop is deprecated. Pass `label` to `<Dialog.CloseButton>` instead.')
+    }
+    if (heading === undefined && !restProps['aria-labelledby'] && !restProps['aria-label']) {
+      console.warn(
+        'Dialog: provide an accessible name. Pass `aria-labelledby` referencing the `id` of the heading inside `<Dialog.Header>`.',
+      )
+    }
+  }, [])
+
+  return (
     <dialog {...restProps} className={clsx('ams-dialog', className)} ref={ref}>
-      <header className="ams-dialog__header">
-        <Heading level={1} size="level-3">
-          {heading}
-        </Heading>
-        <IconButton label={closeButtonLabel} onClick={closeDialog} size="heading-3" type="button" />
-      </header>
-      <div className="ams-dialog__body">{children}</div>
-      {footer && <footer className="ams-dialog__footer">{footer}</footer>}
+      {heading !== undefined && (
+        <header className="ams-dialog__header">
+          <Heading level={1} size="level-3">
+            {heading}
+          </Heading>
+          <IconButton label={closeButtonLabel} onClick={closeDialog} size="heading-3" type="button" />
+        </header>
+      )}
+      {heading !== undefined ? <div className="ams-dialog__body">{children}</div> : children}
+      {footer !== undefined && <footer className="ams-dialog__footer">{footer}</footer>}
     </dialog>
-  ),
-)
+  )
+})
 
 DialogRoot.displayName = 'Dialog'
 
@@ -47,6 +76,10 @@ DialogRoot.displayName = 'Dialog'
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-containers-dialog--docs Dialog docs at Amsterdam Design System}
  */
 export const Dialog = Object.assign(DialogRoot, {
+  Body: DialogBody,
   close: closeDialog,
+  CloseButton: DialogCloseButton,
+  Footer: DialogFooter,
+  Header: DialogHeader,
   open: openDialog,
 })

--- a/packages/react/src/Dialog/DialogBody.test.tsx
+++ b/packages/react/src/Dialog/DialogBody.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { DialogBody } from './DialogBody'
+
+describe('DialogBody', () => {
+  it('renders', () => {
+    const { container } = render(<DialogBody>Body content</DialogBody>)
+
+    const component = container.querySelector('div.ams-dialog__body')
+
+    expect(component).toBeInTheDocument()
+    expect(component).toHaveTextContent('Body content')
+  })
+
+  it('renders an extra class name', () => {
+    const { container } = render(<DialogBody className="extra" />)
+
+    const component = container.querySelector('div')
+
+    expect(component).toHaveClass('ams-dialog__body extra')
+  })
+
+  it('renders children', () => {
+    render(
+      <DialogBody>
+        <p>Inside body</p>
+      </DialogBody>,
+    )
+
+    expect(screen.getByText('Inside body')).toBeInTheDocument()
+  })
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLDivElement>()
+
+    const { container } = render(<DialogBody ref={ref} />)
+
+    expect(ref.current).toBe(container.querySelector('div'))
+  })
+
+  it('passes additional props', () => {
+    const { container } = render(<DialogBody data-test="data-test" id="id" />)
+
+    const component = container.querySelector('div')
+
+    expect(component).toHaveAttribute('id', 'id')
+    expect(component).toHaveAttribute('data-test', 'data-test')
+  })
+})

--- a/packages/react/src/Dialog/DialogBody.tsx
+++ b/packages/react/src/Dialog/DialogBody.tsx
@@ -1,0 +1,21 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
+
+import { clsx } from 'clsx'
+import { forwardRef } from 'react'
+
+export type DialogBodyProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>
+
+export const DialogBody = forwardRef(
+  ({ children, className, ...restProps }: DialogBodyProps, ref: ForwardedRef<HTMLDivElement>) => (
+    <div {...restProps} className={clsx('ams-dialog__body', className)} ref={ref}>
+      {children}
+    </div>
+  ),
+)
+
+DialogBody.displayName = 'Dialog.Body'

--- a/packages/react/src/Dialog/DialogCloseButton.test.tsx
+++ b/packages/react/src/Dialog/DialogCloseButton.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { DialogCloseButton } from './DialogCloseButton'
+
+describe('DialogCloseButton', () => {
+  it('renders a button with the default Sluiten label', () => {
+    render(<DialogCloseButton />)
+
+    const component = screen.getByRole('button', { name: 'Sluiten' })
+
+    expect(component).toBeInTheDocument()
+  })
+
+  it('renders a custom label', () => {
+    render(<DialogCloseButton label="Close" />)
+
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+  })
+
+  it('renders the icon-button BEM class name', () => {
+    render(<DialogCloseButton />)
+
+    expect(screen.getByRole('button')).toHaveClass('ams-icon-button')
+  })
+
+  it('uses type="button" by default', () => {
+    render(<DialogCloseButton />)
+
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
+  })
+
+  it('closes the closest dialog ancestor on click', () => {
+    const mockClose = vi.fn()
+    render(
+      <dialog data-testid="dialog" open>
+        <DialogCloseButton />
+      </dialog>,
+    )
+
+    const dialog = screen.getByTestId('dialog') as HTMLDialogElement
+    dialog.close = mockClose
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(mockClose).toHaveBeenCalled()
+  })
+
+  it('supports a custom onClick handler', () => {
+    const onClick = vi.fn()
+    render(<DialogCloseButton onClick={onClick} />)
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLButtonElement>()
+
+    render(<DialogCloseButton ref={ref} />)
+
+    expect(ref.current).toBe(screen.getByRole('button'))
+  })
+})

--- a/packages/react/src/Dialog/DialogCloseButton.tsx
+++ b/packages/react/src/Dialog/DialogCloseButton.tsx
@@ -1,0 +1,30 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { ForwardedRef } from 'react'
+
+import { forwardRef } from 'react'
+
+import type { IconButtonProps } from '../IconButton'
+
+import { IconButton } from '../IconButton'
+import { closeDialog } from './dialogActions'
+
+export type DialogCloseButtonProps = Omit<IconButtonProps, 'label'> & Partial<Pick<IconButtonProps, 'label'>>
+
+export const DialogCloseButton = forwardRef(
+  (
+    {
+      label = 'Sluiten',
+      onClick = closeDialog,
+      size = 'heading-3',
+      type = 'button',
+      ...restProps
+    }: DialogCloseButtonProps,
+    ref: ForwardedRef<HTMLButtonElement>,
+  ) => <IconButton {...restProps} label={label} onClick={onClick} ref={ref} size={size} type={type} />,
+)
+
+DialogCloseButton.displayName = 'Dialog.CloseButton'

--- a/packages/react/src/Dialog/DialogFooter.test.tsx
+++ b/packages/react/src/Dialog/DialogFooter.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { DialogFooter } from './DialogFooter'
+
+describe('DialogFooter', () => {
+  it('renders', () => {
+    render(<DialogFooter>Footer content</DialogFooter>)
+
+    const component = screen.getByRole('contentinfo')
+
+    expect(component).toBeInTheDocument()
+    expect(component).toHaveTextContent('Footer content')
+  })
+
+  it('renders a design system BEM class name', () => {
+    render(<DialogFooter />)
+
+    const component = screen.getByRole('contentinfo')
+
+    expect(component).toHaveClass('ams-dialog__footer')
+  })
+
+  it('renders an extra class name', () => {
+    render(<DialogFooter className="extra" />)
+
+    const component = screen.getByRole('contentinfo')
+
+    expect(component).toHaveClass('ams-dialog__footer extra')
+  })
+
+  it('renders children', () => {
+    render(
+      <DialogFooter>
+        <button>Click Me</button>
+      </DialogFooter>,
+    )
+
+    expect(screen.getByRole('button', { name: 'Click Me' })).toBeInTheDocument()
+  })
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLElement>()
+
+    render(<DialogFooter ref={ref} />)
+
+    expect(ref.current).toBe(screen.getByRole('contentinfo'))
+  })
+
+  it('passes additional props', () => {
+    render(<DialogFooter aria-label="Footer" data-test="data-test" id="id" />)
+
+    const component = screen.getByRole('contentinfo')
+
+    expect(component).toHaveAttribute('aria-label', 'Footer')
+    expect(component).toHaveAttribute('id', 'id')
+    expect(component).toHaveAttribute('data-test', 'data-test')
+  })
+})

--- a/packages/react/src/Dialog/DialogFooter.tsx
+++ b/packages/react/src/Dialog/DialogFooter.tsx
@@ -1,0 +1,21 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
+
+import { clsx } from 'clsx'
+import { forwardRef } from 'react'
+
+export type DialogFooterProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
+
+export const DialogFooter = forwardRef(
+  ({ children, className, ...restProps }: DialogFooterProps, ref: ForwardedRef<HTMLElement>) => (
+    <footer {...restProps} className={clsx('ams-dialog__footer', className)} ref={ref}>
+      {children}
+    </footer>
+  ),
+)
+
+DialogFooter.displayName = 'Dialog.Footer'

--- a/packages/react/src/Dialog/DialogHeader.test.tsx
+++ b/packages/react/src/Dialog/DialogHeader.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { DialogHeader } from './DialogHeader'
+
+describe('DialogHeader', () => {
+  it('renders', () => {
+    const { container } = render(<DialogHeader>Header content</DialogHeader>)
+
+    const component = container.querySelector('header')
+
+    expect(component).toBeInTheDocument()
+    expect(component).toHaveTextContent('Header content')
+  })
+
+  it('renders a design system BEM class name', () => {
+    const { container } = render(<DialogHeader />)
+
+    const component = container.querySelector('header')
+
+    expect(component).toHaveClass('ams-dialog__header')
+  })
+
+  it('renders an extra class name', () => {
+    const { container } = render(<DialogHeader className="extra" />)
+
+    const component = container.querySelector('header')
+
+    expect(component).toHaveClass('ams-dialog__header extra')
+  })
+
+  it('renders children', () => {
+    render(
+      <DialogHeader>
+        <span>Inside header</span>
+      </DialogHeader>,
+    )
+
+    expect(screen.getByText('Inside header')).toBeInTheDocument()
+  })
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLElement>()
+
+    const { container } = render(<DialogHeader ref={ref} />)
+
+    expect(ref.current).toBe(container.querySelector('header'))
+  })
+
+  it('passes additional props', () => {
+    const { container } = render(<DialogHeader aria-label="Header" data-test="data-test" id="id" />)
+
+    const component = container.querySelector('header')
+
+    expect(component).toHaveAttribute('aria-label', 'Header')
+    expect(component).toHaveAttribute('id', 'id')
+    expect(component).toHaveAttribute('data-test', 'data-test')
+  })
+})

--- a/packages/react/src/Dialog/DialogHeader.tsx
+++ b/packages/react/src/Dialog/DialogHeader.tsx
@@ -1,0 +1,21 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
+
+import { clsx } from 'clsx'
+import { forwardRef } from 'react'
+
+export type DialogHeaderProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
+
+export const DialogHeader = forwardRef(
+  ({ children, className, ...restProps }: DialogHeaderProps, ref: ForwardedRef<HTMLElement>) => (
+    <header {...restProps} className={clsx('ams-dialog__header', className)} ref={ref}>
+      {children}
+    </header>
+  ),
+)
+
+DialogHeader.displayName = 'Dialog.Header'

--- a/packages/react/src/Dialog/dialogActions.ts
+++ b/packages/react/src/Dialog/dialogActions.ts
@@ -1,0 +1,10 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { MouseEvent } from 'react'
+
+export const closeDialog = (event: MouseEvent<HTMLButtonElement>) => event.currentTarget.closest('dialog')?.close()
+
+export const openDialog = (id: string) => (document.querySelector(id) as HTMLDialogElement)?.showModal()

--- a/packages/react/src/Dialog/index.ts
+++ b/packages/react/src/Dialog/index.ts
@@ -5,3 +5,7 @@
 
 export { Dialog } from './Dialog'
 export type { DialogProps } from './Dialog'
+export type { DialogBodyProps } from './DialogBody'
+export type { DialogCloseButtonProps } from './DialogCloseButton'
+export type { DialogFooterProps } from './DialogFooter'
+export type { DialogHeaderProps } from './DialogHeader'

--- a/storybook/src/components/Dialog/Dialog.docs.mdx
+++ b/storybook/src/components/Dialog/Dialog.docs.mdx
@@ -23,18 +23,28 @@ Wire `aria-labelledby` on the root `Dialog` to the `id` of the heading inside `D
 
 ```tsx
 <Dialog aria-labelledby="dialog-label">
-  <Dialog.Header>
-    <Heading id="dialog-label" level={1} size="level-3">
-      Inloggen
-    </Heading>
-    <Dialog.CloseButton />
-  </Dialog.Header>
-  <Dialog.Body>…</Dialog.Body>
-  <Dialog.Footer>
-    <Button>Versturen</Button>
-  </Dialog.Footer>
+  <form>
+    <Dialog.Header>
+      <Heading id="dialog-label" level={1} size="level-3">
+        Inloggen
+      </Heading>
+      <Dialog.CloseButton />
+    </Dialog.Header>
+    <Dialog.Body>…</Dialog.Body>
+    <Dialog.Footer>
+      <Button>Versturen</Button>
+    </Dialog.Footer>
+  </form>
 </Dialog>
 ```
+
+## Keyboard support
+
+| key         | function                                                         |
+| :---------- | :--------------------------------------------------------------- |
+| Tab         | Moves focus to the next focusable element inside the dialog.     |
+| Shift + Tab | Moves focus to the previous focusable element inside the dialog. |
+| Escape      | Closes the dialog.                                               |
 
 ## Examples
 
@@ -60,3 +70,10 @@ The `Dialog.open(id)` and `Dialog.close(event)` static helpers are unaffected.
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />
+
+## See also
+
+- [HTMLDialogElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement)
+- [Return value](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/returnValue)
+- [Modal & Nonmodal Dialogs: When (& When Not) to Use Them](https://www.nngroup.com/articles/modal-nonmodal-dialog/)
+- [Patterns](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)

--- a/storybook/src/components/Dialog/Dialog.docs.mdx
+++ b/storybook/src/components/Dialog/Dialog.docs.mdx
@@ -16,18 +16,46 @@ import { DesignTokensTable } from "../../_components/DesignTokensTable/DesignTok
 
 <Controls />
 
+## Composition
+
+Compose a Dialog from sub-components: `Dialog.Header`, `Dialog.Body`, `Dialog.Footer`, and the optional `Dialog.CloseButton`.
+Wire `aria-labelledby` on the root `Dialog` to the `id` of the heading inside `Dialog.Header` so screen readers announce the dialog with its name.
+
+```tsx
+<Dialog aria-labelledby="dialog-label">
+  <Dialog.Header>
+    <Heading id="dialog-label" level={1} size="level-3">
+      Inloggen
+    </Heading>
+    <Dialog.CloseButton />
+  </Dialog.Header>
+  <Dialog.Body>…</Dialog.Body>
+  <Dialog.Footer>
+    <Button>Versturen</Button>
+  </Dialog.Footer>
+</Dialog>
+```
+
 ## Examples
 
 ### Asking to confirm
 
 Use a `form` when asking the user to confirm an action, e.g. through ‘OK’ and ‘Cancel’ buttons.
 Add `method="dialog"` to make the browser close the Dialog when the form is submitted.
-Wrap multiple Buttons in an [Action Group](/docs/components-layout-action-group--docs) and place it in the `footer`.
+Wrap multiple Buttons in an [Action Group](/docs/components-layout-action-group--docs) and place it in `Dialog.Footer`.
 Add an `id` to the form and use it in the `form` attribute of the buttons.
 Set a `value` on each button to identify which one was clicked.
 Consult [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#handling_the_return_value_from_the_dialog) for more information.
 
 <Canvas of={DialogStories.Confirmation} />
+
+## Migrating from the deprecated props
+
+The `heading`, `footer`, and `closeButtonLabel` props are deprecated and will be removed on or after 2026-11-06.
+Replace them with the composable sub-components shown above.
+The `Dialog.open(id)` and `Dialog.close(event)` static helpers are unaffected.
+
+<Canvas of={DialogStories.LegacyProps} />
 
 ## Design tokens
 

--- a/storybook/src/components/Dialog/Dialog.stories.tsx
+++ b/storybook/src/components/Dialog/Dialog.stories.tsx
@@ -13,8 +13,14 @@ const meta = {
   title: 'Components/Containers/Dialog',
   component: Dialog,
   argTypes: {
-    open: {
-      description: 'Whether the dialog box is active and available for interaction.',
+    closeButtonLabel: {
+      table: { disable: true },
+    },
+    footer: {
+      table: { disable: true },
+    },
+    heading: {
+      table: { disable: true },
     },
   },
   decorators: [
@@ -40,11 +46,11 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    'aria-labelledby': 'ams-dialog-default-heading',
+    'aria-labelledby': 'ams-dialog-example-heading',
     children: (
       <>
         <Dialog.Header>
-          <Heading id="ams-dialog-default-heading" level={1} size="level-3">
+          <Heading id="ams-dialog-example-heading" level={1} size="level-3">
             De gegevens zijn opgeslagen
           </Heading>
           <Dialog.CloseButton
@@ -69,7 +75,7 @@ export const Default: Story = {
         </Dialog.Footer>
       </>
     ),
-    id: 'ams-dialog-default',
+    id: 'ams-dialog-example',
   },
 }
 
@@ -115,14 +121,14 @@ export const Confirmation: Story = {
         </Dialog.Footer>
       </>
     ),
-    id: 'ams-dialog-asking-to-confirm',
+    id: 'ams-dialog-confirmation',
   },
 }
 
 /**
  * The `heading`, `footer`, and `closeButtonLabel` props are deprecated.
  * They will be removed on or after 2026-11-06.
- * Use the composable `Dialog.Header`, `Dialog.Body`, `Dialog.Footer`, and `Dialog.CloseButton` sub-components instead.
+ * Use the composable `Dialog.Header`, `Dialog.Body`, `Dialog.Footer`, and `Dialog.CloseButton` subcomponents instead.
  */
 export const LegacyProps: Story = {
   args: {
@@ -139,5 +145,16 @@ export const LegacyProps: Story = {
     ),
     heading: 'De gegevens zijn opgeslagen',
     id: 'ams-dialog-legacy',
+  },
+  argTypes: {
+    closeButtonLabel: {
+      table: { disable: false },
+    },
+    footer: {
+      table: { disable: false },
+    },
+    heading: {
+      table: { disable: false },
+    },
   },
 }

--- a/storybook/src/components/Dialog/Dialog.stories.tsx
+++ b/storybook/src/components/Dialog/Dialog.stories.tsx
@@ -5,7 +5,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { ActionGroup, Button, Paragraph } from '@amsterdam/design-system-react'
+import { ActionGroup, Button, Heading, Paragraph } from '@amsterdam/design-system-react'
 import { Dialog } from '@amsterdam/design-system-react/src'
 import { action } from 'storybook/actions'
 
@@ -13,12 +13,6 @@ const meta = {
   title: 'Components/Containers/Dialog',
   component: Dialog,
   argTypes: {
-    footer: {
-      table: { disable: true },
-    },
-    heading: {
-      description: 'The text for the heading.',
-    },
     open: {
       description: 'Whether the dialog box is active and available for interaction.',
     },
@@ -46,6 +40,92 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
+    'aria-labelledby': 'ams-dialog-default-heading',
+    children: (
+      <>
+        <Dialog.Header>
+          <Heading id="ams-dialog-default-heading" level={1} size="level-3">
+            De gegevens zijn opgeslagen
+          </Heading>
+          <Dialog.CloseButton
+            onClick={(event) => {
+              action('close')()
+              return Dialog.close(event)
+            }}
+          />
+        </Dialog.Header>
+        <Dialog.Body>
+          <Paragraph>U ontvangt een bevestiging per e-mail.</Paragraph>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <Button
+            onClick={(event) => {
+              action('close')()
+              return Dialog.close(event)
+            }}
+          >
+            Sluiten
+          </Button>
+        </Dialog.Footer>
+      </>
+    ),
+    id: 'ams-dialog-default',
+  },
+}
+
+export const Confirmation: Story = {
+  args: {
+    'aria-labelledby': 'ams-dialog-confirmation-heading',
+    children: (
+      <>
+        <Dialog.Header>
+          <Heading id="ams-dialog-confirmation-heading" level={1} size="level-3">
+            Niet alle gegevens zijn opgeslagen
+          </Heading>
+          <Dialog.CloseButton
+            onClick={(event) => {
+              action('cancel')()
+              return Dialog.close(event)
+            }}
+          />
+        </Dialog.Header>
+        <Dialog.Body>
+          <form id="ams-dialog-form" method="dialog">
+            <Paragraph>
+              Weet u zeker dat u door wilt gaan met het uitvoeren van deze actie? Gegevens die nog niet opgeslagen zijn
+              gaan dan verloren.
+            </Paragraph>
+          </form>
+        </Dialog.Body>
+        <Dialog.Footer>
+          <ActionGroup>
+            <Button form="ams-dialog-form" onClick={action('continue')} type="submit" value="submit">
+              Doorgaan
+            </Button>
+            <Button
+              onClick={(event) => {
+                action('cancel')()
+                return Dialog.close(event)
+              }}
+              variant="secondary"
+            >
+              Stoppen
+            </Button>
+          </ActionGroup>
+        </Dialog.Footer>
+      </>
+    ),
+    id: 'ams-dialog-asking-to-confirm',
+  },
+}
+
+/**
+ * The `heading`, `footer`, and `closeButtonLabel` props are deprecated.
+ * They will be removed on or after 2026-11-06.
+ * Use the composable `Dialog.Header`, `Dialog.Body`, `Dialog.Footer`, and `Dialog.CloseButton` sub-components instead.
+ */
+export const LegacyProps: Story = {
+  args: {
     children: <Paragraph>U ontvangt een bevestiging per e-mail.</Paragraph>,
     footer: (
       <Button
@@ -58,37 +138,6 @@ export const Default: Story = {
       </Button>
     ),
     heading: 'De gegevens zijn opgeslagen',
-    id: 'ams-dialog-default',
-  },
-}
-
-export const Confirmation: Story = {
-  args: {
-    children: (
-      <form id="ams-dialog-form" method="dialog">
-        <Paragraph>
-          Weet u zeker dat u door wilt gaan met het uitvoeren van deze actie? Gegevens die nog niet opgeslagen zijn gaan
-          dan verloren.
-        </Paragraph>
-      </form>
-    ),
-    footer: (
-      <ActionGroup>
-        <Button form="ams-dialog-form" onClick={action('continue')} type="submit" value="submit">
-          Doorgaan
-        </Button>
-        <Button
-          onClick={(event) => {
-            action('cancel')()
-            return Dialog.close(event)
-          }}
-          variant="secondary"
-        >
-          Stoppen
-        </Button>
-      </ActionGroup>
-    ),
-    heading: 'Niet alle gegevens zijn opgeslagen',
-    id: 'ams-dialog-asking-to-confirm',
+    id: 'ams-dialog-legacy',
   },
 }


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Allow composing a Dialog with header, body and footer

## Link

- [Dialog docs](https://designsystem.amsterdam/demo-DES-1829-composable-dialog/?path=/docs/components-containers-dialog--docs)

## What

Introduces a composable API for the Dialog component: `Dialog.Header`, `Dialog.Body`, `Dialog.Footer`, and `Dialog.CloseButton` sub-components.

The existing `heading`, `footer`, and `closeButtonLabel` props are deprecated (console warning + removal date of 2026-11-06) and kept working for backwards compatibility.
All sub-components are exported from the package index with their prop types.

## Why

The Dialog's previous React API hardcoded its header – a `Heading` and an `IconButton` – making it impossible for consumers to substitute their own components in that slot.
This came up concretely when a team building on top of the Amsterdam Design System wanted to place an NL Design System `Heading` and a custom close button inside the Dialog header, which the old API simply didn't allow. The same limitation affects the NL Design System community more broadly: our Dialog looked and worked well, but wasn’t composable enough to adopt or extend.

The new API lets consumers bring their own heading, close button, or any other content:

```tsx
<Dialog aria-labelledby="dialog-label">
  <form>
    <Dialog.Header>
      <Heading id="dialog-label" level={1} size="level-3">Inloggen</Heading>
      <Dialog.CloseButton />
    </Dialog.Header>
    <Dialog.Body>…</Dialog.Body>
    <Dialog.Footer>
      <Button type="submit">Versturen</Button>
    </Dialog.Footer>
  </form>
</Dialog>
```

## How

- `DialogHeader`, `DialogBody`, `DialogFooter`, and `DialogCloseButton` are thin forwarded-ref wrappers that apply the existing BEM class names, keeping the CSS contract unchanged.
- `Dialog.close` and `Dialog.open` are extracted to `dialogActions.ts` so `DialogCloseButton` can reuse `closeDialog` without a circular import.
- The legacy props remain functional: when `heading` is present the component still renders its own header and wraps children in a body div, exactly as before. A `useEffect` fires a `console.warn` for each deprecated prop so consumers get clear migration guidance. The composable path warns when neither `aria-labelledby` nor `aria-label` is set, since the accessible name is now the caller’s responsibility.
- Storybook: `Default` and `Confirmation` stories are rewritten to use the composable API; the old behaviour is preserved in a new `LegacyProps` story. The docs page gains a composition example, a migration guide, and the keyboard-support table (previously only in the CSS README).

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a