### PR TITLE
chore(Icon): Add visual regression tests for all icons

### DIFF
--- a/storybook/src/components/Icon/Icon.test.stories.tsx
+++ b/storybook/src/components/Icon/Icon.test.stories.tsx
@@ -21,8 +21,7 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-const iconNames = Object.keys(Icons) as (keyof typeof Icons)[]
-
+const iconNames = (Object.keys(Icons) as (keyof typeof Icons)[]).sort((a, b) => a.localeCompare(b))
 export const Test: Story = {
   render: (args, context) => (
     <div className="_ams-tests-stack">

--- a/storybook/src/components/Icon/Icon.test.stories.tsx
+++ b/storybook/src/components/Icon/Icon.test.stories.tsx
@@ -5,6 +5,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
+import * as Icons from '@amsterdam/design-system-react-icons/src'
 import { Icon } from '@amsterdam/design-system-react/src'
 
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
@@ -20,7 +21,20 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+const iconNames = Object.keys(Icons) as (keyof typeof Icons)[]
+
 export const Test: Story = {
-  render: (args, context) => renderComponentVariants(Icon, { args }, context),
+  render: (args, context) => (
+    <div className="_ams-tests-stack">
+      <span>Variants of Icon component</span>
+      {renderComponentVariants(Icon, { args }, context)}
+      <span>All icons</span>
+      <div className="_ams-tests-grid">
+        {iconNames.map((name) => (
+          <Icon key={name} size="heading-2" svg={Icons[name]} />
+        ))}
+      </div>
+    </div>
+  ),
   tags: ['!dev', '!autodocs'],
 }


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Extends the existing `Icon` test story to render all icon SVGs in a single Chromatic snapshot, in addition to the existing variant matrix of the Icon component.

## Why

Icon SVGs are auto-generated from source files by SVGR. Until now, icons were only incidentally covered by Chromatic, only icons that happened to appear in other components' test stories were visually tested. A dedicated section for all icons ensures any change introduced by a new icon export is immediately visible as a Chromatic diff.

## How

Added `Object.keys(Icons)` iteration to the existing `Test` story in `Icon.test.stories.tsx`, rendering every icon at `heading-2` size in the standard `_ams-tests-grid`. The story now has two sections: one for Icon component variants, one for the full icon set.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

[Prod test story](https://designsystem.amsterdam/?path=/docs/components-media-icon--test)
[Branch test story](https://designsystem.amsterdam/?path=/docs/components-media-icon--test)