### PR TITLE
chore(ci): Establish consistent naming across GitHub Actions workflows

### DIFF
--- a/.github/scripts/cleanup_deployments.py
+++ b/.github/scripts/cleanup_deployments.py
@@ -1,11 +1,11 @@
 # @license EUPL-1.2+
 # Copyright Gemeente Amsterdam
-"""Delete obsolete GitHub Deployments for a repo.
+"""Delete stale GitHub Deployments for a repo.
 
 Default scope (always on): `demo-*` deployments whose branch is gone.
-A deployment targeting environment `demo-X` is obsolete when no remote branch
+A deployment targeting environment `demo-X` is stale when no remote branch
 matches `X` after stripping the leading `<prefix>/` segment from the branch
-name — the same transform feature-branch-deploy.yml applies.
+name — the same transform deploy-acceptance-storybook.yml applies.
 
 Optional scope (--include-production): `github-pages` and `demo-develop`
 deployments. The branch-existence check doesn't apply (those branches always

--- a/.github/scripts/cleanup_environments.py
+++ b/.github/scripts/cleanup_environments.py
@@ -1,10 +1,10 @@
 # @license EUPL-1.2+
 # Copyright Gemeente Amsterdam
-"""Delete obsolete `demo-*` GitHub Environments for a repo.
+"""Delete stale `demo-*` GitHub Environments for a repo.
 
-A `demo-X` environment is obsolete when no remote branch matches `X` after
+A `demo-X` environment is stale when no remote branch matches `X` after
 stripping the leading `<prefix>/` segment from the branch name — the same
-transform feature-branch-deploy.yml applies when creating the environment.
+transform deploy-acceptance-storybook.yml applies when creating the environment.
 
 Required env vars:
     GITHUB_TOKEN  Token with repo Administration: write (see workflow notes).

--- a/.github/scripts/cleanup_gh_pages_demos.sh
+++ b/.github/scripts/cleanup_gh_pages_demos.sh
@@ -8,7 +8,7 @@ shopt -s nullglob
 
 # Cleanup rules:
 # - demo-X is stale when no active branch short name matches X.
-# - short name mirrors feature-branch-deploy: strip first <prefix>/.
+# - short name mirrors deploy-acceptance-storybook: strip first <prefix>/.
 # - Nested previews (demo-foo/bar) are handled safely.
 #
 # Environment variables:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -91,6 +91,6 @@ The supporting scripts live in [`.github/scripts`](../scripts).
 - **`workflow_run` runs on the default branch.**
   Publish always executes from `develop`, then checks out `main` itself; this is intentional and noted inline in the file.
 - **Required status checks follow job names, not workflow names.**
-  Branch protection refers to a check by its job name, and the job names were left unchanged during the rename, so the required checks carry over. Verify them in the repository settings after renaming all the same.
+  Branch protection and rulesets refer to a check by its job's `name:` (or its id, if the job has no `name:`) — never the workflow's name or file. If you rename a job that's a required check, update the required status checks in the repository settings in the same change, or the check gets stuck on “Expected — waiting for status” forever.
 - **Chromatic only snapshots the story named “Test”.**
   That is a Storybook convention unrelated to any workflow name; see the [testing documentation](../../documentation/tests.md).

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,112 +3,94 @@
 # GitHub Actions workflows
 
 This folder holds every continuous integration and delivery workflow for the design system.
-There are twelve of them, but they only do four kinds of work.
-Reading them by responsibility — rather than by file name — is the quickest way to understand the whole picture.
+There are twelve of them, but they only do four kinds of work, and the file name now starts with the verb for that kind.
+Job ids and step names follow the same rule — a verb first, and a name that matches what actually happens — so keep new ones consistent with their neighbours rather than inventing a new style.
+Reading them by responsibility is the quickest way to understand the whole picture.
 
 - **Check** — quality gates that run on every pull request.
-- **Deploy** — build Storybook and publish it to GitHub Pages.
-- **Release** — publish the packages to npm.
-- **Cleanup** — remove preview deployments once a branch is gone.
+- **Deploy** — build Storybook and deploy it to GitHub Pages.
+- **Publish** — publish the packages to npm.
+- **Remove** — delete preview deployments once a branch is gone.
 
 Pull requests are made against `develop`, our integration branch.
-Changes reach `main` through a release pull request, and that is what triggers the documentation deploy and the release.
+Changes reach `main` through a release pull request, which is what triggers the production deploy and the npm publish.
 
 ## At a glance
 
