### PR TITLE
chore(docs): Use FAQ content for Accordion and condense docs

### DIFF
--- a/packages/css/src/components/accordion/README.md
+++ b/packages/css/src/components/accordion/README.md
@@ -2,50 +2,18 @@
 
 # Accordion
 
-The accordion component is a clickable (vertically stacked) list of headings to hide or show associated content.
-With an accordion, you offer content to users progressively.
+The accordion component is a list of headings that each show or hide associated content.
+Use it to present non-essential content on demand, keeping important content immediately visible.
 
 ## Guidelines
 
-- Use an accordion on a full page with essential and non-essential content.
-- Hiding non-essential content helps users get to important content more quickly.
-- Avoid using an accordion to avoid too much essential content on 1 page.
-- Rewrite the page more compactly or divide the content over multiple pages instead of using the accordion in the first place.
-- Don’t hide essential information in an accordion.
-- An accordion consists of several accordion sections.
-- Use a minimum of 3 and a maximum of 10 sections underneath each other.
-- It is essential for accordion sections to have clear headings, as the user cannot "scan" the hidden content to find relevant information.
-- Hiding the content has the disadvantage that "search in page" does not yield any hidden content results.
-- If you know the search term the user used to get to the accordion page, you can automatically expand the sections that contain the search term.
-- The accordion’s content may contain formatting (e.g. headings, lists, links and buttons).
+Before reaching for an accordion, consider whether splitting the content across multiple pages would serve users better — it often improves both usability and findability through search engines.
+If an accordion is the right fit, follow these rules:
 
