### PR TITLE
fix(tokens): Restore real values to deprecated tokens

### DIFF
--- a/packages-proprietary/react-icons/deprecations.mjs
+++ b/packages-proprietary/react-icons/deprecations.mjs
@@ -44,8 +44,7 @@ for (const [iconName, { removeOnOrAfter }] of Object.entries(deprecatedIcons)) {
 }
 
 /**
- * Builds the `@deprecated` JSDoc comment for an icon, or `undefined` if it is
- * not deprecated.
+ * Builds the `@deprecated` JSDoc comment for an icon, or `undefined` if it is not deprecated.
  *
  * @param {string} iconName File basename of the icon, e.g. `TrashBin`.
  */

--- a/packages-proprietary/tokens/README.md
+++ b/packages-proprietary/tokens/README.md
@@ -187,7 +187,7 @@ End every message with a removal date: `Will be removed on or after YYYY-MM-DD.`
 Keep the old name intact during the deprecation window, while adding the new name for the same value.
 Wire the rename through a `var()` fallback, so downstream overrides of the old name keep working.
 
-1. Point the old token’s `$value` at the replacement, so it resolves to the same value:
+1. Point the deprecated token’s `$value` at the replacement, so it resolves to the same value:
 
 ```jsonc
 "medium": {
@@ -198,7 +198,7 @@ Wire the rename through a `var()` fallback, so downstream overrides of the old n
 }
 ```
 
-2. In the component CSS, reference the old token first, with the replacement as the fallback:
+2. In the component CSS, reference the deprecated token first, with the replacement as the fallback:
    Add an inline deprecation comment next to each use of the token in the component stylesheet.
 
 ```css
@@ -209,9 +209,8 @@ padding-inline: var(
 );
 ```
 
-3. If a theme overrides the replacement (for example Compact Mode), copy the old token’s entry from step 2 into that theme’s tokens file too.
-   Until the old token is removed, every theme that overrides the replacement must also declare the deprecated token.
-   If Compact Mode overrides the replacement but does not also declare the deprecated token, the deprecated token keeps the Spacious value, which the component then reads before the fallback.
+3. If a theme overrides the replacement (for example Compact Mode), copy the deprecated token’s entry from step 2 into that theme’s tokens file too.
+   If the theme does not also declare the deprecated token, it keeps its base value, which the component stylesheet then reads before the theme’s fallback.
 
 ### Removing a token
 

--- a/packages-proprietary/tokens/README.md
+++ b/packages-proprietary/tokens/README.md
@@ -199,14 +199,10 @@ Wire the rename through a `var()` fallback, so downstream overrides of the old n
 ```
 
 2. In the component CSS, reference the deprecated token first, with the replacement as the fallback:
-   Add an inline deprecation comment next to each use of the token in the component stylesheet.
+   Mark the deprecation in the component stylesheet as well; no need to copy the details from the tokens file.
 
 ```css
-padding-inline: var(
-  --ams-grid-medium-padding-inline
-    /* @deprecated Use `--ams-grid-vi-medium-padding-inline` instead. Will be removed on or after 2026-10-20. */,
-  var(--ams-grid-vi-medium-padding-inline)
-);
+padding-inline: var(--ams-grid-medium-padding-inline /* @deprecated */, var(--ams-grid-vi-medium-padding-inline));
 ```
 
 3. If a theme overrides the replacement (for example Compact Mode), overriding the replacement token is enough because the deprecated token references it.

--- a/packages-proprietary/tokens/README.md
+++ b/packages-proprietary/tokens/README.md
@@ -236,12 +236,28 @@ padding-inline: var(
 
 This builds to `--ams-grid-medium-padding-inline: var(--ams-grid-vi-medium-padding-inline)`, so the deprecated token resolves to exactly the same value as its replacement.
 
+3. If the replacement token is overridden in a theme layer (for example Compact Mode), add the deprecated token to that layer’s tokens file as well, pointing at the same replacement:
+
+```jsonc
+// grid.compact.tokens.json
+"medium": {
+  "padding-inline": {
+    "$deprecated": "Use `ams.grid.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
+    "$value": "{ams.grid.vi-medium.padding-inline}"
+  }
+}
+```
+
+CSS substitutes `var()` inside a custom property at the scope where that property is _declared_, not where it is read.
+A deprecated alias declared only on `:root` / `.ams-theme` is frozen to the base value, so a Compact Mode override of the replacement (on `.ams-theme--compact`) would not reach it, and the component — which reads the deprecated token first — would render the default value in Compact Mode.
+Re-declaring the alias inside the layer makes it re-resolve to that layer’s value.
+
 Why a reference? The deprecated token must keep a real value, because consumers may read the custom property directly — `var(--ams-grid-medium-padding-inline)`, without our fallback — for example to line their own elements up with the Grid’s padding.
 A reference gives them that value while everything else keeps working:
 
 - The component’s `var(--deprecated, <fallback>)` resolves to the same value, so the rendered result is unchanged.
-- Overrides keep cascading: because the deprecated token points at the replacement, an override of the replacement — such as a Compact Mode override of `--ams-grid-vi-medium-padding-inline` — flows through to the deprecated token automatically.
 - Downstream overrides of the old name still take precedence, because the component CSS reads it first.
+- An override of the replacement flows through only when it is set at the same scope as the alias (for example globally on `:root`); a scoped theme override such as Compact Mode needs the alias re-declared in that layer, as in step 3.
 
 **Never set the deprecated token’s `$value` to `initial`.**
 For a custom property, `initial` is the [guaranteed-invalid value](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/var#syntax): it makes the `var(--deprecated, <fallback>)` fallback fire, so our own component styles look fine, but any consumer reading the deprecated custom property directly gets the property’s initial value instead — for example `0` for `padding-inline` — which silently breaks their layout.

--- a/packages-proprietary/tokens/README.md
+++ b/packages-proprietary/tokens/README.md
@@ -176,95 +176,61 @@ Note that redefining the value of a token is a much better approach than redecla
 
 ## Deprecating tokens
 
-We deprecate tokens using the DTCG `$deprecated` field. The [official definition](https://www.designtokens.org/tr/drafts/format/#deprecated) allows `$deprecated` to be `true`, `false` or a string explanation.
+A deprecated token keeps working until it is removed, so it must always hold a real value.
 
-In ADS, `$deprecated` should be a string so consumers always get a reason + migration path.
+We provide a reason and a migration path through the DTCG `$deprecated` field.
+When there is a direct replacement, start the message with ``Use `<replacement-token>` instead.``
+End every message with a removal date: `Will be removed on or after YYYY-MM-DD.`
 
-A deprecated token keeps working until it is removed, so it must always hold a real value — never `initial` or another guaranteed-invalid value.
-Consumers may read the custom property directly, and an invalid value resolves to the CSS property’s initial value (for example `0`), silently breaking their layout.
+### Renaming a token
 
-### Deprecation message format
+Keep the old name intact during the deprecation window, while adding the new name for the same value.
+Wire the rename through a `var()` fallback, so downstream overrides of the old name keep working.
 
-- Always include a removal date: `Will be removed on or after YYYY-MM-DD.`
-- If there is a direct replacement, start with: ``Use `<replacement-token>` instead.``
-
-### Simple deprecation (no fallback)
-
-If a deprecated token is still used directly, keep its existing `$value` until removal.
-Also add a deprecation comment next to the token usage in the consuming CSS.
-
-Token JSON:
+1. Point the old token’s `$value` at the replacement, so it resolves to the same value:
 
 ```jsonc
