### PR TITLE
fix(File List): Correct forwarded ref type

### DIFF
--- a/packages/react/src/FileList/FileList.test.tsx
+++ b/packages/react/src/FileList/FileList.test.tsx
@@ -36,7 +36,7 @@ describe('FileList', () => {
   })
 
   it('supports ForwardRef in React', () => {
-    const ref = createRef<HTMLOListElement>()
+    const ref = createRef<HTMLUListElement>()
 
     render(<FileList ref={ref} />)
 

--- a/packages/react/src/FileList/FileList.tsx
+++ b/packages/react/src/FileList/FileList.tsx
@@ -16,7 +16,7 @@ export type FileListProps = PropsWithChildren<HTMLAttributes<HTMLUListElement>>
  * An overview of files, showing their name, type, size, and a preview.
  */
 export const FileListRoot = forwardRef(
-  ({ children, className, ...restProps }: FileListProps, ref: ForwardedRef<HTMLOListElement>) => (
+  ({ children, className, ...restProps }: FileListProps, ref: ForwardedRef<HTMLUListElement>) => (
     <ul {...restProps} className={clsx('ams-file-list', className)} ref={ref}>
       {children}
     </ul>


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Correct forwarded ref type for File List

## What

Fix the forwarded ref type in `FileListRoot` from `HTMLOListElement` to `HTMLUListElement`, and update the corresponding test.

## Why

`FileListRoot` renders a `<ul>` element but the `ForwardedRef` was typed as `HTMLOListElement`. This leaks an incorrect element type to consumers.

## How

One-letter change in each file: `HTMLOListElement` → `HTMLUListElement` in the ref annotation in `FileList.tsx` and in `createRef` in `FileList.test.tsx`.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [[as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11)](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Caught in review of #2678.
