### PR TITLE
fix(Page Header, Pagination): Use stable default link components

### DIFF
--- a/packages/react/src/PageHeader/PageHeader.test.tsx
+++ b/packages/react/src/PageHeader/PageHeader.test.tsx
@@ -283,6 +283,46 @@ describe('PageHeader', () => {
     }
   })
 
+  it('keeps the mega menu closed after its button reappears', async () => {
+    let changeListener: (() => void) | undefined
+    const mediaQueryList = {
+      addEventListener: vi.fn((_event: string, listener: () => void) => {
+        changeListener = listener
+      }),
+      matches: false,
+      removeEventListener: vi.fn(),
+    }
+
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = vi.fn().mockReturnValue(mediaQueryList as unknown as MediaQueryList)
+
+    try {
+      const user = userEvent.setup()
+      const { container } = render(<PageHeader noMenuButtonOnWideWindow>Test</PageHeader>)
+
+      const menuButton = screen.getByRole('button', { hidden: true, name: 'Laat navigatiemenu zien' })
+      await user.click(menuButton)
+
+      // Cross the 'wide' breakpoint: the button is hidden and the menu closes
+      mediaQueryList.matches = true
+      act(() => {
+        changeListener?.()
+      })
+
+      expect(container.querySelector('.ams-page-header__mega-menu')).toHaveClass('ams-page-header__mega-menu--closed')
+
+      // Cross back below the breakpoint: the menu must stay closed, not reopen on its own
+      mediaQueryList.matches = false
+      act(() => {
+        changeListener?.()
+      })
+
+      expect(container.querySelector('.ams-page-header__mega-menu')).toHaveClass('ams-page-header__mega-menu--closed')
+    } finally {
+      window.matchMedia = originalMatchMedia
+    }
+  })
+
   it('renders a short brand name', () => {
     render(<PageHeader brandName="Application name" brandNameShort="App" />)
 

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -6,7 +6,7 @@
 import type { AnchorHTMLAttributes, ElementType, ForwardedRef, HTMLAttributes, ReactNode } from 'react'
 
 import { clsx } from 'clsx'
-import { forwardRef, useEffect, useId, useState } from 'react'
+import { forwardRef, useId, useState } from 'react'
 
 import type { IconProps } from '../Icon'
 import type { LogoBrand } from '../Logo'
@@ -18,6 +18,8 @@ import { LogoLinkContent } from './LogoLinkContent'
 import { PageHeaderGridCellNarrowWindowOnly } from './PageHeaderGridCellNarrowWindowOnly'
 import { PageHeaderMenuIcon } from './PageHeaderMenuIcon'
 import { PageHeaderMenuLink } from './PageHeaderMenuLink'
+
+const DefaultLogoLink = (props: AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...props} />
 
 export type PageHeaderProps = {
   /** The name of the application. */
@@ -66,7 +68,7 @@ const PageHeaderRoot = forwardRef(
       logoAccessibleName,
       logoBrand = 'amsterdam',
       logoLink = '/',
-      logoLinkComponent = (props: AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...props} />,
+      logoLinkComponent = DefaultLogoLink,
       logoLinkTitle,
       menuButtonIcon,
       menuButtonText = 'Menu',
@@ -79,25 +81,21 @@ const PageHeaderRoot = forwardRef(
     }: PageHeaderProps,
     ref: ForwardedRef<HTMLElement>,
   ) => {
-    const [open, setOpen] = useState(false)
+    const [menuOpen, setMenuOpen] = useState(false)
 
     const viewportHasMinWidth = useViewportHasMinWidth('wide')
     const accessibleLabelId = useId()
     const hasMegaMenu = Boolean(children)
     const hasMegaMenuOnWideWindow = hasMegaMenu && viewportHasMinWidth
 
+    // The menu is closed while its button is hidden, since there is then no control to open it.
+    const open = menuOpen && !(noMenuButtonOnWideWindow && hasMegaMenuOnWideWindow)
+
     const LogoLink = logoLinkComponent
 
     // Use short brand name if no full brand name is (invalidly) provided
     const brandNameFullOrShort = brandName || brandNameShort
     const logoLinkContentProps = { brandNameFullOrShort, brandNameShort, logoAccessibleName, logoBrand }
-
-    useEffect(() => {
-      // Close the menu when the menu button disappears
-      if (noMenuButtonOnWideWindow && hasMegaMenuOnWideWindow) {
-        setOpen(false)
-      }
-    }, [hasMegaMenuOnWideWindow, noMenuButtonOnWideWindow])
 
     return (
       <header {...restProps} className={clsx('ams-page-header', className)} ref={ref}>
@@ -132,7 +130,7 @@ const PageHeaderRoot = forwardRef(
                     aria-controls="ams-page-header-mega-menu"
                     aria-expanded={open}
                     className="ams-page-header__mega-menu-button"
-                    onClick={() => setOpen(!open)}
+                    onClick={() => setMenuOpen(!open)}
                     type="button"
                   >
                     <span aria-hidden="true" className="ams-page-header__mega-menu-button-label">

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -81,15 +81,22 @@ const PageHeaderRoot = forwardRef(
     }: PageHeaderProps,
     ref: ForwardedRef<HTMLElement>,
   ) => {
-    const [menuOpen, setMenuOpen] = useState(false)
+    const [open, setOpen] = useState(false)
 
     const viewportHasMinWidth = useViewportHasMinWidth('wide')
     const accessibleLabelId = useId()
     const hasMegaMenu = Boolean(children)
     const hasMegaMenuOnWideWindow = hasMegaMenu && viewportHasMinWidth
+    const menuButtonHidden = noMenuButtonOnWideWindow && hasMegaMenuOnWideWindow
 
-    // The menu is closed while its button is hidden, since there is then no control to open it.
-    const open = menuOpen && !(noMenuButtonOnWideWindow && hasMegaMenuOnWideWindow)
+    // Close the menu when its button is hidden, and keep it closed when the button returns: there is then no control to reopen it.
+    const [menuButtonWasHidden, setMenuButtonWasHidden] = useState(menuButtonHidden)
+    if (menuButtonHidden !== menuButtonWasHidden) {
+      setMenuButtonWasHidden(menuButtonHidden)
+      if (menuButtonHidden) {
+        setOpen(false)
+      }
+    }
 
     const LogoLink = logoLinkComponent
 
@@ -130,7 +137,7 @@ const PageHeaderRoot = forwardRef(
                     aria-controls="ams-page-header-mega-menu"
                     aria-expanded={open}
                     className="ams-page-header__mega-menu-button"
-                    onClick={() => setMenuOpen(!open)}
+                    onClick={() => setOpen((wasOpen) => !wasOpen)}
                     type="button"
                   >
                     <span aria-hidden="true" className="ams-page-header__mega-menu-button-label">

--- a/packages/react/src/Pagination/Pagination.tsx
+++ b/packages/react/src/Pagination/Pagination.tsx
@@ -14,6 +14,8 @@ import { getRange } from './getRange'
 import { LinkItem } from './LinkItem'
 import { Spacer } from './Spacer'
 
+const DefaultLink = (props: AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...props} />
+
 export type PaginationProps = {
   /** The accessible name for the Pagination component. */
   readonly accessibleName?: string
@@ -53,7 +55,7 @@ export const Pagination = forwardRef(
       accessibleName,
       accessibleNameId,
       className,
-      linkComponent = (props: AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...props} />,
+      linkComponent = DefaultLink,
       linkTemplate,
       maxVisiblePages = 7,
       nextAccessibleName,


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

## What

`Pagination` and `PageHeader` define their default link inline — `linkComponent` / `logoLinkComponent` default to `(props) => <a {...props} />` — which React recreates on every render, remounting the links and losing focus and other state. Both now default to a stable module-level component.

In `PageHeader`, removing the inline default also lets `eslint-plugin-react-hooks` analyse the component (the inline component made the React Compiler bail out), which surfaced a pre-existing `set-state-in-effect` violation: the menu was closed by resetting state in an effect. That is replaced with derived state.

## Why

A component defined inline gets a new type every render, forcing React to unmount and remount its subtree — the anti-pattern the routing-libraries guide warns against (added in #2687). It remounts every Pagination page link and the PageHeader logo link. The `set-state-in-effect` violation (which can cause cascading renders) was previously hidden because the inline default made the linter bail out of the component.

## How

- `Pagination`: add a module-level `DefaultLink` and use it as the `linkComponent` default.
- `PageHeader`: add a module-level `DefaultLogoLink` and use it as the `logoLinkComponent` default.
- `PageHeader`: derive the menu state during render — `const open = menuOpen && !(noMenuButtonOnWideWindow && hasMegaMenuOnWideWindow)` — and remove the `useEffect` that called `setOpen(false)`. Behaviour is unchanged: the menu still closes when its button disappears, verified by the existing “closes the mega menu when the screen width passes the breakpoint” test.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

This is a behaviour-preserving refactor — same markup; the defaults just become stable references, and the PageHeader menu-close logic moves from an effect to derived state. The existing unit tests cover it, so no new tests, docs, stories, or exports were needed.

Follow-up to #2687: it addresses the inline-default remount flagged in that PR’s review and the `set-state-in-effect` that surfaced once the inline default was removed.