### PR TITLE
fix(ci): Prevent branch-name script injection in Storybook and Chromatic workflows

### DIFF
--- a/.github/workflows/check-visual-regressions.yml
+++ b/.github/workflows/check-visual-regressions.yml
@@ -35,10 +35,11 @@ jobs:
         id: pr-info
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
-            echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            echo "branch=$HEAD_REF" >> "$GITHUB_OUTPUT"
           else
             PR_DATA=$(gh pr view ${{ github.event.issue.number }} --json headRefOid,headRefName --repo ${{ github.repository }})
             echo "sha=$(echo "$PR_DATA" | jq -r '.headRefOid')" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-visual-regressions.yml
+++ b/.github/workflows/check-visual-regressions.yml
@@ -42,8 +42,8 @@ jobs:
             echo "branch=$HEAD_REF" >> "$GITHUB_OUTPUT"
           else
             PR_DATA=$(gh pr view ${{ github.event.issue.number }} --json headRefOid,headRefName --repo ${{ github.repository }})
-            echo "sha=$(echo "$PR_DATA" | jq -r '.headRefOid')" >> $GITHUB_OUTPUT
-            echo "branch=$(echo "$PR_DATA" | jq -r '.headRefName')" >> $GITHUB_OUTPUT
+            echo "sha=$(echo "$PR_DATA" | jq -r '.headRefOid')" >> "$GITHUB_OUTPUT"
+            echo "branch=$(echo "$PR_DATA" | jq -r '.headRefName')" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check out branch

--- a/.github/workflows/deploy-acceptance-storybook.yml
+++ b/.github/workflows/deploy-acceptance-storybook.yml
@@ -13,6 +13,9 @@ permissions:
   contents: write
   deployments: write
 
+env:
+  RAW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
 jobs:
   build-and-deploy:
     concurrency: ci-${{ github.ref }}
@@ -21,9 +24,8 @@ jobs:
     steps:
       - name: Create branch name without text before first forward slash
         run: |
-          RAW_BRANCH_NAME=${{ github.head_ref || github.ref_name }}
-          BRANCH_NAME=$(echo $RAW_BRANCH_NAME | sed 's/[^/]*\///')
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed 's/[^/]*\///')
+          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
 
       - name: Check out branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/deploy-acceptance-storybook.yml
+++ b/.github/workflows/deploy-acceptance-storybook.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Create branch name without text before first forward slash
         run: |
-          BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed 's/[^/]*\///')
+          BRANCH_NAME=$(printf '%s' "$RAW_BRANCH_NAME" | sed 's/[^/]*\///')
           echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
 
       - name: Check out branch

--- a/.github/workflows/deploy-acceptance-storybook.yml
+++ b/.github/workflows/deploy-acceptance-storybook.yml
@@ -73,7 +73,7 @@ jobs:
           max_attempts: 40
           retry_wait_seconds: 15
           command: |
-            curl -sf https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/demo-${{ env.BRANCH_NAME }}/${{ github.sha }}.txt
+            curl -sf "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/demo-$BRANCH_NAME/${{ github.sha }}.txt"
 
       - name: Update deployment status
         uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0

--- a/.github/workflows/remove-acceptance-storybook.yml
+++ b/.github/workflows/remove-acceptance-storybook.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Create branch name without text before first forward slash
         run: |
-          BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed 's/[^/]*\///')
+          BRANCH_NAME=$(printf '%s' "$RAW_BRANCH_NAME" | sed 's/[^/]*\///')
           echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
 
       - name: Check out branch to access .nvmrc

--- a/.github/workflows/remove-acceptance-storybook.yml
+++ b/.github/workflows/remove-acceptance-storybook.yml
@@ -12,7 +12,7 @@ permissions:
   deployments: write
 
 env:
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  RAW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 jobs:
   remove-demo-directory:
     runs-on: ubuntu-latest
@@ -20,9 +20,8 @@ jobs:
     steps:
       - name: Create branch name without text before first forward slash
         run: |
-          RAW_BRANCH_NAME=${{ github.head_ref || github.ref_name }}
-          BRANCH_NAME=$(echo $RAW_BRANCH_NAME | sed 's/[^/]*\///')
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed 's/[^/]*\///')
+          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
 
       - name: Check out branch to access .nvmrc
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/remove-acceptance-storybook.yml
+++ b/.github/workflows/remove-acceptance-storybook.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           git config --global user.name GitHub Action
           git config --global user.email github-action@users.noreply.github.com
-          git rm demo-${{ env.BRANCH_NAME }} -r
+          git rm "demo-$BRANCH_NAME" -r
           git add .
           git commit -m "Remove feature branch folder"
           git push


### PR DESCRIPTION
# Describe the pull request

## What

Hardens three CI workflows against shell script injection through the branch name:

- `deploy-acceptance-storybook.yml`
- `remove-acceptance-storybook.yml`
- `check-visual-regressions.yml`

Each one now passes `github.head_ref` / `github.ref_name` through an `env` variable and references it as a quoted shell variable, instead of interpolating the `${{ … }}` expression directly into a `run` block.

## Why

`${{ github.head_ref || github.ref_name }}` is expanded by GitHub into the script text *before* the shell runs it. Because Git allows characters like `$`, `(`, `)` and backticks in branch names, a pull request from a branch named e.g. `$(id)` turned the deploy step into `RAW_BRANCH_NAME=$(id)`, which the runner then executed — arbitrary command execution on a job that carries `contents: write` and `deployments: write` permissions.

This was reported to us as a responsible security disclosure. While the value now flows through the environment, the same branch name arrives as literal data and is never executed.

`check-visual-regressions.yml` had the same pattern in a second spot (`echo "branch=${{ github.head_ref }}"`) that wasn’t in the original report; it’s fixed here too.

## How

- Moved the interpolation into an `env` block (`RAW_BRANCH_NAME` / `HEAD_REF`).
- The `run` blocks now read the quoted shell variable, so command substitution can’t fire.
- In `remove-acceptance-storybook.yml` this also removes a redundant re-derivation that was overwriting the workflow-level env var.
- Quoted `"$GITHUB_ENV"` / `"$GITHUB_OUTPUT"` on the touched lines as hygiene.

No behavioural change: the derived branch name is identical for any valid branch.

## Checklist

- [x] Add or update unit tests <!-- n/a: CI workflow change -->
- [x] Add or update documentation <!-- n/a -->
- [x] Add or update stories <!-- n/a -->
- [x] Add or update exports in index.\* files <!-- n/a -->
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- The same injection pattern exists in sibling repositories flagged in the same disclosure (`design-system-prototypes`, `design-system-community-roadmap`, `ee-ads-rhf`, `amsterdam-schema`); those are tracked separately and are out of scope for this PR.
- Recommend adding `actionlint`/`zizmor` to CI to catch this class of issue automatically in future.
