### PR TITLE
chore(deps): Ignore jsdom 27+ until accessible-name regression is fixed upstream

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,11 @@ updates:
       prefix: fix
       prefix-development: chore
       include: scope
+    ignore:
+      # jsdom 27+ changed accessible name computation, dropping the space between
+      # sibling text fragments (e.g. visually-hidden text + adjacent text or SVG
+      # aria-label). This breaks getByRole({ name }) in our Pagination and
+      # PageHeader tests. Real browsers are unaffected. Remove once the upstream
+      # fix lands: https://github.com/eps1lon/dom-accessibility-api/issues/1087
+      - dependency-name: "jsdom"
+        versions: [">=27"]


### PR DESCRIPTION
# Describe the pull request

## What

Adds a Dependabot ignore rule for `jsdom` version 27 and above in [.github/dependabot.yml](.github/dependabot.yml).

## Why

jsdom 27+ changed how accessible names are computed, dropping the space between sibling text fragments (visually-hidden text plus an adjacent text node, or an SVG `aria-label` inside a link). This breaks `getByRole({ name })` queries in our Pagination and PageHeader tests — for example `"Pagina 4"` becomes `"Pagina4"` and `"… logo Go to homepage"` becomes `"… logoGo to homepage"`.

Real browsers are unaffected; it’s purely a jsdom / `dom-accessibility-api` test-environment divergence, tracked upstream in [eps1lon/dom-accessibility-api#1087](https://github.com/eps1lon/dom-accessibility-api/issues/1087) (still open, candidate fix [#971](https://github.com/eps1lon/dom-accessibility-api/pull/971) unmerged).

When #2626 was closed, the ignore only covered v29, so Dependabot surfaced in #2654 (jsdom 28.1.0) — still affected, since the regression starts at 27. This rule sets the floor correctly so no affected version is offered until the upstream fix lands.

## How

Added an `ignore` entry under the existing npm `package-ecosystem` block, scoped to `jsdom` with `versions: [">=27"]`, plus a comment explaining the reason and linking the upstream issue so the rule can be removed once it’s resolved.

## Checklist

- [ ] ~~Add or update unit tests~~ (not applicable — CI config only)
- [ ] ~~Add or update documentation~~ (not applicable)
- [ ] ~~Add or update stories~~ (not applicable)
- [ ] ~~Add or update exports in index.\* files~~ (not applicable)
- [ ] ~~Comment `/chromatic test` and verify visual regression tests pass~~ (no visual changes)
- [x] Start the PR title with a Conventional Commit prefix, [[as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11)](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Supersedes the too-high `>=29` ignore set on #2626; follows the same reasoning.
- After this merges, close #2654 manually — it won’t auto-close.
- Remove this ignore rule once [eps1lon/dom-accessibility-api#1087](https://github.com/eps1lon/dom-accessibility-api/issues/1087) is fixed and released, so jsdom can be upgraded again.