### PR TITLE
fix(Calendar, Date Picker): Localise day numerals and the range boundary separator

### DIFF
--- a/packages/react/src/Calendar/CalendarDay.test.tsx
+++ b/packages/react/src/Calendar/CalendarDay.test.tsx
@@ -68,6 +68,14 @@ describe('CalendarDay', () => {
     expect(screen.getByRole('link', { name: 'maandag 15 juni 2026' })).toHaveAttribute('data-custom')
   })
 
+  it('localises the visible day number so it matches the announced date', () => {
+    render(<CalendarDay date={monday15June2026} isCurrent={false} locale="ar-EG" />)
+
+    // ar-EG uses Arabic-Indic digits, so the visible number and the accessible label agree.
+    expect(screen.getByText('١٥')).toBeInTheDocument()
+    expect(screen.getByText('الاثنين، ١٥ يونيو ٢٠٢٦')).toBeInTheDocument()
+  })
+
   it('marks the date as current when isCurrent is true', () => {
     render(<CalendarDay date={monday15June2026} isCurrent linkTemplate={() => '/day'} locale="nl-NL" />)
 

--- a/packages/react/src/Calendar/CalendarDay.tsx
+++ b/packages/react/src/Calendar/CalendarDay.tsx
@@ -16,7 +16,18 @@ export type CalendarDayProps = {
   readonly isCurrent: boolean
 } & Pick<CalendarProps, 'linkComponent' | 'linkTemplate' | 'locale'>
 
-const formatDayNumber = (date: Date, locale?: string) => new Intl.NumberFormat(locale).format(date.getDate())
+const dayNumberFormatters = new Map<string | undefined, Intl.NumberFormat>()
+
+const formatDayNumber = (date: Date, locale?: string) => {
+  let formatter = dayNumberFormatters.get(locale)
+
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale)
+    dayNumberFormatters.set(locale, formatter)
+  }
+
+  return formatter.format(date.getDate())
+}
 
 const formatAccessibleDate = (date: Date, locale?: string) =>
   new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'long', weekday: 'long', year: 'numeric' }).format(date)

--- a/packages/react/src/Calendar/CalendarDay.tsx
+++ b/packages/react/src/Calendar/CalendarDay.tsx
@@ -16,6 +16,8 @@ export type CalendarDayProps = {
   readonly isCurrent: boolean
 } & Pick<CalendarProps, 'linkComponent' | 'linkTemplate' | 'locale'>
 
+const formatDayNumber = (date: Date, locale?: string) => new Intl.NumberFormat(locale).format(date.getDate())
+
 const formatAccessibleDate = (date: Date, locale?: string) =>
   new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'long', weekday: 'long', year: 'numeric' }).format(date)
 
