### PR TITLE
fix(Pagination): Generate a unique fallback id for the accessible name

### DIFF
--- a/packages/react/src/Pagination/Pagination.test.tsx
+++ b/packages/react/src/Pagination/Pagination.test.tsx
@@ -115,6 +115,21 @@ describe('Pagination', () => {
     expect(component).toHaveAttribute('aria-labelledby', 'custom-id')
   })
 
+  it('generates a unique fallback id when none is provided', () => {
+    render(
+      <>
+        <Pagination linkTemplate={linkTemplate} totalPages={10} />
+        <Pagination linkTemplate={linkTemplate} totalPages={10} />
+      </>,
+    )
+
+    const [first, second] = screen.getAllByRole('navigation', { name: 'Paginering' })
+
+    expect(first).toHaveAttribute('aria-labelledby')
+    expect(second).toHaveAttribute('aria-labelledby')
+    expect(first.getAttribute('aria-labelledby')).not.toBe(second.getAttribute('aria-labelledby'))
+  })
+
   it('should not render when totalPages is 1 or less', () => {
     render(<Pagination linkTemplate={linkTemplate} totalPages={1} />)
 

--- a/packages/react/src/Pagination/Pagination.tsx
+++ b/packages/react/src/Pagination/Pagination.tsx
@@ -7,7 +7,7 @@ import type { AnchorHTMLAttributes, ComponentType, ForwardedRef, HTMLAttributes 
 
 import { ChevronBackwardIcon, ChevronForwardIcon } from '@amsterdam/design-system-react-icons'
 import { clsx } from 'clsx'
-import { forwardRef } from 'react'
+import { forwardRef, useId } from 'react'
 
 import { Icon } from '../Icon'
 import { getRange } from './getRange'
@@ -66,6 +66,8 @@ export const Pagination = forwardRef(
     }: PaginationProps,
     ref: ForwardedRef<HTMLElement>,
   ) => {
+    const generatedId = useId()
+
     // Don't show pagination if you only have one page
     if (totalPages <= 1) {
       return null
@@ -76,14 +78,11 @@ export const Pagination = forwardRef(
     // Get array of page numbers and / or spacers
     const range = getRange(page, totalPages, maxVisiblePages)
 
+    const labelId = accessibleNameId || generatedId
+
     return (
-      <nav
-        {...restProps}
-        aria-labelledby={accessibleNameId || 'ams-pagination-a11y-label'}
-        className={clsx('ams-pagination', className)}
-        ref={ref}
-      >
-        <span className="ams-visually-hidden" id={accessibleNameId || 'ams-pagination-a11y-label'}>
+      <nav {...restProps} aria-labelledby={labelId} className={clsx('ams-pagination', className)} ref={ref}>
+        <span className="ams-visually-hidden" id={labelId}>
           {accessibleName || 'Paginering'}
         </span>
         {page !== 1 && (


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Generate a unique fallback id for the accessible name of Pagination

## What

`Pagination`’s `accessibleNameId` falls back to a `useId()`-generated id instead of the hardcoded `'ams-pagination-a11y-label'` string. Consumers who don’t pass `accessibleNameId` get a guaranteed-unique id automatically.

## Why

Two `Pagination` instances on the same page previously produced duplicate HTML ids and shared an accessible name, which is invalid HTML and trips axe’s `landmark-unique` and duplicate-id checks. Consumers shouldn’t have to set `accessibleNameId` manually just to render two paginations on a page.

## How

- Calls `useId()` at the top of the render function — before the `totalPages <= 1` early return, to satisfy the rules-of-hooks.
- The consumer-provided `accessibleNameId` still wins; the generated id only kicks in when none is provided.
- Added a unit test that renders two `Pagination` instances and asserts their `aria-labelledby` ids differ.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Companion to `chore(Storybook): Give variant-matrix landmarks unique accessible names`, which addresses the same family of axe violations from the test-harness side.