-| Workflow (file)                                               | Kind    | Runs when                                                      | Responsible for                                                                                                                    |
-| :------------------------------------------------------------ | :------ | :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- |
-| Lint and test (`lint-test.yml`)                               | Check   | Every pull request; push to `main`                             | Build all packages, then run the linters and unit tests. The main quality gate.                                                    |
-| Test (`chromatic.yml`)                                        | Check   | Pull request opened or marked ready; `/chromatic test` comment | Visual regression snapshots through Chromatic.                                                                                     |
-| Coverage report (`pr-coverage.yml`)                           | Check   | Every pull request                                             | Run the React tests with coverage and post a summary comment.                                                                      |
-| Bundle size report (`pr-bundle-size.yml`)                     | Check   | Every pull request                                             | Report the compressed size change of the published bundles.                                                                        |
-| PR title validation (`pr-title-validation.yml`)               | Check   | Pull request opened, edited, or synchronized                   | Enforce a Conventional Commit title (`feat`, `fix`, `chore`) so release-please can read it.                                        |
-| Feature branch build and deploy (`feature-branch-deploy.yml`) | Deploy  | Push to any branch except `main`; pull request reopened        | Build Storybook and publish a per-branch preview to `gh-pages` under `demo-<branch>`. Records a GitHub Deployment and Environment. |
-| Main branch build and deploy (`main-branch-deploy.yml`)       | Deploy  | Push to `main`                                                 | Build Storybook and publish the live documentation site to the `gh-pages` root.                                                    |
-| Publish (`publish.yml`)                                       | Release | After “Lint and test” succeeds on `main`                       | Run release-please; if it cuts a release, build and publish the packages to npm.                                                   |
-| Feature branch cleanup (`feature-branch-cleanup.yml`)         | Cleanup | Pull request closed (base is not `main`)                       | Delete that branch’s `demo-<branch>` directory and deactivate its Deployment.                                                      |
-| Cleanup obsolete deployments (`cleanup-deployments.yml`)      | Cleanup | Weekly, Sunday 05:00 UTC; manual                               | Delete GitHub Deployment records for `demo-*` whose branch no longer exists.                                                       |
-| Cleanup obsolete environments (`cleanup-environments.yml`)    | Cleanup | Weekly, Sunday 04:00 UTC; manual                               | Delete `demo-*` GitHub Environments whose branch no longer exists.                                                                 |
-| Cleanup stale demo directories (`cleanup-gh-pages-demos.yml`) | Cleanup | After a major release; manual                                  | Remove stale `demo-*` directories from the `gh-pages` branch.                                                                      |
+| Workflow                      | Runs when                                                      | Responsible for                                                                                                                    |
+| :---------------------------- | :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- |
+| Check build and tests         | Every pull request; push to `main`                             | Build all packages, then run the linters and unit tests. The main quality gate.                                                    |
+| Check visual regressions      | Pull request opened or marked ready; `/chromatic test` comment | Visual regression snapshots through Chromatic.                                                                                     |
+| Check test coverage           | Every pull request                                             | Run the React tests with coverage and post a summary comment.                                                                      |
+| Check bundle size             | Every pull request                                             | Report the compressed size change of the published bundles.                                                                        |
+| Check PR title                | Pull request opened, edited, or synchronized                   | Enforce a Conventional Commit title (`feat`, `fix`, `chore`) so release-please can read it.                                        |
+| Deploy acceptance Storybook   | Push to any branch except `main`; pull request reopened        | Build Storybook and publish a per-branch preview to `gh-pages` under `demo-<branch>`. Records a GitHub Deployment and Environment. |
+| Deploy production Storybook   | Push to `main`                                                 | Build Storybook and publish the live documentation site to the `gh-pages` root.                                                    |
+| Publish packages              | After “Check build and tests” succeeds on `main`               | Run release-please; if it cuts a release, build and publish the packages to npm.                                                   |
+| Remove acceptance Storybook   | Pull request closed (base is not `main`)                       | Delete that branch’s `demo-<branch>` directory and deactivate its Deployment.                                                      |
+| Remove stale deployments      | Weekly, Sunday 05:00 UTC; manual                               | Delete GitHub Deployment records for `demo-*` whose branch no longer exists.                                                       |
+| Remove stale environments     | Weekly, Sunday 04:00 UTC; manual                               | Delete `demo-*` GitHub Environments whose branch no longer exists.                                                                 |
+| Remove stale demo directories | After a major release; manual                                  | Remove stale `demo-*` directories from the `gh-pages` branch.                                                                      |
 
 ## How a change flows through them
 
 ### Opening or updating a pull request
 
 The **Check** workflows run together and gate the merge.
-Lint and test builds the packages and runs the linters and unit tests.
-Chromatic takes visual snapshots, the coverage and bundle-size workflows post their reports as comments, and PR title validation checks the title.
+**Check build and tests** builds the packages and runs the linters and unit tests.
+**Check visual regressions** takes Chromatic snapshots, the coverage and bundle-size workflows post their reports as comments, and the title check validates the pull request title.
 
-At the same time, **Feature branch build and deploy** publishes a live Storybook preview for the branch at `demo-<branch>` on the Pages site.
-This is why every push to a feature branch — or to `develop` — produces a `demo-*` preview.
+At the same time, **Deploy acceptance Storybook** publishes a live Storybook preview for the branch at `demo-<branch>` on GitHub Pages.
 
 ### Merging to `main`
 
 A push to `main` runs two things in parallel.
-**Main branch build and deploy** rebuilds Storybook and replaces the live documentation site at the `gh-pages` root, keeping all `demo-*` previews untouched.
-**Lint and test** runs again on `main`, and its success is the signal that starts **Publish**.
+**Deploy production Storybook** rebuilds Storybook and replaces the live documentation site at the `gh-pages` root, keeping all `demo-*` previews untouched.
+**Check build and tests** runs again on `main`, and its success is the signal that starts **Publish packages**.
 
-**Publish** runs release-please.
+**Publish packages** runs release-please.
 If there are releasable changes, release-please opens or updates a release pull request; merging that is what actually cuts the release.
-When a release is cut, Publish builds the packages and pushes them to npm.
+When a release is cut, the workflow builds the packages and pushes them to npm.
 
 ### Closing a pull request
 
-**Feature branch cleanup** removes that branch’s `demo-<branch>` directory from `gh-pages` and deactivates its Deployment, so previews do not pile up.
+**Remove acceptance Storybook** removes that branch’s `demo-<branch>` directory from `gh-pages` and deactivates its Deployment, so previews do not pile up.
 
 ### On a schedule or a release
 
-The remaining three **Cleanup** workflows sweep up whatever the per-pull-request cleanup missed (see the next section).
+The remaining three **Remove** workflows sweep up whatever the per-pull-request removal missed (see the next section).
 
 ## The demo preview ecosystem
 
