### PR TITLE
chore(Storybook): Narrow test-file exclusion in tsconfig to packages only

### DIFF
--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -20,5 +20,11 @@
     "src/**/*.ts",
     "src/**/*.tsx"
   ],
-  "exclude": ["**/node_modules/*", "../**/*.test.ts", "../**/*.test.tsx"]
+  "exclude": [
+    "**/node_modules/*",
+    "../packages/**/*.test.ts",
+    "../packages/**/*.test.tsx",
+    "../packages-proprietary/**/*.test.ts",
+    "../packages-proprietary/**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
## What

Narrow the `exclude` pattern in [`storybook/tsconfig.json`](storybook/tsconfig.json) so that only test files under `packages/` and `packages-proprietary/` are skipped during type-checking.

## Why

The previous pattern `../**/*.test.ts` (and its `.tsx` counterpart) excluded every test file relative to the storybook directory, which inadvertently included the 9 local test files living under `storybook/src/`.
Those files contain utility functions used only in Storybook and should be covered by the type-checker, just like the source files next to them.

## How

Replace the two broad glob patterns with four narrower ones that explicitly target `../packages/**` and `../packages-proprietary/**`.
This keeps unit tests from the component packages out of the Storybook type-check (they have their own tsconfigs) while letting the 9 local Storybook test files be checked.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Config-only change; no runtime behaviour is affected.