### PR TITLE
chore: Move JSDoc descriptions to compound component exports

### DIFF
--- a/packages/react/src/FileList/FileList.tsx
+++ b/packages/react/src/FileList/FileList.tsx
@@ -12,9 +12,6 @@ import { FileListItem } from './FileListItem'
 
 export type FileListProps = PropsWithChildren<HTMLAttributes<HTMLUListElement>>
 
-/**
- * An overview of files, showing their name, type, size, and a preview.
- */
 export const FileListRoot = forwardRef(
   ({ children, className, ...restProps }: FileListProps, ref: ForwardedRef<HTMLOListElement>) => (
     <ul {...restProps} className={clsx('ams-file-list', className)} ref={ref}>
@@ -26,6 +23,8 @@ export const FileListRoot = forwardRef(
 FileListRoot.displayName = 'FileList'
 
 /**
+ * An overview of files, showing their name, type, size, and a preview.
+ *
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-forms-file-list--docs File List docs at Amsterdam Design System}
  */
 export const FileList = Object.assign(FileListRoot, {

--- a/packages/react/src/LinkList/LinkList.tsx
+++ b/packages/react/src/LinkList/LinkList.tsx
@@ -12,7 +12,6 @@ import { LinkListLink } from './LinkListLink'
 
 export type LinkListProps = PropsWithChildren<HTMLAttributes<HTMLUListElement>>
 
-/** A collection of related links. */
 const LinkListRoot = forwardRef(
   ({ children, className, ...restProps }: LinkListProps, ref: ForwardedRef<HTMLUListElement>) => {
     return (

--- a/packages/react/src/Menu/Menu.tsx
+++ b/packages/react/src/Menu/Menu.tsx
@@ -21,9 +21,6 @@ export type MenuProps = {
   readonly inWideWindow?: boolean
 } & Readonly<PropsWithChildren<HTMLAttributes<HTMLElement>>>
 
-/**
- * A primary navigation leading to key areas of a website.
- */
 export const MenuRoot = forwardRef<HTMLElement, MenuProps>(
   ({ accessibleName = 'Hoofdmenu', children, className, inWideWindow, ...restProps }, ref) => {
     // In a medium or narrow window, the Menu is a child of the `nav` of Page Header.
@@ -53,6 +50,8 @@ export const MenuRoot = forwardRef<HTMLElement, MenuProps>(
 MenuRoot.displayName = 'Menu'
 
 /**
+ * A primary navigation leading to key areas of a website.
+ *
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-navigation-menu--docs Menu docs at Amsterdam Design System}
  */
 export const Menu = Object.assign(MenuRoot, { Link: MenuLink })

--- a/storybook/src/_components/ColorPalette/ColorPalette.tsx
+++ b/storybook/src/_components/ColorPalette/ColorPalette.tsx
@@ -11,17 +11,6 @@ import { forwardRef } from 'react'
 
 type ColorPaletteProps = PropsWithChildren<Omit<HTMLAttributes<HTMLDivElement>, 'className'>>
 
-/**
- * Compound component for displaying a colour palette in documentation.
- * Use `ColorPalette.Swatch` to group related tones and `ColorPalette.Tile` to show an individual colour.
- *
- * @example
- * <ColorPalette>
- *   <ColorPalette.Swatch name="azure">
- *     <ColorPalette.Tile color="#009de6" level="100" />
- *   </ColorPalette.Swatch>
- * </ColorPalette>
- */
 const ColorPaletteRoot = forwardRef(
   ({ children, ...restProps }: ColorPaletteProps, ref: ForwardedRef<HTMLDivElement>) => (
     <div {...restProps} className="_ams-color-palette" ref={ref}>
@@ -65,6 +54,17 @@ const ColorPaletteTile = ({ color, level }: ColorPaletteTileProps) =>
 
 ColorPaletteTile.displayName = 'ColorPalette.Tile'
 
+/**
+ * Displays a colour palette in documentation.
+ * Use `ColorPalette.Swatch` to group related tones and `ColorPalette.Tile` to show an individual colour.
+ *
+ * @example
+ * <ColorPalette>
+ *   <ColorPalette.Swatch name="azure">
+ *     <ColorPalette.Tile color="#009de6" level="100" />
+ *   </ColorPalette.Swatch>
+ * </ColorPalette>
+ */
 export const ColorPalette = Object.assign(ColorPaletteRoot, {
   Swatch: ColorPaletteSwatch,
   Tile: ColorPaletteTile,

--- a/storybook/src/_components/DesignTokensTable/DesignTokensTable.tsx
+++ b/storybook/src/_components/DesignTokensTable/DesignTokensTable.tsx
@@ -26,10 +26,6 @@ type DesignTokensTableRootProps = {
   readonly tokens: Tokens
 } & Readonly<HTMLAttributes<HTMLDivElement>>
 
-/**
- * Compound component that renders a design token JSON file as a three-column table
- * (CSS variable name, value, visual example).
- */
 const DesignTokensTableRoot = ({
   className,
   exclude,
@@ -111,6 +107,9 @@ const DesignTokensTableRoot = ({
 
 DesignTokensTableRoot.displayName = 'DesignTokensTable'
 
+/**
+ * Renders a design token JSON file as a three-column table (CSS variable name, value, visual example).
+ */
 export const DesignTokensTable = Object.assign(DesignTokensTableRoot, {
   Row: DesignTokensTableRow,
 })

--- a/storybook/src/_components/DesignTokensTable/DesignTokensTable.tsx
+++ b/storybook/src/_components/DesignTokensTable/DesignTokensTable.tsx
@@ -108,7 +108,7 @@ const DesignTokensTableRoot = ({
 DesignTokensTableRoot.displayName = 'DesignTokensTable'
 
 /**
- * Renders a design token JSON file as a three-column table (CSS variable name, value, visual example).
+ * Renders a design token JSON file as a table with CSS variable name, value, and optional description/visual example columns.
  */
 export const DesignTokensTable = Object.assign(DesignTokensTableRoot, {
   Row: DesignTokensTableRow,


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Move JSDoc descriptions to compound component exports

## What

Move JSDoc descriptions from internal `Root` components to the exported compound component in `FileList`, `LinkList`, `Menu`, `ColorPalette` and `DesignTokensTable`.

## Why

TypeScript’s IntelliSense attaches hover documentation to the symbol that is actually exported. Placing the description on the unexported `Root` component means consumers never see it in their editor.

## How

For each component, the description comment was moved from the `*Root` declaration to the `Object.assign(…)` export, where it is merged with the existing `@see` tag.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).