### PR TITLE
chore(docs): Rewrite the Introduction home page to lead with its value

### DIFF
--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -1,7 +1,9 @@
 import type { PageProps } from '@amsterdam/design-system-react'
 import type { StoryContext, StoryFn } from '@storybook/react-vite'
+import type { ComponentProps } from 'react'
 
 import { Page } from '@amsterdam/design-system-react'
+import { DocsContainer } from '@storybook/addon-docs/blocks'
 import { withThemeByClassName } from '@storybook/addon-themes'
 import { clsx } from 'clsx'
 
@@ -71,6 +73,16 @@ export const decorators = [
   }),
 ]
 
+// Append the City’s three crosses as a centered footer beneath every docs page.
+const DocsContainerWithFooter = ({ children, ...props }: ComponentProps<typeof DocsContainer>) => (
+  <DocsContainer {...props}>
+    {children}
+    <div aria-hidden="true" style={{ fontSize: '18px', padding: '4rem 0 1rem', textAlign: 'center' }}>
+      ×××
+    </div>
+  </DocsContainer>
+)
+
 export const parameters = {
   backgrounds: { disable: true },
   controls: {
@@ -78,6 +90,7 @@ export const parameters = {
   },
   docs: {
     codePanel: true,
+    container: DocsContainerWithFooter,
     controls: {
       sort: 'alpha', // Sorts controls in the Controls doc block – https://github.com/storybookjs/storybook/issues/25386#issuecomment-1905468177
     },

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -77,7 +77,7 @@ export const decorators = [
 const DocsContainerWithFooter = ({ children, ...props }: ComponentProps<typeof DocsContainer>) => (
   <DocsContainer {...props}>
     {children}
-    <div aria-hidden="true" style={{ fontSize: '18px', padding: '4rem 0 1rem', textAlign: 'center' }}>
+    <div aria-hidden="true" className="_ams-docs-footer">
       ×××
     </div>
   </DocsContainer>

--- a/storybook/src/_components/InlineList/InlineList.test.stories.tsx
+++ b/storybook/src/_components/InlineList/InlineList.test.stories.tsx
@@ -1,0 +1,33 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { InlineList } from './InlineList'
+
+const meta = {
+  title: 'Components/Docs/Inline List',
+} satisfies Meta<typeof InlineList>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Test: Story = {
+  render: () => (
+    <InlineList>
+      <InlineList.Item>
+        <strong>64</strong> components
+      </InlineList.Item>
+      <InlineList.Item>
+        <strong>220+</strong> icons
+      </InlineList.Item>
+      <InlineList.Item>
+        <strong>1100+</strong> design tokens
+      </InlineList.Item>
+    </InlineList>
+  ),
+  tags: ['!dev', '!autodocs'],
+}

--- a/storybook/src/_components/InlineList/InlineList.tsx
+++ b/storybook/src/_components/InlineList/InlineList.tsx
@@ -1,0 +1,41 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { ReactNode } from 'react'
+
+import { Children } from 'react'
+
+import './inline-list.css'
+
+type InlineListProps = {
+  /** A set of `InlineList.Item` elements. */
+  readonly children: ReactNode
+}
+
+// Put a space between items so a line can break (and balance) between them, while each item stays whole.
+// `role` restores the list semantics that `list-style: none` and `display: inline` strip in some browsers.
+const InlineListRoot = ({ children }: InlineListProps) => (
+  <ul className="_ams-inline-list sb-unstyled" role="list">
+    {Children.toArray(children).flatMap((item, index) => (index > 0 ? [' ', item] : item))}
+  </ul>
+)
+
+InlineListRoot.displayName = 'InlineList'
+
+type InlineListItemProps = {
+  /** The content of a single item. */
+  readonly children: ReactNode
+}
+
+const InlineListItem = ({ children }: InlineListItemProps) => (
+  <li className="_ams-inline-list__item" role="listitem">
+    {children}
+  </li>
+)
+
+InlineListItem.displayName = 'InlineList.Item'
+
+/** Displays its items on centred lines of balanced length, keeping each item whole. */
+export const InlineList = Object.assign(InlineListRoot, { Item: InlineListItem })

--- a/storybook/src/_components/InlineList/inline-list.css
+++ b/storybook/src/_components/InlineList/inline-list.css
@@ -1,0 +1,27 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+._ams-inline-list {
+  list-style: none;
+  margin-block: 0 !important;
+  padding-inline-start: 0;
+  text-align: center;
+
+  /* Balances the wrapped lines (3 + 3 rather than 5 + 1). Not yet Baseline-wide; degrades to normal wrapping. */
+  /* stylelint-disable-next-line plugin/use-baseline */
+  text-wrap: balance;
+}
+
+._ams-inline-list__item {
+  display: inline;
+  margin-inline: var(--ams-space-s);
+  white-space: nowrap;
+}
+
+/* Flatten any paragraph the Markdown parser may still wrap around an item’s content. */
+._ams-inline-list__item p {
+  display: inline;
+  margin-block: 0;
+}

--- a/storybook/src/_styles/docs.css
+++ b/storybook/src/_styles/docs.css
@@ -142,6 +142,14 @@
   resize: horizontal;
 }
 
+/* The City’s three crosses, shown centered as a decorative footer beneath every docs page. */
+._ams-docs-footer {
+  font-size: 1.125rem !important;
+  line-height: 1;
+  margin-block-start: 3rem !important;
+  text-align: center;
+}
+
 strong {
   font-weight: var(--ams-typography-body-text-bold-font-weight);
 }

--- a/storybook/src/docs/introduction.docs.mdx
+++ b/storybook/src/docs/introduction.docs.mdx
@@ -45,7 +45,7 @@ And once people learn one, they can use them all, while it matters less which de
 
 People can use City services whatever their ability, device, or situation.
 Every component is built and tested to meet accessibility standards (WCAG) from the start.
-We honour settings like text size and reduced motion.
+We honour preferences like text size and reduced motion.
 
 ## Built in the open
 
@@ -55,14 +55,15 @@ We grow and shape the system from what we learn together.
 
 ## Use as much as you need
 
-Take just the design tokens, add the styles, or use the complete React components – whatever fits your stack.
-One foundation supports various tech stacks, so you can adopt it step by step.
-Mix and match your own components.
+Take just the design tokens, apply the class names, or get all the HTML for free with our React components.
+One foundation supports various tech stacks.
+You can adopt step by step, and mix and match your own components.
 
 ## Robust and predictable
 
 Plan with confidence and upgrade on your own timeline.
-Major changes happen at most once a quarter, and older versions keep working for at least six months.
+Major changes happen at most once a quarter.
+Older versions keep working for at least six months.
 Every release is backed by extensive unit and visual tests.
 
 ## Public and internal services
@@ -73,13 +74,13 @@ Residents and City staff alike get interfaces tailored to the task, whether read
 ## Part of NL Design System
 
 Amsterdam Design System uses the architecture, principles and goals of the [NL Design System](https://nldesignsystem.nl/).
-We coordinate with their core team, share our findings, and work happily together many designers and developers in its community.
+We coordinate with their core team, share our findings, and work happily alongside many designers and developers in its community.
 
 ## Get involved
 
 We are happy to work with you.
 
-- **Contribute**: all code is [on GitHub](http://github.com/Amsterdam/design-system); your ideas, issues and pull requests are welcome.
+- **Contribute**: all code is [on GitHub](https://github.com/Amsterdam/design-system); your ideas, issues and pull requests are welcome.
 - **Download**: get new releases [through npm](https://www.npmjs.com/search?q=keywords:amsterdam-design-system) with clear version numbers and changelogs.
 - **Ask us anything**: [email us](mailto:designsystem@amsterdam.nl) with suggestions, our roadmap, or we can help each other.
 - **Join the conversation**: [in Teams](https://teams.microsoft.com/l/team/19%3afYKS_RD2n1q4UhguA9jwEJk0A_VjYPO4TiLQjYlG_bo1%40thread.tacv2/conversations?groupId=381b5f11-b342-4a3a-8a78-8b371a90457d&tenantId=72fca1b1-2c2e-4376-a445-294d80196804) to stay informed and share your experiences.

--- a/storybook/src/docs/introduction.docs.mdx
+++ b/storybook/src/docs/introduction.docs.mdx
@@ -2,97 +2,84 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
+import { InlineList } from "#storybook/_components/InlineList/InlineList";
+
 <Meta title="Docs/Introduction" />
 
 # Amsterdam Design System
 
-This is the library for the user interfaces (UI) of all digital products offered by the City of Amsterdam.
-It provides reusable components, patterns, and guidelines for teams working on websites.
+All our services familiar, accessible, and trustworthy.
+Faster and cheaper to build and iterate with.
 
-It helps everyone work together faster and better, with more time to create actual value.
-It makes it easier to align all software we create, purchase and use with our corporate identity.
-By using it in all our channels, they appear the same, work similarly, are widely accessible, and inspire trust.
+---
 
-## How does it work
+<InlineList>
+  <InlineList.Item>
+    <strong>64</strong> components
+  </InlineList.Item>
+  <InlineList.Item>
+    <strong>220+</strong> icons
+  </InlineList.Item>
+  <InlineList.Item>
+    <strong>1100+</strong> design tokens
+  </InlineList.Item>
+  <InlineList.Item>
+    <strong>18</strong> templates
+  </InlineList.Item>
+  <InlineList.Item>
+    <strong>2</strong> modes
+  </InlineList.Item>
+  <InlineList.Item>
+    <strong>1500+</strong> tests
+  </InlineList.Item>
+</InlineList>
 
-The most concrete products of the Amsterdam Design System are the reusable user interface components, such as buttons, text components, menus, and form fields.
-They adhere to the City’s branding: colour, typography and dimensions.
-They adapt responsively to different screens and devices and are accessible to everyone.
+---
 
-We make these components available in various libraries so that designers and developers can use them in their work:
+## Familiar everywhere
 
-### Figma
+Consistent experiences help our citizens, entrepreneurs and visitors recognise and trust official Amsterdam services.
+And once people learn one, they can use them all, while it matters less which department is behind any of them.
 
-[Find our Figma Library here](https://www.figma.com/community/file/1530535540611888495/amsterdam-design-system-community-edition).
-Various components, text styles and grid styles are ready to use in your designs.
-Several others are in progress or being reviewed.
-Refer to the introduction and legend on the cover page.
+## Accessible to everyone
 
-### React
+People can use City services whatever their ability, device, or situation.
+Every component is built and tested to meet accessibility standards (WCAG) from the start.
+We honour settings like text size and reduced motion.
 
-On this website, you will find the React Library and documentation – use the table of contents on the left (on wide windows) or under the ‘Sidebar’ tab (on narrow ones).
-These components can be installed and used in your application [via npm](https://www.npmjs.com/search?q=%40amsterdam%2Fdesign-system).
+## Built in the open
 
-### CSS and Design Tokens
+Designers and developers share one source of truth.
+Tested building blocks help teams deliver value faster instead of starting from scratch and scratching the surface.
+We grow and shape the system from what we learn together.
 
-The components are usable without React by applying our classes or design tokens.
-If you would like to follow this approach, please let us know.
+## Use as much as you need
 
-## We build on the NL Design System
+Take just the design tokens, add the styles, or use the complete React components – whatever fits your stack.
+One foundation supports various tech stacks, so you can adopt it step by step.
+Mix and match your own components.
 
-Amsterdam Design System uses the architecture of [NL Design System](https://nldesignsystem.nl/).
+## Robust and predictable
 
-Thanks to the NL Design System, the entire government in the Netherlands can work together to provide understandable, user-friendly and accessible online services.
-A service that is logical and coherent but not necessarily uniform, because it allows room for the identity of government organizations.
+Plan with confidence and upgrade on your own timeline.
+Major changes happen at most once a quarter, and older versions keep working for at least six months.
+Every release is backed by extensive unit and visual tests.
 
-The choice to connect to NL Design System also makes it easier for us to create different libraries.
+## Public and internal services
 
-## Contact us
+The same components and design language serve public-facing websites and internal backoffice applications alike.
+Residents and City staff alike get interfaces tailored to the task, whether reading content or getting work done.
 
-### Join Teams
+## Part of NL Design System
 
-If you work for the City of Amsterdam, [register now for the Design System team](https://teams.microsoft.com/l/team/19%3afYKS_RD2n1q4UhguA9jwEJk0A_VjYPO4TiLQjYlG_bo1%40thread.tacv2/conversations?groupId=381b5f11-b342-4a3a-8a78-8b371a90457d&tenantId=72fca1b1-2c2e-4376-a445-294d80196804) on MS Teams.
-This way, you can easily stay informed, and we can keep in touch.
-The channels have a lot of information you can read, and of course you are more than welcome to participate in threads.
+Amsterdam Design System uses the architecture, principles and goals of the [NL Design System](https://nldesignsystem.nl/).
+We coordinate with their core team, share our findings, and work happily together many designers and developers in its community.
 
-### Watch the demo
+## Get involved
 
-For an overview of what’s new, you are welcome to our quarterly demo and four-weekly sprint review.
-You can also ask questions and provide feedback here.
-You can find the invitation in the ‘Sprint review’ channel in MS Teams.
-We record the sessions for later viewing.
+We are happy to work with you.
 
-### Contribute via Git
-
-[The code repository is on GitHub](http://github.com/Amsterdam/design-system) and is open source.
-Your pull requests and issues are welcome.
-
-### Send a message
-
-Do you want to know how the design system can help you? Questions about our working method or suggestions for the roadmap?
-Let us know; we are happy to work with you.
-
-Don’t hesitate to get in touch with us by email at [designsystem@amsterdam.nl](designsystem@amsterdam.nl).
-
-The current core team:
-Aram Limpens,
-Bas Kroese,
-Inge de Bondt (lead),
-Niels Roozemond,
-Ruben Sibon,
-and
-Vincent Smedinga (lead).
-
-Contributions by:
-Bettina Slee,
-Hee Chan van der Haar,
-Jesper Duinker,
-Justin Straver,
-Laurens van den Akker,
-Mike Alders,
-Nico Druif,
-Renate Schwarzler,
-Rick Zweers,
-Soesanto Arp,
-and
-Tanja van der Heide.
+- **Contribute**: all code is [on GitHub](http://github.com/Amsterdam/design-system); your ideas, issues and pull requests are welcome.
+- **Download**: get new releases [through npm](https://www.npmjs.com/search?q=keywords:amsterdam-design-system) with clear version numbers and changelogs.
+- **Ask us anything**: [email us](mailto:designsystem@amsterdam.nl) with suggestions, our roadmap, or we can help each other.
+- **Join the conversation**: [in Teams](https://teams.microsoft.com/l/team/19%3afYKS_RD2n1q4UhguA9jwEJk0A_VjYPO4TiLQjYlG_bo1%40thread.tacv2/conversations?groupId=381b5f11-b342-4a3a-8a78-8b371a90457d&tenantId=72fca1b1-2c2e-4376-a445-294d80196804) to stay informed and share your experiences.


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Rewrite the Introduction home page to lead with its value

## What

Rewrites the Storybook Introduction (the docs landing page) into a value-first page, adds a small InlineList component for its stats strip, and gives every docs page a City-crosses footer.

- A people-outcome hero, a stats strip, and short value-prop sections — Familiar everywhere, Accessible to everyone, Built in the open, Use as much as you need, Robust and predictable, and Public and internal services — followed by Part of NL Design System and Get involved.
- A new `InlineList` component (with an `InlineList.Item` subcomponent) renders the stats strip on one centred, balanced line.
- The City’s three crosses now appear, centred, as a footer beneath every documentation page.

## Why

The previous page opened with “This is the library for the user interfaces…” and went straight into Figma/React/CSS mechanics and a contact roster. It described what the design system *is* rather than what it *does for people*, so a first-time visitor got no reason to care in the first few seconds. The stats strip needed a reusable, accessible way to sit on one balanced line, and the crosses — previously hard-coded once at the bottom of the Introduction — belong in a single shared footer.

## How

- Plain content only — headings, body text, a centred hero with separators, and lists. No new visual design; the standalone design-system website will get the real layout later.
- `InlineList` lays its items on centred lines of balanced length using `text-wrap: balance`, keeps each item whole (`white-space: nowrap`), and flattens the paragraph the MDX parser wraps around each item’s content.
- It carries `role="list"` / `role="listitem"`, because `list-style: none` and `display: inline` otherwise drop the list semantics in WebKit.
- `text-wrap: balance` isn’t Baseline-wide yet, so it has a scoped, documented `stylelint-disable` for the `use-baseline` rule; it degrades to normal wrapping where unsupported.
- The footer is a thin `DocsContainer` override in the Storybook preview config; the crosses are decorative, so they’re hidden from assistive technology with `aria-hidden`.

## Checklist

- [x] Add or update unit tests (not necessary — documentation and docs-only components)
- [x] Add or update documentation (this PR is the documentation)
- [x] Add or update stories (added a `Test` story for InlineList)
- [x] Add or update exports in index.\* files (not necessary)
- [x] Comment `/chromatic test` and verify visual regression tests pass (needed — the new `Components/Docs/Inline List/Test` story adds a snapshot; docs pages, including the new footer, aren’t captured by Chromatic)
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- The `stylelint-disable` for `text-wrap: balance` is deliberate — it’s the only way to balance wrapped lines in CSS today, scoped to one docs-only line, and it degrades cleanly where unsupported.
- The crosses footer appears on every docs page, including each component’s autodocs page.