### PR TITLE
chore(ci): Cancel superseded check runs and bound job durations

### DIFF
--- a/.github/workflows/check-build-and-tests.yml
+++ b/.github/workflows/check-build-and-tests.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   install:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Check out branch
@@ -36,6 +37,7 @@ jobs:
 
   build-lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: install
 
     steps:

--- a/.github/workflows/check-build-and-tests.yml
+++ b/.github/workflows/check-build-and-tests.yml
@@ -8,10 +8,12 @@ on:
 permissions:
   contents: read
 
-# Cancel superseded runs for pull requests only. Runs for pushes to main must
-# always complete: the publish-packages workflow triggers on their completion.
+# Cancel superseded runs for pull requests only. Runs for pushes to main fall
+# back to their run id, forming a unique group: they never cancel or queue
+# behind each other and always complete — the publish-packages workflow
+# triggers on their completion.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/check-build-and-tests.yml
+++ b/.github/workflows/check-build-and-tests.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded runs for pull requests only. Runs for pushes to main must
+# always complete: the publish-packages workflow triggers on their completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   install:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-bundle-size.yml
+++ b/.github/workflows/check-bundle-size.yml
@@ -16,6 +16,8 @@ jobs:
   report-bundle-size:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # This job builds the packages twice: once for the base branch and once for the PR.
+    timeout-minutes: 20
 
     steps:
       - name: Check out branch

--- a/.github/workflows/check-bundle-size.yml
+++ b/.github/workflows/check-bundle-size.yml
@@ -7,6 +7,11 @@ permissions:
   contents: read
   pull-requests: write
 
+# A new push to the PR makes the run in flight obsolete – cancel it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   report-bundle-size:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -12,6 +12,11 @@ on:
 permissions:
   pull-requests: read
 
+# A new push or title edit makes the run in flight obsolete – cancel it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   validate-pr-title:
     name: Validate PR title

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -21,6 +21,7 @@ jobs:
   validate-pr-title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Validate PR title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1

--- a/.github/workflows/check-test-coverage.yml
+++ b/.github/workflows/check-test-coverage.yml
@@ -16,6 +16,7 @@ jobs:
   report-test-coverage:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Check out branch

--- a/.github/workflows/check-test-coverage.yml
+++ b/.github/workflows/check-test-coverage.yml
@@ -7,6 +7,11 @@ permissions:
   contents: read
   pull-requests: write
 
+# A new push to the PR makes the run in flight obsolete – cancel it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   report-test-coverage:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/check-visual-regressions.yml
+++ b/.github/workflows/check-visual-regressions.yml
@@ -9,6 +9,13 @@ permissions:
   contents: read
   pull-requests: write
 
+# A newer Chromatic run for the same PR makes the one in flight obsolete – cancel it to save snapshots.
+# Only qualifying events may cancel: this workflow triggers on every PR comment, and the job’s `if`
+# only filters after the concurrency group has been entered.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (startsWith(github.event.comment.body, '/chromatic test') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) }}
+
 jobs:
   run-chromatic:
     name: Run Chromatic

--- a/.github/workflows/check-visual-regressions.yml
+++ b/.github/workflows/check-visual-regressions.yml
@@ -20,6 +20,7 @@ jobs:
   run-chromatic:
     name: Run Chromatic
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: |
       (github.event_name == 'pull_request' && 
        (github.event.action == 'ready_for_review' || 

--- a/.github/workflows/deploy-acceptance-storybook.yml
+++ b/.github/workflows/deploy-acceptance-storybook.yml
@@ -17,6 +17,8 @@ jobs:
   build-and-deploy:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
+    # A hung run would hold the concurrency lock above and block deploys of newer commits.
+    timeout-minutes: 30
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Create branch name without text before first forward slash

--- a/.github/workflows/deploy-production-storybook.yml
+++ b/.github/workflows/deploy-production-storybook.yml
@@ -11,6 +11,8 @@ jobs:
   build-and-deploy:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
+    # A hung run would hold the concurrency lock above and block deploys of newer commits.
+    timeout-minutes: 30
 
     steps:
       - name: Check out branch

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   create-release-and-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:

--- a/.github/workflows/remove-acceptance-storybook.yml
+++ b/.github/workflows/remove-acceptance-storybook.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   remove-demo-directory:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Create branch name without text before first forward slash

--- a/.github/workflows/remove-stale-demo-directories.yml
+++ b/.github/workflows/remove-stale-demo-directories.yml
@@ -62,6 +62,7 @@ jobs:
     # majors.
     if: ${{ github.event_name == 'workflow_dispatch' || (startsWith(github.event.release.tag_name, 'design-system-') && endsWith(github.event.release.tag_name, '.0.0')) }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       # Release-triggered runs always perform the deletion; manual runs
       # honour the workflow input (defaults to dry-run).

--- a/.github/workflows/remove-stale-deployments.yml
+++ b/.github/workflows/remove-stale-deployments.yml
@@ -53,6 +53,7 @@ concurrency:
 jobs:
   remove-deployments:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out scripts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/remove-stale-environments.yml
+++ b/.github/workflows/remove-stale-environments.yml
@@ -47,6 +47,7 @@ concurrency:
 jobs:
   remove-environments:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Check out scripts
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## What

Two cost- and hygiene-related improvements to all GitHub Actions workflows:

- Add a top-level `concurrency` block to the five `check-*` workflows so that a new push cancels the in-flight run for the same PR.
- Add `timeout-minutes` to every job in every workflow, replacing the 6-hour GitHub default with realistic upper bounds.

## Why

- Without cancellation, rapid pushes to a PR pile up redundant runs. For most checks that only wastes runner time, but a superseded Chromatic run still consumes snapshots, which is what Chromatic actually bills on.
- Without a timeout, a hung job runs for up to 6 hours. For the two Storybook deploy workflows that’s more than an annoyance: a hung run holds the `ci-${{ github.ref }}` concurrency lock and blocks deploys of newer commits for the duration.

## How

- The check workflows group runs by PR number and cancel superseded ones, with two deliberate exceptions:
  - *Check build and tests* only cancels for `pull_request` events. Runs for pushes to `main` complete untouched, because *Publish packages* triggers on their completion.
  - *Check visual regressions* triggers on every PR comment and only filters in the job’s `if`, which runs after the concurrency group has been entered. Its `cancel-in-progress` therefore mirrors the job’s guard: only `pull_request` events and authorised `/chromatic test` comments may cancel; an unrelated comment merely queues and skips.
- The deploy workflows keep their existing job-level concurrency, which queues rather than cancels — the right behaviour for deploys.
- Timeout values are generous upper bounds per job (5–30 minutes) rather than tight limits, so slow-but-healthy runs won’t be cut off.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- #2732 touches step-level regions of three of these files; the changes here are top-level and job-level, so the two merge cleanly in either order.
- Job names are unchanged, so branch protection required checks are unaffected.
