### PR TITLE
chore(pnpm): post-v11 cleanup and explicit build step

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build workspace packages
-        run: pnpm build
+      - name: Build packages
+        run: pnpm --filter=!storybook -r run build
 
       - name: Run Chromatic
         uses: chromaui/action@1bbb5819252d9782cb7d77122d9becae467def18 # v16.10.1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build workspace packages
+        run: pnpm build
+
       - name: Run Chromatic
         uses: chromaui/action@1bbb5819252d9782cb7d77122d9becae467def18 # v16.10.1
         with:

--- a/.github/workflows/feature-branch-deploy.yml
+++ b/.github/workflows/feature-branch-deploy.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build Storybook
+      - name: Build workspace packages
         env:
           STORYBOOK_BUILD_PATH: demo-${{ env.BRANCH_NAME }}
-        run: pnpm --filter=storybook build
+        run: pnpm build
 
       - name: Create a version mark
         run: |

--- a/.github/workflows/feature-branch-deploy.yml
+++ b/.github/workflows/feature-branch-deploy.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build workspace packages
+      - name: Build packages and Storybook
         env:
           STORYBOOK_BUILD_PATH: demo-${{ env.BRANCH_NAME }}
         run: pnpm build

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build workspace packages
-        run: pnpm build
+      - name: Build packages
+        run: pnpm --filter=!storybook -r run build
 
       - name: "Continuous Integration: lint"
         run: |

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build workspace packages
+        run: pnpm build
+
       - name: "Continuous Integration: lint"
         run: |
           pnpm run --if-present lint

--- a/.github/workflows/main-branch-deploy.yml
+++ b/.github/workflows/main-branch-deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build workspace packages
+      - name: Build packages and Storybook
         run: pnpm build
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/main-branch-deploy.yml
+++ b/.github/workflows/main-branch-deploy.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build Storybook
-        run: pnpm --filter=storybook build
+      - name: Build workspace packages
+        run: pnpm build
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,10 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: pnpm install --frozen-lockfile
 
+      - name: Build workspace packages
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        run: pnpm build
+
       # Reset any tree modifications from earlier steps so pnpm's git checks
       # pass without us having to disable them with --no-git-checks.
       - name: Reset working tree before publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,9 +49,9 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: pnpm install --frozen-lockfile
 
-      - name: Build workspace packages
+      - name: Build packages
         if: ${{ steps.release.outputs.releases_created == 'true' }}
-        run: pnpm build
+        run: pnpm --filter=!storybook -r run build
 
       # Reset any tree modifications from earlier steps so pnpm's git checks
       # pass without us having to disable them with --no-git-checks.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx --no-install lint-staged
+pnpm exec lint-staged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ To enable correct validation and to fix lint/style errors on save, add this to y
 - Build workspace packages: `pnpm build`
 - Run storybook: `pnpm start`
 
-Re-run `pnpm build` after pulling source changes — `pnpm install` is a no-op when the lockfile is unchanged, so it will not rebuild `dist/` for you.
+After pulling updates that include source changes, run `pnpm build` again to rebuild the packages.
 
 ### Run unit tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,10 @@ To enable correct validation and to fix lint/style errors on save, add this to y
 ### Run storybook
 
 - Install dependencies: `pnpm install`
+- Build workspace packages: `pnpm build`
 - Run storybook: `pnpm start`
+
+Re-run `pnpm build` after pulling source changes — `pnpm install` is a no-op when the lockfile is unchanged, so it will not rebuild `dist/` for you.
 
 ### Run unit tests
 

--- a/documentation/continuous-integration.md
+++ b/documentation/continuous-integration.md
@@ -29,7 +29,7 @@ We have used [pin-github-action](https://www.npmjs.com/package/pin-github-action
 Use this command to get the correct format:
 
 ```sh
-npx pin-github-action -c " {ref}" /path/to/workflow.yaml
+pnx pin-github-action -c " {ref}" /path/to/workflow.yaml
 ```
 
 ### Further reading

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "lint-fix:css": "stylelint --fix '**/*.{css,scss}'",
     "lint-fix:js": "eslint . --fix",
     "plop": "plop",
-    "postinstall": "pnpm --filter=!storybook -r run build",
     "prepare": "husky",
     "prettier": "prettier --write .",
     "start": "pnpm run '/^watch:.+$/'",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,6 @@
     "pnpm": "^11"
   },
   "packageManager": "pnpm@11.1.3",
