### PR TITLE
feat(typography): Add italic font style token and apply it to Image

### DIFF
--- a/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
@@ -16,7 +16,6 @@
       "italic": {
         "font-style": {
           "$value": "italic",
-          "$description": "Sets text in the italic style, for example to offset alt text from the surrounding copy.",
           "$extensions": {
             "nl.amsterdam.type": "fontStyle"
           }

--- a/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
@@ -13,6 +13,15 @@
           "nl.amsterdam.type": "hyphenateLimitChars"
         }
       },
+      "italic": {
+        "font-style": {
+          "$value": "italic",
+          "$description": "Sets text in the italic style, for example to offset alt text from the surrounding copy.",
+          "$extensions": {
+            "nl.amsterdam.type": "fontStyle"
+          }
+        }
+      },
       "body-text": {
         "$description": "Text styles for running body copy. Font sizes scale fluidly between 320px and 1600px viewports.",
         "font-size": {

--- a/packages/css/src/components/image/image.scss
+++ b/packages/css/src/components/image/image.scss
@@ -6,7 +6,7 @@
 .ams-image {
   aspect-ratio: var(--ams-image-aspect-ratio);
   block-size: auto; /* [1] */
-  font-style: italic; /* [3] */
+  font-style: var(--ams-typography-italic-font-style); /* [3] */
   inline-size: 100%; /* [1] */
   object-fit: cover; /* [4] */
   vertical-align: middle; /* [2] */

--- a/storybook/src/_components/TypographySample/TypographySample.tsx
+++ b/storybook/src/_components/TypographySample/TypographySample.tsx
@@ -22,6 +22,8 @@ type TypographySampleProps = {
    * Use `rems` so the font size scales automatically if the user changes their browser's base font size.
    */
   readonly fontSize?: string
+  /** A font-style token value, either a CSS value or a token reference. */
+  readonly fontStyle?: string
   /** A font-weight token value, either a CSS value or a token reference. */
   readonly fontWeight?: string
   /** A line-height token value, either a CSS value or a token reference. */
@@ -33,6 +35,7 @@ export const TypographySample = ({
   compact,
   fontFamily,
   fontSize,
+  fontStyle,
   fontWeight = 'body-text',
   lineHeight,
   style,
@@ -45,6 +48,7 @@ export const TypographySample = ({
       ...style,
       ...(fontFamily ? { fontFamily: formatTokenValue(fontFamily) } : {}),
       ...(fontSize ? { fontSize: formatTokenValue(fontSize) } : {}),
+      ...(fontStyle ? { fontStyle: formatTokenValue(fontStyle) } : {}),
       ...(fontWeight ? { fontWeight: formatTokenValue(fontWeight) } : {}),
       ...(lineHeight ? { lineHeight: formatTokenValue(lineHeight) } : {}),
     }}

--- a/storybook/src/brand/design-tokens/typography.docs.mdx
+++ b/storybook/src/brand/design-tokens/typography.docs.mdx
@@ -99,10 +99,7 @@ If it is not available, we use Arial or the generic sans-serif instead.
 
 ### Font style
 
-Text is upright by default.
-Use the italic style sparingly, for example to offset alt text from the surrounding copy.
-The Image component uses it to italicise alt text when an image fails to load.
-You can apply it to a component of your own as the `font-style`.
+Text is upright by default, but can be set in italics as well.
 
 | CSS variable                              | Value  |
 | :---------------------------------------- | :----- |

--- a/storybook/src/brand/design-tokens/typography.docs.mdx
+++ b/storybook/src/brand/design-tokens/typography.docs.mdx
@@ -97,6 +97,16 @@ If it is not available, we use Arial or the generic sans-serif instead.
 | :---------------------------------- | :---------------------------------: |
 | `var(--ams-typography-font-family)` | 'Amsterdam Sans', Arial, sans-serif |
 
+### Font style
+
+Text is upright by default.
+Use the italic style sparingly, for example to offset alt text from the surrounding copy.
+None of our components use it yet, but you can apply it to a component of your own as the `font-style`.
+
+| CSS variable                              | Value  |
+| :---------------------------------------- | :----- |
+| `var(--ams-typography-italic-font-style)` | italic |
+
 ### Hyphenation
 
 Words that do not fit on a single line will be split with a hyphen and continue on the next line.

--- a/storybook/src/brand/design-tokens/typography.docs.mdx
+++ b/storybook/src/brand/design-tokens/typography.docs.mdx
@@ -101,9 +101,9 @@ If it is not available, we use Arial or the generic sans-serif instead.
 
 Text is upright by default, but can be set in italics as well.
 
-| CSS variable                              | Value  |
-| :---------------------------------------- | :----- |
-| `var(--ams-typography-italic-font-style)` | italic |
+| CSS variable                              | Value  | Example                                                                  |
+| :---------------------------------------- | :----- | :----------------------------------------------------------------------- |
+| `var(--ams-typography-italic-font-style)` | italic | <TypographySample fontStyle="var(--ams-typography-italic-font-style)" /> |
 
 ### Hyphenation
 

--- a/storybook/src/brand/design-tokens/typography.docs.mdx
+++ b/storybook/src/brand/design-tokens/typography.docs.mdx
@@ -101,7 +101,8 @@ If it is not available, we use Arial or the generic sans-serif instead.
 
 Text is upright by default.
 Use the italic style sparingly, for example to offset alt text from the surrounding copy.
-None of our components use it yet, but you can apply it to a component of your own as the `font-style`.
+The Image component uses it to italicise alt text when an image fails to load.
+You can apply it to a component of your own as the `font-style`.
 
 | CSS variable                              | Value  |
 | :---------------------------------------- | :----- |


### PR DESCRIPTION
## What

- Adds `ams.typography.italic.font-style` token (CSS: `--ams-typography-italic-font-style`) with value `italic`.
- Applies the token in the Image component CSS, replacing the previously hardcoded `font-style: italic` that italicises alt text when the image fails to load.
- Adds a 'Font style' section to the typography design tokens docs page.

## Why

The Image component already italicised alt text to visually offset it from surrounding copy (following the pattern described at [csswizardry.com](https://x.com/csswizardry/status/1717841334462005661)), but the value was hardcoded.
Tokenising it aligns italic with how all other typographic aspects are exposed, and makes the intent explicit for anyone applying it in their own components.

The token lives at the root of `ams.typography` rather than inside `body-text`, because italic is a cross-cutting modifier applicable to any text role — not a variant of body copy specifically.

## How

- Added `ams.typography.italic.font-style` to `typography.tokens.json` with `nl.amsterdam.type: fontStyle`.
- Updated `image.scss` to reference `var(--ams-typography-italic-font-style)` instead of the literal `italic`.
- Added a Font style section to `typography.docs.mdx`.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

No stories or exports needed — the token is consumed directly via CSS and the Image component's behaviour is unchanged.
Run `/chromatic test` to confirm no visual regression.