-"row-gap": {
-  "$deprecated": "Whitespace is now applied through the `ams.description-list.*.margin-block-end` tokens. Will be removed on or after 2026-10-20.",
-  "$value": "0"
+"medium": {
+  "padding-inline": {
+    "$deprecated": "Use `ams.grid.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
+    "$value": "{ams.grid.vi-medium.padding-inline}"
+  }
 }
 ```
 
-Component CSS:
-
-```css
-row-gap: var(--ams-description-list-row-gap); /* This token is @deprecated. Will be removed on or after 2026-10-20. */
-```
-
-### Renames that use `var()` fallback
-
-When a token is renamed but we still want (downstream) overrides of the old token to keep working, we implement the rename through CSS `var()` fallback.
-
-Always add an inline deprecation comment next to the deprecated custom property inside the `var()` call.
-
-1. Update the component CSS to reference the deprecated token first, and the replacement token as the fallback:
+2. In the component CSS, reference the old token first, with the replacement as the fallback:
+   Add an inline deprecation comment next to each use of the token in the component stylesheet.
 
 ```css
 padding-inline: var(
-  --ams-grid-medium-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+  --ams-grid-medium-padding-inline
+    /* @deprecated Use `--ams-grid-vi-medium-padding-inline` instead. Will be removed on or after 2026-10-20. */,
   var(--ams-grid-vi-medium-padding-inline)
 );
 ```
 
-2. In the token JSON, mark the old token as deprecated and set its `$value` to a reference to the replacement token:
+3. If a theme overrides the replacement (for example Compact Mode), copy the old token’s entry from step 2 into that theme’s tokens file too.
+   Until the old token is removed, every theme that overrides the replacement must also declare the deprecated token.
+   If Compact Mode overrides the replacement but does not also declare the deprecated token, the deprecated token keeps the Spacious value, which the component then reads before the fallback.
+
+### Removing a token
+
+A removal will always be a breaking change, so it must be part of a major release.
+Plan the deprecation early, as it must stay in place for at least six months.
+The value of the token cannot change during the deprecation window, as we consider visual consequences for downstream users a breaking change.
 
 ```jsonc
-"medium": {
-  "padding-inline": {
-    "$deprecated": "Use `ams.grid.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
-    "$value": "{ams.grid.vi-medium.padding-inline}"
-  }
+"row-gap": {
+  "$deprecated": "Whitespace is now applied through the `ams.description-list.*.margin-block-end` tokens. Will be removed on or after 2026-10-20.",
+  "$value": "(unchanged value)"
 }
 ```
 
-This builds to `--ams-grid-medium-padding-inline: var(--ams-grid-vi-medium-padding-inline)`, so the deprecated token resolves to exactly the same value as its replacement.
+Surface the deprecation in the stylesheet as well.
 
-3. If the replacement token is overridden in a theme layer (for example Compact Mode), add the deprecated token to that layer’s tokens file as well, pointing at the same replacement:
-
-```jsonc
-// grid.compact.tokens.json
-"medium": {
-  "padding-inline": {
-    "$deprecated": "Use `ams.grid.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
-    "$value": "{ams.grid.vi-medium.padding-inline}"
-  }
-}
+```css
+row-gap: var(--ams-description-list-row-gap); /* @deprecated Will be removed on or after 2026-10-20. */
 ```
-
-CSS substitutes `var()` inside a custom property at the scope where that property is _declared_, not where it is read.
-A deprecated alias declared only on `:root` / `.ams-theme` is frozen to the base value, so a Compact Mode override of the replacement (on `.ams-theme--compact`) would not reach it, and the component — which reads the deprecated token first — would render the default value in Compact Mode.
-Re-declaring the alias inside the layer makes it re-resolve to that layer’s value.
-
-Why a reference? The deprecated token must keep a real value, because consumers may read the custom property directly — `var(--ams-grid-medium-padding-inline)`, without our fallback — for example to line their own elements up with the Grid’s padding.
-A reference gives them that value while everything else keeps working:
-
-- The component’s `var(--deprecated, <fallback>)` resolves to the same value, so the rendered result is unchanged.
-- Downstream overrides of the old name still take precedence, because the component CSS reads it first.
-- An override of the replacement flows through only when it is set at the same scope as the alias (for example globally on `:root`); a scoped theme override such as Compact Mode needs the alias re-declared in that layer, as in step 3.
-
-**Never set the deprecated token’s `$value` to `initial`.**
-For a custom property, `initial` is the [guaranteed-invalid value](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/var#syntax): it makes the `var(--deprecated, <fallback>)` fallback fire, so our own component styles look fine, but any consumer reading the deprecated custom property directly gets the property’s initial value instead — for example `0` for `padding-inline` — which silently breaks their layout.
-
-### Deprecations without a 1:1 replacement
-
-If there is no 1:1 replacement (design/behavior changed), keep the existing `$value` until removal and update the consuming CSS/markup before deleting the token.
 
 ## Token types
 

--- a/packages-proprietary/tokens/README.md
+++ b/packages-proprietary/tokens/README.md
@@ -209,8 +209,8 @@ padding-inline: var(
 );
 ```
 
-3. If a theme overrides the replacement (for example Compact Mode), copy the deprecated token’s entry from step 2 into that theme’s tokens file too.
-   If the theme does not also declare the deprecated token, it keeps its base value, which the component stylesheet then reads before the theme’s fallback.
+3. If a theme overrides the replacement (for example Compact Mode), overriding the replacement token is enough because the deprecated token references it.
+   Only repeat the deprecated token in a theme tokens file if you need to override the deprecated token itself for legacy consumers.
 
 ### Removing a token
 

--- a/packages-proprietary/tokens/README.md
+++ b/packages-proprietary/tokens/README.md
@@ -180,6 +180,9 @@ We deprecate tokens using the DTCG `$deprecated` field. The [official definition
 
 In ADS, `$deprecated` should be a string so consumers always get a reason + migration path.
 
+A deprecated token keeps working until it is removed, so it must always hold a real value — never `initial` or another guaranteed-invalid value.
+Consumers may read the custom property directly, and an invalid value resolves to the CSS property’s initial value (for example `0`), silently breaking their layout.
+
 ### Deprecation message format
 
 - Always include a removal date: `Will be removed on or after YYYY-MM-DD.`
@@ -220,20 +223,28 @@ padding-inline: var(
 );
 ```
 
-2. In the token JSON, mark the old token as deprecated and set its `$value` to the CSS-wide keyword `initial`:
+2. In the token JSON, mark the old token as deprecated and set its `$value` to a reference to the replacement token:
 
 ```jsonc
 "medium": {
   "padding-inline": {
     "$deprecated": "Use `ams.grid.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
-    "$value": "initial"
+    "$value": "{ams.grid.vi-medium.padding-inline}"
   }
 }
 ```
 
-Why `initial`? Per CSS `var()` rules, when a custom property is [not set or is set to a CSS-wide keyword](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/var#syntax) like `initial`, the fallback value is used. This makes the replacement token the default while keeping the deprecated token visible and overrideable.
+This builds to `--ams-grid-medium-padding-inline: var(--ams-grid-vi-medium-padding-inline)`, so the deprecated token resolves to exactly the same value as its replacement.
 
-Only apply this `initial` rule when the deprecated token is used in a `var(--deprecated, <fallback>)` pattern.
+Why a reference? The deprecated token must keep a real value, because consumers may read the custom property directly — `var(--ams-grid-medium-padding-inline)`, without our fallback — for example to line their own elements up with the Grid’s padding.
+A reference gives them that value while everything else keeps working:
+
+- The component’s `var(--deprecated, <fallback>)` resolves to the same value, so the rendered result is unchanged.
+- Overrides keep cascading: because the deprecated token points at the replacement, an override of the replacement — such as a Compact Mode override of `--ams-grid-vi-medium-padding-inline` — flows through to the deprecated token automatically.
+- Downstream overrides of the old name still take precedence, because the component CSS reads it first.
+
+**Never set the deprecated token’s `$value` to `initial`.**
+For a custom property, `initial` is the [guaranteed-invalid value](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/var#syntax): it makes the `var(--deprecated, <fallback>)` fallback fire, so our own component styles look fine, but any consumer reading the deprecated custom property directly gets the property’s initial value instead — for example `0` for `padding-inline` — which silently breaks their layout.
 
 ### Deprecations without a 1:1 replacement
 

--- a/packages-proprietary/tokens/src/components/ams/description-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/description-list.tokens.json
@@ -9,7 +9,7 @@
       },
       "column-gap": {
         "$deprecated": "Use `ams.description-list.vi-medium.column-gap` instead. Will be removed on or after 2026-10-20.",
-        "$value": "initial",
+        "$value": "{ams.description-list.vi-medium.column-gap}",
         "$extensions": {
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
@@ -130,7 +130,7 @@
       "narrow": {
         "grid-template-columns": {
           "$deprecated": "Use `ams.description-list.vi-medium.narrow.grid-template-columns` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.description-list.vi-medium.narrow.grid-template-columns}",
           "$extensions": {
             "nl.amsterdam.type": "gridTemplateColumns"
           }
@@ -139,7 +139,7 @@
       "medium": {
         "grid-template-columns": {
           "$deprecated": "Use `ams.description-list.vi-medium.medium.grid-template-columns` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.description-list.vi-medium.medium.grid-template-columns}",
           "$extensions": {
             "nl.amsterdam.type": "gridTemplateColumns"
           }
@@ -148,7 +148,7 @@
       "wide": {
         "grid-template-columns": {
           "$deprecated": "Use `ams.description-list.vi-medium.wide.grid-template-columns` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.description-list.vi-medium.wide.grid-template-columns}",
           "$extensions": {
             "nl.amsterdam.type": "gridTemplateColumns"
           }

--- a/packages-proprietary/tokens/src/components/ams/dialog.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/dialog.tokens.json
@@ -14,7 +14,7 @@
         }
       },
       "border-radius": {
-        "$value": "initial",
+        "$value": "0",
         "$extensions": {
           "nl.amsterdam.type": "borderRadius"
         }
@@ -32,7 +32,7 @@
         }
       },
       "box-shadow": {
-        "$value": "initial",
+        "$value": "none",
         "$extensions": {
           "nl.amsterdam.type": "shadow"
         }

--- a/packages-proprietary/tokens/src/components/ams/dialog.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/dialog.tokens.json
@@ -14,7 +14,7 @@
         }
       },
       "border-radius": {
-        "$value": "0",
+        "$value": "initial",
         "$extensions": {
           "nl.amsterdam.type": "borderRadius"
         }
@@ -32,7 +32,7 @@
         }
       },
       "box-shadow": {
-        "$value": "none",
+        "$value": "initial",
         "$extensions": {
           "nl.amsterdam.type": "shadow"
         }

--- a/packages-proprietary/tokens/src/components/ams/dialog.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/dialog.tokens.json
@@ -72,12 +72,12 @@
       "medium": {
         "inline-size": {
           "$deprecated": "Use `ams.dialog.vi-medium.inline-size` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.dialog.vi-medium.inline-size}",
           "$type": "dimension"
         },
         "max-block-size": {
           "$deprecated": "Use `ams.dialog.vi-medium.max-block-size` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.dialog.vi-medium.max-block-size}",
           "$type": "dimension"
         }
       },
@@ -126,7 +126,7 @@
         "medium": {
           "padding-block": {
             "$deprecated": "Use `ams.dialog.header.vi-medium.padding-block` instead. Will be removed on or after 2026-10-20.",
-            "$value": "initial",
+            "$value": "{ams.dialog.header.vi-medium.padding-block}",
             "$type": "dimension",
             "$extensions": {
               "nl.amsterdam.subtype": "space"
@@ -134,7 +134,7 @@
           },
           "padding-inline": {
             "$deprecated": "Use `ams.dialog.header.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
-            "$value": "initial",
+            "$value": "{ams.dialog.header.vi-medium.padding-inline}",
             "$type": "dimension",
             "$extensions": {
               "nl.amsterdam.subtype": "space"
@@ -176,7 +176,7 @@
         "medium": {
           "padding-inline": {
             "$deprecated": "Use `ams.dialog.body.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
-            "$value": "initial",
+            "$value": "{ams.dialog.body.vi-medium.padding-inline}",
             "$type": "dimension",
             "$extensions": {
               "nl.amsterdam.subtype": "space"
@@ -211,7 +211,7 @@
         "medium": {
           "padding-block": {
             "$deprecated": "Use `ams.dialog.footer.vi-medium.padding-block` instead. Will be removed on or after 2026-10-20.",
-            "$value": "initial",
+            "$value": "{ams.dialog.footer.vi-medium.padding-block}",
             "$type": "dimension",
             "$extensions": {
               "nl.amsterdam.subtype": "space"
@@ -219,7 +219,7 @@
           },
           "padding-inline": {
             "$deprecated": "Use `ams.dialog.footer.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
-            "$value": "initial",
+            "$value": "{ams.dialog.footer.vi-medium.padding-inline}",
             "$type": "dimension",
             "$extensions": {
               "nl.amsterdam.subtype": "space"

--- a/packages-proprietary/tokens/src/components/ams/grid.compact.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/grid.compact.tokens.json
@@ -8,26 +8,6 @@
           "nl.amsterdam.type": "dimension"
         }
       },
-      "medium": {
-        "padding-inline": {
-          "$deprecated": "Use `ams.grid.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
-          "$value": "{ams.grid.vi-medium.padding-inline}",
-          "$extensions": {
-            "nl.amsterdam.subtype": "space",
-            "nl.amsterdam.type": "dimension"
-          }
-        }
-      },
-      "wide": {
-        "padding-inline": {
-          "$deprecated": "Use `ams.grid.vi-wide.padding-inline` instead. Will be removed on or after 2026-10-20.",
-          "$value": "{ams.grid.vi-wide.padding-inline}",
-          "$extensions": {
-            "nl.amsterdam.subtype": "space",
-            "nl.amsterdam.type": "dimension"
-          }
-        }
-      },
       "vi-medium": {
         "padding-inline": {
           "$value": "{ams.space.l}",

--- a/packages-proprietary/tokens/src/components/ams/grid.compact.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/grid.compact.tokens.json
@@ -8,6 +8,26 @@
           "nl.amsterdam.type": "dimension"
         }
       },
+      "medium": {
+        "padding-inline": {
+          "$deprecated": "Use `ams.grid.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
+          "$value": "{ams.grid.vi-medium.padding-inline}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        }
+      },
+      "wide": {
+        "padding-inline": {
+          "$deprecated": "Use `ams.grid.vi-wide.padding-inline` instead. Will be removed on or after 2026-10-20.",
+          "$value": "{ams.grid.vi-wide.padding-inline}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        }
+      },
       "vi-medium": {
         "padding-inline": {
           "$value": "{ams.space.l}",

--- a/packages-proprietary/tokens/src/components/ams/grid.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/grid.tokens.json
@@ -123,7 +123,7 @@
       },
       "cell": {
         "background-color": {
-          "$value": "initial",
+          "$value": "transparent",
           "$extensions": {
             "nl.amsterdam.type": "color"
           }
@@ -135,13 +135,13 @@
           "$value": "inline-size"
         },
         "padding-block": {
-          "$value": "initial",
+          "$value": "0",
           "$extensions": {
             "nl.amsterdam.type": "dimension"
           }
         },
         "padding-inline": {
-          "$value": "initial",
+          "$value": "0",
           "$extensions": {
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/grid.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/grid.tokens.json
@@ -123,7 +123,7 @@
       },
       "cell": {
         "background-color": {
-          "$value": "transparent",
+          "$value": "initial",
           "$extensions": {
             "nl.amsterdam.type": "color"
           }
@@ -135,13 +135,13 @@
           "$value": "inline-size"
         },
         "padding-block": {
-          "$value": "0",
+          "$value": "initial",
           "$extensions": {
             "nl.amsterdam.type": "dimension"
           }
         },
         "padding-inline": {
-          "$value": "0",
+          "$value": "initial",
           "$extensions": {
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/grid.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/grid.tokens.json
@@ -68,12 +68,12 @@
       "medium": {
         "column-count": {
           "$deprecated": "Use `ams.grid.vi-medium.column-count` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.grid.vi-medium.column-count}",
           "$type": "number"
         },
         "padding-inline": {
           "$deprecated": "Use `ams.grid.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.grid.vi-medium.padding-inline}",
           "$extensions": {
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
@@ -83,12 +83,12 @@
       "wide": {
         "column-count": {
           "$deprecated": "Use `ams.grid.vi-wide.column-count` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.grid.vi-wide.column-count}",
           "$type": "number"
         },
         "padding-inline": {
           "$deprecated": "Use `ams.grid.vi-wide.padding-inline` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.grid.vi-wide.padding-inline}",
           "$extensions": {
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"

--- a/packages-proprietary/tokens/src/components/ams/menu.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/menu.tokens.json
@@ -42,12 +42,12 @@
       "wide": {
         "max-inline-size": {
           "$deprecated": "Use `ams.menu.vi-wide.max-inline-size` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.menu.vi-wide.max-inline-size}",
           "$type": "dimension"
         },
         "padding-block": {
           "$deprecated": "Use `ams.menu.vi-wide.padding-block` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.menu.vi-wide.padding-block}",
           "$type": "dimension",
           "$extensions": {
             "nl.amsterdam.subtype": "space"
@@ -55,7 +55,7 @@
         },
         "padding-inline": {
           "$deprecated": "Use `ams.menu.vi-wide.padding-inline` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.menu.vi-wide.padding-inline}",
           "$type": "dimension",
           "$extensions": {
             "nl.amsterdam.subtype": "space"
@@ -157,7 +157,7 @@
         "wide": {
           "gap": {
             "$deprecated": "Use `ams.menu.link.vi-wide.gap` instead. Will be removed on or after 2026-10-20.",
-            "$value": "initial",
+            "$value": "{ams.menu.link.vi-wide.gap}",
             "$type": "dimension",
             "$extensions": {
               "nl.amsterdam.subtype": "space"

--- a/packages-proprietary/tokens/src/components/ams/page-footer.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/page-footer.tokens.json
@@ -39,7 +39,7 @@
         "medium": {
           "padding-inline": {
             "$deprecated": "Use `ams.page-footer.menu.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
-            "$value": "initial",
+            "$value": "{ams.page-footer.menu.vi-medium.padding-inline}",
             "$extensions": {
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
@@ -49,7 +49,7 @@
         "wide": {
           "padding-inline": {
             "$deprecated": "Use `ams.page-footer.menu.vi-wide.padding-inline` instead. Will be removed on or after 2026-10-20.",
-            "$value": "initial",
+            "$value": "{ams.page-footer.menu.vi-wide.padding-inline}",
             "$extensions": {
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"

--- a/packages-proprietary/tokens/src/components/ams/page-header.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/page-header.tokens.json
@@ -31,7 +31,7 @@
       "medium": {
         "padding-inline": {
           "$deprecated": "Use `ams.page-header.vi-medium.padding-inline` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.page-header.vi-medium.padding-inline}",
           "$extensions": {
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
@@ -41,7 +41,7 @@
       "wide": {
         "padding-inline": {
           "$deprecated": "Use `ams.page-header.vi-wide.padding-inline` instead. Will be removed on or after 2026-10-20.",
-          "$value": "initial",
+          "$value": "{ams.page-header.vi-wide.padding-inline}",
           "$extensions": {
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"

--- a/packages-proprietary/tokens/src/components/ams/progress-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/progress-list.tokens.json
@@ -128,7 +128,7 @@
         "medium": {
           "gap": {
             "$deprecated": "Use `ams.progress-list.step.vi-medium.gap` instead. Will be removed on or after 2026-10-20.",
-            "$value": "initial",
+            "$value": "{ams.progress-list.step.vi-medium.gap}",
             "$type": "dimension",
             "$extensions": {
               "nl.amsterdam.subtype": "space"
@@ -315,7 +315,7 @@
             "medium": {
               "margin-inline-end": {
                 "$deprecated": "Use `ams.progress-list.substeps.step.indicator.vi-medium.margin-inline-end` instead. Will be removed on or after 2026-10-20.",
-                "$value": "initial",
+                "$value": "{ams.progress-list.substeps.step.indicator.vi-medium.margin-inline-end}",
                 "$type": "dimension",
                 "$extensions": {
                   "nl.amsterdam.subtype": "space"

--- a/packages/css/src/components/breakout/breakout.scss
+++ b/packages/css/src/components/breakout/breakout.scss
@@ -119,21 +119,13 @@ $ams-breakout-row-span-max: 4;
 
   @media (min-width: $ams-breakpoint-medium) {
     margin-inline: calc(
-      var(
-          --ams-grid-medium-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-          var(--ams-grid-vi-medium-padding-inline)
-        ) *
-        -1
+      var(--ams-grid-medium-padding-inline /* @deprecated */, var(--ams-grid-vi-medium-padding-inline)) * -1
     );
   }
 
   @media (min-width: $ams-breakpoint-wide) {
     margin-inline: calc(
-      var(
-          --ams-grid-wide-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-          var(--ams-grid-vi-wide-padding-inline)
-        ) *
-        -1
+      var(--ams-grid-wide-padding-inline /* @deprecated */, var(--ams-grid-vi-wide-padding-inline)) * -1
     );
   }
 

--- a/packages/css/src/components/description-list/description-list.scss
+++ b/packages/css/src/components/description-list/description-list.scss
@@ -28,7 +28,7 @@ $ams-description-list-breakpoint: 32rem;
   font-family: var(--ams-description-list-font-family);
   font-size: var(--ams-description-list-font-size);
   line-height: var(--ams-description-list-line-height);
-  row-gap: var(--ams-description-list-row-gap); /* This token is @deprecated. Will be removed on or after 2026-10-20. */
+  row-gap: var(--ams-description-list-row-gap); /* @deprecated */
 
   @include hyphenation;
   @include text-rendering;
@@ -39,7 +39,7 @@ $ams-description-list-breakpoint: 32rem;
   .ams-description-list__section {
     align-items: start;
     column-gap: var(
-      --ams-description-list-column-gap /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-description-list-column-gap /* @deprecated */,
       var(--ams-description-list-vi-medium-column-gap)
     );
     display: grid;
@@ -49,8 +49,7 @@ $ams-description-list-breakpoint: 32rem;
   .ams-description-list--narrow,
   .ams-description-list--narrow .ams-description-list__section {
     grid-template-columns: var(
-      --ams-description-list-narrow-grid-template-columns
-        /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-description-list-narrow-grid-template-columns /* @deprecated */,
       var(--ams-description-list-vi-medium-narrow-grid-template-columns)
     );
   }
@@ -58,8 +57,7 @@ $ams-description-list-breakpoint: 32rem;
   .ams-description-list--medium,
   .ams-description-list--medium .ams-description-list__section {
     grid-template-columns: var(
-      --ams-description-list-medium-grid-template-columns
-        /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-description-list-medium-grid-template-columns /* @deprecated */,
       var(--ams-description-list-vi-medium-medium-grid-template-columns)
     );
   }
@@ -67,8 +65,7 @@ $ams-description-list-breakpoint: 32rem;
   .ams-description-list--wide,
   .ams-description-list--wide .ams-description-list__section {
     grid-template-columns: var(
-      --ams-description-list-wide-grid-template-columns
-        /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-description-list-wide-grid-template-columns /* @deprecated */,
       var(--ams-description-list-vi-medium-wide-grid-template-columns)
     );
   }

--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -38,12 +38,9 @@ so do not apply these styles without an `open` attribute. */
   }
 
   @media (min-width: $ams-breakpoint-medium) {
-    inline-size: var(
-      --ams-dialog-medium-inline-size /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-      var(--ams-dialog-vi-medium-inline-size)
-    );
+    inline-size: var(--ams-dialog-medium-inline-size /* @deprecated */, var(--ams-dialog-vi-medium-inline-size));
     max-block-size: var(
-      --ams-dialog-medium-max-block-size /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-dialog-medium-max-block-size /* @deprecated */,
       var(--ams-dialog-vi-medium-max-block-size)
     );
   }
@@ -74,11 +71,11 @@ so do not apply these styles without an `open` attribute. */
 
   @media (min-width: $ams-breakpoint-medium) {
     padding-block: var(
-      --ams-dialog-header-medium-padding-block /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-dialog-header-medium-padding-block /* @deprecated */,
       var(--ams-dialog-header-vi-medium-padding-block)
     );
     padding-inline: var(
-      --ams-dialog-header-medium-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-dialog-header-medium-padding-inline /* @deprecated */,
       var(--ams-dialog-header-vi-medium-padding-inline)
     );
   }
@@ -93,7 +90,7 @@ so do not apply these styles without an `open` attribute. */
 
   @media (min-width: $ams-breakpoint-medium) {
     padding-inline: var(
-      --ams-dialog-body-medium-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-dialog-body-medium-padding-inline /* @deprecated */,
       var(--ams-dialog-body-vi-medium-padding-inline)
     );
   }
@@ -112,11 +109,11 @@ so do not apply these styles without an `open` attribute. */
 
   @media (min-width: $ams-breakpoint-medium) {
     padding-block: var(
-      --ams-dialog-footer-medium-padding-block /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-dialog-footer-medium-padding-block /* @deprecated */,
       var(--ams-dialog-footer-vi-medium-padding-block)
     );
     padding-inline: var(
-      --ams-dialog-footer-medium-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-dialog-footer-medium-padding-inline /* @deprecated */,
       var(--ams-dialog-footer-vi-medium-padding-inline)
     );
   }

--- a/packages/css/src/components/grid/_mixins.scss
+++ b/packages/css/src/components/grid/_mixins.scss
@@ -14,30 +14,18 @@
 
   @media (min-width: $ams-breakpoint-medium) {
     grid-template-columns: repeat(
-      var(
-        --ams-grid-medium-column-count /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-        var(--ams-grid-vi-medium-column-count)
-      ),
+      var(--ams-grid-medium-column-count /* @deprecated */, var(--ams-grid-vi-medium-column-count)),
       1fr
     );
-    padding-inline: var(
-      --ams-grid-medium-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-      var(--ams-grid-vi-medium-padding-inline)
-    );
+    padding-inline: var(--ams-grid-medium-padding-inline /* @deprecated */, var(--ams-grid-vi-medium-padding-inline));
   }
 
   @media (min-width: $ams-breakpoint-wide) {
     grid-template-columns: repeat(
-      var(
-        --ams-grid-wide-column-count /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-        var(--ams-grid-vi-wide-column-count)
-      ),
+      var(--ams-grid-wide-column-count /* @deprecated */, var(--ams-grid-vi-wide-column-count)),
       1fr
     );
-    padding-inline: var(
-      --ams-grid-wide-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-      var(--ams-grid-vi-wide-padding-inline)
-    );
+    padding-inline: var(--ams-grid-wide-padding-inline /* @deprecated */, var(--ams-grid-vi-wide-padding-inline));
   }
 }
 

--- a/packages/css/src/components/menu/menu.scss
+++ b/packages/css/src/components/menu/menu.scss
@@ -25,33 +25,17 @@
 
   @media (min-width: $ams-breakpoint-medium) {
     margin-inline: calc(
-      var(
-          --ams-grid-medium-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-          var(--ams-grid-vi-medium-padding-inline)
-        ) *
-        -1
+      var(--ams-grid-medium-padding-inline /* @deprecated */, var(--ams-grid-vi-medium-padding-inline)) * -1
     );
-    padding-inline: var(
-      --ams-grid-medium-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-      var(--ams-grid-vi-medium-padding-inline)
-    );
+    padding-inline: var(--ams-grid-medium-padding-inline /* @deprecated */, var(--ams-grid-vi-medium-padding-inline));
   }
 
   @media (min-width: $ams-breakpoint-wide) {
     display: none;
     margin-inline: 0; // Override negative margin above.
-    max-inline-size: var(
-      --ams-menu-wide-max-inline-size /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-      var(--ams-menu-vi-wide-max-inline-size)
-    );
-    padding-block: var(
-      --ams-menu-wide-padding-block /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-      var(--ams-menu-vi-wide-padding-block)
-    );
-    padding-inline: var(
-      --ams-menu-wide-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-      var(--ams-menu-vi-wide-padding-inline)
-    );
+    max-inline-size: var(--ams-menu-wide-max-inline-size /* @deprecated */, var(--ams-menu-vi-wide-max-inline-size));
+    padding-block: var(--ams-menu-wide-padding-block /* @deprecated */, var(--ams-menu-vi-wide-padding-block));
+    padding-inline: var(--ams-menu-wide-padding-inline /* @deprecated */, var(--ams-menu-vi-wide-padding-inline));
   }
 }
 
@@ -101,10 +85,7 @@
     align-items: center;
     display: flex; // The links do stretch in the vertical layout of Menu.
     flex-direction: column;
-    gap: var(
-      --ams-menu-link-wide-gap /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-      var(--ams-menu-link-vi-wide-gap)
-    );
+    gap: var(--ams-menu-link-wide-gap /* @deprecated */, var(--ams-menu-link-vi-wide-gap));
     text-align: center;
 
     .ams-menu__icon {

--- a/packages/css/src/components/page-footer/page-footer.scss
+++ b/packages/css/src/components/page-footer/page-footer.scss
@@ -28,16 +28,14 @@
 
   @media (min-width: $ams-breakpoint-medium) {
     padding-inline: var(
-      --ams-page-footer-menu-medium-padding-inline
-        /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-page-footer-menu-medium-padding-inline /* @deprecated */,
       var(--ams-page-footer-menu-vi-medium-padding-inline)
     );
   }
 
   @media (min-width: $ams-breakpoint-wide) {
     padding-inline: var(
-      --ams-page-footer-menu-wide-padding-inline
-        /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-page-footer-menu-wide-padding-inline /* @deprecated */,
       var(--ams-page-footer-menu-vi-wide-padding-inline)
     );
   }

--- a/packages/css/src/components/page-header/page-header.scss
+++ b/packages/css/src/components/page-header/page-header.scss
@@ -21,14 +21,14 @@
 
   @media (min-width: $ams-breakpoint-medium) {
     padding-inline: var(
-      --ams-page-header-medium-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-page-header-medium-padding-inline /* @deprecated */,
       var(--ams-page-header-vi-medium-padding-inline)
     );
   }
 
   @media (min-width: $ams-breakpoint-wide) {
     padding-inline: var(
-      --ams-page-header-wide-padding-inline /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-page-header-wide-padding-inline /* @deprecated */,
       var(--ams-page-header-vi-wide-padding-inline)
     );
   }
@@ -134,10 +134,7 @@
 }
 
 @mixin page-header-menu-action {
-  color: var(
-    --ams-page-header-menu-item-color
-  ); /* This token is @deprecated. Will be removed on or after 2026-09-13. */
-
+  color: var(--ams-page-header-menu-item-color); /* @deprecated */
   font-size: var(--ams-page-header-menu-item-font-size);
   font-weight: var(--ams-page-header-menu-item-font-weight);
   line-height: var(--ams-page-header-menu-item-line-height);
@@ -199,9 +196,7 @@
   }
 
   &[aria-expanded="true"] {
-    font-weight: var(
-      --ams-page-header-mega-menu-button-label-open-font-weight
-    ); /* This token is @deprecated. Will be removed on or after 2026-09-13. */
+    font-weight: var(--ams-page-header-mega-menu-button-label-open-font-weight); /* @deprecated */
   }
 }
 

--- a/packages/css/src/components/progress-list/progress-list.scss
+++ b/packages/css/src/components/progress-list/progress-list.scss
@@ -38,10 +38,7 @@
   gap: var(--ams-progress-list-step-gap);
 
   @media (min-width: $ams-breakpoint-medium) {
-    gap: var(
-      --ams-progress-list-step-medium-gap /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-      var(--ams-progress-list-step-vi-medium-gap)
-    );
+    gap: var(--ams-progress-list-step-medium-gap /* @deprecated */, var(--ams-progress-list-step-vi-medium-gap));
   }
 }
 
@@ -244,16 +241,14 @@
 
   @media (min-width: $ams-breakpoint-medium) {
     margin-inline-end: var(
-      --ams-progress-list-substeps-step-indicator-medium-margin-inline-end
-        /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
+      --ams-progress-list-substeps-step-indicator-medium-margin-inline-end /* @deprecated */,
       var(--ams-progress-list-substeps-step-indicator-vi-medium-margin-inline-end)
     );
     margin-inline-start: calc(
       -1 *
-        var(
-          --ams-progress-list-step-medium-gap /* This token is @deprecated. Will be removed on or after 2026-10-20. */,
-          var(--ams-progress-list-step-vi-medium-gap)
-        ) - var(--ams-progress-list-step-marker-shape-block-size)
+        var(--ams-progress-list-step-medium-gap /* @deprecated */, var(--ams-progress-list-step-vi-medium-gap)) - var(
+          --ams-progress-list-step-marker-shape-block-size
+        )
     );
   }
 }

--- a/packages/react/src/Accordion/AccordionSection.test.tsx
+++ b/packages/react/src/Accordion/AccordionSection.test.tsx
@@ -99,7 +99,7 @@ describe('AccordionSection', () => {
     )
 
     expect(spy).toHaveBeenCalledWith(
-      'Accordion.Section: The `expanded` prop is deprecated. Use `defaultExpanded` instead.',
+      '@deprecated The `expanded` prop of Accordion Section has been renamed. Use `defaultExpanded` instead.',
     )
 
     spy.mockRestore()

--- a/packages/react/src/Accordion/AccordionSection.tsx
+++ b/packages/react/src/Accordion/AccordionSection.tsx
@@ -44,7 +44,9 @@ export const AccordionSection = forwardRef(
     const initialExpandedRef = useRef(expanded)
     useEffect(() => {
       if (initialExpandedRef.current !== undefined) {
-        console.warn('Accordion.Section: The `expanded` prop is deprecated. Use `defaultExpanded` instead.')
+        console.warn(
+          '@deprecated The `expanded` prop of Accordion Section has been renamed. Use `defaultExpanded` instead.',
+        )
       }
     }, [])
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Restore real values to deprecated tokens

## What

Restores a real value to the 25 deprecated component tokens that were set to `"$value": "initial"` — the `medium`/`wide` breakpoint variants (renamed to `vi-medium`/`vi-wide` in #2502) across Grid, Description List, Dialog, Menu, Page Footer, Page Header and Progress List. Also updates the token deprecation guide to match.

## Why

For a CSS custom property, `initial` is the guaranteed-invalid value. A consumer reading a deprecated variable directly — e.g. `var(--ams-grid-wide-padding-inline)` to line their own element up with the Grid — got `0` instead of the spacing value, silently breaking their layout after v4.0.x. (Our own components were unaffected, because they read through a `var(--deprecated, var(--vi-…))` fallback.)

## How

Each deprecated token now references its replacement (e.g. `"$value": "{ams.grid.vi-medium.padding-inline}"`), which builds to `var(--ams-grid-vi-medium-padding-inline)`. The deprecated token therefore holds a real value for direct consumers while the component fallback, downstream overrides and the Compact Mode cascade all keep working — no rendered-output change in either theme. The README now recommends this reference instead of `initial`.

## Checklist

- [x] Add or update unit tests (not applicable)
- [x] Add or update documentation
- [x] Add or update stories (not applicable)
- [x] Add or update exports in index.* files (not applicable)
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- Closes the report that `--ams-grid-medium-padding-inline` / `--ams-grid-wide-padding-inline` resolved to `0` after upgrading.
- No visual changes expected: the default and Compact themes both render identical values. Compact-mode value tuning stays with #2561.