-  "workspaces": [
-    "./packages/*",
-    "./packages-proprietary/*",
-    "./storybook"
-  ],
   "scripts": {
     "build": "pnpm -r run build",
     "clean:dist": "pnpm -r run clean:dist",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": "^24",
     "pnpm": "^11"
   },
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.1.3",
   "workspaces": [
     "./packages/*",
     "./packages-proprietary/*",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
-minimumReleaseAge: 1440 # Delay installing a newly published version of a package for 1440 minutes (1 day)
 packages:
   - "packages/*"
   - "packages-proprietary/*"
@@ -8,9 +7,6 @@ overrides:
   tar: ">=7.5.11"
 engineStrict: true
 savePrefix: ""
-allowBuilds:
-  "@bundled-es-modules/glob": false
-  "@parcel/watcher": false
-  esbuild: false
-  sharp: false
-  style-dictionary: false
+# Refuse to resolve transitive deps from git URLs, tarballs, or other non-registry sources.
+# Supply-chain hardening — see https://pnpm.io/supply-chain-security
+blockExoticSubdeps: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,12 @@ savePrefix: ""
 # Refuse to resolve transitive deps from git URLs, tarballs, or other non-registry sources.
 # Supply-chain hardening — see https://pnpm.io/supply-chain-security
 blockExoticSubdeps: true
+# Explicitly mark these dependencies' install scripts as ignored.
+# Under v11's default `strictDepBuilds: true`, packages with install scripts that
+# aren't listed here would cause `pnpm install` to fail with ERR_PNPM_IGNORED_BUILDS.
+# Setting `false` means: pnpm has been told not to run the script — neither runs nor errors.
+allowBuilds:
+  "@bundled-es-modules/glob": false
+  "@parcel/watcher": false
+  esbuild: false
+  style-dictionary: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,6 @@ overrides:
   tar: ">=7.5.11"
 engineStrict: true
 savePrefix: ""
-# Refuse to resolve transitive deps from git URLs, tarballs, or other non-registry sources.
-# Supply-chain hardening — see https://pnpm.io/supply-chain-security
-blockExoticSubdeps: true
 # Explicitly mark these dependencies' install scripts as ignored.
 # Under v11's default `strictDepBuilds: true`, packages with install scripts that
 # aren't listed here would cause `pnpm install` to fail with ERR_PNPM_IGNORED_BUILDS.


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# pnpm: cleanup and explicit build step after upgrade to pnpm v11 

## What

- Drop the root `postinstall` script and add a `Build workspace packages` step (running `pnpm build`) to the five CI workflows that previously relied on it: [main-branch-deploy.yml](.github/workflows/main-branch-deploy.yml), [feature-branch-deploy.yml](.github/workflows/feature-branch-deploy.yml), [lint-test.yml](.github/workflows/lint-test.yml), [chromatic.yml](.github/workflows/chromatic.yml), [publish.yml](.github/workflows/publish.yml).
- Update [CONTRIBUTING.md](CONTRIBUTING.md) so first-time setup is `pnpm install && pnpm build`, with a note explaining why `pnpm install` alone no longer rebuilds.
- Align [pnpm-workspace.yaml](pnpm-workspace.yaml) with pnpm v11 supply-chain defaults: drop `minimumReleaseAge: 1440` (already the v11 default) and the `allowBuilds: { …: false }` map (a no-op under v11's default `strictDepBuilds: true`). Add `blockExoticSubdeps: true` to refuse transitive deps from git URLs, tarballs, or other non-registry sources.
- Remove the npm/yarn-style `workspaces` array from [package.json](package.json); pnpm reads workspace globs from `pnpm-workspace.yaml` and the two lists could drift silently.
- Replace `pnx lint-staged` with `pnpm exec lint-staged` in [.husky/pre-commit](.husky/pre-commit) — `lint-staged` is a local devDep so `pnpm exec` skips the registry fetch that `pnx` (= `pnpm dlx`) does.
- Document the preference for `pnx` over `npx` for one-off tools in [documentation/continuous-integration.md](documentation/continuous-integration.md).

## Why

After the pnpm 10 → 11 upgrade, `pnpm install` short-circuits to a no-op when the lockfile and store are already in sync, and **skips lifecycle scripts including `postinstall`** in that case. The root `postinstall` was our build trigger for workspace `dist/` directories, so the common post-pull flow (`git pull` → `pnpm install`) silently left builds stale. Demonstrated locally: delete `packages/css/dist/`, run `pnpm install`, get "Already up to date" in ~50 ms with no rebuild — even `pnpm install --force` doesn't reinstate it.

The rest is incidental cleanup that piled up around the v11 migration: settings that duplicate v11 defaults, a dead workspaces array that npm/yarn would use but pnpm ignores, and an opportunity to add `blockExoticSubdeps` while we were touching the file.

## How

- Reproduced the postinstall regression by wiping `packages/*/dist`, `packages-proprietary/*/dist`, and `storybook/dist`, then running `pnpm install` and confirming the dirs stayed missing. `pnpm build` after that restores all five expected artifacts.
- For the CI workflows: `pnpm build` (root script = `pnpm -r run build`) is added between install and any consumer step. Two existing workflows (`pr-bundle-size.yml`, `pr-coverage.yml`) already use `--ignore-scripts` plus an explicit build and were not touched.
- In [publish.yml](.github/workflows/publish.yml), the new build step sits before the existing `git reset --hard HEAD && git clean -fd`. Verified `dist/` is gitignored (line 10), so `clean -fd` leaves the just-built artifacts in place.
- For `pnpm-workspace.yaml`: verified via [pnpm.io/settings](https://pnpm.io/settings) that `minimumReleaseAge` defaults to 1440 in v11 and that `strictDepBuilds: true` blocks unlisted packages by default, making the `false` entries redundant. Ran `pnpm install` after the changes — clean, no warnings about unrecognised settings, no `blockExoticSubdeps` rejections against the current tree.
- Verified the overrides (`@tootallnate/once@<3.0.1` and `tar: ">=7.5.11"`) are still load-bearing with `pnpm why` — they hold transitive deps at safe versions, so they stayed.

## Checklist

- [x] Add or update unit tests — n/a, no runtime code changed
- [x] Add or update documentation — [CONTRIBUTING.md](CONTRIBUTING.md) updated; [documentation/continuous-integration.md](documentation/continuous-integration.md) updated
- [x] Add or update stories — n/a
- [x] Add or update exports in `index.*` files — n/a
- [x] Comment `/chromatic test` and verify visual regression tests pass — not expected to change visuals, but worth running once to confirm the new CI flow produces a green Chromatic build
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- Resolves DES-1850.
- After merge, contributors pulling `develop` for the first time will need to run `pnpm install && pnpm build` rather than just `pnpm install`. Documented in CONTRIBUTING.md.
- The fastest place to spot regressions is the first run of [lint-test.yml](.github/workflows/lint-test.yml) on this PR — if React tests pass there, the explicit-build path is wired correctly.
