### PR TITLE
fix(Storybook): Let a story’s lang follow its locale control

### DIFF
--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -39,11 +39,19 @@ export const argTypes = {
   },
 }
 
-// Set the language to Dutch and apply the page background overrides for Canvas and Stories.
+// Set the page language and apply the page background overrides for Canvas and Stories.
 // Components that need a realistic Page or a width constraint add that themselves through a decorator.
 export const decorators = [
   (Story: StoryFn, context: StoryContext) => {
-    const { args } = context
+    const { args, parameters } = context
+
+    // The language of the story frame, so localised examples announce and hyphenate correctly and
+    // any `:lang()`-based styling resolves. In priority order:
+    //   1. `parameters.lang` — a story or component pins a fixed language;
+    //   2. the language subtag of the `locale` arg — a story with a locale control; `lang` tracks it;
+    //   3. `'nl'` — the Dutch default.
+    const locale = args['locale']
+    const lang = parameters['lang'] ?? (typeof locale === 'string' ? locale.split('-')[0] : undefined) ?? 'nl'
 
     return (
       <div
@@ -51,7 +59,7 @@ export const decorators = [
           '_ams-page-background--dark': args['color'] === 'inverse',
           '_ams-page-background--light': args['color'] === 'contrast',
         })}
-        lang="nl"
+        lang={lang}
       >
         <Story />
       </div>


### PR DESCRIPTION
# Let a story’s lang follow its locale control

## What

The global preview decorator no longer hard-codes `lang="nl"` on the story frame. The frame’s `lang` now resolves in priority order: `parameters.lang`, then the language subtag of the `locale` arg, then `'nl'` as the Dutch default. Stories with a `locale` control — Calendar and Date Picker today — get the right `lang` automatically as you switch locale, and any other story can pin one with `parameters.lang`.

## Why

Every non-Dutch example previously claimed to be Dutch, so screen readers mispronounced the English, German, French, Turkish and Arabic content.

It also explains a puzzling report: the Calendar and Date Picker navigation chevrons pointed the wrong way in the `demo-develop` deployment but mirrored correctly locally, at the same commit. The mirror rule is written with `:dir(rtl)`, which resolves from the `dir` attribute, so locally it works. In the production build, though, Vite’s CSS minifier (Lightning CSS — the silent default whenever `build.cssMinify` isn’t the exact string `'esbuild'`) lowers `:dir(rtl)` into a `:is(:lang(ar), :lang(he), …)` approximation, because `:dir()` can’t be expressed with static selectors. That approximation keys off `lang`, not `dir`, and the frame’s `lang` was stuck on `nl` — so nothing matched and the chevrons never flipped.

Setting `lang` correctly makes the mirroring robust either way: the real `:dir(rtl)` follows `dir`, the lowered `:lang()` form follows `lang`, and now both resolve.

## How

`storybook/config/preview.tsx` reads `args.locale` (and `parameters.lang`) in the decorator and derives the language subtag, so the value reacts to the locale control live. `dir` is left untouched — the component still owns it. The published `@amsterdam/design-system-css` keeps the real `:dir()` (verified in `dist/index.css`), so no consumer in a normal browser was ever affected; this change is scoped to the Storybook demo.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Story to check in the feature deploy: **Components → Navigation → Calendar → Default**, with the `locale` control set to `العربية (Arabic)`; the navigation chevrons should mirror. The same applies to Date Picker.
- Follow-up worth a separate discussion: the `:dir()` selector in `packages/css/src/components/icon/icon.scss` is fragile under any consumer bundler that runs Lightning CSS (Vite 8’s default `cssMinify`). Making the library itself robust — rather than relying on consumers to set `lang` — is out of scope here.
