### PR TITLE
chore(docs): Clarify favicon and web app installation steps

### DIFF
--- a/storybook/src/brand/assets/favicon.docs.mdx
+++ b/storybook/src/brand/assets/favicon.docs.mdx
@@ -18,10 +18,10 @@ This set covers all common browsers (Chrome, Safari, Edge, and Firefox).
 
 ### Install assets
 
-First, install these assets as they come with the [Amsterdam Design System Assets](https://www.npmjs.com/package/@amsterdam/design-system-assets):
+First, ensure that you have the [Amsterdam Design System Assets](https://www.npmjs.com/package/@amsterdam/design-system-assets) installed:
 
 ```sh
-npm i @amsterdam/design-system-assets
+npm install @amsterdam/design-system-assets
 ```
 
 ### Link assets

--- a/storybook/src/brand/assets/favicon.docs.mdx
+++ b/storybook/src/brand/assets/favicon.docs.mdx
@@ -12,7 +12,7 @@ Represent the website in bookmarks, on home screens, in syndication and other to
 Here’s how to display a website icon (a favicon) in the web browser.
 This set covers all common browsers (Chrome, Safari, Edge, and Firefox).
 
-> There is separate documentation on [how to publish a web app with the proper app names and icons](/docs/docs-developer-guide-web-app--docs).
+**Note**: There is separate documentation on [how to publish a web app with the proper app names and icons](/docs/docs-developer-guide-web-app--docs).
 
 ## How to use
 
@@ -42,14 +42,16 @@ cd public
 ln -s ../node_modules/@amsterdam/design-system-assets/favicon favicon
 ```
 
-> Important: the target path (the first argument) is resolved relative to the directory containing the symlink, not your current shell directory. The simplest way to avoid surprises is to `cd` to that directory first, as in the example above.
+**Important**: the target path (the first argument) is resolved relative to the directory containing the symlink, not your current shell directory. The simplest way to avoid surprises is to `cd` to that directory first, as in the example above.
 
-> Remove the symlink without affecting the original files:
->
-> ```sh
-> # Note: do not include a trailing slash — that follows the symlink and unlink will refuse to remove a directory.
-> unlink favicon
-> ```
+#### Remove symlink
+
+Remove the symlink without affecting the original files:
+
+```sh
+# Note: do not include a trailing slash — that follows the symlink and unlink will refuse to remove a directory.
+unlink favicon
+```
 
 #### Link in HTML
 

--- a/storybook/src/brand/assets/favicon.docs.mdx
+++ b/storybook/src/brand/assets/favicon.docs.mdx
@@ -26,13 +26,16 @@ npm install @amsterdam/design-system-assets
 
 ### Link assets
 
-You can manually [symlink (symbolic link)](https://en.wikipedia.org/wiki/Symbolic_link#POSIX_and_Unix-like_operating_systems) and copy the files to the root or a `public` folder next to where the `index.html` is located in your project.
-An advantage of symlinking is that it tracks changes to the assets when there are package updates. Symlinks are basically shortcuts to files or directories.
+#### Copy or symlink assets
+
+Copy the icon assets found in `node_modules/@amsterdam/design-system-assets/favicon` to your project. Often the best place is the `public` folder, but the proper location might also be the root directory or any other directory where static files are stored. This depends on your project structure and build process.
+
+Alternatively, in macOS and Linux shells you can manually [symlink (symbolic link)](https://en.wikipedia.org/wiki/Symbolic_link#POSIX_and_Unix-like_operating_systems) to your project. An advantage of symlinking is that it tracks changes to the assets when there are package updates. Symlinks are basically shortcuts to files or directories.
 
 Symlinking [the entire favicon directory](https://github.com/Amsterdam/design-system/tree/develop/packages-proprietary/assets/favicon) can be done as follows:
 
 ```sh
-# `cd` to the directory where you want to make the symlinks. For example:
+# Change to the directory where you want to make the symlink. For example:
 cd public
 
 # Symlink the icons folder. The symlink file (the last argument) can be named anything you like.
@@ -49,7 +52,9 @@ ln -s ../node_modules/@amsterdam/design-system-assets/favicon favicon
 > unlink favicon
 > ```
 
-Then link all these assets by placing the following tags in the `<head>`:
+#### Linking in HTML
+
+Then link all these assets in the HTML by placing the following tags in the `<head>`:
 
 ```html
 <head>
@@ -61,9 +66,11 @@ Then link all these assets by placing the following tags in the `<head>`:
 </head>
 ```
 
+How this is done exactly depends on your project structure and build process. Follow the documentation of your framework or build tool for the best way to link static assets in the HTML.
+
 ### Submit Changes
 
-The symlink(s) and edited files can be committed to the repository.
+The copied files or symlink(s) can be committed to the repository.
 
 ## Examples
 

--- a/storybook/src/brand/assets/favicon.docs.mdx
+++ b/storybook/src/brand/assets/favicon.docs.mdx
@@ -51,7 +51,7 @@ ln -s ../node_modules/@amsterdam/design-system-assets/favicon favicon
 > unlink favicon
 > ```
 
-#### Linking in HTML
+#### Link in HTML
 
 Then link all these assets in the HTML by placing the following tags in the `<head>`:
 
@@ -93,7 +93,7 @@ Roughly 75% of browsers support SVG favicons, which are more efficient and versa
 <link rel="icon" type="image/svg+xml" href="icon.svg" />
 ```
 
-### Apple Touch Icon
+### Icon for Apple devices
 
 <AppleTouchIcon />
 

--- a/storybook/src/brand/assets/favicon.docs.mdx
+++ b/storybook/src/brand/assets/favicon.docs.mdx
@@ -12,7 +12,7 @@ Represent the website in bookmarks, on home screens, in syndication and other to
 Here’s how to display a website icon (a favicon) in the web browser.
 This set covers all common browsers (Chrome, Safari, Edge, and Firefox).
 
-> There is seperate documentation on [how to publish a web app with the proper app names and icons](/docs/docs-developer-guide-web-app--docs).
+> There is separate documentation on [how to publish a web app with the proper app names and icons](/docs/docs-developer-guide-web-app--docs).
 
 ## How to use
 
@@ -28,9 +28,9 @@ npm install @amsterdam/design-system-assets
 
 #### Copy or symlink assets
 
-Copy the icon assets found in `node_modules/@amsterdam/design-system-assets/favicon` to your project. Often the best place is the `public` folder, but the proper location might also be the root directory or any other directory where static files are stored. This depends on your project structure and build process.
+Copy the icon assets found in `node_modules/@amsterdam/design-system-assets/favicon` to your project. Typically this is the `public` folder next to your `index.html`, though the right location depends on your project structure and build process.
 
-Alternatively, in macOS and Linux shells you can manually [symlink (symbolic link)](https://en.wikipedia.org/wiki/Symbolic_link#POSIX_and_Unix-like_operating_systems) to your project. An advantage of symlinking is that it tracks changes to the assets when there are package updates. Symlinks are basically shortcuts to files or directories.
+Alternatively, on macOS and Linux you can create a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link#POSIX_and_Unix-like_operating_systems) in your project that points to the package directory. An advantage of symlinking is that it tracks changes to the assets when there are package updates. Symlinks are basically shortcuts to files or directories.
 
 Symlinking [the entire favicon directory](https://github.com/Amsterdam/design-system/tree/develop/packages-proprietary/assets/favicon) can be done as follows:
 
@@ -42,13 +42,12 @@ cd public
 ln -s ../node_modules/@amsterdam/design-system-assets/favicon favicon
 ```
 
-> Important: the symlink, the last argument in the above command, cannot be a path, but can only be the file or directory name.
-> I.e. you need to be in the directory where you want to make the symbolic link.
+> Important: the target path (the first argument) is resolved relative to the directory containing the symlink, not your current shell directory. The simplest way to avoid surprises is to `cd` to that directory first, as in the example above.
 
-> Remove the symlink without affecting the original files by unlinking:
+> Remove the symlink without affecting the original files:
 >
 > ```sh
-> # May not be a path, but only the file or directory name without a trailing slash.
+> # Note: do not include a trailing slash — that follows the symlink and unlink will refuse to remove a directory.
 > unlink favicon
 > ```
 
@@ -68,7 +67,7 @@ Then link all these assets in the HTML by placing the following tags in the `<he
 
 How this is done exactly depends on your project structure and build process. Follow the documentation of your framework or build tool for the best way to link static assets in the HTML.
 
-### Submit Changes
+### Submit changes
 
 The copied files or symlink(s) can be committed to the repository.
 

--- a/storybook/src/brand/assets/favicon.docs.mdx
+++ b/storybook/src/brand/assets/favicon.docs.mdx
@@ -42,10 +42,11 @@ ln -s ../node_modules/@amsterdam/design-system-assets/favicon favicon
 > Important: the symlink, the last argument in the above command, cannot be a path, but can only be the file or directory name.
 > I.e. you need to be in the directory where you want to make the symbolic link.
 
-> Note that undoing a symlink can be done by simply removing the created file or directory link:
+> Remove the symlink without affecting the original files by unlinking:
 >
 > ```sh
-> rm -r favicon
+> # May not be a path, but only the file or directory name without a trailing slash.
+> unlink favicon
 > ```
 
 Then link all these assets by placing the following tags in the `<head>`:

--- a/storybook/src/docs/developer-guide/web-app.docs.mdx
+++ b/storybook/src/docs/developer-guide/web-app.docs.mdx
@@ -45,10 +45,12 @@ cp ../node_modules/@amsterdam/design-system-assets/manifest/app.webmanifest app.
 > Important: the symlink, the last argument in the above command, cannot be a path, but can only be the file or directory name.
 > I.e. you need to be in the directory where you want to make the symbolic link.
 
-> Note that undoing a symlink can be done by simply removing the created file or directory link:
+> Remove the symlink and the webmanifest without affecting the original files:
 >
 > ```sh
-> rm -r app-icons app.webmanifest
+> # May not be a path, but only the file or directory name without a trailing slash.
+> unlink app-icons
+> rm app.webmanifest
 > ```
 
 > Note: not all servers recognize the `.webmanifest` extension.

--- a/storybook/src/docs/developer-guide/web-app.docs.mdx
+++ b/storybook/src/docs/developer-guide/web-app.docs.mdx
@@ -12,7 +12,7 @@ Turn a website into a Progressive Web App (PWA) with a web manifest and app icon
 Here’s how to publish a web app with the proper app names and icons.
 This set covers all combinations of common operating systems (Android, iOS, macOS, and Windows) and browsers (Chrome, Safari, Edge, and Firefox).
 
-> There is separate documentation on [how to add a website icon (a “favicon”)](/docs/brand-assets-favicon--docs).
+**Note**: There is separate documentation on [how to add a website icon (a “favicon”)](/docs/brand-assets-favicon--docs).
 
 ## How to use
 
@@ -45,7 +45,7 @@ ln -s ../node_modules/@amsterdam/design-system-assets/app-icons app-icons
 cp ../node_modules/@amsterdam/design-system-assets/manifest/app.webmanifest app.webmanifest
 ```
 
-> Important: the target path (the first argument) is resolved relative to the directory containing the symlink, not your current shell directory. The simplest way to avoid surprises is to `cd` to that directory first, as in the example above.
+**Important**: the target path (the first argument) is resolved relative to the directory containing the symlink, not your current shell directory. The simplest way to avoid surprises is to `cd` to that directory first, as in the example above.
 
 > Remove the symlink and the webmanifest without affecting the original files:
 >
@@ -86,8 +86,7 @@ Then link all these assets in the HTML by placing the following tags in the `<he
 
 How this is done exactly depends on your project structure and build process. Follow the documentation of your framework or build tool for the best way to link static assets in the HTML.
 
-> Note: not all servers recognize the `.webmanifest` extension.
-> See [Using a link element to link to a manifest on W3.org](https://www.w3.org/TR/appmanifest/#using-a-link-element-to-link-to-a-manifest) for more information.
+**Note**: not all servers recognize the `.webmanifest` extension. See [Using a link element to link to a manifest on W3.org](https://www.w3.org/TR/appmanifest/#using-a-link-element-to-link-to-a-manifest) for more information.
 
 ### Submit changes
 
@@ -114,8 +113,7 @@ Link the Web Manifest in the `<head>`:
 <link rel="manifest" href="app.webmanifest" />
 ```
 
-> Note: only include a Web Manifest if you want the website to be installable as a Progressive Web App (PWA).
-> Browsers [may prompt the user to install the app](https://web.dev/learn/pwa/installation-prompt) on their device if a manifest is found.
+**Note**: only include a web manifest if you want the website to be installable as a progressive web app (PWA). Browsers [may prompt the user to install the app](https://web.dev/learn/pwa/installation-prompt) on their device if a manifest is found.
 
 ## Further reading
 

--- a/storybook/src/docs/developer-guide/web-app.docs.mdx
+++ b/storybook/src/docs/developer-guide/web-app.docs.mdx
@@ -12,7 +12,7 @@ Turn a website into a Progressive Web App (PWA) with a web manifest and app icon
 Here’s how to publish a web app with the proper app names and icons.
 This set covers all combinations of common operating systems (Android, iOS, macOS, and Windows) and browsers (Chrome, Safari, Edge, and Firefox).
 
-> There is seperate documentation on [how to add a website icon (a “favicon”)](/docs/brand-assets-favicon--docs).
+> There is separate documentation on [how to add a website icon (a “favicon”)](/docs/brand-assets-favicon--docs).
 
 ## How to use
 
@@ -28,11 +28,11 @@ npm install @amsterdam/design-system-assets
 
 #### Copy or symlink assets
 
-Copy the icon assets found in `node_modules/@amsterdam/design-system-assets/favicon` to your project. Often the best place is the `public` folder, but the proper location might also be the root directory or any other directory where static files are stored. This depends on your project structure and build process.
+Copy the app icons found in `node_modules/@amsterdam/design-system-assets/app-icons` and the Web Manifest from `node_modules/@amsterdam/design-system-assets/manifest/app.webmanifest` to your project. Typically this is the `public` folder next to your `index.html`, though the right location depends on your project structure and build process.
 
-Alternatively, in macOS and Linux shells you can manually [symlink (symbolic link)](https://en.wikipedia.org/wiki/Symbolic_link#POSIX_and_Unix-like_operating_systems) to your project. An advantage of symlinking is that it tracks changes to the assets when there are package updates. Symlinks are basically shortcuts to files or directories.
+Alternatively, on macOS and Linux you can create a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link#POSIX_and_Unix-like_operating_systems) in your project that points to the package directory. An advantage of symlinking is that it tracks changes to the assets when there are package updates. Symlinks are basically shortcuts to files or directories.
 
-Symlink the app icons and copy the [Web Manifest](https://github.com/Amsterdam/design-system/tree/develop/packages-proprietary/assets/app.manifest):
+Symlink the app icons and copy the [Web Manifest](https://github.com/Amsterdam/design-system/blob/develop/packages-proprietary/assets/manifest/app.webmanifest):
 
 ```sh
 # Change to the directory where you want to make the symlink. For example:
@@ -45,21 +45,17 @@ ln -s ../node_modules/@amsterdam/design-system-assets/app-icons app-icons
 cp ../node_modules/@amsterdam/design-system-assets/manifest/app.webmanifest app.webmanifest
 ```
 
-> Important: the symlink, the last argument in the above command, cannot be a path, but can only be the file or directory name.
-> I.e. you need to be in the directory where you want to make the symbolic link.
+> Important: the target path (the first argument) is resolved relative to the directory containing the symlink, not your current shell directory. The simplest way to avoid surprises is to `cd` to that directory first, as in the example above.
 
 > Remove the symlink and the webmanifest without affecting the original files:
 >
 > ```sh
-> # May not be a path, but only the file or directory name without a trailing slash.
+> # Note: do not include a trailing slash — that follows the symlink and unlink will refuse to remove a directory.
 > unlink app-icons
 > rm app.webmanifest
 > ```
 
 #### Edit Web Manifest
-
-> Note: not all servers recognize the `.webmanifest` extension.
-> See [Using a link element to link to a manifest on W3.org](https://www.w3.org/TR/appmanifest/#using-a-link-element-to-link-to-a-manifest) for more information.
 
 Make sure that the Web Manifest, stating the app's name and referencing the PNG icons, is available in the same location.
 Edit the `app.webmanifest` file to include the app's name and the icons you want to use.
@@ -89,6 +85,9 @@ Then link all these assets in the HTML by placing the following tags in the `<he
 ```
 
 How this is done exactly depends on your project structure and build process. Follow the documentation of your framework or build tool for the best way to link static assets in the HTML.
+
+> Note: not all servers recognize the `.webmanifest` extension.
+> See [Using a link element to link to a manifest on W3.org](https://www.w3.org/TR/appmanifest/#using-a-link-element-to-link-to-a-manifest) for more information.
 
 ### Submit changes
 

--- a/storybook/src/docs/developer-guide/web-app.docs.mdx
+++ b/storybook/src/docs/developer-guide/web-app.docs.mdx
@@ -7,7 +7,7 @@ import { WebAppIcons } from "../../_components/AppIcons/AppIcons";
 
 # Web app
 
-Turn a website into a Progressive Web App (PWA) with a web manifest and app icons.
+Turn a website into a progressive web app (PWA) with a web app manifest (web manifest hereafter) and app icons.
 
 Here’s how to publish a web app with the proper app names and icons.
 This set covers all combinations of common operating systems (Android, iOS, macOS, and Windows) and browsers (Chrome, Safari, Edge, and Firefox).
@@ -28,11 +28,11 @@ npm install @amsterdam/design-system-assets
 
 #### Copy or symlink assets
 
-Copy the app icons found in `node_modules/@amsterdam/design-system-assets/app-icons` and the Web Manifest from `node_modules/@amsterdam/design-system-assets/manifest/app.webmanifest` to your project. Typically this is the `public` folder next to your `index.html`, though the right location depends on your project structure and build process.
+Copy the app icons found in `node_modules/@amsterdam/design-system-assets/app-icons` and the web manifest from `node_modules/@amsterdam/design-system-assets/manifest/app.webmanifest` to your project. Typically this is the `public` folder next to your `index.html`, though the right location depends on your project structure and build process.
 
 Alternatively, on macOS and Linux you can create a [symbolic link](https://en.wikipedia.org/wiki/Symbolic_link#POSIX_and_Unix-like_operating_systems) in your project that points to the package directory. An advantage of symlinking is that it tracks changes to the assets when there are package updates. Symlinks are basically shortcuts to files or directories.
 
-Symlink the app icons and copy the [Web Manifest](https://github.com/Amsterdam/design-system/blob/develop/packages-proprietary/assets/manifest/app.webmanifest):
+Symlink the app icons and copy the [web manifest](https://github.com/Amsterdam/design-system/blob/develop/packages-proprietary/assets/manifest/app.webmanifest):
 
 ```sh
 # Change to the directory where you want to make the symlink. For example:
@@ -41,23 +41,25 @@ cd public
 # Symlink the app icons. The symlink file (the last argument) can be named anything you like.
 ln -s ../node_modules/@amsterdam/design-system-assets/app-icons app-icons
 
-# Copy the Web Manifest. Don't forget to edit it with the app's name.
+# Copy the web manifest. Don't forget to edit it with the app's name.
 cp ../node_modules/@amsterdam/design-system-assets/manifest/app.webmanifest app.webmanifest
 ```
 
 **Important**: the target path (the first argument) is resolved relative to the directory containing the symlink, not your current shell directory. The simplest way to avoid surprises is to `cd` to that directory first, as in the example above.
 
-> Remove the symlink and the webmanifest without affecting the original files:
->
-> ```sh
-> # Note: do not include a trailing slash — that follows the symlink and unlink will refuse to remove a directory.
-> unlink app-icons
-> rm app.webmanifest
-> ```
+#### Remove symlink
+
+Remove the symlink and the web manifest without affecting the original files:
+
+```sh
+# Note: do not include a trailing slash — that follows the symlink and unlink will refuse to remove a directory.
+unlink app-icons
+rm app.webmanifest
+```
 
 #### Edit web manifest
 
-Make sure that the Web Manifest, stating the app's name and referencing the PNG icons, is available in the same location.
+Make sure that the web manifest, stating the app's name and referencing the PNG icons, is available in the same location.
 Edit the `app.webmanifest` file to include the app's name and the icons you want to use.
 For example:
 
@@ -107,7 +109,7 @@ Include `icons` object in `*.webmanifest` (see [How to use](#how-to-use)):
 }
 ```
 
-Link the Web Manifest in the `<head>`:
+Link the web manifest in the `<head>`:
 
 ```html
 <link rel="manifest" href="app.webmanifest" />

--- a/storybook/src/docs/developer-guide/web-app.docs.mdx
+++ b/storybook/src/docs/developer-guide/web-app.docs.mdx
@@ -26,13 +26,16 @@ npm install @amsterdam/design-system-assets
 
 ### Link assets
 
-You can manually [symlink (symbolic link)](https://en.wikipedia.org/wiki/Symbolic_link#POSIX_and_Unix-like_operating_systems) and copy the files to the root or a `public` folder next to where the `index.html` is located in your project.
-An advantage of symlinking is that it tracks changes to the assets when there are package updates. Symlinks are basically shortcuts to files or directories.
+#### Copy or symlink assets
+
+Copy the icon assets found in `node_modules/@amsterdam/design-system-assets/favicon` to your project. Often the best place is the `public` folder, but the proper location might also be the root directory or any other directory where static files are stored. This depends on your project structure and build process.
+
+Alternatively, in macOS and Linux shells you can manually [symlink (symbolic link)](https://en.wikipedia.org/wiki/Symbolic_link#POSIX_and_Unix-like_operating_systems) to your project. An advantage of symlinking is that it tracks changes to the assets when there are package updates. Symlinks are basically shortcuts to files or directories.
 
 Symlink the app icons and copy the [Web Manifest](https://github.com/Amsterdam/design-system/tree/develop/packages-proprietary/assets/app.manifest):
 
 ```sh
-# `cd` to the directory where you want to make the symlinks. For example:
+# Change to the directory where you want to make the symlink. For example:
 cd public
 
 # Symlink the app icons. The symlink file (the last argument) can be named anything you like.
@@ -53,6 +56,8 @@ cp ../node_modules/@amsterdam/design-system-assets/manifest/app.webmanifest app.
 > rm app.webmanifest
 > ```
 
+#### Edit Web Manifest
+
 > Note: not all servers recognize the `.webmanifest` extension.
 > See [Using a link element to link to a manifest on W3.org](https://www.w3.org/TR/appmanifest/#using-a-link-element-to-link-to-a-manifest) for more information.
 
@@ -71,7 +76,9 @@ For example:
 }
 ```
 
-Then link all these assets by placing the following tags in the `<head>`:
+#### Linking in HTML
+
+Then link all these assets in the HTML by placing the following tags in the `<head>`:
 
 ```html
 <head>
@@ -81,9 +88,11 @@ Then link all these assets by placing the following tags in the `<head>`:
 </head>
 ```
 
+How this is done exactly depends on your project structure and build process. Follow the documentation of your framework or build tool for the best way to link static assets in the HTML.
+
 ### Submit changes
 
-The symlink(s) and copied and edited files can be committed to the repository.
+The copied files or symlink(s) can be committed to the repository.
 
 ## Web app icons
 

--- a/storybook/src/docs/developer-guide/web-app.docs.mdx
+++ b/storybook/src/docs/developer-guide/web-app.docs.mdx
@@ -18,10 +18,10 @@ This set covers all combinations of common operating systems (Android, iOS, macO
 
 ### Install assets
 
-First, install these assets as they come with the [Amsterdam Design System Assets](https://www.npmjs.com/package/@amsterdam/design-system-assets):
+First, ensure that you have the [Amsterdam Design System Assets](https://www.npmjs.com/package/@amsterdam/design-system-assets) installed:
 
 ```sh
-npm i @amsterdam/design-system-assets
+npm install @amsterdam/design-system-assets
 ```
 
 ### Link assets

--- a/storybook/src/docs/developer-guide/web-app.docs.mdx
+++ b/storybook/src/docs/developer-guide/web-app.docs.mdx
@@ -5,7 +5,7 @@ import { WebAppIcons } from "../../_components/AppIcons/AppIcons";
 
 <Meta title="Docs/Developer Guide/Web App" />
 
-# Web App
+# Web app
 
 Turn a website into a Progressive Web App (PWA) with a web manifest and app icons.
 
@@ -55,7 +55,7 @@ cp ../node_modules/@amsterdam/design-system-assets/manifest/app.webmanifest app.
 > rm app.webmanifest
 > ```
 
-#### Edit Web Manifest
+#### Edit web manifest
 
 Make sure that the Web Manifest, stating the app's name and referencing the PNG icons, is available in the same location.
 Edit the `app.webmanifest` file to include the app's name and the icons you want to use.
@@ -72,7 +72,7 @@ For example:
 }
 ```
 
-#### Linking in HTML
+#### Link in HTML
 
 Then link all these assets in the HTML by placing the following tags in the `<head>`:
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## What

Refines the Favicon and Web App developer guides:

- Reframes the install step as a check that `@amsterdam/design-system-assets` is present, and uses `npm install` instead of `npm i`.
- Splits the “Link assets” section into clearer subsections: _Copy or symlink assets_, _Edit Web Manifest_ (Web App only), and _Linking in HTML_.
- States explicitly that you can copy the icon assets (often into `public`), with symlinking presented as an alternative for macOS and Linux shells.
- Replaces `rm -r` with `unlink` for removing symlinks, and notes the argument must be a name rather than a path.
- Adds a note that linking static assets in HTML depends on the project’s framework or build tool.
- Updates “Submit changes” to mention copied files as well as symlinks.

## Why

The previous wording implied symlinking was the recommended (or only) path and used commands that could affect the original files. The new structure better matches how teams actually integrate the assets and avoids the footgun of `rm -r` on a symlink target.

Resolves [DES-1822](https://amsterdam.atlassian.net/browse/DES-1822).

## How

Editorial changes only to:

- `storybook/src/brand/assets/favicon.docs.mdx`
- `storybook/src/docs/developer-guide/web-app.docs.mdx`

No code, components, or exports affected.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Docs-only change; no visual regressions expected.
- Please review the wording around copy-vs-symlink — happy to tighten further if either path should be recommended over the other.


[DES-1822]: https://gemeente-amsterdam.atlassian.net/browse/DES-1822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