### PR TITLE
chore(react-icons): Generate icon deprecation comments

### DIFF
--- a/packages-proprietary/react-icons/deprecations.mjs
+++ b/packages-proprietary/react-icons/deprecations.mjs
@@ -43,17 +43,21 @@ for (const [iconName, { removeOnOrAfter }] of Object.entries(deprecatedIcons)) {
   }
 }
 
-// The `@deprecated` JSDoc comment for each deprecated icon, keyed by file
-// basename.
-/** @type {Record<string, string>} */
-export const deprecatedIconComments = Object.fromEntries(
-  Object.entries(deprecatedIcons).map(([iconName, { removeOnOrAfter, replacement }]) => [
-    iconName,
-    [
-      '/**',
-      ` * @deprecated The ‘${iconName}’ icon will be removed on or after ${removeOnOrAfter}.`,
-      ` * Use ‘${replacement}’ instead.`,
-      ' */',
-    ].join('\n'),
-  ]),
-)
+/**
+ * Builds the `@deprecated` JSDoc comment for an icon, or `undefined` if it is
+ * not deprecated.
+ *
+ * @param {string} iconName File basename of the icon, e.g. `TrashBin`.
+ */
+export const deprecatedIconComment = (iconName) => {
+  const deprecation = deprecatedIcons[iconName]
+
+  if (!deprecation) return undefined
+
+  return [
+    '/**',
+    ` * @deprecated The ‘${iconName}’ icon will be removed on or after ${deprecation.removeOnOrAfter}.`,
+    ` * Use ‘${deprecation.replacement}’ instead.`,
+    ' */',
+  ].join('\n')
+}

--- a/packages-proprietary/react-icons/deprecations.mjs
+++ b/packages-proprietary/react-icons/deprecations.mjs
@@ -1,3 +1,8 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
 // Icons whose component is deprecated, by file basename (e.g. `TrashBin`,
 // exported as `TrashBinIcon`). Adds an `@deprecated` comment to the component.
 export const deprecatedIcons = {

--- a/packages-proprietary/react-icons/deprecations.mjs
+++ b/packages-proprietary/react-icons/deprecations.mjs
@@ -1,0 +1,39 @@
+// Icons whose component is deprecated, by file basename (e.g. `TrashBin`,
+// exported as `TrashBinIcon`). Adds an `@deprecated` comment to the component.
+export const deprecatedIcons = {
+  Bell: { removeOnOrAfter: '2026-07-09', replacement: 'Notification' },
+  BellFill: { removeOnOrAfter: '2026-07-09', replacement: 'NotificationFill' },
+  CheckMarkCircle: { removeOnOrAfter: '2026-05-01', replacement: 'Success' },
+  CheckMarkCircleFill: { removeOnOrAfter: '2026-05-01', replacement: 'SuccessFill' },
+  Cogwheel: { removeOnOrAfter: '2026-05-01', replacement: 'Settings' },
+  CogwheelFill: { removeOnOrAfter: '2026-05-01', replacement: 'SettingsFill' },
+  HandWithEuroCoin: { removeOnOrAfter: '2026-05-01', replacement: 'PersonsWithEuroCoin' },
+  PersonCircle: { removeOnOrAfter: '2026-07-09', replacement: 'UserAccount' },
+  PersonCircleFill: { removeOnOrAfter: '2026-07-09', replacement: 'UserAccountFill' },
+  TrashBin: { removeOnOrAfter: '2026-07-09', replacement: 'Delete' },
+  TrashBinFill: { removeOnOrAfter: '2026-07-09', replacement: 'DeleteFill' },
+}
+
+// Deprecated re-exports that alias an icon under another name, keyed by alias.
+export const deprecatedAliases = {
+  LinkedinIcon: {
+    comment:
+      'This icon misspells the brand as ‘Linkedin’, with a lowercase ‘i’. Use ‘LinkedInIcon’ instead. Will be removed on or after 2026-05-01.',
+    icon: 'LinkedIn',
+  },
+}
+
+// Builds the `@deprecated` JSDoc comment for an icon, or `undefined` if it is
+// not deprecated. `iconName` is the file basename, e.g. `TrashBin`.
+export function deprecatedIconComment(iconName) {
+  const deprecation = deprecatedIcons[iconName]
+
+  if (!deprecation) return undefined
+
+  return [
+    '/**',
+    ` * @deprecated The ‘${iconName}’ icon will be removed on or after ${deprecation.removeOnOrAfter}.`,
+    ` * Use ‘${deprecation.replacement}’ instead.`,
+    ' */',
+  ].join('\n')
+}

--- a/packages-proprietary/react-icons/deprecations.mjs
+++ b/packages-proprietary/react-icons/deprecations.mjs
@@ -43,21 +43,17 @@ for (const [iconName, { removeOnOrAfter }] of Object.entries(deprecatedIcons)) {
   }
 }
 
