### PR TITLE
fix(Progress List): Show dashed connector for collapsed current step with substeps

### DIFF
--- a/packages/css/src/components/progress-list/progress-list.scss
+++ b/packages/css/src/components/progress-list/progress-list.scss
@@ -124,7 +124,7 @@
     border-inline-style: var(--ams-progress-list-step-completed-connector-border-inline-style);
   }
 
-  .ams-progress-list__step--current.ams-progress-list__step--has-substeps & {
+  .ams-progress-list__step--current.ams-progress-list__step--has-substeps:not(.ams-progress-list__step--collapsed) & {
     border-inline-color: var(--ams-progress-list-step-current-connector-border-inline-color);
     border-inline-style: solid;
   }

--- a/storybook/src/components/ProgressList/ProgressList.test.stories.tsx
+++ b/storybook/src/components/ProgressList/ProgressList.test.stories.tsx
@@ -130,7 +130,7 @@ export const Test: Story = {
         </ProgressList.Step>
       </ProgressList>
 
-      {/* Collapsible, collapsed last step with substeps: connector hidden */}
+      {/* Collapsible steps with substeps: collapsed last step (connector hidden) and collapsed current step (dashed connector) */}
       <ProgressList collapsible headingLevel={3}>
         <ProgressList.Step heading="2026" status="completed">
           <Paragraph>Content for 2026.</Paragraph>

--- a/storybook/src/components/ProgressList/ProgressList.test.stories.tsx
+++ b/storybook/src/components/ProgressList/ProgressList.test.stories.tsx
@@ -135,13 +135,21 @@ export const Test: Story = {
         <ProgressList.Step heading="2026" status="completed">
           <Paragraph>Content for 2026.</Paragraph>
         </ProgressList.Step>
-        <ProgressList.Step heading="2027" status="current">
+        <ProgressList.Step defaultCollapsed hasSubsteps heading="2027" status="current">
           <Paragraph>Content for 2027.</Paragraph>
+          <ProgressList.Substeps>
+            <ProgressList.Substep status="completed">
+              <Paragraph>Substep one</Paragraph>
+            </ProgressList.Substep>
+            <ProgressList.Substep>
+              <Paragraph>Substep two</Paragraph>
+            </ProgressList.Substep>
+          </ProgressList.Substeps>
         </ProgressList.Step>
         <ProgressList.Step defaultCollapsed hasSubsteps heading="2028">
           <Paragraph>Content for 2028.</Paragraph>
           <ProgressList.Substeps>
-            <ProgressList.Substep status="completed">
+            <ProgressList.Substep>
               <Paragraph>Substep one</Paragraph>
             </ProgressList.Substep>
             <ProgressList.Substep>


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## What
Fixes the connector for a `Step` that is both `current` and `collapsed` with substeps, it now correctly shows as dashed instead of solid.

Before: 
<img width="1920" height="848" alt="CleanShot 2026-06-11 at 12 06 33" src="https://github.com/user-attachments/assets/b230b8ee-6f5e-413a-af08-444d1f530a65" />

After:
<img width="1894" height="636" alt="CleanShot 2026-06-11 at 12 07 34" src="https://github.com/user-attachments/assets/713fd90a-1f2a-4fc6-986a-b06ec7b3047d" />

Also updates a test story to cover this case.

## Why
The line style for current steps with substeps was always applied, even when the substeps were collapsed. When collapsed, the dashed line (from the default style) should remain, as the substeps are hidden. The solid line should only appear when the substeps are visible.

## How
Added `:not(.ams-progress-list__step--collapsed)` to the CSS selector that sets `border-inline-style: solid`, so the solid connector only applies when the step is expanded.

## Checklist
- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes
- Manually collapse the current step to see the change
[Develop](https://designsystem.amsterdam/?path=/story/components-containers-progress-list--with-substeps)
[Branch build](https://designsystem.amsterdam/?path=/story/components-containers-progress-list--with-substeps)