-You can navigate an accordion with your keyboard:
-
-| key            | element                                                                                                               |
-| :------------- | :-------------------------------------------------------------------------------------------------------------------- |
-| Enter or Space | Open or close the accordion section that has the focus                                                                |
-| Tab            | Go to the next element that can have focus                                                                            |
-| Shift + Tab    | Go to the next element that can have focus                                                                            |
-| Down arrow     | If an accordion section has focus, go to the next section; if the last section has focus, go to the first section     |
-| Up arrow       | If an accordion section has focus, go to the previous section; if the first section has focus, go to the last section |
-| Home           | If an accordion section has focus: go to the first section                                                            |
-| End            | If an accordion section has focus, go to the last section                                                             |
-
-## Relevant WCAG requirements
-
-The WCAG requirements for the Button and Heading components also apply to the accordion header.
-
-Pay extra attention to these parts:
-
-- [WCAG requirement 1.3.1](https://www.w3.org/TR/WCAG21/#info-and-relationships): the heading level of the accordion sections depends on where in the page the accordion is placed, this may differ per page.
-- [WCAG requirement 1.3.6](https://www.w3.org/TR/WCAG21/#identify-purpose): use `aria-controls` for the button, and use a `region` landmark for the expandable region (use the HTML element `<section>` for this)
-- [WCAG requirement 1.4.3](https://www.w3.org/TR/WCAG21/#contrast-minimum): contrast between text and background and between icon and background is sufficient in all variants, all interactive statuses and all possible combinations.
-- [WCAG requirement 3.2.1](https://www.w3.org/TR/WCAG21/#on-focus): do not automatically make the accordion expanded when the button gets focus.
-- [WCAG requirement 2.1.3](https://www.w3.org/TR/WCAG21/#keyboard-no-exception): Support the optional keys: `Down Arrow`, `Up Arrow`, `Home` and `End`.
-- `Space` should activate the button, not scroll the page (use `keypressEvt.preventDefault()`).
-- [WCAG requirement 2.4.6](https://www.w3.org/TR/WCAG21/#headings-and-labels): The text used both as a heading and as a label for the button must be clear because the content is not always visible.
-- [WCAG requirement 2.4.10](https://www.w3.org/TR/WCAG21/#section-headings): accordions that are part of the running text must use section headings.
-
-## References
-
-- [W3C - Accordion Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/)
+- Don't hide essential information in an accordion.
+- Use between 3 and 10 sections.
+- Set the heading level to match the accordion's position in the page hierarchy; all sections share the same level.
+- Write clear headings — users cannot scan hidden content.
+- Note that browser "find in page" (Ctrl+F) does not search hidden content.
+  If you know the user's search term, expand sections that contain it automatically.
+- Sections may contain formatted content such as headings, lists, links, and buttons.

--- a/storybook/src/components/Accordion/Accordion.docs.mdx
+++ b/storybook/src/components/Accordion/Accordion.docs.mdx
@@ -12,23 +12,11 @@ import { DesignTokensTable } from "../../_components/DesignTokensTable/DesignTok
 
 <Markdown>{README}</Markdown>
 
-Each accordion section has its unique name.
-Provide this name via the `label` property of the `Accordion.Section` component.
-
 <Primary />
 
 <Controls />
 
 ## Examples
-
-### Level
-
-There are 3 hierarchical levels of headings possible.
-There is no default value; determine the correct level for each instance.
-Every Accordion Section Heading in an Accordion has the same hierarchical level.
-Changing the level also changes the visual size of the heading.
-
-<Canvas of={AccordionStories.Level} />
 
 ### Expanded by default
 
@@ -44,24 +32,14 @@ Let Accordions with 6 Sections or more render generic `div` elements through `se
 
 <Canvas of={AccordionStories.ReduceLandmarks} />
 
-### Technical considerations
+## Keyboard navigation
 
-### The `Accordion` parent component
-
-The parent component is used for several reasons:
-
-- It sets the spacing between Accordion Sections.
-- It allows you to set the same heading level for all Accordion Sections.
-- It allows you to set the same HTML element for all Accordion Sections.
-- It adds the extra keyboard navigation described in the guidelines.
-
-### The HTML `details` element
-
-Currently (28-6-2023), the `details` element has some accessibility problems.
-[For example, a heading in a summary is not adequately understood by screen readers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary#summaries_as_headings) and
-NVDA does not read Chrome and Edge’s collapsed and expanded status correctly.
-That’s why we chose not to use this native element.
-If these problems are solved, we could do this.
+| Key             | Behaviour                                                 |
+| :-------------- | :-------------------------------------------------------- |
+| Enter or Space  | Open or close the focused section                         |
+| Tab / Shift+Tab | Move to the next or previous focusable element            |
+| Down / Up arrow | Move focus to the next or previous section (wraps around) |
+| Home / End      | Move focus to the first or last section                   |
 
 ## See also
 

--- a/storybook/src/components/Accordion/Accordion.stories.tsx
+++ b/storybook/src/components/Accordion/Accordion.stories.tsx
@@ -62,13 +62,6 @@ export const Default: Story = {
   },
 }
 
-export const Level: Story = {
-  args: {
-    children: <Accordion.Section label={faqItems[0].label}>{faqItems[0].content}</Accordion.Section>,
-    headingLevel: 4,
-  },
-}
-
 export const ExpandedByDefault: Story = {
   args: {
     children: faqItems.map(({ content, label }, index) => (

--- a/storybook/src/components/Accordion/Accordion.stories.tsx
+++ b/storybook/src/components/Accordion/Accordion.stories.tsx
@@ -5,17 +5,40 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { Paragraph } from '@amsterdam/design-system-react'
+import { Link, Paragraph } from '@amsterdam/design-system-react'
 import { Accordion } from '@amsterdam/design-system-react/src'
 
-import { exampleAccordionHeading, exampleParagraph } from '../../_common/exampleContent'
-
-const heading1 = exampleAccordionHeading()
-const heading2 = exampleAccordionHeading()
-const heading3 = exampleAccordionHeading()
-const paragraph1 = exampleParagraph()
-const paragraph2 = exampleParagraph()
-const paragraph3 = exampleParagraph()
+const faqItems = [
+  {
+    content: (
+      <Paragraph>
+        Op de pagina <Link href="#">Solliciteren bij Amsterdam</Link> vind je uitgebreide informatie over solliciteren
+        bij de gemeente Amsterdam. De gemeente Amsterdam volgt daarbij de <Link href="#">NVP Sollicitatiecode</Link>.
+        Dit is een gedragscode met basisregels die een transparant en eerlijk werving- en selectieproces waarborgt.
+      </Paragraph>
+    ),
+    label: 'Hoe ziet de sollicitatieprocedure eruit?',
+  },
+  {
+    content: (
+      <Paragraph>
+        Het is momenteel alleen mogelijk om een open sollicitatie voor stages in te sturen. Kun je geen passende{' '}
+        <Link href="#">stagevacature</Link> vinden en wil je een open sollicitatie insturen? Mail dan jouw cv en een
+        korte motivatie naar <Link href="#">stage@amsterdam.nl</Link>.
+      </Paragraph>
+    ),
+    label: 'Kan ik een open sollicitatie sturen?',
+  },
+  {
+    content: (
+      <Paragraph>
+        Ja, als je gaat werken bij de gemeente Amsterdam heb je een VOG nodig. Een VOG staat voor Verklaring Omtrent het
+        Gedrag. Meer informatie hierover vind je op de pagina <Link href="#">VOG</Link>.
+      </Paragraph>
+    ),
+    label: 'Heb ik een VOG nodig?',
+  },
+]
 
 const meta = {
   title: 'Components/Containers/Accordion',
@@ -31,60 +54,38 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    children: [
-      <Accordion.Section key={1} label={heading1}>
-        <Paragraph>{paragraph1}</Paragraph>
-      </Accordion.Section>,
-      <Accordion.Section key={2} label={heading2}>
-        <Paragraph>{paragraph2}</Paragraph>
-      </Accordion.Section>,
-      <Accordion.Section key={3} label={heading3}>
-        <Paragraph>{paragraph3}</Paragraph>
-      </Accordion.Section>,
-    ],
+    children: faqItems.map(({ content, label }, index) => (
+      <Accordion.Section key={index} label={label}>
+        {content}
+      </Accordion.Section>
+    )),
   },
 }
 
 export const Level: Story = {
   args: {
-    children: (
-      <Accordion.Section label="Heading level 4">
-        <Paragraph>{paragraph1}</Paragraph>
-      </Accordion.Section>
-    ),
+    children: <Accordion.Section label={faqItems[0].label}>{faqItems[0].content}</Accordion.Section>,
     headingLevel: 4,
   },
 }
 
 export const ExpandedByDefault: Story = {
   args: {
-    children: [
-      <Accordion.Section key={1} label={heading1}>
-        <Paragraph>{paragraph1}</Paragraph>
-      </Accordion.Section>,
-      <Accordion.Section defaultExpanded key={2} label={heading2}>
-        <Paragraph>{paragraph2}</Paragraph>
-      </Accordion.Section>,
-      <Accordion.Section key={3} label={heading3}>
-        <Paragraph>{paragraph3}</Paragraph>
-      </Accordion.Section>,
-    ],
+    children: faqItems.map(({ content, label }, index) => (
+      <Accordion.Section defaultExpanded={index === 0} key={index} label={label}>
+        {content}
+      </Accordion.Section>
+    )),
   },
 }
 
 export const ReduceLandmarks: Story = {
   args: {
-    children: [
-      <Accordion.Section key={1} label={heading1}>
-        <Paragraph>{paragraph1}</Paragraph>
-      </Accordion.Section>,
-      <Accordion.Section key={2} label={heading2}>
-        <Paragraph>{paragraph2}</Paragraph>
-      </Accordion.Section>,
-      <Accordion.Section key={3} label={heading3}>
-        <Paragraph>{paragraph3}</Paragraph>
-      </Accordion.Section>,
-    ],
+    children: faqItems.map(({ content, label }, index) => (
+      <Accordion.Section key={index} label={label}>
+        {content}
+      </Accordion.Section>
+    )),
     sectionAs: 'div',
   },
 }

--- a/storybook/src/components/Accordion/Accordion.stories.tsx
+++ b/storybook/src/components/Accordion/Accordion.stories.tsx
@@ -54,8 +54,8 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    children: faqItems.map(({ content, label }, index) => (
-      <Accordion.Section key={index} label={label}>
+    children: faqItems.map(({ content, label }) => (
+      <Accordion.Section key={label} label={label}>
         {content}
       </Accordion.Section>
     )),
@@ -65,7 +65,7 @@ export const Default: Story = {
 export const ExpandedByDefault: Story = {
   args: {
     children: faqItems.map(({ content, label }, index) => (
-      <Accordion.Section defaultExpanded={index === 0} key={index} label={label}>
+      <Accordion.Section defaultExpanded={index === 0} key={label} label={label}>
         {content}
       </Accordion.Section>
     )),
@@ -74,8 +74,8 @@ export const ExpandedByDefault: Story = {
 
 export const ReduceLandmarks: Story = {
   args: {
-    children: faqItems.map(({ content, label }, index) => (
-      <Accordion.Section key={index} label={label}>
+    children: faqItems.map(({ content, label }) => (
+      <Accordion.Section key={label} label={label}>
         {content}
       </Accordion.Section>
     )),


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

## What

- Replaces generic example content in the Accordion stories with a real FAQ example about applying at Gemeente Amsterdam.
- Removes the Heading Level example story; adds a one-line guideline to the README instead.
- Condenses the Accordion guidelines: shorter intro, tighter keyboard table, and a note to consider splitting content across multiple pages before using an accordion.
- Removes the WCAG guidelines; we don’t maintain them consistenlty yet.

## Why

- Real content makes stories more useful as a reference and easier to review visually.
- The guidelines had grown verbose; trimming them makes the page easier to scan.
- The multi-page nudge was already implied in the old guidelines but is now more prominent.

## How

- Updated `Accordion.stories.tsx` to define a shared `faqItems` array used across all stories.
- Rewrote `README.md` for conciseness and reorganised `Accordion.docs.mdx` accordingly.

## Checklist

- [x] Add or update unit tests — not applicable
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files — not applicable
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11)

## Additional notes

- n/a