@@ -33,7 +35,7 @@ export const CalendarDay = ({ date, isCurrent, linkComponent, linkTemplate, loca
 
   const content = (
     <>
-      <span aria-hidden={true}>{date.getDate()}</span>
+      <span aria-hidden={true}>{formatDayNumber(date, locale)}</span>
       <span className="ams-visually-hidden">{formatAccessibleDate(date, locale)}</span>
     </>
   )

--- a/packages/react/src/DatePicker/DatePicker.test.tsx
+++ b/packages/react/src/DatePicker/DatePicker.test.tsx
@@ -166,6 +166,27 @@ describe('DatePicker', () => {
     expect(screen.getByRole('button', { name: 'dinsdag 10 maart 2026, startdatum, einddatum' })).toBeInTheDocument()
   })
 
+  it('names a single-day range with the start and end labels joined by a locale-aware separator', () => {
+    const day = new Date(2026, 2, 10)
+
+    render(
+      <DatePicker
+        defaultMonth={march2026}
+        locale="ar-MA"
+        mode="range"
+        onChange={noop}
+        rangeEndAccessibleName="تاريخ الانتهاء"
+        rangeStartAccessibleName="تاريخ البدء"
+        value={{ start: day, end: day }}
+      />,
+    )
+
+    // The Arabic comma (U+060C) joins both the date and the two labels consistently.
+    expect(
+      screen.getByRole('button', { name: 'الثلاثاء، 10 مارس 2026، تاريخ البدء، تاريخ الانتهاء' }),
+    ).toBeInTheDocument()
+  })
+
   it('does not select a disabled date', () => {
     const onChange = vi.fn()
 

--- a/packages/react/src/DatePicker/DatePicker.tsx
+++ b/packages/react/src/DatePicker/DatePicker.tsx
@@ -12,7 +12,7 @@ import { getDaysInMonth, isSameDay, isSameMonth, startOfDay } from '../common/da
 import { useMonthNavigation } from '../common/useMonthNavigation'
 import { DatePickerBody } from './DatePickerBody'
 import { DatePickerHeader } from './DatePickerHeader'
-import { getNextFocusDate, isOutOfBounds, isWithinRange, nextRange } from './utils'
+import { getListSeparator, getNextFocusDate, isOutOfBounds, isWithinRange, nextRange } from './utils'
 
 /** A start and end date. Either side may be `null` while the range is being chosen. */
 export type DateRange = {
@@ -181,7 +181,7 @@ export const DatePicker = forwardRef((props: DatePickerProps, ref: ForwardedRef<
     const isStart = start !== null && isSameDay(date, start)
     const isEnd = end !== null && isSameDay(date, end)
 
-    if (isStart && isEnd) return `${rangeStartAccessibleName}, ${rangeEndAccessibleName}`
+    if (isStart && isEnd) return `${rangeStartAccessibleName}${getListSeparator(locale)}${rangeEndAccessibleName}`
     if (isStart) return rangeStartAccessibleName
     if (isEnd) return rangeEndAccessibleName
 

--- a/packages/react/src/DatePicker/DatePickerDay.test.tsx
+++ b/packages/react/src/DatePicker/DatePickerDay.test.tsx
@@ -28,6 +28,27 @@ describe('DatePickerDay', () => {
     expect(screen.getByRole('button', { name: 'zaterdag 14 maart 2026' })).toBeInTheDocument()
   })
 
+  it('appends the boundary label to the accessible name', () => {
+    render(<DatePickerDay {...defaultProps} boundaryLabel="startdatum" />)
+
+    expect(screen.getByRole('button', { name: 'zaterdag 14 maart 2026, startdatum' })).toBeInTheDocument()
+  })
+
+  it('localises the visible day number so it matches the announced date', () => {
+    render(<DatePickerDay {...defaultProps} locale="ar-EG" />)
+
+    // ar-EG uses Arabic-Indic digits, so the visible number and the announced date agree.
+    expect(screen.getByText('١٤')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'السبت، ١٤ مارس ٢٠٢٦' })).toBeInTheDocument()
+  })
+
+  it('joins the boundary label with the Arabic comma for Arabic locales', () => {
+    render(<DatePickerDay {...defaultProps} boundaryLabel="تاريخ البدء" locale="ar-EG" />)
+
+    // U+060C keeps the appended label consistent with the comma inside the Arabic date.
+    expect(screen.getByRole('button', { name: 'السبت، ١٤ مارس ٢٠٢٦، تاريخ البدء' })).toBeInTheDocument()
+  })
+
   it('marks today with aria-current', () => {
     render(<DatePickerDay {...defaultProps} isCurrent />)
 

--- a/packages/react/src/DatePicker/DatePickerDay.tsx
+++ b/packages/react/src/DatePicker/DatePickerDay.tsx
@@ -9,6 +9,8 @@ import { clsx } from 'clsx'
 
 import type { DatePickerProps } from './DatePicker'
 
+import { getListSeparator } from './utils'
+
 export type DatePickerDayProps = {
   /** Text appended to the accessible name, e.g. to mark the start or end of a range. */
   readonly boundaryLabel?: string
@@ -28,6 +30,8 @@ export type DatePickerDayProps = {
   readonly onSelect: (date: Date) => void
 } & Pick<DatePickerProps, 'locale'>
 
+const formatDayNumber = (date: Date, locale?: string) => new Intl.NumberFormat(locale).format(date.getDate())
+
 const formatAccessibleDate = (date: Date, locale?: string, boundaryLabel?: string) => {
   const fullDate = new Intl.DateTimeFormat(locale, {
     day: 'numeric',
@@ -36,7 +40,7 @@ const formatAccessibleDate = (date: Date, locale?: string, boundaryLabel?: strin
     year: 'numeric',
   }).format(date)
 
-  return boundaryLabel ? `${fullDate}, ${boundaryLabel}` : fullDate
+  return boundaryLabel ? `${fullDate}${getListSeparator(locale)}${boundaryLabel}` : fullDate
 }
 
 export const DatePickerDay = ({
@@ -60,7 +64,7 @@ export const DatePickerDay = ({
       tabIndex={isFocused ? 0 : -1}
       type="button"
     >
-      <span aria-hidden={true}>{date.getDate()}</span>
+      <span aria-hidden={true}>{formatDayNumber(date, locale)}</span>
       <span className="ams-visually-hidden">{formatAccessibleDate(date, locale, boundaryLabel)}</span>
     </button>
   </div>

--- a/packages/react/src/DatePicker/DatePickerDay.tsx
+++ b/packages/react/src/DatePicker/DatePickerDay.tsx
@@ -30,7 +30,18 @@ export type DatePickerDayProps = {
   readonly onSelect: (date: Date) => void
 } & Pick<DatePickerProps, 'locale'>
 
-const formatDayNumber = (date: Date, locale?: string) => new Intl.NumberFormat(locale).format(date.getDate())
+const dayNumberFormatters = new Map<string | undefined, Intl.NumberFormat>()
+
+const formatDayNumber = (date: Date, locale?: string) => {
+  let formatter = dayNumberFormatters.get(locale)
+
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale)
+    dayNumberFormatters.set(locale, formatter)
+  }
+
+  return formatter.format(date.getDate())
+}
 
 const formatAccessibleDate = (date: Date, locale?: string, boundaryLabel?: string) => {
   const fullDate = new Intl.DateTimeFormat(locale, {

--- a/packages/react/src/DatePicker/utils.test.ts
+++ b/packages/react/src/DatePicker/utils.test.ts
@@ -10,6 +10,7 @@ import {
   addMonths,
   addYears,
   endOfWeek,
+  getListSeparator,
   getNextFocusDate,
   isOutOfBounds,
   isWithinRange,
@@ -129,5 +130,22 @@ describe('getNextFocusDate', () => {
   it('returns undefined for keys that do not move focus', () => {
     expect(getNextFocusDate('Enter', false, new Date(2026, 2, 15))).toBeUndefined()
     expect(getNextFocusDate(' ', false, new Date(2026, 2, 15))).toBeUndefined()
+  })
+})
+
+describe('getListSeparator', () => {
+  it('uses an ASCII comma for Latin-script locales', () => {
+    expect(getListSeparator('nl-NL')).toBe(', ')
+    expect(getListSeparator('en-GB')).toBe(', ')
+  })
+
+  it('uses the Arabic comma for Arabic-script locales', () => {
+    // The separator is U+060C followed by a space, matching the comma Intl places inside Arabic dates.
+    expect(getListSeparator('ar-MA')).toBe('، ')
+    expect(getListSeparator('ar-EG')).toBe('، ')
+  })
+
+  it('falls back to an ASCII comma when no locale is given', () => {
+    expect(getListSeparator()).toBe(', ')
   })
 })

--- a/packages/react/src/DatePicker/utils.ts
+++ b/packages/react/src/DatePicker/utils.ts
@@ -66,6 +66,19 @@ export const startOfWeek = (date: Date) => addDays(date, -((date.getDay() + 6) %
 export const endOfWeek = (date: Date) => addDays(startOfWeek(date), 6)
 
 /**
+ * The separator that joins fragments of an accessible name, matching the locale’s script.
+ * Arabic locales use the Arabic comma (U+060C), keeping it consistent with the comma that
+ * `Intl` already places inside the dates it formats for them.
+ */
+export const getListSeparator = (locale?: string): string => {
+  if (locale === undefined) {
+    return ', '
+  }
+
+  return new Intl.Locale(locale).maximize().script === 'Arab' ? '، ' : ', '
+}
+
+/**
  * Returns the date that keyboard focus should move to for a navigation key,
  * or `undefined` when the key does not move focus.
  */


### PR DESCRIPTION
## What

Make the Calendar and Date Picker day cells locale-correct in two ways:

- **Visible day numerals** now render through `Intl.NumberFormat(locale)` instead of `date.getDate()`, so the visible number matches the numbering system used in the accessible label (e.g. `ar-EG` shows `١٤`, not `14`).
- **The list separator** in accessible names now adapts to the locale’s script. A new `getListSeparator` helper returns the Arabic comma (U+060C) for Arabic-script locales and the ASCII comma otherwise. It replaces the hard-coded `", "` in both `DatePickerDay`’s boundary label and `DatePicker.getBoundaryLabel`.

## Why

The accessible label is built with `Intl`, but the visible number was `date.getDate()` — always Latin digits. For locales whose default numbering system isn’t `latn` (e.g. `ar-EG` → `arab`) the visible and announced numerals disagreed.

Separately, `Intl` already formats Arabic dates with the Arabic comma inside the string, so appending an ASCII comma to build the boundary/range label produced a mix of two comma glyphs within a single accessible name.

## How

- Added `formatDayNumber` (via `Intl.NumberFormat`) in `CalendarDay` and `DatePickerDay`.
- Added `getListSeparator(locale)` to `DatePicker/utils.ts`; it uses `new Intl.Locale(locale).maximize().script === 'Arab'` to pick the comma, and falls back to `", "` when no locale is given.

Behaviour is unchanged for the six currently supported locales, all of which default to `latn` and an ASCII comma — the existing Dutch tests still pass alongside the new Arabic ones.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- Purely locale-correctness; no visual or API change for the currently supported locales, so no story or docs updates were needed.
