### PR TITLE
chore(docs): Remove Dutch thousands separators in English prose

### DIFF
--- a/storybook/src/brand/design-tokens/grid.docs.mdx
+++ b/storybook/src/brand/design-tokens/grid.docs.mdx
@@ -62,7 +62,7 @@ In this context, the grid takes up the entire width of the window.
 
 A maximum width for the grid ensures that white space and typography do not grow indefinitely.
 This prevents page elements from getting too far apart, keeping text comfortably readable.
-The maximum width is 1.440 pixels for public websites, and 1.920 for internal ones.
+The maximum width is 1440 pixels for public websites, and 1920 for internal ones.
 
 There is no explicit minimum width.
 Even in windows narrower than 320 pixels, to the extent that they occur in practice,

--- a/storybook/src/docs/developer-guide/breakpoints.docs.mdx
+++ b/storybook/src/docs/developer-guide/breakpoints.docs.mdx
@@ -17,7 +17,7 @@ They are defined in ‘rem’ units to respect changes that users may make to th
 - `$ams-breakpoint-medium: 37.5rem;`
 - `$ams-breakpoint-wide: 72.5rem;`
 
-They compute to 600 and 1.160 pixels if the root font size is 16.
+They compute to 600 and 1160 pixels if the root font size is 16.
 The values are based on steps of 280 pixels, starting with a base of 40 pixels.
 So, 600 = 40 + 2 × 280 and 1160 = 40 + 4 × 280.
 To complement, the [Page](/docs/components-containers-page--docs) container component sets a maximum width of 90rem, which is 1440 pixels = 40 + 5 × 280.

--- a/storybook/src/docs/developer-guide/breakpoints.docs.mdx
+++ b/storybook/src/docs/developer-guide/breakpoints.docs.mdx
@@ -20,8 +20,8 @@ They are defined in ‘rem’ units to respect changes that users may make to th
 They compute to 600 and 1.160 pixels if the root font size is 16.
 The values are based on steps of 280 pixels, starting with a base of 40 pixels.
 So, 600 = 40 + 2 × 280 and 1160 = 40 + 4 × 280.
-To complement, the [Page](/docs/components-containers-page--docs) container component sets a maximum width of 90rem, which is 1.440 pixels = 40 + 5 × 280.
-For internal websites, this is 1.920 pixels.
+To complement, the [Page](/docs/components-containers-page--docs) container component sets a maximum width of 90rem, which is 1440 pixels = 40 + 5 × 280.
+For internal websites, this is 1920 pixels.
 
 ## Where they work
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Remove thousands separators.

## Why

“1.440 pixels” / “1.920 pixels” use the Dutch thousands separator in English prose, which English readers will parse as 1.44 and 1.92.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a