### PR TITLE
chore(docs): Document pull request options in the release flow

### DIFF
--- a/documentation/publishing.md
+++ b/documentation/publishing.md
@@ -102,9 +102,9 @@ git push
 
 If `develop` has progressed since the merge to `main`, this will produce a merge commit.
 
-Chances are that a [branch protection rule](https://github.com/Amsterdam/design-system/settings/rules) prevents you from pushing directly to `develop`.
-One way around that is to disable the rule temporarily, merge, and re-enable it.
-Another is to create a pull request to merge `main` into `develop`.
+If a [branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) prevents you from pushing directly to `develop`, you won’t be able to complete the merge-back with a direct push.
+If you have admin access, you can temporarily disable the rule, merge, and re-enable it.
+Alternatively, create a pull request to merge `main` into `develop`.
 
 ### Gotchas
 

--- a/documentation/publishing.md
+++ b/documentation/publishing.md
@@ -61,6 +61,10 @@ git merge --ff-only origin/develop
 git push
 ```
 
+**Optional**: To leave a reviewable record of each promotion, open a draft pull request from `develop` into `main` before you run `git push`.
+This doesn’t interfere with the release PR that Release Please creates.
+GitHub will mark the pull request as merged automatically when you push.
+
 Pushing to `main` triggers the “Lint and test” workflow on GitHub. When this workflow completes successfully, it triggers the “Publish” workflow.
 On this first run, Release Please opens (or updates) a release PR. The workflow runs again later, after that PR is merged, to create the GitHub release and publish to npm.
 

--- a/documentation/publishing.md
+++ b/documentation/publishing.md
@@ -102,6 +102,10 @@ git push
 
 If `develop` has progressed since the merge to `main`, this will produce a merge commit.
 
+Chances are that a [branch protection rule](https://github.com/Amsterdam/design-system/settings/rules) prevents you from pushing directly to `develop`.
+One way around that is to disable the rule temporarily, merge, and re-enable it.
+Another is to create a pull request to merge `main` into `develop`.
+
 ### Gotchas
 
 #### Don’t change the PR title

--- a/documentation/publishing.md
+++ b/documentation/publishing.md
@@ -61,7 +61,7 @@ git merge --ff-only origin/develop
 git push
 ```
 
-**Optional**: To leave a reviewable record of each promotion, open a draft pull request from `develop` into `main` before you run `git push`.
+**Optional**: To leave a reviewable record of each promotion, open a draft pull request from `develop` into `main` before the final `git push` to `main`.
 This doesn’t interfere with the release PR that Release Please creates.
 GitHub will mark the pull request as merged automatically when you push.
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Document pull request options in the release flow

## What

Two additions to the publishing documentation:

- An optional draft pull request from `develop` into `main` to leave a reviewable record of each promotion. The fast-forward push marks it merged automatically.
- A note that branch protection may block pushing directly to `develop` when merging back, with two ways around it: disabling the rule temporarily, or opening a pull request to merge `main` into `develop`.

## Why

The release steps only described local pushes. Maintainers who want a pull-request trail for a promotion, or who hit branch protection on the merge back, had no guidance.

## How

Documentation-only changes to `documentation/publishing.md`. No behaviour changes.

## Checklist

- [x] Add or update unit tests — N/A, documentation only.
- [x] Add or update documentation — this PR is the documentation change.
- [x] Add or update stories — N/A.
- [x] Add or update exports in index.\* files — N/A.
- [x] Comment `/chromatic test` and verify visual regression tests pass — N/A, no component changes.
- [x] Start the PR title with a Conventional Commit prefix.

## Additional notes

- The branch-protection note links to the repository’s rules settings page, which only maintainers with admin access can open. Happy to swap it for a different link or drop it if preferred.