-A single feature-branch preview is not one object — it spans three separate GitHub surfaces, each created by **Feature branch build and deploy**:
+A single feature-branch preview is not one object — it spans three separate GitHub surfaces, each created by **Deploy acceptance Storybook**:
 
 1. a `demo-<branch>` **directory** on the `gh-pages` branch (the actual files),
 2. a GitHub **Deployment** record (the entry in the Deployments timeline),
 3. a GitHub **Environment** named `demo-<branch>` (the entry under Settings → Environments).
 
-**Feature branch cleanup** handles the common case: when a pull request is closed it deletes the directory and deactivates the Deployment.
-But branches can disappear without a clean pull-request close, and the Environment is never removed by that workflow, so orphans accumulate on all three surfaces over time.
+**Remove acceptance Storybook** handles the common case: when a pull request is closed it deletes the directory and deactivates the Deployment.
+But branches can disappear without a clean pull-request close, and the Environment is never removed by that workflow, so stale items accumulate on all three surfaces over time.
 
-That is why there are three scheduled or release-driven cleanups rather than one — each targets a different surface and needs a different mechanism:
+That is why there are three scheduled or release-driven removals rather than one — each targets a different surface and needs a different mechanism:
 
-| Workflow                       | Surface it cleans      | Mechanism        | Trigger               |
-| :----------------------------- | :--------------------- | :--------------- | :-------------------- |
-| Cleanup stale demo directories | `gh-pages` directories | Git, Bash script | Major release; manual |
-| Cleanup obsolete deployments   | Deployment records     | REST API, Python | Weekly; manual        |
-| Cleanup obsolete environments  | Environments           | REST API, Python | Weekly; manual        |
+| Workflow                      | Surface it cleans      | Mechanism        | Trigger               |
+| :---------------------------- | :--------------------- | :--------------- | :-------------------- |
+| Remove stale demo directories | `gh-pages` directories | Git, Bash script | Major release; manual |
+| Remove stale deployments      | Deployment records     | REST API, Python | Weekly; manual        |
+| Remove stale environments     | Environments           | REST API, Python | Weekly; manual        |
 
-All three decide what is obsolete the same way: a `demo-X` item is stale when no remote branch matches `X` after stripping the leading `<prefix>/` segment — exactly the transformation **Feature branch build and deploy** uses when it creates the preview.
+All three decide what is stale the same way: a `demo-X` item is stale when no remote branch matches `X` after stripping the leading `<prefix>/` segment — exactly the transformation **Deploy acceptance Storybook** uses when it creates the preview.
 They default to a dry run and apply a grace window so an in-flight deploy is never raced into deletion.
 The supporting scripts live in [`.github/scripts`](../scripts).
 
-## Diagram
-
-```mermaid
-flowchart TD
-  subgraph PR["Pull request open or updated"]
-    Checks["Check: lint-test · chromatic · coverage · bundle-size · pr-title"]
-    Preview["Deploy: feature-branch-deploy → demo-&lt;branch&gt; preview"]
-  end
-
-  Close(["Pull request closed"]) --> CleanupPR["Cleanup: feature-branch-cleanup<br/>removes demo-&lt;branch&gt;"]
-
-  Main(["Push to main"]) --> Site["Deploy: main-branch-deploy → docs site"]
-  Main --> LintMain["Lint and test on main"] --> Publish["Release: publish → release-please → npm"]
-  Publish -. "major release" .-> CleanupDirs["Cleanup: cleanup-gh-pages-demos"]
-
-  Schedule(["Weekly schedule"]) --> CleanupApi["Cleanup: cleanup-deployments + cleanup-environments"]
-```
-
 ## Notes and gotchas
 
-- **Publish depends on the name “Lint and test”.**
-  `publish.yml` triggers on `workflow_run` for the workflow literally named `Lint and test`.
-  If you rename that workflow, update the `workflows:` list in `publish.yml` in the same change, or releases stop running.
+- **Publish depends on the name “Check build and tests”.**
+  `publish-packages.yml` triggers on `workflow_run` for the workflow with that exact name.
+  If you rename that workflow, update the `workflows:` list in `publish-packages.yml` in the same change, or releases stop running.
 - **`workflow_run` runs on the default branch.**
   Publish always executes from `develop`, then checks out `main` itself; this is intentional and noted inline in the file.
-- **Renaming a workflow can drop required status checks.**
-  Branch protection refers to workflows and jobs by name, so renaming may silently un-require a check until it is re-selected in the repository settings.
+- **Required status checks follow job names, not workflow names.**
+  Branch protection refers to a check by its job name, and the job names were left unchanged during the rename, so the required checks carry over. Verify them in the repository settings after renaming all the same.
 - **Chromatic only snapshots the story named “Test”.**
