### PR TITLE
chore: Handle SBOtherType for `string | number` props in matrix

### DIFF
--- a/storybook/src/_common/variantFixtures.test.ts
+++ b/storybook/src/_common/variantFixtures.test.ts
@@ -87,4 +87,22 @@ describe('fixtureValuesFor', () => {
       ),
     ).toBeUndefined()
   })
+
+  it('returns the string sample for an SBOtherType whose raw value mentions "string" (e.g. "string | number")', () => {
+    expect(fixtureValuesFor(argType({ name: 'label', type: { name: 'other', value: 'string | number' } }))).toEqual({
+      hasIcon: null,
+      values: [STRING_SAMPLE],
+    })
+  })
+
+  it('returns the number sample for an SBOtherType whose raw value mentions "number" but not "string"', () => {
+    expect(fixtureValuesFor(argType({ name: 'count', type: { name: 'other', value: 'number | bigint' } }))).toEqual({
+      hasIcon: null,
+      values: [NUMBER_SAMPLE],
+    })
+  })
+
+  it('returns undefined for an SBOtherType that mentions neither (e.g. "ReactNode")', () => {
+    expect(fixtureValuesFor(argType({ name: 'content', type: { name: 'other', value: 'ReactNode' } }))).toBeUndefined()
+  })
 })

--- a/storybook/src/_common/variantFixtures.ts
+++ b/storybook/src/_common/variantFixtures.ts
@@ -61,10 +61,16 @@ const primitiveFixture = (scalarName: string): Omit<PropWithValues, 'name'> | un
  * Returns design-system specific test values for a prop, or undefined when
  * the prop has no fixture (so the parser can fall back to argType.type).
  *
- * Union types (e.g. `string | number`) reach here as `SBUnionType`. We
- * resolve them by preferring the string fixture when present, otherwise
- * number — matching the behaviour the old `__docgenInfo`-based parser
- * had for the literal type name `'string | number'`.
+ * Storybook represents non-trivial unions in two different shapes:
+ *
+ *   • `SBUnionType` — explicit member array. Resolve by preferring the
+ *     string fixture when present, otherwise number.
+ *   • `SBOtherType` (`name: 'other'`, `value: '<raw type string>'`) —
+ *     used when the underlying analyser couldn't classify the union
+ *     into discrete members. In practice `react-docgen-typescript`
+ *     emits this for `string | number`, with `value === 'string | number'`.
+ *     Pattern-match the raw string to recover the same behaviour the old
+ *     `__docgenInfo`-based parser had.
  */
 export const fixtureValuesFor = (argType: StrictInputType): Omit<PropWithValues, 'name'> | undefined => {
   const fixture = byPropName[argType.name]
@@ -83,6 +89,12 @@ export const fixtureValuesFor = (argType: StrictInputType): Omit<PropWithValues,
     const memberNames = new Set(type.value.map((member) => member.name))
     if (memberNames.has('string')) return primitiveFixture('string')
     if (memberNames.has('number')) return primitiveFixture('number')
+    return undefined
+  }
+
+  if (type.name === 'other' && typeof type.value === 'string') {
+    if (/\bstring\b/.test(type.value)) return primitiveFixture('string')
+    if (/\bnumber\b/.test(type.value)) return primitiveFixture('number')
     return undefined
   }
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request


## What

Follow-up for #2635.

The previous commit added SBUnionType handling on the assumption that Storybook normalises `string | number` props to a union with discrete member types. In practice it doesn't: `react-docgen-typescript` emits the type as `{ name: 'string | number' }` (a flat string for `name`), and Storybook wraps that as `SBOtherType { name: 'other', value: 'string | number' }`.

Extend `fixtureValuesFor` to also pattern-match the raw value string when the type is `'other'`, preferring the string fixture and falling back to number. This restores Badge.label's contribution to the matrix (10 instances, matching develop).

The SBUnionType branch stays — Storybook does emit unions in other shapes (notably for non-string|number combinations), and the cost of keeping the branch is one extra check.

Three new tests cover the SBOtherType paths: `'string | number'` → string fixture, `'number | bigint'` → number fixture, `'ReactNode'` → undefined.

## Why

n/a

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a