### PR TITLE
chore(Dialog): Explain where to place the initial focus

### DIFF
--- a/storybook/src/components/Dialog/Dialog.docs.mdx
+++ b/storybook/src/components/Dialog/Dialog.docs.mdx
@@ -35,13 +35,12 @@ To close it, either call the `Dialog.close` function or add a `<form>` as in the
 
 Wrap multiple buttons in an [Action Group](/docs/components-layout-action-group--docs).
 
-### Setting the initial focus
+#### Focusing a specific element
 
 When a Dialog opens (and no element has `autofocus`), the browser places focus on the first focusable element inside it.
 In this component that is the close button, which is a safe default: the user can read the Dialog before acting.
 
-To give another element the initial focus instead, add the `autofocus` attribute to it.
-In React, set the `autoFocus` prop on that element.
+To give another element the initial focus instead, add the `autofocus` attribute to it, or the `autoFocus` prop in React.
 Use this for the single element you expect the user to act on first, such as a text field or the primary Button.
 
 Moving the initial focus has risks, so choose that element with care:

--- a/storybook/src/components/Dialog/Dialog.docs.mdx
+++ b/storybook/src/components/Dialog/Dialog.docs.mdx
@@ -37,10 +37,10 @@ Wrap multiple buttons in an [Action Group](/docs/components-layout-action-group-
 
 ### Setting the initial focus
 
-When a Dialog opens, the browser places focus on the first focusable element inside it.
+When a Dialog opens (and no element has `autofocus`), the browser places focus on the first focusable element inside it.
 In this component that is the close button, which is a safe default: the user can read the Dialog before acting.
 
-Add the `autofocus` attribute to another element to give it the initial focus instead.
+To give another element the initial focus instead, add the `autofocus` attribute to it.
 In React, set the `autoFocus` prop on that element.
 Use this for the single element you expect the user to act on first, such as a text field or the primary Button.
 

--- a/storybook/src/components/Dialog/Dialog.docs.mdx
+++ b/storybook/src/components/Dialog/Dialog.docs.mdx
@@ -35,6 +35,23 @@ To close it, either call the `Dialog.close` function or add a `<form>` as in the
 
 Wrap multiple buttons in an [Action Group](/docs/components-layout-action-group--docs).
 
+### Setting the initial focus
+
+When a Dialog opens, the browser places focus on the first focusable element inside it.
+In this component that is the close button, which is a safe default: the user can read the Dialog before acting.
+
+Add the `autofocus` attribute to another element to give it the initial focus instead.
+In React, set the `autoFocus` prop on that element.
+Use this for the single element you expect the user to act on first, such as a text field or the primary Button.
+
+Moving the initial focus has risks, so choose that element with care:
+
+- Focus that lands past the heading and body text can cause screen reader users to skip the explanation above it. Only move focus when one element clearly comes first.
+- Don’t place focus on a destructive or irreversible action. A user confirming by reflex with Enter or Space could lose data. In the confirmation example below, focus the option that keeps the user’s data safe.
+- On touchscreen devices, autofocus on a text field opens the on-screen keyboard immediately, which can hide part of the Dialog.
+
+For more information: [MDN: the dialog element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#accessibility).
+
 ## Examples
 
 ### Asking to confirm


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

## What

Adds a "Setting the initial focus" section to the Dialog documentation.
It explains:
- where focus lands by default when a Dialog opens (the close button, the first focusable element).
- how to move it with the `autofocus` attribute (the `autoFocus` prop in React) and which element to choose.
- the accessibility risks of moving focus.

## Why

The Dialog docs gave no guidance on focus management.

## How

⌨️

## Checklist

- [x] Add or update unit tests.
- [x] Add or update documentation.
- [x] Add or update stories.
- [x] Add or update exports in index.\* files.
- [x] Comment `/chromatic test` and verify visual regression tests pass.
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

[Prod docs](https://designsystem.amsterdam/?path=/docs/components-containers-dialog--docs)
[Branch deploy docs](https://designsystem.amsterdam/?path=/docs/components-containers-dialog--docs)