-  That is unrelated to this workflow’s display name also being “Test”; the two “Test” names are a coincidence worth disambiguating.
+  That is a Storybook convention unrelated to any workflow name; see the [testing documentation](../../documentation/tests.md).

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,114 @@
+<!-- @license CC0-1.0 -->
+
+# GitHub Actions workflows
+
+This folder holds every continuous integration and delivery workflow for the design system.
+There are twelve of them, but they only do four kinds of work.
+Reading them by responsibility — rather than by file name — is the quickest way to understand the whole picture.
+
+- **Check** — quality gates that run on every pull request.
+- **Deploy** — build Storybook and publish it to GitHub Pages.
+- **Release** — publish the packages to npm.
+- **Cleanup** — remove preview deployments once a branch is gone.
+
+Pull requests are made against `develop`, our integration branch.
+Changes reach `main` through a release pull request, and that is what triggers the documentation deploy and the release.
+
+## At a glance
+
+| Workflow (file)                                               | Kind    | Runs when                                                      | Responsible for                                                                                                                    |
+| :------------------------------------------------------------ | :------ | :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- |
+| Lint and test (`lint-test.yml`)                               | Check   | Every pull request; push to `main`                             | Build all packages, then run the linters and unit tests. The main quality gate.                                                    |
+| Test (`chromatic.yml`)                                        | Check   | Pull request opened or marked ready; `/chromatic test` comment | Visual regression snapshots through Chromatic.                                                                                     |
+| Coverage report (`pr-coverage.yml`)                           | Check   | Every pull request                                             | Run the React tests with coverage and post a summary comment.                                                                      |
+| Bundle size report (`pr-bundle-size.yml`)                     | Check   | Every pull request                                             | Report the compressed size change of the published bundles.                                                                        |
+| PR title validation (`pr-title-validation.yml`)               | Check   | Pull request opened, edited, or synchronized                   | Enforce a Conventional Commit title (`feat`, `fix`, `chore`) so release-please can read it.                                        |
+| Feature branch build and deploy (`feature-branch-deploy.yml`) | Deploy  | Push to any branch except `main`; pull request reopened        | Build Storybook and publish a per-branch preview to `gh-pages` under `demo-<branch>`. Records a GitHub Deployment and Environment. |
+| Main branch build and deploy (`main-branch-deploy.yml`)       | Deploy  | Push to `main`                                                 | Build Storybook and publish the live documentation site to the `gh-pages` root.                                                    |
+| Publish (`publish.yml`)                                       | Release | After “Lint and test” succeeds on `main`                       | Run release-please; if it cuts a release, build and publish the packages to npm.                                                   |
+| Feature branch cleanup (`feature-branch-cleanup.yml`)         | Cleanup | Pull request closed (base is not `main`)                       | Delete that branch’s `demo-<branch>` directory and deactivate its Deployment.                                                      |
+| Cleanup obsolete deployments (`cleanup-deployments.yml`)      | Cleanup | Weekly, Sunday 05:00 UTC; manual                               | Delete GitHub Deployment records for `demo-*` whose branch no longer exists.                                                       |
+| Cleanup obsolete environments (`cleanup-environments.yml`)    | Cleanup | Weekly, Sunday 04:00 UTC; manual                               | Delete `demo-*` GitHub Environments whose branch no longer exists.                                                                 |
+| Cleanup stale demo directories (`cleanup-gh-pages-demos.yml`) | Cleanup | After a major release; manual                                  | Remove stale `demo-*` directories from the `gh-pages` branch.                                                                      |
+
+## How a change flows through them
+
+### Opening or updating a pull request
+
+The **Check** workflows run together and gate the merge.
+Lint and test builds the packages and runs the linters and unit tests.
+Chromatic takes visual snapshots, the coverage and bundle-size workflows post their reports as comments, and PR title validation checks the title.
+
+At the same time, **Feature branch build and deploy** publishes a live Storybook preview for the branch at `demo-<branch>` on the Pages site.
+This is why every push to a feature branch — or to `develop` — produces a `demo-*` preview.
+
+### Merging to `main`
+
+A push to `main` runs two things in parallel.
+**Main branch build and deploy** rebuilds Storybook and replaces the live documentation site at the `gh-pages` root, keeping all `demo-*` previews untouched.
+**Lint and test** runs again on `main`, and its success is the signal that starts **Publish**.
+
+**Publish** runs release-please.
+If there are releasable changes, release-please opens or updates a release pull request; merging that is what actually cuts the release.
+When a release is cut, Publish builds the packages and pushes them to npm.
+
+### Closing a pull request
+
+**Feature branch cleanup** removes that branch’s `demo-<branch>` directory from `gh-pages` and deactivates its Deployment, so previews do not pile up.
+
+### On a schedule or a release
+
+The remaining three **Cleanup** workflows sweep up whatever the per-pull-request cleanup missed (see the next section).
+
+## The demo preview ecosystem
+
+A single feature-branch preview is not one object — it spans three separate GitHub surfaces, each created by **Feature branch build and deploy**:
+
+1. a `demo-<branch>` **directory** on the `gh-pages` branch (the actual files),
+2. a GitHub **Deployment** record (the entry in the Deployments timeline),
+3. a GitHub **Environment** named `demo-<branch>` (the entry under Settings → Environments).
+
+**Feature branch cleanup** handles the common case: when a pull request is closed it deletes the directory and deactivates the Deployment.
+But branches can disappear without a clean pull-request close, and the Environment is never removed by that workflow, so orphans accumulate on all three surfaces over time.
+
+That is why there are three scheduled or release-driven cleanups rather than one — each targets a different surface and needs a different mechanism:
+
+| Workflow                       | Surface it cleans      | Mechanism        | Trigger               |
+| :----------------------------- | :--------------------- | :--------------- | :-------------------- |
+| Cleanup stale demo directories | `gh-pages` directories | Git, Bash script | Major release; manual |
+| Cleanup obsolete deployments   | Deployment records     | REST API, Python | Weekly; manual        |
+| Cleanup obsolete environments  | Environments           | REST API, Python | Weekly; manual        |
+
+All three decide what is obsolete the same way: a `demo-X` item is stale when no remote branch matches `X` after stripping the leading `<prefix>/` segment — exactly the transformation **Feature branch build and deploy** uses when it creates the preview.
+They default to a dry run and apply a grace window so an in-flight deploy is never raced into deletion.
+The supporting scripts live in [`.github/scripts`](../scripts).
+
+## Diagram
+
+```mermaid
+flowchart TD
+  subgraph PR["Pull request open or updated"]
+    Checks["Check: lint-test · chromatic · coverage · bundle-size · pr-title"]
+    Preview["Deploy: feature-branch-deploy → demo-&lt;branch&gt; preview"]
+  end
+
+  Close(["Pull request closed"]) --> CleanupPR["Cleanup: feature-branch-cleanup<br/>removes demo-&lt;branch&gt;"]
+
+  Main(["Push to main"]) --> Site["Deploy: main-branch-deploy → docs site"]
+  Main --> LintMain["Lint and test on main"] --> Publish["Release: publish → release-please → npm"]
+  Publish -. "major release" .-> CleanupDirs["Cleanup: cleanup-gh-pages-demos"]
+
+  Schedule(["Weekly schedule"]) --> CleanupApi["Cleanup: cleanup-deployments + cleanup-environments"]
+```
+
+## Notes and gotchas
+
+- **Publish depends on the name “Lint and test”.**
+  `publish.yml` triggers on `workflow_run` for the workflow literally named `Lint and test`.
+  If you rename that workflow, update the `workflows:` list in `publish.yml` in the same change, or releases stop running.
+- **`workflow_run` runs on the default branch.**
+  Publish always executes from `develop`, then checks out `main` itself; this is intentional and noted inline in the file.
+- **Renaming a workflow can drop required status checks.**
+  Branch protection refers to workflows and jobs by name, so renaming may silently un-require a check until it is re-selected in the repository settings.
+- **Chromatic only snapshots the story named “Test”.**
+  That is unrelated to this workflow’s display name also being “Test”; the two “Test” names are a coincidence worth disambiguating.

