### PR TITLE
chore: Correct setup-python SHA and upgrade to v6.2.0 in cleanup workflows

### DIFF
--- a/.github/workflows/cleanup-deployments.yml
+++ b/.github/workflows/cleanup-deployments.yml
@@ -61,7 +61,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Set up Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/cleanup-deployments.yml
+++ b/.github/workflows/cleanup-deployments.yml
@@ -61,7 +61,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Set up Python
-        uses: actions/setup-python@42375524d0a3c83d1a8f3d1779a827123c5c2a43 # v5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/cleanup-environments.yml
+++ b/.github/workflows/cleanup-environments.yml
@@ -55,7 +55,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Set up Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/cleanup-environments.yml
+++ b/.github/workflows/cleanup-environments.yml
@@ -55,7 +55,7 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Set up Python
-        uses: actions/setup-python@42375524d0a3c83d1a8f3d1779a827123c5c2a43 # v5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

## What

Fix a typo in the pinned SHA for `actions/setup-python` in the two cleanup workflows, and upgrade the action from v5.4.0 to v6.2.0 while at it.

## Why

The SHA `42375524d…` doesn't exist in the `actions/setup-python` repository — one character off from the real v5.4.0 SHA — causing both workflows to fail on every run ([environments](https://github.com/Amsterdam/design-system/actions/runs/27489671927), [deployments](https://github.com/Amsterdam/design-system/actions/runs/27490815557)).

And v5.4.0 was also already 16 months behind the current v6.2.0.

## How

Corrected the SHA to the one GitHub's API returns for the `v5.4.0` tag, then updated both files to v6.2.0 (SHA verified the same way).

The v6.0.0 breaking change (Node 24 runtime) requires runner ≥ v2.327.1; `ubuntu-latest` has met that requirement since September 2025.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Dependabot would not have caught this automatically: it resolves pinned SHAs to version tags to detect updates, and an invalid SHA prevents that resolution entirely.