### PR TITLE
chore(docs): Add Spacing page and cross-references to Developer Guide

### DIFF
--- a/packages/css/src/components/blockquote/README.md
+++ b/packages/css/src/components/blockquote/README.md
@@ -10,6 +10,7 @@ A quote appears differently from the main text to make it stand out.
 - Quote someone’s literal written or oral text.
 - A quote has a width of half or a whole column of text.
 - The component adds the correct quotation marks.
+- Use [Margin](/docs/utilities-css-margin--docs) or [Prose](/docs/utilities-css-prose--docs) to add vertical whitespace.
 
 ## Relevant WCAG requirements
 

--- a/packages/css/src/components/button/README.md
+++ b/packages/css/src/components/button/README.md
@@ -14,6 +14,7 @@ Allows the user to perform an action or operate the interface.
 - Use the verb’s infinitive form, such as “Verwijderen” or “Opslaan”, not “Verwijder” or “Sla op”.
 - Use only 1 primary Button per screen.
 - Wrap 2 or more consecutive buttons and/or links in an [Action Group](https://designsystem.amsterdam/?path=/docs/components-layout-action-group--docs).
+- Use [Margin](/docs/utilities-css-margin--docs) or [Prose](/docs/utilities-css-prose--docs) to add vertical whitespace.
 - Add `type="submit"` to make the Button submit a form.
 
 ## Relevant WCAG requirements

--- a/packages/css/src/components/call-to-action-link/README.md
+++ b/packages/css/src/components/call-to-action-link/README.md
@@ -17,3 +17,4 @@ This informs users that a new page will open and that they can either copy the l
   Ensure the emphasis is on one product, and divide the content into several pages if needed.
 - Use the verb’s infinitive form, such as “Kapotte parkeerautomaat melden”, not “Meld kapotte parkeerautomaat”.
 - For additional guidelines, refer to the [Link](/docs/components-navigation-link--docs) component.
+- Use [Margin](/docs/utilities-css-margin--docs) or [Prose](/docs/utilities-css-prose--docs) to add vertical whitespace.

--- a/packages/css/src/components/heading/README.md
+++ b/packages/css/src/components/heading/README.md
@@ -19,6 +19,7 @@ Introduces a page section and describes the following content.
   - Most Headings on overview pages, e.g. Card, Table of Content, and ‘Link Blocks’, use a size of ‘level-3’.
   - The same applies to large sections – e.g. Accordion, Alert, Dialog and the caption of a Table.
     Most of them can be given a different size if appropriate.
+- Use [Margin](/docs/utilities-css-margin--docs) or [Prose](/docs/utilities-css-prose--docs) to add vertical whitespace.
 
 ## Relevant WCAG requirements
 

--- a/packages/css/src/components/margin/README.md
+++ b/packages/css/src/components/margin/README.md
@@ -23,6 +23,7 @@ They are also smaller in [Compact Mode](https://designsystem.amsterdam/docs/docs
 ## Guidelines
 
 - Use this utility class to vertically separate one element from the next.
+- Consult the [vertical space](/docs/docs-designer-guide-vertical-space--docs) guidelines to find the recommended length.
 - It can be used on any element and sets the `margin-block-end` CSS property.
   This declaration is marked with the `!important` flag to ensure it overrides any other margins.
 - Elements’ top and bottom margins are sometimes collapsed into a single margin.
@@ -30,4 +31,4 @@ They are also smaller in [Compact Mode](https://designsystem.amsterdam/docs/docs
   Consult [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_box_model/Mastering_margin_collapsing) for details.
 - To add equal margins between elements, either use the [Gap](/docs/utilities-css-gap--docs) utility class on their common parent or wrap them in a [Column](/docs/components-layout-column--docs) component.
   This helps in loops: it prevents having to treat the last element differently.
-- Wrap editorial content in the [Prose](/docs/utilities-css-prose--docs) utility class to have all spacing set automatically.
+- Wrap editorial content in the [Prose](/docs/utilities-css-prose--docs) utility class instead to have all spacing set automatically.

--- a/packages/css/src/components/ordered-list/README.md
+++ b/packages/css/src/components/ordered-list/README.md
@@ -12,3 +12,7 @@ List items indent their text by a fixed distance.
 
 The list uses ascending numbers as markers, providing enough space for numbers up to 99.
 Extra white space between items enhances the distinction, mainly when they consist of multiple lines of text.
+
+## Guidelines
+
+- Use [Margin](/docs/utilities-css-margin--docs) or [Prose](/docs/utilities-css-prose--docs) to add vertical whitespace.

--- a/packages/css/src/components/paragraph/README.md
+++ b/packages/css/src/components/paragraph/README.md
@@ -10,6 +10,7 @@ Represents a paragraph of running text, form instructions, and other standalone 
   Start a new paragraph when the text shifts to a different topic or has its own purpose.
 - Consider whether a paragraph with more than 7 sentences or 140 words would be clearer if you divide the text into two paragraphs.
   Texts with not overly long paragraphs are easier to understand, and grouping makes information quicker to locate.
+- Use [Margin](/docs/utilities-css-margin--docs) or [Prose](/docs/utilities-css-prose--docs) to add vertical whitespace.
 
 ## Relevant WCAG rules
 

--- a/packages/css/src/components/standalone-link/README.md
+++ b/packages/css/src/components/standalone-link/README.md
@@ -13,3 +13,4 @@ As a result, pages can have sections with either one or several links used inter
 - Use a Standalone Link for a single link on its own line of text.
 - Within running body text, use a regular Link instead.
 - For additional guidelines, refer to the [Link](/docs/components-navigation-link--docs) component.
+- Use [Margin](/docs/utilities-css-margin--docs) or [Prose](/docs/utilities-css-prose--docs) to add vertical whitespace.

--- a/packages/css/src/components/table/README.md
+++ b/packages/css/src/components/table/README.md
@@ -9,3 +9,4 @@ Structures data in rows and columns to help users work with large amounts of inf
 - Add a caption so users can find and understand the table without reading its data.
 - Use a [Heading](https://designsystem.amsterdam/?path=/docs/components-text-heading--docs) in the caption, at the level that fits the document outline.
   It becomes the table’s accessible name, announced by screen readers on every encounter.
+- Use [Margin](/docs/utilities-css-margin--docs) or [Prose](/docs/utilities-css-prose--docs) to add vertical whitespace.

--- a/packages/css/src/components/unordered-list/README.md
+++ b/packages/css/src/components/unordered-list/README.md
@@ -13,3 +13,7 @@ Text in the list items is indented by a fixed distance.
 Items of an unordered list have square markers.
 There is extra white space between the items.
 This provides better distinction between the items, especially when they consist of multiple lines of text.
+
+## Guidelines
+
+- Use [Margin](/docs/utilities-css-margin--docs) or [Prose](/docs/utilities-css-prose--docs) to add vertical whitespace.

--- a/storybook/src/brand/assets/favicon.docs.mdx
+++ b/storybook/src/brand/assets/favicon.docs.mdx
@@ -49,7 +49,7 @@ ln -s ../node_modules/@amsterdam/design-system-assets/favicon favicon
 Remove the symlink without affecting the original files:
 
 ```sh
-# Note: do not include a trailing slash — that follows the symlink and unlink will refuse to remove a directory.
+# Note: do not include a trailing slash – that follows the symlink and unlink will refuse to remove a directory.
 unlink favicon
 ```
 

--- a/storybook/src/brand/assets/icons.docs.mdx
+++ b/storybook/src/brand/assets/icons.docs.mdx
@@ -68,7 +68,7 @@ These icons can accompany links to external products or services:
 
 ## Functional icons
 
-Some icons are widely recognised and can stand on their own without a label — for example, in an icon button.
+Some icons are widely recognised and can stand on their own without a label – for example, in an icon button.
 Their names are usually **verbs** that describe the associated function.
 
 **Note:** Use these icons only for the action their name represents, and don’t use another icon for such an action.

--- a/storybook/src/components/Accordion/Accordion.docs.mdx
+++ b/storybook/src/components/Accordion/Accordion.docs.mdx
@@ -63,6 +63,10 @@ NVDA does not read Chrome and Edge’s collapsed and expanded status correctly.
 That’s why we chose not to use this native element.
 If these problems are solved, we could do this.
 
+## See also
+
+- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/Accordion/Accordion.docs.mdx
+++ b/storybook/src/components/Accordion/Accordion.docs.mdx
@@ -65,7 +65,7 @@ If these problems are solved, we could do this.
 
 ## See also
 
-- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+- [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.
 
 ## Design tokens
 

--- a/storybook/src/components/Blockquote/Blockquote.docs.mdx
+++ b/storybook/src/components/Blockquote/Blockquote.docs.mdx
@@ -25,6 +25,10 @@ This ensures the colour of the text provides enough contrast.
 
 <Canvas of={BlockquoteStories.InverseColour} />
 
+## See also
+
+- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/Blockquote/Blockquote.docs.mdx
+++ b/storybook/src/components/Blockquote/Blockquote.docs.mdx
@@ -27,7 +27,7 @@ This ensures the colour of the text provides enough contrast.
 
 ## See also
 
-- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+- [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.
 
 ## Design tokens
 

--- a/storybook/src/components/Button/Button.docs.mdx
+++ b/storybook/src/components/Button/Button.docs.mdx
@@ -65,6 +65,10 @@ This can happen if no shorter text is available, two buttons sit next to each ot
 
 <Canvas of={ButtonStories.TextWrapping} />
 
+## See also
+
+- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/Button/Button.docs.mdx
+++ b/storybook/src/components/Button/Button.docs.mdx
@@ -67,7 +67,7 @@ This can happen if no shorter text is available, two buttons sit next to each ot
 
 ## See also
 
-- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+- [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.
 
 ## Design tokens
 

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -101,7 +101,7 @@ export const TextWrapping: Story = {
   },
   decorators: [
     (Story) => (
-      <div style={{ maxWidth: '16rem' }}>
+      <div style={{ maxInlineSize: '16rem' }}>
         <Story />
       </div>
     ),

--- a/storybook/src/components/CallToActionLink/CallToActionLink.docs.mdx
+++ b/storybook/src/components/CallToActionLink/CallToActionLink.docs.mdx
@@ -18,7 +18,7 @@ import { DesignTokensTable } from "../../_components/DesignTokensTable/DesignTok
 
 ## See also
 
-- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+- [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.
 
 ## Design tokens
 

--- a/storybook/src/components/CallToActionLink/CallToActionLink.docs.mdx
+++ b/storybook/src/components/CallToActionLink/CallToActionLink.docs.mdx
@@ -16,6 +16,10 @@ import { DesignTokensTable } from "../../_components/DesignTokensTable/DesignTok
 
 <Controls />
 
+## See also
+
+- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/Card/Card.stories.tsx
+++ b/storybook/src/components/Card/Card.stories.tsx
@@ -15,8 +15,8 @@ import { formatDate } from '../../_common/formatDate'
 
 const topTask = exampleTopTask()
 
-const maxWidthDecorator: Decorator = (Story) => (
-  <div style={{ maxWidth: '24rem' }}>
+const maxInlineSizeDecorator: Decorator = (Story) => (
+  <div style={{ maxInlineSize: '24rem' }}>
     <Story />
   </div>
 )
@@ -39,7 +39,7 @@ export const Default: Story = {
       <Paragraph key={2}>{topTask.description}</Paragraph>,
     ],
   },
-  decorators: [maxWidthDecorator],
+  decorators: [maxInlineSizeDecorator],
 }
 
 export const WithTagline: Story = {
@@ -55,7 +55,7 @@ export const WithTagline: Story = {
       </Paragraph>,
     ],
   },
-  decorators: [maxWidthDecorator],
+  decorators: [maxInlineSizeDecorator],
 }
 
 type WithImageProps = {
@@ -89,7 +89,7 @@ export const WithImage: WithImageStory = {
     tagline: { control: 'text' },
     text: { control: 'text' },
   },
-  decorators: [maxWidthDecorator],
+  decorators: [maxInlineSizeDecorator],
   render: ({ aspectRatio, date, heading, imageSrc, tagline, text, ...args }) => (
     <Card {...args}>
       <Card.Image alt="" aspectRatio={aspectRatio} src={imageSrc} />

--- a/storybook/src/components/Card/Card.test.stories.tsx
+++ b/storybook/src/components/Card/Card.test.stories.tsx
@@ -23,7 +23,7 @@ export const Test: Story = {
     <Card
       {...args}
       style={{
-        maxWidth: '24rem',
+        maxInlineSize: '24rem',
       }}
     >
       <Card.Image alt="" aspectRatio="4:3" src="https://picsum.photos/id/122/1280/720" />

--- a/storybook/src/components/Column/Column.docs.mdx
+++ b/storybook/src/components/Column/Column.docs.mdx
@@ -65,6 +65,10 @@ In this example, the Column uses a `<section>` element to group the heading and 
 
 <Canvas of={ColumnStories.ImproveSemantics} />
 
+## See also
+
+- [Spacing](/docs/docs-developer-guide-spacing--docs) — which tools to use for white space and when.
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/Column/Column.docs.mdx
+++ b/storybook/src/components/Column/Column.docs.mdx
@@ -67,7 +67,7 @@ In this example, the Column uses a `<section>` element to group the heading and 
 
 ## See also
 
-- [Spacing](/docs/docs-developer-guide-spacing--docs) — which tools to use for white space and when.
+- [Spacing](/docs/docs-developer-guide-spacing--docs) – which tools to use for white space and when.
 
 ## Design tokens
 

--- a/storybook/src/components/DateInput/DateInput.docs.mdx
+++ b/storybook/src/components/DateInput/DateInput.docs.mdx
@@ -48,7 +48,7 @@ To let the user select a specific time on a date, use the `datetime-local` type.
 Note that the control’s UI varies in general from browser to browser.
 
 The value represents a local date and time, not necessarily the user’s local date and time.
-In other words, the input allows any valid combination of year, month, day, hour, and minute — even if such a combination is invalid in the user’s local time zone.
+In other words, the input allows any valid combination of year, month, day, hour, and minute – even if such a combination is invalid in the user’s local time zone.
 
 <Canvas of={DateInputStories.DateTime} />
 

--- a/storybook/src/components/DescriptionList/DescriptionList.docs.mdx
+++ b/storybook/src/components/DescriptionList/DescriptionList.docs.mdx
@@ -51,6 +51,10 @@ This ensures the colour of the text provides enough contrast.
 
 <Canvas of={DescriptionListStories.InverseColour} />
 
+## See also
+
+- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/DescriptionList/DescriptionList.docs.mdx
+++ b/storybook/src/components/DescriptionList/DescriptionList.docs.mdx
@@ -53,7 +53,7 @@ This ensures the colour of the text provides enough contrast.
 
 ## See also
 
-- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+- [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.
 
 ## Design tokens
 

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -114,6 +114,10 @@ Use the `as` prop on either to make your markup more semantic.
 - If the total of both values is too large, the browser adds columns to the grid.
   This is not allowed.
 
+## See also
+
+- [Spacing](/docs/docs-developer-guide-spacing--docs) — which tools to use for white space and when.
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -116,7 +116,7 @@ Use the `as` prop on either to make your markup more semantic.
 
 ## See also
 
-- [Spacing](/docs/docs-developer-guide-spacing--docs) — which tools to use for white space and when.
+- [Spacing](/docs/docs-developer-guide-spacing--docs) – which tools to use for white space and when.
 
 ## Design tokens
 

--- a/storybook/src/components/Heading/Heading.docs.mdx
+++ b/storybook/src/components/Heading/Heading.docs.mdx
@@ -63,6 +63,10 @@ Use a [Row](/docs/components-layout-row--docs) and the `size` prop of [Icon](/do
 
 <Canvas of={HeadingStories.WithIcon} />
 
+## See also
+
+- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/Heading/Heading.docs.mdx
+++ b/storybook/src/components/Heading/Heading.docs.mdx
@@ -65,7 +65,7 @@ Use a [Row](/docs/components-layout-row--docs) and the `size` prop of [Icon](/do
 
 ## See also
 
-- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+- [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.
 
 ## Design tokens
 

--- a/storybook/src/components/Image/Image.docs.mdx
+++ b/storybook/src/components/Image/Image.docs.mdx
@@ -35,7 +35,7 @@ Consider setting this for images below the top area of the page.
 
 ## See also
 
-- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+- [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.
 
 ## Design tokens
 

--- a/storybook/src/components/Image/Image.docs.mdx
+++ b/storybook/src/components/Image/Image.docs.mdx
@@ -33,6 +33,10 @@ Consider setting this for images below the top area of the page.
 
 <Canvas of={ImageStories.LazyLoading} />
 
+## See also
+
+- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/ImageSlider/ImageSlider.docs.mdx
+++ b/storybook/src/components/ImageSlider/ImageSlider.docs.mdx
@@ -29,7 +29,7 @@ Don’t forget to still include the required `src` attribute.
 ### With captions
 
 Add a caption to any image to display a description below it, e.g. for context or attribution.
-Keep it short — they take up vertical space, especially on mobile.
+Keep it short – they take up vertical space, especially on mobile.
 Consistent caption lengths across images help avoid large layout shifts when sliding.
 
 <Canvas of={ImageSliderStories.WithCaptions} />

--- a/storybook/src/components/ImageSlider/ImageSlider.docs.mdx
+++ b/storybook/src/components/ImageSlider/ImageSlider.docs.mdx
@@ -29,7 +29,7 @@ Don’t forget to still include the required `src` attribute.
 ### With captions
 
 Add a caption to any image to display a description below it, e.g. for context or attribution.
-Keep it short – they take up vertical space, especially on mobile.
+Keep captions short – they take up vertical space, especially on mobile.
 Consistent caption lengths across images help avoid large layout shifts when sliding.
 
 <Canvas of={ImageSliderStories.WithCaptions} />

--- a/storybook/src/components/LinkList/LinkList.docs.mdx
+++ b/storybook/src/components/LinkList/LinkList.docs.mdx
@@ -66,6 +66,10 @@ It will make the Link white.
 
 <Canvas of={LinkListStories.InverseColour} />
 
+## See also
+
+- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/LinkList/LinkList.docs.mdx
+++ b/storybook/src/components/LinkList/LinkList.docs.mdx
@@ -68,7 +68,7 @@ It will make the Link white.
 
 ## See also
 
-- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+- [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.
 
 ## Design tokens
 

--- a/storybook/src/components/OrderedList/OrderedList.docs.mdx
+++ b/storybook/src/components/OrderedList/OrderedList.docs.mdx
@@ -69,7 +69,7 @@ When using a list in small text, set the prop for each item in the list.
 
 ## See also
 
-- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+- [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.
 
 ## Design tokens
 

--- a/storybook/src/components/OrderedList/OrderedList.docs.mdx
+++ b/storybook/src/components/OrderedList/OrderedList.docs.mdx
@@ -67,6 +67,10 @@ When using a list in small text, set the prop for each item in the list.
 
 <Canvas of={OrderedListStories.SmallText} />
 
+## See also
+
+- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/PageHeader/PageHeader.docs.mdx
+++ b/storybook/src/components/PageHeader/PageHeader.docs.mdx
@@ -51,7 +51,7 @@ import { DesignTokensTable } from "../../_components/DesignTokensTable/DesignTok
 - This menu gets accessed through the menu button and offers much room for more links.
 - Use the `GridCellNarrowWindowOnly` subcomponent to contain links from the inline menu that disappear in narrow windows.
 - If the collapsible menu contains [Headings](https://designsystem.amsterdam/?path=/docs/components-text-heading--docs), give them level 2 and a size of ‘level-3’.
-- Don’t add whitespace to the Grid in the collapsible menu — its container already provides this.
+- Don’t add whitespace to the Grid in the collapsible menu – its container already provides this.
 
 ## Examples
 

--- a/storybook/src/components/Paragraph/Paragraph.docs.mdx
+++ b/storybook/src/components/Paragraph/Paragraph.docs.mdx
@@ -50,7 +50,7 @@ Use a [Row](/docs/components-layout-row--docs) and the `size` prop of [Icon](/do
 
 ## See also
 
-- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+- [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.
 
 ## Design tokens
 

--- a/storybook/src/components/Paragraph/Paragraph.docs.mdx
+++ b/storybook/src/components/Paragraph/Paragraph.docs.mdx
@@ -48,6 +48,10 @@ Use a [Row](/docs/components-layout-row--docs) and the `size` prop of [Icon](/do
 
 <Canvas of={ParagraphStories.WithIcon} />
 
+## See also
+
+- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/Row/Row.docs.mdx
+++ b/storybook/src/components/Row/Row.docs.mdx
@@ -88,7 +88,7 @@ Items that may not fit together on a single line should be allowed to wrap onto 
 
 ## See also
 
-- [Spacing](/docs/docs-developer-guide-spacing--docs) — which tools to use for white space and when.
+- [Spacing](/docs/docs-developer-guide-spacing--docs) – which tools to use for white space and when.
 
 ## Design tokens
 

--- a/storybook/src/components/Row/Row.docs.mdx
+++ b/storybook/src/components/Row/Row.docs.mdx
@@ -86,6 +86,10 @@ Items that may not fit together on a single line should be allowed to wrap onto 
 
 <Canvas of={RowStories.Wrapping} />
 
+## See also
+
+- [Spacing](/docs/docs-developer-guide-spacing--docs) — which tools to use for white space and when.
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
+++ b/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
@@ -74,7 +74,7 @@ export const WithHeadingAndParagraph: Story = {
   },
   decorators: [
     (Story) => (
-      <article style={{ maxWidth: '32rem' }}>
+      <article style={{ maxInlineSize: '32rem' }}>
         <Story />
       </article>
     ),

--- a/storybook/src/components/Table/Table.docs.mdx
+++ b/storybook/src/components/Table/Table.docs.mdx
@@ -45,6 +45,10 @@ Set `aria-labelledby` to keep only the heading as the table’s accessible name,
 
 <Canvas of={TableStories.WithDescriptionInCaption} />
 
+## See also
+
+- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/Table/Table.docs.mdx
+++ b/storybook/src/components/Table/Table.docs.mdx
@@ -47,7 +47,7 @@ Set `aria-labelledby` to keep only the heading as the table’s accessible name,
 
 ## See also
 
-- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+- [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.
 
 ## Design tokens
 

--- a/storybook/src/components/Table/TableCell.stories.tsx
+++ b/storybook/src/components/Table/TableCell.stories.tsx
@@ -39,6 +39,6 @@ type Story = StoryObj<typeof meta>
 export const Cell: Story = {
   args: {
     children: '€ 77,85',
-    style: { width: '8rem' },
+    style: { inlineSize: '8rem' },
   },
 }

--- a/storybook/src/components/Tabs/Tabs.stories.tsx
+++ b/storybook/src/components/Tabs/Tabs.stories.tsx
@@ -24,8 +24,8 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-const maxWidthDecorator: Decorator = (Story) => (
-  <div style={{ maxWidth: '20rem' }}>
+const maxInlineSizeDecorator: Decorator = (Story) => (
+  <div style={{ maxInlineSize: '20rem' }}>
     <Story />
   </div>
 )
@@ -60,5 +60,5 @@ export const Default: Story = {
       </Tabs.Panel>,
     ],
   },
-  decorators: [maxWidthDecorator],
+  decorators: [maxInlineSizeDecorator],
 }

--- a/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
+++ b/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
@@ -54,6 +54,10 @@ When using a list in small text, set the prop for each item in the list.
 
 <Canvas of={UnorderedListStories.SmallText} />
 
+## See also
+
+- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
+++ b/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
@@ -56,7 +56,7 @@ When using a list in small text, set the prop for each item in the list.
 
 ## See also
 
-- [Prose](/docs/utilities-css-prose--docs) — applies the recommended vertical spacing for editorial content
+- [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.
 
 ## Design tokens
 

--- a/storybook/src/docs/designer-guide/vertical-space.docs.mdx
+++ b/storybook/src/docs/designer-guide/vertical-space.docs.mdx
@@ -159,4 +159,4 @@ Set the [Prose](/docs/utilities-css-prose--docs) utility class (`.ams-prose`) to
 
 ## See also
 
-- Consult the [space tokens](/docs/brand-design-tokens-space--docs) to get the various pixel values for each size.
+- [Space design tokens](/docs/brand-design-tokens-space--docs) – the names and lengths for each available size.

--- a/storybook/src/docs/developer-guide/spacing.docs.mdx
+++ b/storybook/src/docs/developer-guide/spacing.docs.mdx
@@ -7,7 +7,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 # Spacing
 
 The design system offers various tools for adding white space around and between elements.
-They operate at different scales — from the entire page layout to individual elements — each serving a distinct purpose.
+They operate at different scales – from the entire page layout to individual elements – each serving a distinct purpose.
 This page explains which to use in each situation.
 
 ## Grid
@@ -17,18 +17,18 @@ It provides 4, 8, or 12 columns depending on the window width.
 Its children are Grid Cells that define how many columns they span and, optionally, where they start.
 
 Use Grid as the top-level layout container for every page.
+This makes Grid Cells the context for nearly all elements.
 A single page can have several consecutive Grids, which allows mixing in full-width elements.
-Do not nest Grids inside each other, and do not apply Gap utility classes to a Grid — it manages its own spacing.
 
 ## Row and Column
 
-[Row](/docs/components-layout-row--docs) and [Column](/docs/components-layout-column--docs) arrange a set of children with uniform spacing between them.
+[Row](/docs/components-layout-row--docs) and [Column](/docs/components-layout-column--docs) arrange a set of children with uniform spacing.
 They use CSS flexbox.
 Row places items side by side; Column stacks them vertically.
-Both provide a `gap` prop that maps to the [space design tokens](/docs/brand-design-tokens-space--docs) and alignment props for fine control over how children are positioned.
+Both create a gap between their elements and can align them in both directions.
 
-Employ them inside Grid Cells when a group of elements needs equal spacing between them.
-Do not use Column for editorial text — various element types require different amounts of space between them.
+Use them inside Grid Cells when a group of elements needs equal spacing between them.
+Do not use Column for editorial text – various element types require different amounts of space between them.
 Use [Prose](#prose) instead.
 
 ## Gap
@@ -62,5 +62,5 @@ Margin is the right choice for a single targeted override; Prose is the right ch
 
 ## See also
 
-- [Space design tokens](/docs/brand-design-tokens-space--docs) — the names and lengths for each available size
-- [Vertical space](/docs/docs-designer-guide-vertical-space--docs) — how much space to use between specific combinations
+- [Space design tokens](/docs/brand-design-tokens-space--docs) – the names and lengths for each available size.
+- [Vertical space](/docs/docs-designer-guide-vertical-space--docs) – how much space to use between specific combinations.

--- a/storybook/src/docs/developer-guide/spacing.docs.mdx
+++ b/storybook/src/docs/developer-guide/spacing.docs.mdx
@@ -1,0 +1,66 @@
+{/* @license CC0-1.0 */}
+
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Docs/Developer Guide/Spacing" />
+
+# Spacing
+
+The design system offers various tools for adding white space around and between elements.
+They operate at different scales — from the entire page layout to individual elements — each serving a distinct purpose.
+This page explains which to use in each situation.
+
+## Grid
+
+[Grid](/docs/components-layout-grid--docs) divides the page into areas and is the foundation of every [Page](/docs/components-containers-page--docs) layout.
+It provides 4, 8, or 12 columns depending on the window width.
+Its children are Grid Cells that define how many columns they span and, optionally, where they start.
+
+Use Grid as the top-level layout container for every page.
+A single page can have several consecutive Grids, which allows mixing in full-width elements.
+Do not nest Grids inside each other, and do not apply Gap utility classes to a Grid — it manages its own spacing.
+
+## Row and Column
+
+[Row](/docs/components-layout-row--docs) and [Column](/docs/components-layout-column--docs) arrange a set of children with uniform spacing between them.
+They use CSS flexbox.
+Row places items side by side; Column stacks them vertically.
+Both provide a `gap` prop that maps to the [space design tokens](/docs/brand-design-tokens-space--docs) and alignment props for fine control over how children are positioned.
+
+Employ them inside Grid Cells when a group of elements needs equal spacing between them.
+Do not use Column for editorial text — various element types require different amounts of space between them.
+Use [Prose](#prose) instead.
+
+## Gap
+
+The [Gap](/docs/utilities-css-gap--docs) utility classes add equal white space between all children of the element it’s applied to.
+They use CSS grid layout and can be seen as a basic version of Column.
+
+## Margin
+
+The [Margin](/docs/utilities-css-margin--docs) utility classes create white space below a single element.
+Use it for individual or a few consecutive elements, where they need specific amounts of space below them.
+
+Refer to the [vertical space](/docs/docs-designer-guide-vertical-space--docs) guidelines to find the recommended size for each combination.
+When the same spacing applies to all siblings, use Gap or Column instead, which avoids singling out the last element.
+
+## Prose
+
+[Prose](/docs/utilities-css-prose--docs) applies the recommended vertical spacing between all children of a container at once.
+Use it for editorial content, like rich-text output from a CMS, or any mix of headings, paragraphs, lists, etc.
+
+Margin is the right choice for a single targeted override; Prose is the right choice when spacing should be applied to a whole document.
+
+## Quick reference
+
+| Situation                         | Tool                                                                                                                             |
+| :-------------------------------- | :------------------------------------------------------------------------------------------------------------------------------- |
+| Top-level page layout             | [Grid](/docs/components-layout-grid--docs)                                                                                       |
+| Equal spacing between siblings    | [Row](/docs/components-layout-row--docs), [Column](/docs/components-layout-column--docs) or [Gap](/docs/utilities-css-gap--docs) |
+| Space below one element           | [Margin](/docs/utilities-css-margin--docs)                                                                                       |
+| Editorial content (articles, CMS) | [Prose](/docs/utilities-css-prose--docs)                                                                                         |
+
+## See also
+
+- [Space design tokens](/docs/brand-design-tokens-space--docs) — the names and lengths for each available size
+- [Vertical space](/docs/docs-designer-guide-vertical-space--docs) — how much space to use between specific combinations

--- a/storybook/src/docs/developer-guide/web-app.docs.mdx
+++ b/storybook/src/docs/developer-guide/web-app.docs.mdx
@@ -52,7 +52,7 @@ cp ../node_modules/@amsterdam/design-system-assets/manifest/app.webmanifest app.
 Remove the symlink and the web manifest without affecting the original files:
 
 ```sh
-# Note: do not include a trailing slash — that follows the symlink and unlink will refuse to remove a directory.
+# Note: do not include a trailing slash – that follows the symlink and unlink will refuse to remove a directory.
 unlink app-icons
 rm app.webmanifest
 ```

--- a/storybook/src/pages/internal/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/internal/HomePage/HomePage.stories.tsx
@@ -22,19 +22,19 @@ const meta = {
       <Grid.Cell appearance="transparent" span="all">
         <Heading level={1}>Titel van de pagina</Heading>
       </Grid.Cell>
-      <Grid.Cell span={{ narrow: 4, medium: 5, wide: 8 }} style={{ height: '12rem' }} />
-      <Grid.Cell span={{ narrow: 1, medium: 3, wide: 4 }} style={{ height: '10rem' }} />
+      <Grid.Cell span={{ narrow: 4, medium: 5, wide: 8 }} style={{ blockSize: '12rem' }} />
+      <Grid.Cell span={{ narrow: 1, medium: 3, wide: 4 }} style={{ blockSize: '10rem' }} />
       <Grid.Cell span={{ narrow: 3, medium: 3, wide: 3 }}>
         <Paragraph>{exampleParagraph1}</Paragraph>
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 5, wide: 9 }}>
         <Paragraph>{exampleParagraph2}</Paragraph>
       </Grid.Cell>
-      <Grid.Cell span={{ narrow: 2, medium: 3, wide: 6 }} style={{ height: '8rem' }} />
-      <Grid.Cell span={{ narrow: 2, medium: 3, wide: 6 }} style={{ height: '8rem' }} />
-      <Grid.Cell span={{ narrow: 3, medium: 2, wide: 4 }} style={{ height: '6rem' }} />
-      <Grid.Cell span={{ narrow: 1, medium: 4, wide: 4 }} style={{ height: '8rem' }} />
-      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }} style={{ height: '6rem' }} />
+      <Grid.Cell span={{ narrow: 2, medium: 3, wide: 6 }} style={{ blockSize: '8rem' }} />
+      <Grid.Cell span={{ narrow: 2, medium: 3, wide: 6 }} style={{ blockSize: '8rem' }} />
+      <Grid.Cell span={{ narrow: 3, medium: 2, wide: 4 }} style={{ blockSize: '6rem' }} />
+      <Grid.Cell span={{ narrow: 1, medium: 4, wide: 4 }} style={{ blockSize: '8rem' }} />
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }} style={{ blockSize: '6rem' }} />
     </Grid>
   ),
 } satisfies Meta

--- a/storybook/src/utils/Gap/Gap.docs.mdx
+++ b/storybook/src/utils/Gap/Gap.docs.mdx
@@ -11,3 +11,7 @@ import README from "../../../../packages/css/src/components/gap/README.md?raw";
 <Primary />
 
 <Controls />
+
+## See also
+
+- [Spacing](/docs/docs-developer-guide-spacing--docs) — which tools to use for white space and when.

--- a/storybook/src/utils/Gap/Gap.docs.mdx
+++ b/storybook/src/utils/Gap/Gap.docs.mdx
@@ -14,4 +14,4 @@ import README from "../../../../packages/css/src/components/gap/README.md?raw";
 
 ## See also
 
-- [Spacing](/docs/docs-developer-guide-spacing--docs) — which tools to use for white space and when.
+- [Spacing](/docs/docs-developer-guide-spacing--docs) – which tools to use for white space and when.

--- a/storybook/src/utils/Margin/Margin.docs.mdx
+++ b/storybook/src/utils/Margin/Margin.docs.mdx
@@ -14,4 +14,4 @@ import README from "../../../../packages/css/src/components/margin/README.md?raw
 
 ## See also
 
-- [Spacing](/docs/docs-developer-guide-spacing--docs) — which tools to use for white space and when.
+- [Spacing](/docs/docs-developer-guide-spacing--docs) – which tools to use for white space and when.

--- a/storybook/src/utils/Margin/Margin.docs.mdx
+++ b/storybook/src/utils/Margin/Margin.docs.mdx
@@ -11,3 +11,7 @@ import README from "../../../../packages/css/src/components/margin/README.md?raw
 <Primary />
 
 <Controls />
+
+## See also
+
+- [Spacing](/docs/docs-developer-guide-spacing--docs) — which tools to use for white space and when.

--- a/storybook/src/utils/Prose/Prose.docs.mdx
+++ b/storybook/src/utils/Prose/Prose.docs.mdx
@@ -18,4 +18,4 @@ import README from "../../../../packages/css/src/components/prose/README.md?raw"
 
 ## See also
 
-- [Spacing](/docs/docs-developer-guide-spacing--docs) — which tools to use for white space and when.
+- [Spacing](/docs/docs-developer-guide-spacing--docs) – which tools to use for white space and when.

--- a/storybook/src/utils/Prose/Prose.docs.mdx
+++ b/storybook/src/utils/Prose/Prose.docs.mdx
@@ -15,3 +15,7 @@ import README from "../../../../packages/css/src/components/prose/README.md?raw"
 <Markdown>{README}</Markdown>
 
 <Primary />
+
+## See also
+
+- [Spacing](/docs/docs-developer-guide-spacing--docs) — which tools to use for white space and when.

--- a/storybook/src/utils/Prose/Prose.stories.tsx
+++ b/storybook/src/utils/Prose/Prose.stories.tsx
@@ -6,6 +6,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import {
+  Accordion,
   CallToActionLink,
   Heading,
   Link,
@@ -28,6 +29,7 @@ const render = (props: ProseProps) => (
       Afgelopen maand konden bewoners hun reactie op de plannen geven tijdens informatiebijeenkomsten. Online kunt u tot
       en met 31 oktober reageren op de plannen.
     </Paragraph>
+
     <Heading level={2}>Waar vinden de werkzaamheden plaats?</Heading>
     <Paragraph>
       De Oranjeloper loopt van oost naar west door de stad. We passen onderstaande straten en kruispunten aan, zodat de
@@ -42,6 +44,7 @@ const render = (props: ProseProps) => (
       <UnorderedList.Item>Nieuwezijds Voorburgwal</UnorderedList.Item>
       <UnorderedList.Item>Molenslootbrug en Ritsaert ten Catebrug</UnorderedList.Item>
     </UnorderedList>
+
     <Heading level={2}>Planning per fase</Heading>
     <Paragraph>
       We richten de rotonde bij de Bouhuijstunnel opnieuw in en maken het veiliger. Ook het fiets- en voetpad passen we
@@ -52,6 +55,7 @@ const render = (props: ProseProps) => (
       we de planning in overleg met de aannemer op. We informeren bewoners en ondernemers dan minimaal een week van
       tevoren.
     </Paragraph>
+
     <Heading level={3}>Fasen van de rotonde</Heading>
     <OrderedList>
       <OrderedList.Item>Voorbereiden van de werkzaamheden: 25 september tot 27 september.</OrderedList.Item>
@@ -72,6 +76,7 @@ const render = (props: ProseProps) => (
         Afronden van de werkzaamheden en verwijderen van tijdelijke maatregelen: 7 december tot 15 december.
       </OrderedList.Item>
     </OrderedList>
+
     <Heading level={2}>Bereikbaarheid tijdens de werkzaamheden</Heading>
     <Paragraph>
       Tijdens de uitvoering leiden we het verkeer om via de belangrijkste aanrijroutes. Fietsers en voetgangers kunnen
@@ -112,6 +117,43 @@ const render = (props: ProseProps) => (
         </Table.Row>
       </Table.Body>
     </Table>
+
+    <Heading level={2}>Veelgestelde vragen</Heading>
+    <Paragraph>
+      Hieronder vindt u antwoorden op vragen die bewoners en ondernemers ons het vaakst stellen over de werkzaamheden.
+      Staat uw vraag er niet bij, neem dan contact op via het contactformulier onderaan deze pagina.
+    </Paragraph>
+    <Accordion headingLevel={3}>
+      <Accordion.Section label="Wat gebeurt er met mijn parkeerplaats tijdens de werkzaamheden?">
+        <Paragraph>
+          Tijdens de uitvoering vervallen een aantal parkeerplaatsen langs de route tijdelijk. Bewoners met een
+          parkeervergunning kunnen in overleg met de gemeente gebruikmaken van aangewezen uitwijklocaties in de buurt.
+          Ondernemers met een laad- en losvergunning ontvangen vooraf bericht over tijdelijke alternatieven. We proberen
+          de overlast zo beperkt mogelijk te houden en informeren betrokkenen minimaal twee weken van tevoren. Zodra een
+          fase is afgerond, worden de parkeerplaatsen zo snel mogelijk teruggegeven.
+        </Paragraph>
+      </Accordion.Section>
+      <Accordion.Section label="Kan ik mijn woning of bedrijf blijven bereiken?">
+        <Paragraph>
+          Uw woning en bedrijf blijven gedurende de gehele periode bereikbaar, al kan de route tijdelijk afwijken van
+          wat u gewend bent. Voor voetgangers en fietsers zorgen we altijd voor een veilige doorgang langs de
+          werkzaamheden. Autoverkeer wordt via omleidingsborden naar de dichtstbijzijnde alternatieve route geleid.
+          Heeft u bijzondere bereikbaarheidsbehoeften, bijvoorbeeld voor medisch vervoer of een zwaar transport, neem
+          dan vooraf contact met ons op zodat we samen een oplossing kunnen zoeken.
+        </Paragraph>
+      </Accordion.Section>
+      <Accordion.Section label="Wat doe ik als ik schade ondervind door de werkzaamheden?">
+        <Paragraph>
+          Constateert u schade aan uw woning, bedrijfspand of voertuig die mogelijk is veroorzaakt door de
+          werkzaamheden, meld dit dan zo snel mogelijk via <Link href="#">amsterdam.nl/schade-melden</Link>. Voeg
+          daarbij zo veel mogelijk documentatie toe, zoals foto&apos;s met datum en tijdstip. De gemeente beoordeelt
+          iedere melding afzonderlijk en neemt binnen vijf werkdagen contact met u op. Is de schade dringend, bel dan de
+          gemeentelijke storingsdienst op 14 020. Schade veroorzaakt door de aannemer wordt in eerste instantie door de
+          aannemer afgehandeld; de gemeente fungeert daarbij als aanspreekpunt.
+        </Paragraph>
+      </Accordion.Section>
+    </Accordion>
+
     <Heading level={2}>Op de hoogte blijven</Heading>
     <Paragraph>
       Op <Link href="https://amsterdam.nl/oranjeloper">amsterdam.nl/oranjeloper</Link> vindt u een actueel overzicht van

--- a/storybook/src/utils/Prose/Prose.stories.tsx
+++ b/storybook/src/utils/Prose/Prose.stories.tsx
@@ -174,5 +174,12 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ maxInlineSize: '44.375rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
   render,
 }


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Add Spacing page and cross-references to Developer Guide

## What

- Adds a new Spacing page to the Developer Guide that explains when to use Grid, Row, Column, Gap, Margin, and Prose, with a quick-reference table and links to each.
- Adds a `## See also` section linking to the Spacing page on the docs pages for Grid, Row, Column, Gap, Margin, and Prose.
- Adds a `## See also` section linking to the Prose page on the docs pages for all components that Prose adds spacing to: Accordion, Blockquote, Button, Call to Action Link, Description List, Heading, Image, Link List, Ordered List, Paragraph, Table, and Unordered List.
- Adds a short guideline pointing to Margin and Prose on Blockquote, Button, Call to Action Link, Heading, Ordered List, Paragraph, Standalone Link, Table, and Unordered List.
- Extends the Prose default story with an Accordion section and constrains its width to 7 of 12 columns for a realistic reading measure.

## Why

Developers had no single reference for deciding which spacing tool to reach for.
The individual component and utility pages also lacked cross-references, making the system hard to navigate.

## How

- New MDX page added at `storybook/src/docs/developer-guide/spacing.docs.mdx`, following the existing Developer Guide conventions.
- `## See also` sections added to the relevant `.docs.mdx` files, placed immediately before `## Design tokens`. For utilities without design tokens (Gap, Margin, Prose) the section was appended at the end.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