--- a/.github/workflows/check-build-and-tests.yml
+++ b/.github/workflows/check-build-and-tests.yml
@@ -1,4 +1,4 @@
-name: Lint and test
+name: Check build and tests
 
 on:
   push:

--- a/.github/workflows/check-build-and-tests.yml
+++ b/.github/workflows/check-build-and-tests.yml
@@ -51,10 +51,10 @@ jobs:
       - name: Build packages
         run: pnpm --filter=!storybook -r run build
 
-      - name: "Continuous Integration: lint"
+      - name: Lint packages
         run: |
           pnpm run --if-present lint
 
-      - name: "Continuous Integration: test"
+      - name: Test packages
         run: |
           pnpm run --if-present test

--- a/.github/workflows/check-bundle-size.yml
+++ b/.github/workflows/check-bundle-size.yml
@@ -8,7 +8,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  compressed-size:
+  report-bundle-size:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-bundle-size.yml
+++ b/.github/workflows/check-bundle-size.yml
@@ -1,4 +1,4 @@
-name: Bundle size report
+name: Check bundle size
 
 on:
   pull_request:

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,6 +1,6 @@
 # https://github.com/marketplace/actions/semantic-pull-request
 
-name: PR title validation
+name: Check PR title
 
 on:
   pull_request_target:

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -13,8 +13,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  pr-title-validation:
-    name: PR title validation
+  validate-pr-title:
+    name: Validate PR title
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -17,7 +17,8 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/check-test-coverage.yml
+++ b/.github/workflows/check-test-coverage.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run tests with coverage
         run: pnpm --filter @amsterdam/design-system-react test
 
-      - name: Report coverage
+      - name: Report test coverage
         uses: davelosert/vitest-coverage-report-action@3c054a2d2e2ca45446417ad5d6d5eb33092af8f1 # v2.12.1
         with:
           json-summary-path: packages/react/coverage/coverage-summary.json

--- a/.github/workflows/check-test-coverage.yml
+++ b/.github/workflows/check-test-coverage.yml
@@ -1,4 +1,4 @@
-name: Coverage report
+name: Check test coverage
 
 on:
   pull_request:

--- a/.github/workflows/check-test-coverage.yml
+++ b/.github/workflows/check-test-coverage.yml
@@ -8,7 +8,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  coverage:
+  report-test-coverage:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-visual-regressions.yml
+++ b/.github/workflows/check-visual-regressions.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  chromatic:
+  run-chromatic:
     name: Run Chromatic
     runs-on: ubuntu-latest
     if: |

--- a/.github/workflows/check-visual-regressions.yml
+++ b/.github/workflows/check-visual-regressions.yml
@@ -1,4 +1,4 @@
-name: "Test"
+name: Check visual regressions
 
 on:
   issue_comment:

--- a/.github/workflows/deploy-acceptance-storybook.yml
+++ b/.github/workflows/deploy-acceptance-storybook.yml
@@ -1,6 +1,6 @@
 # Based on https://evilmartians.com/chronicles/super-github-pages-budget-frontend-staging-with-storybook-and-more
 
-name: Feature branch build and deploy
+name: Deploy acceptance Storybook
 
 on:
   push:

--- a/.github/workflows/deploy-acceptance-storybook.yml
+++ b/.github/workflows/deploy-acceptance-storybook.yml
@@ -25,7 +25,7 @@ jobs:
           BRANCH_NAME=$(echo $RAW_BRANCH_NAME | sed 's/[^/]*\///')
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
 
-      - name: Check out
+      - name: Check out branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Create deployment
@@ -57,7 +57,7 @@ jobs:
         run: |
           touch ./storybook/dist/${{ github.sha }}.txt
 
-      - name: Pushing to pages branch
+      - name: Push to pages branch
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages

--- a/.github/workflows/deploy-production-storybook.yml
+++ b/.github/workflows/deploy-production-storybook.yml
@@ -1,4 +1,4 @@
-name: Main branch build and deploy
+name: Deploy production Storybook
 
 on:
   push:

--- a/.github/workflows/deploy-production-storybook.yml
+++ b/.github/workflows/deploy-production-storybook.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out
+      - name: Check out branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install pnpm

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,8 +1,8 @@
-name: Publish
+name: Publish packages
 
 on:
   workflow_run:
-    workflows: [Lint and test]
+    workflows: ["Check build and tests"]
     types: [completed]
     branches: [main]
 

--- a/.github/workflows/remove-acceptance-storybook.yml
+++ b/.github/workflows/remove-acceptance-storybook.yml
@@ -1,6 +1,6 @@
 # Based on https://evilmartians.com/chronicles/super-github-pages-budget-frontend-staging-with-storybook-and-more
 
