### PR TITLE
feat(typography): Add tokens for ‘light’ and ‘extra bold’ font weights of Amsterdam Sans

### DIFF
--- a/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
@@ -33,6 +33,12 @@
           },
           "$type": "number"
         },
+        "light": {
+          "font-weight": {
+            "$value": "300",
+            "$type": "fontWeight"
+          }
+        },
         "bold": {
           "font-weight": {
             "$value": "700",

--- a/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
@@ -45,6 +45,12 @@
             "$type": "fontWeight"
           }
         },
+        "extra-bold": {
+          "font-weight": {
+            "$value": "800",
+            "$type": "fontWeight"
+          }
+        },
         "black": {
           "font-weight": {
             "$value": "900",

--- a/storybook/src/brand/design-tokens/typography.docs.mdx
+++ b/storybook/src/brand/design-tokens/typography.docs.mdx
@@ -38,17 +38,18 @@ Do not combine tokens of different sizes.
 
 ### Font weight
 
-The font weight can be regular, bold, or black.
+The font weight can be light, regular, bold, or black.
 
 | CSS variable                                        | Value | Example                                                                                                                                                         |
 | :-------------------------------------------------- | :---: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `var(--ams-typography-body-text-light-font-weight)` |  300  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-light-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" /> |
 | `var(--ams-typography-body-text-font-weight)`       |  400  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" />       |
 | `var(--ams-typography-body-text-bold-font-weight)`  |  700  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-bold-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" />  |
 | `var(--ams-typography-body-text-black-font-weight)` |  900  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-black-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" /> |
 
-None of our components use the black weight yet.
-You might apply it to a component of your own by referencing its token as the `font-weight`.
-Reserve this weight for short, prominent display text; it is much heavier than bold.
+None of our components use the light or black weight yet.
+You might apply either to a component of your own by referencing its token as the `font-weight`.
+Reserve the black weight for short, prominent display text; it is much heavier than bold.
 
 ## Headings
 

--- a/storybook/src/brand/design-tokens/typography.docs.mdx
+++ b/storybook/src/brand/design-tokens/typography.docs.mdx
@@ -38,17 +38,18 @@ Do not combine tokens of different sizes.
 
 ### Font weight
 
-The font weight can be light, regular, bold, or black.
+The font weight can be light, regular, bold, extra bold, or black.
 
-| CSS variable                                        | Value | Example                                                                                                                                                         |
-| :-------------------------------------------------- | :---: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `var(--ams-typography-body-text-light-font-weight)` |  300  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-light-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" /> |
-| `var(--ams-typography-body-text-font-weight)`       |  400  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" />       |
-| `var(--ams-typography-body-text-bold-font-weight)`  |  700  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-bold-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" />  |
-| `var(--ams-typography-body-text-black-font-weight)` |  900  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-black-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" /> |
+| CSS variable                                             | Value | Example                                                                                                                                                              |
+| :------------------------------------------------------- | :---: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `var(--ams-typography-body-text-light-font-weight)`      |  300  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-light-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" />      |
+| `var(--ams-typography-body-text-font-weight)`            |  400  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" />            |
+| `var(--ams-typography-body-text-bold-font-weight)`       |  700  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-bold-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" />       |
+| `var(--ams-typography-body-text-extra-bold-font-weight)` |  800  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-extra-bold-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" /> |
+| `var(--ams-typography-body-text-black-font-weight)`      |  900  | <TypographySample fontSize="1.25rem" fontWeight="var(--ams-typography-body-text-black-font-weight)" lineHeight="var(--ams-typography-body-text-line-height)" />      |
 
-None of our components use the light or black weight yet.
-You might apply either to a component of your own by referencing its token as the `font-weight`.
+None of our components use the light, extra bold, or black weight yet.
+You can apply any of these to a component of your own by referencing its token as the `font-weight`.
 Reserve the black weight for short, prominent display text; it is much heavier than bold.
 
 ## Headings


### PR DESCRIPTION
## What

Add two new font weight tokens to the Amsterdam Sans typography set: light (300) and extra bold (800).

## Why

Amsterdam Sans supports these weights, but they were absent from the design token set.
The black (900) weight was added recently; this brings the remaining intermediate weights in line with what the typeface offers.

## How

- Added `light` and `extra-bold` entries to `typography.tokens.json` with the correct `$value` and `$type: fontWeight`.
- Updated the font weight table in `typography.docs.mdx` to show all five weights — light, regular, bold, extra bold, black — each with a live `TypographySample` preview.
- Revised the surrounding prose to reflect the expanded set.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Token additions only — no component logic changed.