### PR TITLE
chore: Publish all packages with provenance statements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,12 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: pnpm install --frozen-lockfile
 
+      # Reset any tree modifications from earlier steps so pnpm's git checks
+      # pass without us having to disable them with --no-git-checks.
+      - name: Reset working tree before publish
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        run: git reset --hard HEAD && git clean -fd
+
       - name: Publish
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: pnpm -r publish

--- a/.npmpackagejsonlintrc.json
+++ b/.npmpackagejsonlintrc.json
@@ -18,6 +18,7 @@
     "no-caret-version-devDependencies": "error",
     "no-tilde-version-dependencies": "error",
     "no-tilde-version-devDependencies": "error",
+    "prefer-provenance": "error",
     "preferGlobal-type": "error",
     "private-type": "error",
     "repository-type": "error",

--- a/packages-proprietary/assets/package.json
+++ b/packages-proprietary/assets/package.json
@@ -14,7 +14,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages-proprietary/react-icons/package.json
+++ b/packages-proprietary/react-icons/package.json
@@ -14,7 +14,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/packages-proprietary/tokens/package.json
+++ b/packages-proprietary/tokens/package.json
@@ -15,7 +15,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -13,6 +13,10 @@
     "nl-design-system"
   ],
   "private": false,
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Amsterdam/design-system.git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,7 +14,8 @@
   ],
   "private": false,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Publish all packages with provenance statements

## What

- Set `publishConfig.provenance` to `true` for all our packages.
- Add a `publishConfig` block to the CSS package, which didn’t have one yet.
- Reset the working tree in the publish workflow right before `pnpm -r publish`, so pnpm’s git cleanliness checks don’t trip on artefacts left behind by earlier steps.
- Enable the `prefer-provenance` rule in `.npmpackagejsonlintrc.json` so future publishable packages can’t be added without provenance enabled.

## Why

NL Design System is auditing all packages to ensure releases are published securely.

Some of our recent versions on npm have a provenance statement and some don’t ([example: tokens](https://www.npmjs.com/package/@amsterdam/design-system-tokens?activeTab=versions)).

The gaps line up with releases that had to be published manually from a terminal, because manual publishes can’t generate provenance — only a trusted CI publish can.

Setting `provenance: true` per package guarantees that every future CI publish produces a signed attestation linking the tarball back to this repository and the workflow run that built it.

The working-tree reset is defence-in-depth so the publish step doesn’t fail with `ERR_PNPM_GIT_UNCLEAN` if a future workflow step happens to leave the tree dirty (this previously caused a manual fallback publish).

The lint rule prevents the configuration drift that caused this issue in the first place: a publishable package being added without `provenance: true`.

## How

- Added `"provenance": true` to each package’s `publishConfig` (and a full `publishConfig` to `packages/css/package.json`, which had none).
- Added a `git reset --hard HEAD && git clean -fd` step in `.github/workflows/publish.yml`, gated on the same `releases_created` condition as the surrounding publish steps.
- The `-x` flag is intentionally omitted from `git clean` so gitignored `dist/` build output (produced by the `postinstall` build) and `node_modules/` are preserved.
- Enabled [`prefer-provenance`](https://npmpackagejsonlint.org/docs/rules/package-json-properties/prefer-provenance) at `error` severity. It only checks packages where `private` isn’t `true`, so it covers the five publishable packages and ignores the root and Storybook workspaces.

## Checklist

- [x] Add or update unit tests — N/A, release configuration only.
- [x] Add or update documentation — N/A, no user-facing behaviour changes.
- [x] Add or update stories — N/A.
- [x] Add or update exports in index.\* files — N/A.
- [x] Comment `/chromatic test` and verify visual regression tests pass — N/A, no component changes.
- [x] Start the PR title with a Conventional Commit prefix.

## Additional notes

- Addresses [#2597](https://github.com/Amsterdam/design-system/issues/2597).
- Trusted publishing is already configured on npm for all five packages (confirmed: some past CSS package versions show the green provenance badge), so enabling `provenance: true` should not require any additional npm-side configuration.
- After merging, the next release-please-driven publish should produce provenance statements for all five packages.