-name: Feature branch cleanup
+name: Remove acceptance Storybook
 
 on:
   pull_request:

--- a/.github/workflows/remove-acceptance-storybook.yml
+++ b/.github/workflows/remove-acceptance-storybook.yml
@@ -14,7 +14,7 @@ permissions:
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 jobs:
-  remove_stale_pages:
+  remove-demo-directory:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:

--- a/.github/workflows/remove-acceptance-storybook.yml
+++ b/.github/workflows/remove-acceptance-storybook.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Set up Node.js version
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           cache: pnpm
           node-version-file: .nvmrc
@@ -40,7 +41,7 @@ jobs:
         with:
           ref: gh-pages
 
-      - name: Delete folder
+      - name: Remove demo directory
         run: |
           git config --global user.name GitHub Action
           git config --global user.email github-action@users.noreply.github.com

--- a/.github/workflows/remove-stale-demo-directories.yml
+++ b/.github/workflows/remove-stale-demo-directories.yml
@@ -55,7 +55,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  cleanup-demos:
+  remove-demo-directories:
     # Run on manual dispatch, or on a major-version release of a `design-system-*`
     # package — tag format is `design-system-<pkg>-v<major>.<minor>.<patch>`, so
     # the prefix scopes us to our release-please tags and the suffix scopes us to

--- a/.github/workflows/remove-stale-demo-directories.yml
+++ b/.github/workflows/remove-stale-demo-directories.yml
@@ -10,7 +10,7 @@
 #
 # A directory `demo-X` is considered stale when no remote branch matches `X`
 # after stripping the leading `<prefix>/` segment from the branch name — the
-# same transformation feature-branch-deploy.yml applies when creating these
+# same transformation deploy-acceptance-storybook.yml applies when creating these
 # directories.
 #
 # Release-triggered runs force `dry_run=false` and apply a 14-day grace
@@ -27,7 +27,7 @@
 # Safety guard: if more than 25 stale demo directories are selected, the job
 # aborts unless `i_really_mean_it=true` is provided for manual runs.
 
-name: Cleanup stale demo directories from gh-pages
+name: Remove stale demo directories
 
 on:
   workflow_dispatch:
@@ -51,7 +51,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: cleanup-gh-pages-demos
+  group: remove-stale-demo-directories
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/remove-stale-deployments.yml
+++ b/.github/workflows/remove-stale-deployments.yml
@@ -51,7 +51,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  cleanup-deployments:
+  remove-deployments:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts

--- a/.github/workflows/remove-stale-deployments.yml
+++ b/.github/workflows/remove-stale-deployments.yml
@@ -1,13 +1,13 @@
 # @license EUPL-1.2+
 # Copyright Gemeente Amsterdam
 
-# GitHub Actions workflow to clean up obsolete GitHub Deployments.
+# GitHub Actions workflow to clean up stale GitHub Deployments.
 # Runs on a weekly schedule and can be triggered manually.
 #
 # Default scope: `demo-*` deployments whose branch is gone. A deployment
-# targeting environment `demo-X` is obsolete when no remote branch matches `X`
+# targeting environment `demo-X` is stale when no remote branch matches `X`
 # after stripping the leading `<prefix>/` segment — the same transformation
-# feature-branch-deploy.yml applies when creating these deployments.
+# deploy-acceptance-storybook.yml applies when creating these deployments.
 #
 # Optional scope (manual dispatch with `include_production=true`):
 # `github-pages` and `demo-develop`. Branch-existence does not apply (those
@@ -18,7 +18,7 @@
 # The default `dry_run=true` only logs what would be deleted.
 # Pass `dry_run=false` from the Actions UI to perform deletions.
 
-name: Cleanup obsolete deployments
+name: Remove stale deployments
 
 on:
   workflow_dispatch:
@@ -47,7 +47,7 @@ permissions:
   deployments: write
 
 concurrency:
-  group: cleanup-deployments
+  group: remove-stale-deployments
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/remove-stale-deployments.yml
+++ b/.github/workflows/remove-stale-deployments.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: "pip install --only-binary=:all: --require-hashes -r .github/scripts/requirements.txt"
 
-      - name: Cleanup deployments
+      - name: Remove deployments
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/remove-stale-environments.yml
+++ b/.github/workflows/remove-stale-environments.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install dependencies
         run: "pip install --only-binary=:all: --require-hashes -r .github/scripts/requirements.txt"
 
-      - name: Cleanup environments
+      - name: Remove environments
         env:
           # Falls through to GITHUB_TOKEN when the admin secret isn't set so
           # dry-runs and listing still work; see permissions note above.

--- a/.github/workflows/remove-stale-environments.yml
+++ b/.github/workflows/remove-stale-environments.yml
@@ -45,7 +45,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  cleanup-environments:
+  remove-environments:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts

--- a/.github/workflows/remove-stale-environments.yml
+++ b/.github/workflows/remove-stale-environments.yml
@@ -1,18 +1,18 @@
 # @license EUPL-1.2+
 # Copyright Gemeente Amsterdam
 
-# GitHub Actions workflow to clean up obsolete `demo-*` GitHub Environments.
+# GitHub Actions workflow to clean up stale `demo-*` GitHub Environments.
 # Runs on a weekly schedule and can be triggered manually.
 #
-# A `demo-X` environment is considered obsolete when no remote branch matches
+# A `demo-X` environment is considered stale when no remote branch matches
 # `X` after stripping the leading `<prefix>/` segment — the same transformation
-# feature-branch-deploy.yml applies when creating these environments. Other
+# deploy-acceptance-storybook.yml applies when creating these environments. Other
 # environment names are left alone.
 #
 # The default `dry_run=true` only logs what would be deleted. Pass
 # `dry_run=false` from the Actions UI to perform the deletions.
 
