### PR TITLE
feat(Dialog, Table, Tabs, Tab Navigation): Improve scrolling behaviour

### DIFF
--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -82,6 +82,7 @@ so do not apply these styles without an `open` attribute. */
 }
 
 .ams-dialog__body {
+  overflow-x: hidden;
   overflow-y: auto;
   /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
   overscroll-behavior-y: contain;

--- a/packages/css/src/components/tab-navigation/tab-navigation.scss
+++ b/packages/css/src/components/tab-navigation/tab-navigation.scss
@@ -13,6 +13,7 @@
   box-shadow: var(--ams-tab-navigation-list-box-shadow);
   display: flex;
   overflow-x: auto;
+  overflow-y: hidden;
   /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
   overscroll-behavior-x: contain;
   scroll-snap-type: x mandatory;
@@ -26,6 +27,7 @@
       box-shadow: var(--ams-tab-navigation-list-vertical-box-shadow);
       flex-direction: column;
       overflow-x: visible;
+      overflow-y: visible;
     }
   }
 }

--- a/packages/css/src/components/table/table.scss
+++ b/packages/css/src/components/table/table.scss
@@ -5,6 +5,9 @@
 
 .ams-table {
   overflow-x: auto;
+  overflow-y: hidden;
+  /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
+  overscroll-behavior-x: contain;
 }
 
 .ams-table__table {

--- a/packages/css/src/components/tabs/tabs.scss
+++ b/packages/css/src/components/tabs/tabs.scss
@@ -15,6 +15,9 @@
   box-shadow: var(--ams-tabs-list-box-shadow);
   display: flex;
   overflow-x: auto;
+  overflow-y: hidden;
+  /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
+  overscroll-behavior-x: contain;
 }
 
 .ams-tabs__button {
@@ -80,4 +83,7 @@
 
 .ams-tabs__panel {
   overflow-x: auto;
+  overflow-y: hidden;
+  /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
+  overscroll-behavior-x: contain;
 }

--- a/packages/css/src/components/tabs/tabs.scss
+++ b/packages/css/src/components/tabs/tabs.scss
@@ -18,6 +18,7 @@
   overflow-y: hidden;
   /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
   overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
 }
 
 .ams-tabs__button {
@@ -35,6 +36,7 @@
   outline-offset: var(--ams-tabs-button-outline-offset);
   padding-block: var(--ams-tabs-button-padding-block);
   padding-inline: var(--ams-tabs-button-padding-inline);
+  scroll-snap-align: start;
 
   &:disabled {
     color: var(--ams-tabs-button-disabled-color);


### PR DESCRIPTION
## What

Hardens the scrolling containers in four components:
- **Tabs** & **Table** — explicit `overflow-y: hidden` + `overscroll-behavior-x: contain`
- **Tabs** — `scroll-snap-type: x mandatory` on the list and `scroll-snap-align: start` on the buttons
- **Dialog** — explicit `overflow-x: hidden` on the body (mirror axis)
- **Tab Navigation** — explicit `overflow-y: hidden` on the list (vertical variant resets overflow)

## Why

Addresses #2585. `overflow-x: auto` silently makes the cross-axis compute to `auto`, which can pop a stray scrollbar; `overscroll-behavior-x: contain` prevents scroll-chaining and touch back-navigation. Tabs and Table were the only horizontal scrollers missing `overscroll-behavior` — Tab Navigation and Image Slider already had it, so this brings them in line. The Tabs snap matches Tab Navigation so tabs rest on their edges while scrolling.

## How

Pure SCSS, no React changes. `overflow` is written as longhands to match house style. Each `overscroll-behavior-*` carries the existing `plugin/use-baseline` “Progressive enhancement” disable comment, consistent with the other scroll containers. Tab Navigation’s vertical variant resets `overflow-y: visible` so the column layout keeps growing freely.

## Checklist

- [x] Add or update unit tests — n/a, CSS-only; existing tests pass
- [x] Add or update documentation — n/a
- [x] Add or update stories — n/a (an optional narrow-overflow demo could be added)
- [ ] Comment `/chromatic test` and verify visual regression tests pass — no diffs expected
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- Addresses #2585.
- CSS snap improves scroll feel but doesn’t reveal an already-selected off-screen tab on load — that needs a small `scrollIntoView`, deferred.
- Follow-up planned: a stylelint guard (defensive-css `scroll-chaining`) to enforce `overscroll-behavior` on future scrollers.