-/**
- * Builds the `@deprecated` JSDoc comment for an icon, or `undefined` if it is
- * not deprecated.
- *
- * @param {string} iconName File basename of the icon, e.g. `TrashBin`.
- */
-export function deprecatedIconComment(iconName) {
-  const deprecation = deprecatedIcons[iconName]
-
-  if (!deprecation) return undefined
-
-  return [
-    '/**',
-    ` * @deprecated The ‘${iconName}’ icon will be removed on or after ${deprecation.removeOnOrAfter}.`,
-    ` * Use ‘${deprecation.replacement}’ instead.`,
-    ' */',
-  ].join('\n')
-}
+// The `@deprecated` JSDoc comment for each deprecated icon, keyed by file
+// basename.
+/** @type {Record<string, string>} */
+export const deprecatedIconComments = Object.fromEntries(
+  Object.entries(deprecatedIcons).map(([iconName, { removeOnOrAfter, replacement }]) => [
+    iconName,
+    [
+      '/**',
+      ` * @deprecated The ‘${iconName}’ icon will be removed on or after ${removeOnOrAfter}.`,
+      ` * Use ‘${replacement}’ instead.`,
+      ' */',
+    ].join('\n'),
+  ]),
+)

--- a/packages-proprietary/react-icons/deprecations.mjs
+++ b/packages-proprietary/react-icons/deprecations.mjs
@@ -3,8 +3,11 @@
  * Copyright Gemeente Amsterdam
  */
 
+// @ts-check
+
 // Icons whose component is deprecated, by file basename (e.g. `TrashBin`,
 // exported as `TrashBinIcon`). Adds an `@deprecated` comment to the component.