-name: Cleanup obsolete environments
+name: Remove stale environments
 
 on:
   workflow_dispatch:
@@ -41,7 +41,7 @@ permissions:
   # delete step will return 403 once dry_run is set to false.
 
 concurrency:
-  group: cleanup-environments
+  group: remove-stale-environments
   cancel-in-progress: false
 
 jobs:

--- a/documentation/continuous-integration.md
+++ b/documentation/continuous-integration.md
@@ -2,6 +2,8 @@
 
 # Continuous integration
 
+For an overview of every workflow and how they fit together, see the [workflows README](../.github/workflows/README.md).
+
 ## Commit hashes for GitHub Actions
 
 We use a commit hash instead of a version number to specify which release of a GitHub Action we use in our workflows.
@@ -36,9 +38,9 @@ pnx pin-github-action -c " {ref}" /path/to/workflow.yaml
 
 Three workflows prune artefacts left behind by feature-branch deploys:
 
-- `Cleanup stale demo directories from gh-pages` ([cleanup-gh-pages-demos.yml](../.github/workflows/cleanup-gh-pages-demos.yml))
-- `Cleanup obsolete environments` ([cleanup-environments.yml](../.github/workflows/cleanup-environments.yml))
-- `Cleanup obsolete deployments` ([cleanup-deployments.yml](../.github/workflows/cleanup-deployments.yml))
+- `Remove stale demo directories` ([remove-stale-demo-directories.yml](../.github/workflows/remove-stale-demo-directories.yml))
+- `Remove stale environments` ([remove-stale-environments.yml](../.github/workflows/remove-stale-environments.yml))
+- `Remove stale deployments` ([remove-stale-deployments.yml](../.github/workflows/remove-stale-deployments.yml))
 
 Each runs on a schedule as a dry-run.
 To perform real deletions, dispatch from the Actions UI with `dry_run=false`.

--- a/documentation/publishing.md
+++ b/documentation/publishing.md
@@ -3,13 +3,13 @@
 # Publishing
 
 We use a [Release Please GitHub Action](https://github.com/googleapis/release-please-action) to create changelogs and release PRs for all our packages.
-When the release PR is merged, the Publish workflow (specifically the `pnpm -r publish` step in `.github/workflows/publish.yml`) publishes the new release to npm, after Release Please reports `releases_created == 'true'`. Release Please itself creates the release PR and the GitHub release, but does not publish to npm.
-A separate “Main branch build and deploy” workflow keeps our main Storybook environment up to date with `main`.
+When the release PR is merged, the “Publish packages” workflow (specifically the `pnpm -r publish` step in `.github/workflows/publish-packages.yml`) publishes the new release to npm, after Release Please reports `releases_created == 'true'`. Release Please itself creates the release PR and the GitHub release, but does not publish to npm.
+A separate “Deploy production Storybook” workflow keeps our main Storybook environment up to date with `main`.
 
 The [maintainers](./maintainers.md) can release new versions of our packages.
 If you want to have rights to publish as well, contact one of the maintainers.
 
-The “Publish” workflow uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC), so individual maintainers don’t need personal npm credentials.
+The “Publish packages” workflow uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC), so individual maintainers don’t need personal npm credentials.
 
 ## Conventional commits
 
@@ -65,10 +65,10 @@ git push
 This doesn’t interfere with the release PR that Release Please creates.
 GitHub will mark the pull request as merged automatically when you push.
 
-Pushing to `main` triggers the “Lint and test” workflow on GitHub. When this workflow completes successfully, it triggers the “Publish” workflow.
+Pushing to `main` triggers the “Check build and tests” workflow on GitHub. When this workflow completes successfully, it triggers the “Publish packages” workflow.
 On this first run, Release Please opens (or updates) a release PR. The workflow runs again later, after that PR is merged, to create the GitHub release and publish to npm.
 
-A separate “Main branch build and deploy” workflow runs in parallel and refreshes our main Storybook environment from the latest `main`.
+A separate “Deploy production Storybook” workflow runs in parallel and refreshes our main Storybook environment from the latest `main`.
 
 ### Review the release PR
 
@@ -87,7 +87,7 @@ See below for details.
 
 Approve the release PR, then merge it – no need to wait for the checks, since the release PR only bumps versions and updates changelogs (no source code changes). The merge must be done manually; the workflow does not merge the PR automatically.
 
-After merging, the “Publish” workflow runs again. Release Please now reports `releases_created == 'true'`, which gates the npm publish step, so the new versions are pushed to GitHub and npm.
+After merging, the “Publish packages” workflow runs again. Release Please now reports `releases_created == 'true'`, which gates the npm publish step, so the new versions are pushed to GitHub and npm.
 
 ### Merge back into develop
 

--- a/documentation/tests.md
+++ b/documentation/tests.md
@@ -11,7 +11,7 @@ We test our components to ensure their quality and prevent unintended changes.
 | Principle | Check specific properties of a component.                           |
 | Example   | Does the button still have className `.button-primary` as expected? |
 
