### PR TITLE
chore(Storybook): Exclude compiled JS files from stories glob

### DIFF
--- a/storybook/config/main.ts
+++ b/storybook/config/main.ts
@@ -44,7 +44,7 @@ const config: StorybookConfig = {
   },
 
   staticDirs: ['../../packages-proprietary/assets'],
-  stories: ['../src/**/*.docs.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../src/**/*.docs.mdx', '../src/**/*.stories.@(ts|tsx)'],
 
   typescript: {
     reactDocgen: 'react-docgen-typescript',


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Narrows the stories pattern from `*.stories.@(js|jsx|ts|tsx)` to `*.stories.@(ts|tsx)` so that JS files emitted by the TypeScript compiler are not indexed by Storybook, preventing a NoMetaError that breaks the preview build entirely.

## Why

n/a

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a