+/** @type {Record<string, { removeOnOrAfter: string; replacement: string }>} */
 export const deprecatedIcons = {
   Bell: { removeOnOrAfter: '2026-07-09', replacement: 'Notification' },
   BellFill: { removeOnOrAfter: '2026-07-09', replacement: 'NotificationFill' },
@@ -20,6 +23,7 @@ export const deprecatedIcons = {
 }
 
 // Deprecated re-exports that alias an icon under another name, keyed by alias.
+/** @type {Record<string, { comment: string; icon: string }>} */
 export const deprecatedAliases = {
   LinkedinIcon: {
     comment:
@@ -28,8 +32,23 @@ export const deprecatedAliases = {
   },
 }
 
-// Builds the `@deprecated` JSDoc comment for an icon, or `undefined` if it is
-// not deprecated. `iconName` is the file basename, e.g. `TrashBin`.
+// Fail the build on a malformed removal date.
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+
+for (const [iconName, { removeOnOrAfter }] of Object.entries(deprecatedIcons)) {
+  if (!ISO_DATE.test(removeOnOrAfter)) {
+    throw new Error(
+      `deprecatedIcons.${iconName}: ‘removeOnOrAfter’ must be a YYYY-MM-DD date, got ‘${removeOnOrAfter}’.`,
+    )
+  }
+}
+
+/**
+ * Builds the `@deprecated` JSDoc comment for an icon, or `undefined` if it is
+ * not deprecated.
+ *
+ * @param {string} iconName File basename of the icon, e.g. `TrashBin`.
+ */
 export function deprecatedIconComment(iconName) {
   const deprecation = deprecatedIcons[iconName]
 

--- a/packages-proprietary/react-icons/indexTemplate.mjs
+++ b/packages-proprietary/react-icons/indexTemplate.mjs
@@ -1,5 +1,12 @@
 import path from 'path'
 
+import { deprecatedAliases } from './deprecations.mjs'
+
+const licenseHeader = `/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */`
+
 export function indexTemplate(filePaths) {
   const exportEntries = filePaths.map(({ path: filePath }) => {
     const basename = path.basename(filePath, path.extname(filePath))
@@ -8,5 +15,13 @@ export function indexTemplate(filePaths) {
     // The name of the React component for each icon ends with `Icon`
     return `export { default as ${exportName}Icon } from './${basename}'`
   })
-  return exportEntries.join('\n')
+
+  // Re-export deprecated alias names (e.g. the misspelled `LinkedinIcon`) with
+  // an `@deprecated` JSDoc comment, configured in `deprecations.mjs`.
+  const aliasEntries = Object.entries(deprecatedAliases).map(
+    ([aliasName, { comment, icon }]) =>
+      `export {\n  /** @deprecated ${comment} */\n  default as ${aliasName},\n} from './${icon}'`,
+  )
+
+  return [licenseHeader, '', ...exportEntries, ...aliasEntries].join('\n')
 }

--- a/packages-proprietary/react-icons/src/index.ts
+++ b/packages-proprietary/react-icons/src/index.ts
@@ -186,11 +186,11 @@ export { default as LightningFillIcon } from './LightningFill'
 export { default as LineChartDownIcon } from './LineChartDown'
 export { default as LineChartUpIcon } from './LineChartUp'
 export { default as LinkIcon } from './Link'
+export { default as LinkedInIcon } from './LinkedIn'
 export {
   /** @deprecated This icon misspells the brand as ‘Linkedin’, with a lowercase ‘i’. Use ‘LinkedInIcon’ instead. Will be removed on or after 2026-05-01. */
   default as LinkedinIcon,
 } from './LinkedIn'
-export { default as LinkedInIcon } from './LinkedIn'
 export { default as LinkExternalIcon } from './LinkExternal'
 export { default as LinkExternalFillIcon } from './LinkExternalFill'
 export { default as ListIcon } from './List'

--- a/packages-proprietary/react-icons/svgr.config.mjs
+++ b/packages-proprietary/react-icons/svgr.config.mjs
@@ -1,4 +1,4 @@
-import { deprecatedIconComments } from './deprecations.mjs'
+import { deprecatedIconComment } from './deprecations.mjs'
 import { indexTemplate } from './indexTemplate.mjs'
 
 // Matches SVGR’s default output, but adds the `@deprecated` JSDoc comment for
@@ -10,8 +10,7 @@ ${variables.interfaces};
 const ${variables.componentName} = (${variables.props}) => ${variables.jsx};
 ${variables.exports};
 `
-
-  const comment = deprecatedIconComments[variables.componentName.replace(/^Svg/, '')]
+  const comment = deprecatedIconComment(variables.componentName.replace(/^Svg/, ''))
   const component = statements.find((statement) => statement.type === 'VariableDeclaration')
 
   if (comment && component) {

--- a/packages-proprietary/react-icons/svgr.config.mjs
+++ b/packages-proprietary/react-icons/svgr.config.mjs
@@ -1,4 +1,4 @@
-import { deprecatedIconComment } from './deprecations.mjs'
+import { deprecatedIconComments } from './deprecations.mjs'
 import { indexTemplate } from './indexTemplate.mjs'
 
 // Matches SVGR’s default output, but adds the `@deprecated` JSDoc comment for
@@ -11,7 +11,7 @@ const ${variables.componentName} = (${variables.props}) => ${variables.jsx};
 ${variables.exports};
 `
 
-  const comment = deprecatedIconComment(variables.componentName.replace(/^Svg/, ''))
+  const comment = deprecatedIconComments[variables.componentName.replace(/^Svg/, '')]
   const component = statements.find((statement) => statement.type === 'VariableDeclaration')
 
   if (comment && component) {

--- a/packages-proprietary/react-icons/svgr.config.mjs
+++ b/packages-proprietary/react-icons/svgr.config.mjs
@@ -1,4 +1,35 @@
+import { deprecatedIconComment } from './deprecations.mjs'
 import { indexTemplate } from './indexTemplate.mjs'
+
+// Matches SVGR’s default output, but adds the `@deprecated` JSDoc comment for
+// icons listed in `deprecations.mjs` so it is reapplied on each run.
+function template(variables, { tpl }) {
+  const statements = tpl`
+${variables.imports};
+${variables.interfaces};
+const ${variables.componentName} = (${variables.props}) => ${variables.jsx};
+${variables.exports};
+`
+
+  const comment = deprecatedIconComment(variables.componentName.replace(/^Svg/, ''))
+
+  if (comment) {
+    // Two-line gap in the synthetic loc keeps a blank line above the comment.
+    const value = comment.slice(2, -2)
+    const component = statements.at(-2)
+
+    component.loc = { start: { column: 0, line: 1 }, end: { column: 0, line: 1 } }
+    component.trailingComments = [
+      {
+        loc: { start: { column: 0, line: 3 }, end: { column: 0, line: 2 + value.split('\n').length } },
+        type: 'CommentBlock',
+        value,
+      },
+    ]
+  }
+
+  return statements
+}
 
 export default {
   indexTemplate,
@@ -9,5 +40,6 @@ export default {
     'aria-hidden': 'true',
     focusable: 'false',
   },
+  template,
   typescript: true,
 }

--- a/packages-proprietary/react-icons/svgr.config.mjs
+++ b/packages-proprietary/react-icons/svgr.config.mjs
@@ -12,11 +12,11 @@ ${variables.exports};
 `
 
   const comment = deprecatedIconComment(variables.componentName.replace(/^Svg/, ''))
+  const component = statements.find((statement) => statement.type === 'VariableDeclaration')
 
-  if (comment) {
+  if (comment && component) {
     // Two-line gap in the synthetic loc keeps a blank line above the comment.
     const value = comment.slice(2, -2)
-    const component = statements.at(-2)
 
     component.loc = { start: { column: 0, line: 1 }, end: { column: 0, line: 1 } }
     component.trailingComments = [


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

Thank you for contributing to the project!
Please use this template to help us handle your PR smoothly.

## What

Makes the icon generator add the `@deprecated` JSDoc comments itself, configured in a single config file.

- `deprecations.mjs` listing the deprecated icon components (removal date + replacement) and the deprecated alias re-export (`LinkedinIcon`).
- The SVGR `template` adds the `@deprecated` comment to a component's default export for every icon in the config.
- `indexTemplate.mjs` re-exports the deprecated aliases with their comment, and now also emits the `@license` header so it is no longer added by hand after each run.

## Why

Deprecation comments were added to the generated icon files by hand, so every `pnpm run generate` overwrote them and they had to be re-added manually (the same was true for the `@license` header on `index.ts`). Moving this into configuration means the comments generation and there is one place to manage which icons are deprecated.

## How

A custom SVGR component `template` reads the config and attaches the comment to the export. To keep the generated code identical to before, the comment is attached as a trailing block comment of the component, so the generator keeps the blank line above it. The same config feeds `indexTemplate` for the deprecated alias exports.

Verified by running `pnpm run generate`: the 11 deprecated component files come back byte-for-byte identical (comment + blank line intact), and the only change is the corrected export sort order in `index.ts`. `eslint` and `pnpm run build` pass, and the `@deprecated` comments land in the published `dist/*.d.ts` types.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories _(n/a — no component changes)_
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- To confirm the behaviour: delete a `@deprecated` block from a generated icon file, run `pnpm run generate`, and it is restored.