### PR TITLE
chore(Page Footer): Fix accessibility issue in visual test

### DIFF
--- a/storybook/src/components/PageFooter/PageFooter.test.stories.tsx
+++ b/storybook/src/components/PageFooter/PageFooter.test.stories.tsx
@@ -5,6 +5,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
+import { Paragraph } from '@amsterdam/design-system-react'
 import { PageFooter } from '@amsterdam/design-system-react/src'
 
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
@@ -24,10 +25,7 @@ export const Test: Story = {
   args: {
     children: [
       <PageFooter.Spotlight key={1}>
-        <ul>
-          <li>Contactformulier</li>
-          <li>Adressen en openingstijden</li>
-        </ul>
+        <Paragraph color="inverse">Adressen en openingstijden</Paragraph>
       </PageFooter.Spotlight>,
       <PageFooter.Menu key={2}>
         <PageFooter.MenuLink href="#">Over deze site</PageFooter.MenuLink>


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Makes some text in the blue area of our Page Footer white instead of black, which was obviously not giving enough color contrast.

Not sure why we didn’t catch this earlier – it was introduced in #2257, more than half a year ago.

## Why

Address an a11y issue in our visual regression test.

## How

Replace plain HTML with a simple paragraph with `color="inverse"`.

Note that this makes the Page Footer test vulnerable to changes in Paragraph, so we could also use `<p style={{color: 'white'}}>`.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a
