### PR TITLE
feat: Decrease font weight for all bold text

### DIFF
--- a/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
@@ -35,7 +35,7 @@
         },
         "bold": {
           "font-weight": {
-            "$value": "800",
+            "$value": "700",
             "$type": "fontWeight"
           }
         },
@@ -95,7 +95,7 @@
       "heading": {
         "$description": "Text styles for section headings. Larger headings use tighter line-heights for visual balance.",
         "font-weight": {
-          "$value": "800",
+          "$value": "700",
           "$type": "fontWeight"
         },
         "text-wrap": {

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -90,11 +90,6 @@ You shouldn’t need a reset stylesheet.
 Do not change the base font-size – e.g. through `html { font-size: 62.5% }`.
 Our typography system expects `1rem` to be the browser default of 16 pixels.
 
-#### Use extra bold text
-
-We only use the regular and extra bold weights of our font, Amsterdam Sans.
-Apply `font-weight: var(--ams-typography-body-text-bold-font-weight)` to elements that display bold text like `b`, `strong`, and `dt`.
-
 ## Updating
 
 We follow semantic versioning and publish a [change log](https://github.com/Amsterdam/design-system/blob/main/packages/css/CHANGELOG.md) to guide you through updates.

--- a/storybook/src/_components/ColorPalette/color-palette.css
+++ b/storybook/src/_components/ColorPalette/color-palette.css
@@ -43,7 +43,7 @@
 }
 
 ._ams-color-palette-name {
-  font-weight: 800;
+  font-weight: 700;
 }
 
 ._ams-color-palette-sample {

--- a/storybook/src/_components/ColorPalette/color-palette.css
+++ b/storybook/src/_components/ColorPalette/color-palette.css
@@ -43,7 +43,7 @@
 }
 
 ._ams-color-palette-name {
-  font-weight: 700;
+  font-weight: var(--ams-typography-body-text-bold-font-weight);
 }
 
 ._ams-color-palette-sample {

--- a/storybook/src/brand/design-tokens/typography.docs.mdx
+++ b/storybook/src/brand/design-tokens/typography.docs.mdx
@@ -42,7 +42,7 @@ The font weight can either be regular or bold.
 | CSS variable                                       | Value | Example                                                                                                                                                        |
 | :------------------------------------------------- | :---: | :------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `var(--ams-typography-body-text-font-weight)`      |  400  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" />      |
-| `var(--ams-typography-body-text-bold-font-weight)` |  800  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-bold-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" /> |
+| `var(--ams-typography-body-text-bold-font-weight)` |  700  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-bold-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" /> |
 
 ## Headings
 
@@ -76,7 +76,7 @@ Headings only use the bold font weight.
 
 | CSS variable                                | Value | Example                                                                                                                                                   |
 | :------------------------------------------ | :---: | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `var(--ams-typography-heading-font-weight)` |  800  | <TypographySample fontSize="1.5625rem" fontWeight="var(--ams-typography-heading-font-weight)" lineHeight="var(--ams-typography-heading-3-line-height)" /> |
+| `var(--ams-typography-heading-font-weight)` |  700  | <TypographySample fontSize="1.5625rem" fontWeight="var(--ams-typography-heading-font-weight)" lineHeight="var(--ams-typography-heading-3-line-height)" /> |
 
 ## Other aspects
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Replaces all our usage of ‘extra bold’ with ‘regular’ bold.

## Why

1. Looks much better.
2. Easier to read.
3. Less shouty.
4. The update style guide of the City [only mentioned](https://www.amsterdam.nl/stijlweb/basiselementen/typografie/#h277421d6-3972-47ac-8bd5-ad845ee536f3) bold, not extra bold.
5. We were never really sure whether the extra bold font weight was intentional in the designs we inherited.

## How

Change a couple of tokens and docs. Done. Chromatic here we go.

Removed some docs on ‘extra bold’ altoghether. The practical, default CSS value for bold is now correct for us.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a
