### PR TITLE
feat(Dialog): Prevent body from scrolling while a modal Dialog is open

### DIFF
--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -62,7 +62,7 @@ so do not apply these styles without an `open` attribute. */
  * JS for a hard guarantee on touch.
  */
 @supports selector(:has(*)) {
-  .ams-body:has(dialog:modal) {
+  .ams-body:has(.ams-dialog:modal) {
     overflow: hidden;
   }
 }

--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -54,6 +54,19 @@ so do not apply these styles without an `open` attribute. */
   }
 }
 
+/*
+ * showModal() makes content inert but doesn’t lock scrolling: gestures over
+ * the ::backdrop still scroll the page. overflow: hidden on the body (not
+ * html) suppresses this because body overflow propagates to the viewport.
+ * Wrapped in @supports as a progressive enhancement; iOS Safari still needs
+ * JS for a hard guarantee on touch.
+ */
+@supports selector(:has(*)) {
+  .ams-body:has(dialog:modal) {
+    overflow: hidden;
+  }
+}
+
 .ams-dialog__header {
   align-items: flex-start;
   display: flex;


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Prevent body from scrolling while a modal Dialog is open

## What

Adds `overflow: hidden` to `.ams-body` whenever a modal Dialog is open, wrapped in `@supports selector(:has(*))` as a progressive enhancement.

## Why

`showModal()` makes the rest of the document inert, but it doesn't lock scrolling. Wheel and touch gestures over the `::backdrop` still scroll the page behind the dialog, which is disorienting. Browsers without `:has()` are unaffected and keep their default behaviour. iOS Safari still requires JavaScript for a hard guarantee on touch scroll.

## How

The rule targets `.ams-body:has(dialog:modal)`. Setting `overflow: hidden` on the body (not `html`) works because body overflow propagates to the viewport in the default case where `html` has no explicit `overflow` set. `:modal` only matches dialogs opened via `showModal()`, so non-modal Dialogs don't trigger the lock.

We don’t use `html` because it’s technically out of reach for the design system. We may implement the [Root](https://nldesignsystem.nl/root/) component of NL Design System soon, and update this selector.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

n/a

