### PR TITLE
chore(docs): Clarify Field Set guidelines and improve example stories

### DIFF
--- a/packages/css/src/components/field-set/README.md
+++ b/packages/css/src/components/field-set/README.md
@@ -10,7 +10,7 @@ Groups a set of Radio buttons or Checkboxes, or other related form fields.
   This allows them to share a label, description, and error message, while each option still has its own label.
 - A Field Set can also express the relation between a group of inputs or other controls.
   For instance, you might want to group several text inputs into one Field Set when requesting an address or various parts of a name.
-- Mark a Field Set as `optional` only for a list of Radios or Checkboxes, and if checking any of them is not necessary.
+- Mark a Field Set as `optional` only for a list of Radios or Checkboxes, and if selecting any option is not necessary.
 - There’s no need to add white space between the children of a Field Set.
   The component does this automatically.
 

--- a/packages/css/src/components/field-set/README.md
+++ b/packages/css/src/components/field-set/README.md
@@ -2,14 +2,17 @@
 
 # Field Set
 
-A component to group related form inputs.
+Groups a set of Radio buttons or Checkboxes, or other related form fields.
 
 ## Guidelines
 
-- Use Field Set when you need to show a relationship between multiple form inputs. For example, you may need to group a set of text inputs into a single Field Set when asking for an address.
-- Set `optional` to `true` if all inputs in a Field Set are not required.
-- Use `hint` to show a custom hint text.
-- There’s no need to add white space between the children of a Field Set. The component does this automatically.
+- Group a collection of [Radio](/docs/components-forms-radio--docs) buttons or [Checkboxes](/docs/components-forms-checkbox--docs) into a Field Set.
+  This allows them to share a label, description, and error message, while each option still has its own label.
+- A Field Set can also express the relation between a group of inputs or other controls.
+  For instance, you might want to group several text inputs into one Field Set when requesting an address or various parts of a name.
+- Mark a Field Set as `optional` only for a list of Radios or Checkboxes, and if checking any of them is not necessary.
+- There’s no need to add white space between the children of a Field Set.
+  The component does this automatically.
 
 ## Relevant WCAG requirements
 

--- a/storybook/src/components/DateInput/DateInput.stories.tsx
+++ b/storybook/src/components/DateInput/DateInput.stories.tsx
@@ -113,13 +113,20 @@ export const MemorableDateWithValidation: Story = {
           <Label htmlFor="input-b1" inFieldSet>
             Dag
           </Label>
-          <TextInput autoComplete="bday-day" id="input-b1" inputMode="numeric" name="dag" size={2} value={16} />
+          <TextInput autoComplete="bday-day" defaultValue={16} id="input-b1" inputMode="numeric" name="dag" size={2} />
         </Column>
         <Column gap="small">
           <Label htmlFor="input-b2" inFieldSet>
             Maand
           </Label>
-          <TextInput autoComplete="bday-month" id="input-b2" inputMode="numeric" name="maand" size={2} value={8} />
+          <TextInput
+            autoComplete="bday-month"
+            defaultValue={8}
+            id="input-b2"
+            inputMode="numeric"
+            name="maand"
+            size={2}
+          />
         </Column>
         <Column gap="small">
           <Label htmlFor="input-b3" inFieldSet>

--- a/storybook/src/components/DateInput/DateInput.stories.tsx
+++ b/storybook/src/components/DateInput/DateInput.stories.tsx
@@ -107,19 +107,19 @@ export const MemorableDateWithValidation: Story = {
   render: (args) => (
     <FieldSet aria-describedby="description-b error-b" invalid legend="Wanneer ben je geboren?">
       <Paragraph id="description-b">Bijvoorbeeld 1 1 2000.</Paragraph>
-      <ErrorMessage id="error-b">De datum moet in het verleden liggen.</ErrorMessage>
+      <ErrorMessage id="error-b">Vul alle drie de velden in.</ErrorMessage>
       <Row>
         <Column gap="small">
           <Label htmlFor="input-b1" inFieldSet>
             Dag
           </Label>
-          <TextInput autoComplete="bday-day" id="input-b1" inputMode="numeric" invalid name="dag" size={2} />
+          <TextInput autoComplete="bday-day" id="input-b1" inputMode="numeric" name="dag" size={2} value={16} />
         </Column>
         <Column gap="small">
           <Label htmlFor="input-b2" inFieldSet>
             Maand
           </Label>
-          <TextInput autoComplete="bday-month" id="input-b2" inputMode="numeric" invalid name="maand" size={2} />
+          <TextInput autoComplete="bday-month" id="input-b2" inputMode="numeric" name="maand" size={2} value={8} />
         </Column>
         <Column gap="small">
           <Label htmlFor="input-b3" inFieldSet>

--- a/storybook/src/components/FieldSet/FieldSet.stories.tsx
+++ b/storybook/src/components/FieldSet/FieldSet.stories.tsx
@@ -29,7 +29,6 @@ const meta = {
     hint: '',
     invalid: false,
     legend: 'Wat is uw naam?',
-    optional: false,
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/Radio/Radio.stories.tsx
+++ b/storybook/src/components/Radio/Radio.stories.tsx
@@ -83,7 +83,7 @@ export const InAFieldSet: Story = {
       optional
       role="radiogroup"
     >
-      <Paragraph id="description1">De laatstgenoemde melding.</Paragraph>
+      <Paragraph id="description1">Kies de categorie die het beste past.</Paragraph>
       {invalid && <ErrorMessage id="error1">Geef aan waar uw laatstgenoemde melding over gaat.</ErrorMessage>}
       <Column gap="x-small">
         <Radio invalid={invalid} name="about" value="horeca">
@@ -126,7 +126,7 @@ export const InAFieldSetWithValidation: Story = {
       legend="Waar gaat uw melding over?"
       role="radiogroup"
     >
-      <Paragraph id="description2">De laatstgenoemde melding.</Paragraph>
+      <Paragraph id="description2">Kies de categorie die het beste past.</Paragraph>
       {invalid && <ErrorMessage id="error2">Geef aan waar uw laatstgenoemde melding over gaat.</ErrorMessage>}
       <Column gap="x-small">
         <Radio aria-required="true" invalid={invalid} name="about" value="horeca">


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Clarify Field Set guidelines and improve example stories

## What

- Rewrite the Field Set README so the guidelines explicitly cover grouping Radios and Checkboxes, and clarify that `optional` only applies to such lists.
- Drop the redundant `optional: false` default from the FieldSet story args.
- Replace the clipped placeholder descriptions in the Radio “In a Field Set” stories with complete sentences.
- Update the DateInput `MemorableDateWithValidation` story to demonstrate partial validation (one missing field) instead of marking every field invalid.

## Why

- The previous Field Set guidelines didn’t make it clear when `optional` is meaningful, and the example stories used fragments where full sentences are more representative of real usage.
- The DateInput validation example also didn’t reflect a realistic partial-validation scenario.

## How

Documentation and Storybook-only changes; no component behavior or API was touched.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a