### PR TITLE
fix(Breakout): Apply the `as` prop instead of leaking it to the DOM

### DIFF
--- a/packages/react/src/Breakout/Breakout.test.tsx
+++ b/packages/react/src/Breakout/Breakout.test.tsx
@@ -3,11 +3,12 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { createRef } from 'react'
 import { describe, expect, it } from 'vitest'
 
-import { gridGaps, gridPaddings } from '../Grid/Grid'
+import { ariaRoleForTag } from '../common/accessibility'
+import { gridGaps, gridPaddings, gridTags } from '../Grid/Grid'
 import { Breakout } from './Breakout'
 
 describe('Breakout', () => {
@@ -76,8 +77,18 @@ describe('Breakout', () => {
     })
   })
 
+  gridTags.forEach((tag) => {
+    it(`renders with a custom ${tag} tag`, () => {
+      const { container } = render(<Breakout aria-label={tag === 'section' ? 'Accessible name' : undefined} as={tag} />)
+
+      const component = tag === 'div' ? container.querySelector(tag) : screen.getByRole(ariaRoleForTag[tag])
+
+      expect(component).toBeInTheDocument()
+    })
+  })
+
   it('supports ForwardRef in React', () => {
-    const ref = createRef<HTMLDivElement>()
+    const ref = createRef<HTMLElement>()
 
     const { container } = render(<Breakout ref={ref} />)
 

--- a/packages/react/src/Breakout/Breakout.tsx
+++ b/packages/react/src/Breakout/Breakout.tsx
@@ -3,7 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
-import type { ForwardedRef } from 'react'
+import type { ElementType } from 'react'
 
 import { clsx } from 'clsx'
 import { forwardRef } from 'react'
@@ -18,24 +18,25 @@ export type BreakoutRowNumbers = { narrow: BreakoutRowNumber; medium: BreakoutRo
 
 export type BreakoutProps = GridProps
 
-const BreakoutRoot = forwardRef(
-  (
-    { children, className, gapVertical, paddingBottom, paddingTop, paddingVertical, ...restProps }: BreakoutProps,
-    ref: ForwardedRef<HTMLDivElement>,
-  ) => (
-    <div
-      {...restProps}
-      className={clsx(
-        'ams-breakout',
-        gapVertical && `ams-breakout--gap-vertical--${gapVertical}`,
-        paddingClasses('breakout', paddingBottom, paddingTop, paddingVertical),
-        className,
-      )}
-      ref={ref}
-    >
-      {children}
-    </div>
-  ),
+const BreakoutRoot = forwardRef<HTMLElement, BreakoutProps>(
+  ({ as, children, className, gapVertical, paddingBottom, paddingTop, paddingVertical, ...restProps }, ref) => {
+    const Tag = (as ?? 'div') as ElementType
+
+    return (
+      <Tag
+        {...restProps}
+        className={clsx(
+          'ams-breakout',
+          gapVertical && `ams-breakout--gap-vertical--${gapVertical}`,
+          paddingClasses('breakout', paddingBottom, paddingTop, paddingVertical),
+          className,
+        )}
+        ref={ref}
+      >
+        {children}
+      </Tag>
+    )
+  },
 )
 
 BreakoutRoot.displayName = 'Breakout'


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## What

Breakout now renders the tag passed through its `as` prop, just like Grid does.

## Why

`BreakoutProps` is based on `GridProps` and therefore accepts an `as` prop, but the component never applied it.
It leaked through the rest props onto the rendered `div` as an invalid `as="…"` DOM attribute, and the requested tag was ignored.

## How

Followed the established pattern from `Grid.tsx`: destructure `as`, render it as the tag with `div` as the default, and widen the ref type from `HTMLDivElement` to `HTMLElement` to match.
Added the same unit tests Grid has for rendering each of its allowed tags.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- No documentation or story changes needed: the `as` prop and its description come from `GridProps`, and Storybook picks the control up from the types.
- There is no visual change – Chromatic runs automatically on this PR.
