### PR TITLE
chore(docs): Add cells to default Grid example

### DIFF
--- a/storybook/src/components/Grid/Grid.stories.tsx
+++ b/storybook/src/components/Grid/Grid.stories.tsx
@@ -69,6 +69,14 @@ const CellStoryTemplate: CellStory = {
 
 export const Default: Story = {
   ...StoryTemplate,
+  args: {
+    ...StoryTemplate.args,
+    children: [
+      <Grid.Cell className="_ams-item" key={1} span="all" />,
+      <Grid.Cell className="_ams-item" key={2} span={{ narrow: 4, medium: 4, wide: 8 }} />,
+      <Grid.Cell className="_ams-item" key={3} span={4} />,
+    ],
+  },
 }
 
 export const VerticalPadding: Story = {


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Adds three cells to the [default Grid example](https://designsystem.amsterdam/demo-default-grid-example/?path=/docs/components-layout-grid--docs#design).

## Why

We didn’t add cells to the first example to let it focus on the Grid, the actual component, rather than on Cells. But @dlnr pointed out that this makes the controls below the grid appear broken, because they have no visual effect. That’s a fair point.

We could remove the controls, but that would break the convention. Adding cells in the first example anyway is defensible because the point of a grid is positioning things on it.

I’ve chosen two rows to show the effect of `verticalGap`, and spans of `all`, `8` and `4` because they form the minimal hint at the general ‘header, body, sidebar’ layout. It did require using three values for `span` immediately, but I guess that’s acceptable as well.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a
