### PR TITLE
chore(Calendar): Pin test story to a fixed date to prevent daily Chromatic diffs

### DIFF
--- a/storybook/src/_common/mockDate.ts
+++ b/storybook/src/_common/mockDate.ts
@@ -10,14 +10,18 @@
  */
 export const mockDate = (date: Date): (() => void) => {
   const RealDate = Date
+
   const fixedMs = date.getTime()
+
   const MockDate = new Proxy(RealDate, {
-    apply: (_target, _thisArg, args) => (args.length === 0 ? new RealDate(fixedMs) : new RealDate(...(args as []))),
+    apply: () => new RealDate(fixedMs).toString(),
     construct: (_target, args) => (args.length === 0 ? new RealDate(fixedMs) : Reflect.construct(RealDate, args)),
+    get: (target, prop) => (prop === 'now' ? () => fixedMs : target[prop as keyof typeof RealDate]),
   })
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(globalThis as any).Date = MockDate
+
+  Object.defineProperty(globalThis, 'Date', { configurable: true, value: MockDate, writable: true })
+
   return () => {
-    globalThis.Date = RealDate
+    Object.defineProperty(globalThis, 'Date', { configurable: true, value: RealDate, writable: true })
   }
 }

--- a/storybook/src/_common/mockDate.ts
+++ b/storybook/src/_common/mockDate.ts
@@ -1,0 +1,23 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+/**
+ * Replaces the global Date constructor with a Proxy that returns a fixed date
+ * when called with no arguments. Returns a cleanup function that restores the real Date.
+ * Use in a story's `beforeEach` to keep Chromatic snapshots stable across days.
+ */
+export const mockDate = (date: Date): (() => void) => {
+  const RealDate = Date
+  const fixedMs = date.getTime()
+  const MockDate = new Proxy(RealDate, {
+    apply: (_target, _thisArg, args) => (args.length === 0 ? new RealDate(fixedMs) : new RealDate(...(args as []))),
+    construct: (_target, args) => (args.length === 0 ? new RealDate(fixedMs) : Reflect.construct(RealDate, args)),
+  })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(globalThis as any).Date = MockDate
+  return () => {
+    globalThis.Date = RealDate
+  }
+}

--- a/storybook/src/components/Calendar/Calendar.test.stories.tsx
+++ b/storybook/src/components/Calendar/Calendar.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Calendar } from '@amsterdam/design-system-react/src'
 
+import { mockDate } from '../../_common/mockDate'
 import { renderComponentVariants } from '../../_common/renderComponentVariants'
 import { default as calendarMeta } from './Calendar.stories'
 
@@ -28,19 +29,7 @@ export const Test: Story = {
     defaultMonth: new Date(2026, 11, 31),
     locale: 'nl',
   },
-  beforeEach: () => {
-    const RealDate = Date
-    const fixedMs = +new RealDate(2026, 11, 31)
-    const MockDate = new Proxy(RealDate, {
-      apply: (_target, _thisArg, args) => (args.length === 0 ? new RealDate(fixedMs) : new RealDate(...(args as []))),
-      construct: (_target, args) => (args.length === 0 ? new RealDate(fixedMs) : Reflect.construct(RealDate, args)),
-    })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(globalThis as any).Date = MockDate
-    return () => {
-      globalThis.Date = RealDate
-    }
-  },
+  beforeEach: () => mockDate(new Date(2026, 11, 31)),
   render: (args, context) => renderComponentVariants(Calendar, { args }, context),
   tags: ['!dev', '!autodocs'],
 }

--- a/storybook/src/components/Calendar/Calendar.test.stories.tsx
+++ b/storybook/src/components/Calendar/Calendar.test.stories.tsx
@@ -6,7 +6,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Calendar } from '@amsterdam/design-system-react/src'
-import { vi } from '@storybook/test'
 
 import { renderComponentVariants } from '../../_common/renderComponentVariants'
 import { default as calendarMeta } from './Calendar.stories'
@@ -30,9 +29,17 @@ export const Test: Story = {
     locale: 'nl',
   },
   beforeEach: () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(2026, 11, 31))
-    return () => vi.useRealTimers()
+    const RealDate = Date
+    const fixedMs = +new RealDate(2026, 11, 31)
+    const MockDate = new Proxy(RealDate, {
+      apply: (_target, _thisArg, args) => (args.length === 0 ? new RealDate(fixedMs) : new RealDate(...(args as []))),
+      construct: (_target, args) => (args.length === 0 ? new RealDate(fixedMs) : Reflect.construct(RealDate, args)),
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).Date = MockDate
+    return () => {
+      globalThis.Date = RealDate
+    }
   },
   render: (args, context) => renderComponentVariants(Calendar, { args }, context),
   tags: ['!dev', '!autodocs'],

--- a/storybook/src/components/Calendar/Calendar.test.stories.tsx
+++ b/storybook/src/components/Calendar/Calendar.test.stories.tsx
@@ -24,12 +24,14 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+const testDate = new Date(2026, 11, 31)
+
 export const Test: Story = {
   args: {
-    defaultMonth: new Date(2026, 11, 31),
+    defaultMonth: new Date(testDate),
     locale: 'nl',
   },
-  beforeEach: () => mockDate(new Date(2026, 11, 31)),
+  beforeEach: () => mockDate(testDate),
   render: (args, context) => renderComponentVariants(Calendar, { args }, context),
   tags: ['!dev', '!autodocs'],
 }

--- a/storybook/src/components/Calendar/Calendar.test.stories.tsx
+++ b/storybook/src/components/Calendar/Calendar.test.stories.tsx
@@ -6,6 +6,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Calendar } from '@amsterdam/design-system-react/src'
+import { vi } from '@storybook/test'
 
 import { renderComponentVariants } from '../../_common/renderComponentVariants'
 import { default as calendarMeta } from './Calendar.stories'
@@ -25,7 +26,13 @@ type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
   args: {
+    defaultMonth: new Date(2026, 11, 31),
     locale: 'nl',
+  },
+  beforeEach: () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 11, 31))
+    return () => vi.useRealTimers()
   },
   render: (args, context) => renderComponentVariants(Calendar, { args }, context),
   tags: ['!dev', '!autodocs'],


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Pin Calendar test story to a fixed date to prevent daily Chromatic diffs

## What

The Calendar test story now always renders December 31, 2026 — both as the displayed month and as the highlighted ‘today’ date.

A reusable `mockDate` utility is extracted to `storybook/src/_common/` for use in other test stories.

## Why

`CalendarBody` calls `new Date()` on every render to determine today’s date, and the story’s `defaultMonth` also defaulted to `new Date()`.

Both values changed daily, causing Chromatic to flag a visual difference every day even when nothing in the component had changed.

## How

- Set `defaultMonth: new Date(2026, 11, 31)` in the test story’s args to fix the displayed month to December 2026.
- Add a `beforeEach` hook that replaces the global `Date` constructor with a `Proxy` for the duration of the story render. The proxy intercepts:
  - no-argument `new Date()` calls (returning the fixed timestamp)
  - `Date()` function calls (returning the fixed date as a string, matching native behaviour)
  - `Date.now()` (returning the fixed timestamp)
- All other `Date` usage — `new Date(year, month, day)` etc. — is delegated to the real constructor unchanged, so the calendar grid continues to build correctly.
- The proxy logic lives in a shared `mockDate(date: Date): () => void` helper; the returned cleanup function restores the real `Date` after each render.
- This approach requires no changes to the public Calendar API and no additional dependencies.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a