### PR TITLE
fix(Logo): Apply proprietary licence to generated brand logo components

### DIFF
--- a/packages/react/src/Logo/AmsterdamLogo.test.tsx
+++ b/packages/react/src/Logo/AmsterdamLogo.test.tsx
@@ -7,7 +7,7 @@ import { render, screen } from '@testing-library/react'
 import { createRef } from 'react'
 import { describe, expect, it } from 'vitest'
 
-import { AmsterdamLogo } from '.'
+import { AmsterdamLogo } from './brands'
 
 // This test is representative for all `*Logo.tsx` components in this directory.
 // They all follow the same structure, so no need to add separate tests for the others.

--- a/packages/react/src/Logo/brands/AmsterdamEnglishLogo.tsx
+++ b/packages/react/src/Logo/brands/AmsterdamEnglishLogo.tsx
@@ -1,7 +1,3 @@
-/**
- * @license EUPL-1.2+
- * Copyright Gemeente Amsterdam
- */
 import type { ForwardedRef, SVGProps } from 'react'
 
 import { forwardRef } from 'react'

--- a/packages/react/src/Logo/brands/AmsterdamLogo.tsx
+++ b/packages/react/src/Logo/brands/AmsterdamLogo.tsx
@@ -1,7 +1,3 @@
-/**
- * @license EUPL-1.2+
- * Copyright Gemeente Amsterdam
- */
 import type { ForwardedRef, SVGProps } from 'react'
 
 import { forwardRef } from 'react'

--- a/packages/react/src/Logo/brands/GgdAmsterdamInspectieLogo.tsx
+++ b/packages/react/src/Logo/brands/GgdAmsterdamInspectieLogo.tsx
@@ -1,7 +1,3 @@
-/**
- * @license EUPL-1.2+
- * Copyright Gemeente Amsterdam
- */
 import type { ForwardedRef, SVGProps } from 'react'
 
 import { forwardRef } from 'react'

--- a/packages/react/src/Logo/brands/GgdAmsterdamLogo.tsx
+++ b/packages/react/src/Logo/brands/GgdAmsterdamLogo.tsx
@@ -1,7 +1,3 @@
-/**
- * @license EUPL-1.2+
- * Copyright Gemeente Amsterdam
- */
 import type { ForwardedRef, SVGProps } from 'react'
 
 import { forwardRef } from 'react'

--- a/packages/react/src/Logo/brands/LICENSE.md
+++ b/packages/react/src/Logo/brands/LICENSE.md
@@ -1,0 +1,7 @@
+<!-- @license CC0-1.0 -->
+
+# License
+
+The open-source licence does NOT apply to files in this directory.
+
+These are proprietary assets to the City of Amsterdam.

--- a/packages/react/src/Logo/brands/MuseumWeespLogo.tsx
+++ b/packages/react/src/Logo/brands/MuseumWeespLogo.tsx
@@ -1,7 +1,3 @@
-/**
- * @license EUPL-1.2+
- * Copyright Gemeente Amsterdam
- */
 import type { ForwardedRef, SVGProps } from 'react'
 
 import { forwardRef } from 'react'

--- a/packages/react/src/Logo/brands/StadsarchiefLogo.tsx
+++ b/packages/react/src/Logo/brands/StadsarchiefLogo.tsx
@@ -1,7 +1,3 @@
-/**
- * @license EUPL-1.2+
- * Copyright Gemeente Amsterdam
- */
 import type { ForwardedRef, SVGProps } from 'react'
 
 import { forwardRef } from 'react'

--- a/packages/react/src/Logo/brands/StadsbankVanLeningLogo.tsx
+++ b/packages/react/src/Logo/brands/StadsbankVanLeningLogo.tsx
@@ -1,7 +1,3 @@
-/**
- * @license EUPL-1.2+
- * Copyright Gemeente Amsterdam
- */
 import type { ForwardedRef, SVGProps } from 'react'
 
 import { forwardRef } from 'react'

--- a/packages/react/src/Logo/brands/VgaVerzekeringenLogo.tsx
+++ b/packages/react/src/Logo/brands/VgaVerzekeringenLogo.tsx
@@ -1,7 +1,3 @@
-/**
- * @license EUPL-1.2+
- * Copyright Gemeente Amsterdam
- */
 import type { ForwardedRef, SVGProps } from 'react'
 
 import { forwardRef } from 'react'

--- a/packages/react/src/Logo/brands/index.ts
+++ b/packages/react/src/Logo/brands/index.ts
@@ -1,8 +1,3 @@
-/**
- * @license EUPL-1.2+
- * Copyright Gemeente Amsterdam
- */
-
 export { default as AmsterdamEnglishLogo } from './AmsterdamEnglishLogo'
 export { default as AmsterdamLogo } from './AmsterdamLogo'
 export { default as GgdAmsterdamInspectieLogo } from './GgdAmsterdamInspectieLogo'

--- a/packages/react/src/Logo/logoIndexTemplate.mjs
+++ b/packages/react/src/Logo/logoIndexTemplate.mjs
@@ -5,5 +5,5 @@ export function logoIndexTemplate(filePaths) {
     const name = path.basename(filePath, path.extname(filePath))
     return `export { default as ${name} } from './${name}'`
   })
-  return ['/**', ' * @license EUPL-1.2+', ' * Copyright Gemeente Amsterdam', ' */', '', ...exports, ''].join('\n')
+  return [...exports, ''].join('\n')
 }

--- a/packages/react/src/Logo/logoTemplate.mjs
+++ b/packages/react/src/Logo/logoTemplate.mjs
@@ -5,10 +5,6 @@ export function logoTemplate({ componentName, jsx }, { tpl }) {
   const name = componentName.replace(/^Svg/, '')
 
   return tpl`
-    /**
-     * @license EUPL-1.2+
-     * Copyright Gemeente Amsterdam
-     */
     import type { ForwardedRef, SVGProps } from 'react'
     import { forwardRef } from 'react'
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

## What

The React logo components generated into `Logo/brands/` carried an `EUPL-1.2+` licence header, but the SVG artwork embedded in them comes from proprietary City of Amsterdam brand assets. This PR corrects the mislabelling.

## Why

The EUPL-1.2 header on these files misrepresents the licence of their content. A directory-level `LICENSE.md` (the recognised REUSE pattern) is the right place to declare that these generated files are proprietary assets, consistent with how `packages-proprietary/assets/logo/` already handles it.

## How

- Removed the `@license EUPL-1.2+` / `Copyright` block from `logoTemplate.mjs` and `logoIndexTemplate.mjs`, so newly generated brand files carry no licence header.
- Added `Logo/brands/LICENSE.md` with the same proprietary notice as `packages-proprietary/assets/LICENSE.md`.
- Regenerated all brand logo components.
- Moved `AmsterdamLogo.test.tsx` up from `brands/` to `Logo/` — it is our own EUPL-licensed test code and does not belong inside the proprietary directory.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11)

## Additional notes

Addresses #2665.