### PR TITLE
chore(lint): Scope React lint rules to packages that use React

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,9 +71,9 @@ export default tseslint.config(
     ...eslintConfigPrettier,
   },
 
-  // JavaScript, TypeScript and React
+  // JavaScript and TypeScript
   {
-    name: 'amsterdam-design-system/javascript-typescript-react',
+    name: 'amsterdam-design-system/javascript-typescript',
     files: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx'],
     plugins: {
       '@typescript-eslint': tsPlugin,
@@ -81,7 +81,6 @@ export default tseslint.config(
       import: importPlugin,
       vitest,
       perfectionist,
-      react,
     },
     languageOptions: {
       parser: tsParser,
@@ -95,13 +94,11 @@ export default tseslint.config(
           extensions: ['js', 'mjs', 'jsx', 'ts', 'tsx'],
         },
       },
-      react: { version: 'detect' },
     },
     rules: {
       ...eslint.configs.recommended.rules,
       ...vitest.configs.recommended.rules,
       ...perfectionist.configs['recommended-natural'].rules,
-      ...react.configs.recommended.rules,
       ...tsPlugin.configs.recommended.rules,
 
       // TypeScript
@@ -210,8 +207,23 @@ export default tseslint.config(
       ],
       'perfectionist/sort-modules': 'off', // This impacts readability in a negative way. We want to decide the order of modules ourselves.
       'perfectionist/sort-union-types': 'off', // This causes more issues than it solves
+    },
+  },
 
-      // React
+  // React
+  {
+    name: 'amsterdam-design-system/react',
+    files: [
+      'packages/react/**/*.{js,jsx,ts,tsx}',
+      'packages-proprietary/react-icons/**/*.{js,jsx,ts,tsx}',
+      'storybook/**/*.{js,jsx,ts,tsx}',
+    ],
+    plugins: { react },
+    settings: {
+      react: { version: 'detect' },
+    },
+    rules: {
+      ...react.configs.recommended.rules,
       'react/react-in-jsx-scope': 'off',
     },
   },


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Scope React lint rules to packages that use React

## What

Split the root ESLint config so the `eslint-plugin-react` plugin, settings, and rules are no longer applied to every JS/TS file in the repo. General JS/TS rules still apply repo-wide; React-specific rules now apply only to `packages/react`, `packages-proprietary/react-icons`, and `storybook`.

## Why

The root config set `react: { version: 'detect' }` globally, but React isn’t installed at the root. Every ESLint run emitted:

> Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.

Scoping the React block to packages that actually depend on React lets version detection resolve from those packages’ own `node_modules`, silencing the warning. It also stops the React rules from being applied to non-React code (token build scripts, SVGO configs).

## How

Extracted the React plugin, `react: { version: 'detect' }` setting, recommended rules, and `react/react-in-jsx-scope: 'off'` override into a new config block in [eslint.config.mjs](eslint.config.mjs) with a `files` glob limited to the three React-using packages.

The remaining general block keeps the same `files: ['**/*.{js,jsx,ts,tsx}']` and the parser/JSX/import-resolver settings, which are still needed wherever `.jsx`/`.tsx` files appear.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Verified locally: `pnpm run lint:js` no longer emits the React version warning, and the remaining errors/warnings match `develop`.