### PR TITLE
chore(Storybook): Give variant-matrix landmarks unique accessible names

### DIFF
--- a/storybook/src/_common/buildComponentProps.test.ts
+++ b/storybook/src/_common/buildComponentProps.test.ts
@@ -74,4 +74,20 @@ describe('buildComponentProps', () => {
     })
     expect(result).toMatchObject({ icon: ChevronDownIcon, iconBefore: true })
   })
+
+  it('omits accessibleName and accessibleNameId when the flags are not set', () => {
+    const result = buildComponentProps(baseParams)
+    expect(result).not.toHaveProperty('accessibleName')
+    expect(result).not.toHaveProperty('accessibleNameId')
+  })
+
+  it('injects a unique accessibleName derived from the variant when the flag is set', () => {
+    const result = buildComponentProps({ ...baseParams, acceptsAccessibleName: true })
+    expect(result).toMatchObject({ accessibleName: 'none-color-primary-default' })
+  })
+
+  it('injects a unique accessibleNameId derived from the variant when the flag is set', () => {
+    const result = buildComponentProps({ ...baseParams, acceptsAccessibleNameId: true })
+    expect(result).toMatchObject({ accessibleNameId: 'variant-none-color-primary-default' })
+  })
 })

--- a/storybook/src/_common/buildComponentProps.ts
+++ b/storybook/src/_common/buildComponentProps.ts
@@ -11,8 +11,15 @@ import type { BuildComponentPropsParams } from './renderComponentVariantTypes'
  * Assembles the props for a single component instance in the variant matrix.
  * Handles state classes (`hover`), disabled flag, size routing and the
  * inverse background trigger used in tests.css.
+ *
+ * For components that render an ARIA landmark and expose `accessibleName`
+ * / `accessibleNameId` props, a per-variant value is injected so each
+ * landmark in the matrix has a unique accessible name and id. This avoids
+ * axe's `landmark-unique` and duplicate-id violations in Chromatic.
  */
 export const buildComponentProps = ({
+  acceptsAccessibleName,
+  acceptsAccessibleNameId,
   args,
   hasIcon,
   propName,
@@ -20,14 +27,20 @@ export const buildComponentProps = ({
   sizePropName,
   state,
   variant,
-}: BuildComponentPropsParams) => ({
-  ...args,
-  ...(state === 'disabled' && { [state]: true }),
-  ...(hasIcon ?? {}),
-  ...(sizePropName && { [sizePropName]: size }),
-  className: clsx(
-    state === 'hovered' && 'hover',
-    typeof variant === 'string' && variant === 'inverse' && state !== 'disabled' && '_ams-page-background--dark',
-  ),
-  ...(propName !== sizePropName && { [propName]: variant }),
-})
+}: BuildComponentPropsParams) => {
+  const variantKey = `${size ?? 'none'}-${propName}-${String(variant)}-${state}`
+
+  return {
+    ...args,
+    ...(state === 'disabled' && { [state]: true }),
+    ...(hasIcon ?? {}),
+    ...(sizePropName && { [sizePropName]: size }),
+    className: clsx(
+      state === 'hovered' && 'hover',
+      typeof variant === 'string' && variant === 'inverse' && state !== 'disabled' && '_ams-page-background--dark',
+    ),
+    ...(propName !== sizePropName && { [propName]: variant }),
+    ...(acceptsAccessibleName && { accessibleName: variantKey }),
+    ...(acceptsAccessibleNameId && { accessibleNameId: `variant-${variantKey}` }),
+  }
+}

--- a/storybook/src/_common/renderComponentVariantTypes.ts
+++ b/storybook/src/_common/renderComponentVariantTypes.ts
@@ -21,6 +21,8 @@ export type renderComponentVariantsParams = {
 }
 
 export type BuildComponentPropsParams = {
+  acceptsAccessibleName: boolean
+  acceptsAccessibleNameId: boolean
   args: Meta['args']
   hasIcon?: { icon: IconProps['svg'] } | null
   propName: string

--- a/storybook/src/_common/renderComponentVariantTypes.ts
+++ b/storybook/src/_common/renderComponentVariantTypes.ts
@@ -21,8 +21,8 @@ export type renderComponentVariantsParams = {
 }
 
 export type BuildComponentPropsParams = {
-  acceptsAccessibleName: boolean
-  acceptsAccessibleNameId: boolean
+  acceptsAccessibleName?: boolean
+  acceptsAccessibleNameId?: boolean
   args: Meta['args']
   hasIcon?: { icon: IconProps['svg'] } | null
   propName: string

--- a/storybook/src/_common/renderComponentVariants.tsx
+++ b/storybook/src/_common/renderComponentVariants.tsx
@@ -40,6 +40,8 @@ export const renderComponentVariants = (
   const propsWithValues = extractVariantsFromArgTypes(context.argTypes)
   const allVariants = [...variants, 'default']
   const sizes = extractSize(propsWithValues)
+  const acceptsAccessibleName = 'accessibleName' in context.argTypes
+  const acceptsAccessibleNameId = 'accessibleNameId' in context.argTypes
 
   if (propsWithValues.length === 0) {
     return (
@@ -49,6 +51,8 @@ export const renderComponentVariants = (
             {createElement(component, {
               ...args,
               ...(state === 'disabled' ? { disabled: true } : {}),
+              ...(acceptsAccessibleName && { accessibleName: state }),
+              ...(acceptsAccessibleNameId && { accessibleNameId: `variant-${state}` }),
               className: state === 'hovered' ? 'hover' : undefined,
             })}
           </div>
@@ -83,6 +87,8 @@ export const renderComponentVariants = (
                     {createElement(
                       component,
                       buildComponentProps({
+                        acceptsAccessibleName,
+                        acceptsAccessibleNameId,
                         args,
                         hasIcon,
                         propName: name,


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Give variant-matrix landmarks unique accessible names

## What

Detect when a component declares `accessibleName` / `accessibleNameId` props (via `context.argTypes`) inside `renderComponentVariants` and inject a unique per-variant value, so every landmark in the test matrix has a distinct accessible name and id.

## Why

Chromatic flags `landmark-unique` and duplicate-id violations whenever `renderComponentVariants` produces multiple instances of a landmark-rendering component — Pagination is the most recent example. Each variant inherits the same hardcoded fallback label and id, which trips axe.

## How

- `renderComponentVariants` reads `'accessibleName' in context.argTypes` and `'accessibleNameId' in context.argTypes` once per render and threads two boolean flags into `buildComponentProps` (and into the no-variants branch).
- `buildComponentProps` derives a `variantKey` from `size` / `propName` / `variant` / `state` — the same shape already used as the React key — and conditionally spreads `accessibleName: variantKey` and `accessibleNameId: \`variant-${variantKey}\``.
- Convention-based: no story changes required. The Pagination test story benefits automatically; Breadcrumb, Menu, and TabNavigation will too once their test stories land.
- PageHeader uses a different prop name (`navigationLabel`) and isn’t covered here. PageFooter has no name prop today; both are component-level follow-ups.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- The injected `accessibleName` lives only in the visually-hidden span, so Chromatic visual diffs are unaffected.
- Pagination’s hardcoded `'ams-pagination-a11y-label'` id fallback is the deeper issue for real consumers (two paginations on a page would still collide); that’s tracked on a separate branch (`fix/pagination-unique-id`).