-Unit tests are written using [Vitest](https://vitest.dev) and [React Testing Library](https://github.com/testing-library/react-testing-library). These tests run on every [pull request](https://github.com/Amsterdam/design-system/blob/develop/.github/workflows/lint-test.yml).
+Unit tests are written using [Vitest](https://vitest.dev) and [React Testing Library](https://github.com/testing-library/react-testing-library). These tests run on every [pull request](https://github.com/Amsterdam/design-system/blob/develop/.github/workflows/check-build-and-tests.yml).
 All components must have their own unit tests, which are located in a separate file named `component.test.tsx`.
 
 ## Interaction tests
@@ -54,8 +54,8 @@ Accessibility tests are not configured on a component basis. The accessibility r
 
 With each pull request there are two actions:
 
-1. [Unit Tests](https://github.com/Amsterdam/design-system/actions/workflows/lint-test.yml)
-2. [Interaction, Visual, Accessibility tests](https://github.com/Amsterdam/design-system/actions/workflows/chromatic.yml)
+1. [Unit Tests](https://github.com/Amsterdam/design-system/actions/workflows/check-build-and-tests.yml)
+2. [Interaction, Visual, Accessibility tests](https://github.com/Amsterdam/design-system/actions/workflows/check-visual-regressions.yml)
 
 The interaction, visual, and accessibility tests are run by [Chromatic](https://chromatic.com). Chromatic runs these tests on each story labeled ‘Test’. If any changes are detected, they must be approved before merging the pull request. You can accept changes directly through the Chromatic dashboard. Once the changes are accepted, the pull request can be merged.
 
@@ -63,13 +63,13 @@ These actions are required to succeed before merging a pull-request.
 
 ### Chromatic configuration
 
-Chromatic uses two tokens to run: a project ID and a [secret token](https://www.chromatic.com/manage?appId=68db9df886b46f139748c074&view=configure). The project ID is public within the [repo](https://github.com/Amsterdam/design-system/blob/develop/storybook/chromatic.config.json), while the secret token is used in the [workflow](https://github.com/Amsterdam/design-system/blob/develop/.github/workflows/chromatic.yml).
+Chromatic uses two tokens to run: a project ID and a [secret token](https://www.chromatic.com/manage?appId=68db9df886b46f139748c074&view=configure). The project ID is public within the [repo](https://github.com/Amsterdam/design-system/blob/develop/storybook/chromatic.config.json), while the secret token is used in the [workflow](https://github.com/Amsterdam/design-system/blob/develop/.github/workflows/check-visual-regressions.yml).
 
 The secret is configured in two places: [within the repo secrets](https://github.com/Amsterdam/design-system/settings/secrets/actions) and the Dependabot secrets. Since Dependabot does not have default access to repo secrets, separate secrets for Dependabot are configured on the [Dependabot secrets configuration page](https://github.com/Amsterdam/design-system/settings/secrets/dependabot).
 
 Chromatic also uses a [GitHub App](https://github.com/apps/chromatic-com) to integrate with the repository. This app was installed by the enablement team, which is also part of our team within Chromatic. Occasionally, the enablement team may need to refresh the connection.
 
-On every pull request, the [workflow](https://github.com/Amsterdam/design-system/blob/develop/.github/workflows/chromatic.yml) builds Storybook and publishes it to Chromatic, where the tests are run. The test status is displayed in the pull request through the app integration.
+On every pull request, the [workflow](https://github.com/Amsterdam/design-system/blob/develop/.github/workflows/check-visual-regressions.yml) builds Storybook and publishes it to Chromatic, where the tests are run. The test status is displayed in the pull request through the app integration.
 
 #### How to get access
 


### PR DESCRIPTION
## What

Renames all twelve GitHub Actions workflow files, their `name:` fields, job ids/names, and step names so that every naming layer is consistent, verb-first, and derivable from the others — no more drift between a workflow's filename and what shows in the Actions UI. Also rewrites `.github/workflows/README.md` to document the twelve workflows and the naming convention itself, and folds "orphaned"/"obsolete" language into a single "stale" term throughout.

## Why

The workflow files, their display names, job names, and step names had each been named independently over time and had drifted apart — e.g. `chromatic.yml` displayed as "Test" in the Actions UI, a job called `pr-title-validation` displayed as "PR title validation", and a couple of steps had no name at all. That made the Actions tab harder to scan and the file tree harder to navigate. This establishes one naming rule (a verb first, matching the filename, casing aside) at every level, and documents it so new workflows, jobs, and steps stay consistent going forward.

## How

- Renamed each workflow file and its `name:` field to match (e.g. `chromatic.yml` → `check-visual-regressions.yml`, `name: Test` → `name: Check visual regressions`).
- Renamed job ids to be verb-first and consistent (e.g. `cleanup-deployments` → `remove-deployments`), and updated `publish-packages.yml`'s `workflow_run` trigger to match the renamed "Check build and tests" workflow.
- Filled in the two steps that had no `name:` at all, and renamed steps that had drifted from their job's new name or used inconsistent phrasing (`Continuous Integration: lint` → `Lint packages`, `Pushing to pages branch` → `Push to pages branch`, etc.).
- Rewrote `.github/workflows/README.md`: dropped the file-name and "Kind" columns from the overview table (both are now inferable from the workflow name itself), standardised name emphasis to bold, removed an outdated diagram, and added a line documenting the job/step naming convention.
- Updated `documentation/continuous-integration.md`, `documentation/publishing.md`, and `documentation/tests.md` wherever they named or linked to a renamed workflow.

**One thing worth a close look on review:** `main`'s branch protection requires a status check literally named "PR title validation". Since that's a job-level `name:`, not a workflow name, renaming it to "Validate PR title" would have silently broken that required check — so `main`'s required status checks were updated live via the GitHub API in the same change, and the new name was verified to match byte-for-byte. Every other renamed job and step was confirmed *not* to be a required check before renaming.

## Checklist

- [x] Add or update unit tests — not necessary, no component code changed
- [x] Add or update documentation — updated the workflows README and three `documentation/` pages
- [x] Add or update stories — not necessary
- [x] Add or update exports in index.* files — not necessary
- [x] Comment `/chromatic test` and verify visual regression tests pass — not necessary, only workflow and documentation files changed; Chromatic runs automatically on PR open
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- No component code, tests, or Storybook stories are touched — this is CI/CD configuration and documentation only.
- Every rename was cross-checked against `main`'s branch protection and `develop`'s ruleset (both fetched live via the GitHub API) to confirm nothing required stayed unintentionally broken.