### PR TITLE
chore(Storybook): Make controls consistent across all stories

### DIFF
--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -125,17 +125,15 @@ Children of React components are often React components themselves, which isn’
 However, sometimes it is useful to add `children` to the controls.
 For example, when the child is a simple string (like in the default Button component story).
 
-To do this, you can override the default like so:
+To do this, use the shared arg type:
 
 ```txt
 argTypes: {
-  children: {
-    table: { disable: false },
-  },
+  children: childrenArgType('The text content.'),
 },
 ```
 
-A short argTypes `description` such as ‘The text content.’ is welcome here – `children` has no JSDoc of its own.
+It unhides the arg, offers a text control, and sets the description – `children` has no JSDoc of its own.
 
 ## Best practices for stories
 

--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -65,8 +65,8 @@ Follow these guidelines:
    Leave the arg out instead.
 3. Hide args with `table: { disable: true }` in the `argTypes` object if they don’t apply to the story, e.g. if the story composes multiple instances of the component.
    We don’t hide ‘less relevant’ args in other cases, not even in stories that focus on a single prop.
-4. Be aware that changing an arg value changes the rendered output, and thereby Chromatic snapshots.
-   Changing only argTypes does not, with one exception: test stories derive their variant matrix from argTypes – see [Test stories](#test-stories).
+4. Note that the args and argTypes of the meta feed the Test story, which is the only story Chromatic snapshots – see [Test stories](#test-stories).
+   Changing them can therefore change snapshots; the args of individual stories don’t reach Chromatic.
 
 ### Choosing a control
 

--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -83,6 +83,7 @@ Set `control.type` explicitly whenever you provide `options` – don’t rely on
    Set `min`, `max`, and `step` when the type or the component’s behaviour constrains them.
 5. For an optional prop, include `undefined` in the options and label it with the effective default value: `labels: { undefined: 'medium (default)' }`.
    This teaches users the default instead of hiding it.
+   Remove the default value from the options themselves, so it doesn’t appear twice: `options: [undefined, ...tags.filter((tag) => tag !== 'div')]`.
 6. Only offer options that the prop’s type allows, and offer all of them.
    If a story deliberately shows a subset, add a comment explaining why.
 7. For an icon prop, use the shared icon arg type from `storybook/src/_common/argTypes.ts`.

--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -19,51 +19,108 @@ Component names are in title case – starting each word with a capital letter �
 ## Best practices for controls
 
 Controls are automatically generated based on the component’s typing.
+The guidelines below describe when and how to adjust them.
+The goal is a controls table where every row is useful: each prop offers a fitting control and shows its description and default value.
+Controls are sorted alphabetically through the global configuration.
 
 ### Prop descriptions
 
-We use JSDoc to describe each prop to keep documentation close to the actual definition.
+We use JSDoc to describe each prop of our React components, keeping documentation close to the actual definition.
 This also helps IDEs pick up the description and display it in their user interface.
-The description briefly explains the essence of the prop.
-A guideline on how to use the prop may be added, as well as a description of its effect, e.g. visually.
-Prevent mentioning the component’s name in a prop description – that should be obvious.
-Prop types that aren’t exported don’t require their properties to be described.
+Storybook displays these descriptions in the controls table.
+An argTypes `description` is only needed for props that have no JSDoc source – see [Native HTML attributes](#native-html-attributes).
+
+Follow these guidelines:
+
+1. Always use `/** … */` comments – single-asterisk block comments don’t reach the docs.
+2. Briefly explain the essence of the prop.
+   A guideline on how to use the prop may be added, as well as a description of its effect, e.g. visually.
+3. Add an `@default` tag if the prop has a default value.
+   A global enhancer in `preview.tsx` displays it in the ‘Default’ column of the controls table.
+4. Add an `@deprecated` tag with migration instructions when phasing out a prop.
+   A global enhancer in `preview.tsx` then leads the description with a bold notice and groups the prop under a ‘Deprecated’ category.
+5. Prevent mentioning the component’s name in a prop description – that should be obvious.
+6. When mentioning another component, write its name in title case, e.g. ‘Card’ or ‘Form Field’.
+   This represents the component more strongly and helps users recognise them as such.
+7. Prop types that aren’t exported don’t require their properties to be described.
+
+### Native HTML attributes
+
+Native HTML attributes (`href`, `disabled`, `checked`, `id`, `rows`, …) have no JSDoc in our code base, so document them with a `description` in `argTypes` instead.
+This includes attributes that a component inherits from its underlying element, such as `checked` on an input.
+Use terse sentences that end with a full stop.
+Reuse the shared description snippets from `storybook/src/_common/argTypes.ts`, so the same attribute reads the same everywhere.
+When adding a snippet, check for an existing description of the same attribute and move it to the shared file.
+Don’t override `name` or `type` for these args – Storybook infers those correctly.
 
 ### Args
 
-Add [`args`](https://storybook.js.org/docs/react/writing-stories/args) to the Story to set initial values for props.
+Add [`args`](https://storybook.js.org/docs/writing-stories/args) to the Story to set initial values for props.
 Follow these guidelines:
 
-1. For Boolean props, set their default value to `false`,
-   unless this has side effects e.g. rendering a class name.
+1. For Boolean props, set their default value to `false`, unless this has side effects e.g. rendering a class name.
    In that case, don’t specify a value.
-   Storybook will then display a button ‘Set boolean’ that show a switch.
-2. Hide args with `table: { disable: true }` in the `argTypes` object if they don’t apply to the story,
-   e.g. if the story composes multiple instances of the component.
+   Storybook will then display a button ‘Set boolean’ that shows a switch.
+2. Don’t use an empty string as a placeholder value – it can defeat component behaviour such as generating an id or rendering an optional hint.
+   Leave the arg out instead.
+3. Hide args with `table: { disable: true }` in the `argTypes` object if they don’t apply to the story, e.g. if the story composes multiple instances of the component.
    We don’t hide ‘less relevant’ args in other cases, not even in stories that focus on a single prop.
+4. Be aware that changing an arg value changes the rendered output, and thereby Chromatic snapshots.
+   Changing only argTypes does not, with one exception: test stories derive their variant matrix from argTypes – see [Test stories](#test-stories).
 
-### Arg Types
+### Choosing a control
 
-Add [`argTypes`](https://storybook.js.org/docs/api/arg-types) to the Story to document native HTML attributes or override the generated controls.
-Follow these guidelines:
+Pick the control that matches the shape of the prop.
+Set `control.type` explicitly whenever you provide `options` – don’t rely on inference.
 
-1. Add a `description` field instead of a JSDoc comment for native HTML attributes.
-   Use terse sentences that end with a full stop.
-   When adding a prop, check for a corresponding existing prop and copy its description.
-2. When mentioning a component, write its name in title case, e.g. ‘Card’ or ‘Form Field’.
-   This represents the component more strongly and helps users recognise them as such.
-3. For props offering five options or less, use radio buttons rather than a select.
+1. For a Boolean prop, the automatically generated boolean control is fine.
+2. For a union of five options or less, use radio buttons rather than a select.
    This makes it easier to compare the options.
    It saves the user a click to select each option and shows everything up front.
-4. Don’t use inline radios.
-   Their options appear rather small, making them difficult to target with a pointing device.
+   Inline radios are fine for these as well; prefer stacked radios when the option labels are long.
+3. For more than five options, use a select.
+4. For a numeric prop, use a number control.
+   Set `min`, `max`, and `step` when the type or the component’s behaviour constrains them.
+5. For an optional prop, include `undefined` in the options and label it with the effective default value: `labels: { undefined: 'medium (default)' }`.
+   This teaches users the default instead of hiding it.
+6. Only offer options that the prop’s type allows, and offer all of them.
+   If a story deliberately shows a subset, add a comment explaining why.
+7. For an icon prop, use the shared icon arg type from `storybook/src/_common/argTypes.ts`.
+   It offers a select of all icon names, mapped to the icon components, labelling `undefined` as ‘none’ for optional props.
 
-More to follow.
+### Props without a useful control
+
+Some props have no control that makes sense: functions, React elements, and complex object types.
+Two mechanisms exist, with different meanings:
+
+1. `control: false` keeps the row in the controls table, without a control.
+   Use it when seeing the prop with its type and description is useful – e.g. `linkComponent`, a slot like `footer`, or a callback that is part of the component’s API.
+2. `table: { disable: true }` removes the row entirely.
+   Use it only when the prop doesn’t apply to the story at all.
+
+The global configuration already hides `children`, `className`, `style`, `defaultValue`, `onChange`, and `onSubmit` for every story.
+Unhide them with `table: { disable: false }` where they are meaningful, e.g. `defaultValue` and `onChange` for form controls.
+
+### Derived args
+
+Some args update automatically, through a decorator or the component itself – for example, a prop that follows a media query.
+Mark these with the shared derived arg type from `storybook/src/_common/argTypes.ts`: no control, a read-only row under the ‘Derived’ category, and a description that explains what drives the value.
+Locale-synced label args keep their read-only text controls, so their live values remain visible.
+
+### Conditional controls
+
+Use [`if`](https://storybook.js.org/docs/api/arg-types#conditional-controls) to show a control only when it applies – e.g. `iconBefore` only when an `icon` is set, or `closeButtonLabel` only when `closeable` is `true`.
+This keeps the controls table focused.
+
+### Actions
+
+Name actions after the event they represent: `'changed'`, `'toggled'`, `'submitted'`.
+Don’t use `'clicked'` for a change handler.
 
 ### The `children` prop
 
 By default, we hide the `children` prop from the controls.
-Children of React components are often React components themselves, which isn't very useful to show in Storybook.
+Children of React components are often React components themselves, which isn’t very useful to show in Storybook.
 However, sometimes it is useful to add `children` to the controls.
 For example, when the child is a simple string (like in the default Button component story).
 
@@ -77,6 +134,8 @@ argTypes: {
 },
 ```
 
+A short argTypes `description` such as ‘The text content.’ is welcome here – `children` has no JSDoc of its own.
+
 ## Best practices for stories
 
 1. Import the Story’s component from the `src` directory so that Storybook can display its types.
@@ -85,3 +144,11 @@ argTypes: {
    Decorators are not shown in the code view, `args.children` are.
 3. Always check your stories’ code view.
 4. `args.children` can be an array, separated by commas and given ascending numbers as keys.
+5. Define argTypes in the meta rather than on individual stories, so all stories of a component present the same controls.
+   A story-level override is fine when a story genuinely needs different options – add a comment explaining why.
+
+## Test stories
+
+Test stories (`*.test.stories.tsx`) render all states of a component in the single story named ‘Test’, which is the only story Chromatic snapshots.
+They inherit the component’s meta and must not define argTypes of their own.
+Note that `renderComponentVariants` reads the meta’s argTypes to build its variant matrix – changing options or hiding args can change what the Test story renders and snapshots.

--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -83,10 +83,11 @@ Set `control.type` explicitly whenever you provide `options` – don’t rely on
    Set `min`, `max`, and `step` when the type or the component’s behaviour constrains them.
 5. For an optional prop, include `undefined` in the options and label it with the effective default value: `labels: { undefined: 'medium (default)' }`.
    This teaches users the default instead of hiding it.
+   When the default has no named value – such as the regular text colour – label it plainly ‘default’.
    Remove the default value from the options themselves, so it doesn’t appear twice: `options: [undefined, ...tags.filter((tag) => tag !== 'div')]`.
 6. Only offer options that the prop’s type allows, and offer all of them.
    If a story deliberately shows a subset, add a comment explaining why.
-7. For an icon prop, use the shared icon arg type from `storybook/src/_common/argTypes.ts`.
+7. For an icon prop, use the shared icon arg type from `storybook/src/_common/iconArgTypes.ts`.
    It offers a select of all icon names, mapped to the icon components, labelling `undefined` as ‘none’ for optional props.
 
 ### Props without a useful control

--- a/packages/react/src/Accordion/Accordion.tsx
+++ b/packages/react/src/Accordion/Accordion.tsx
@@ -14,11 +14,11 @@ import { AccordionSection } from './AccordionSection'
 
 export type AccordionProps = {
   /**
-   * The hierarchical level of this Accordion’s Section Headings within the document.
+   * The hierarchical level of the Section Headings within the document.
    * There is no default value; determine the correct level for each instance.
    */
   readonly headingLevel: 2 | 3 | 4
-  /** The HTML element to use for each Accordion Section. */
+  /** The HTML element to use for each Section. */
   readonly sectionAs?: 'div' | 'section'
 } & Readonly<PropsWithChildren<HTMLAttributes<HTMLDivElement>>>
 

--- a/packages/react/src/Accordion/AccordionSection.tsx
+++ b/packages/react/src/Accordion/AccordionSection.tsx
@@ -16,7 +16,10 @@ import { Icon } from '../Icon'
 import { AccordionContext } from './AccordionContext'
 
 export type AccordionSectionProps = {
-  /** Whether the content is displayed initially. */
+  /**
+   * Whether the content is displayed initially.
+   * @default false
+   */
   readonly defaultExpanded?: boolean
   /**
    * Whether the content is displayed initially.

--- a/packages/react/src/Alert/Alert.tsx
+++ b/packages/react/src/Alert/Alert.tsx
@@ -20,20 +20,20 @@ import { Row } from '../Row'
 type Severity = 'error' | 'success' | 'warning'
 
 export type AlertProps = {
-  /** Whether the user can dismiss the Alert. Adds a button to its top right. */
+  /** Whether the user can dismiss the alert. Adds a button to its top right. */
   readonly closeable?: boolean
-  /** The label for the button that dismisses the Alert. */
+  /** The label for the button that dismisses the alert. */
   readonly closeButtonLabel?: string
   /** The text for the Heading. */
   readonly heading: string
   /**
-   * The id of the Heading element, which is used to label the Alert.
+   * The id of the Heading element, which is used to label the alert.
    * Can be set to `null` to explicitly remove the label.
    * Note: must be unique for the page.
    */
   readonly headingId?: string | null
   /**
-   * The hierarchical level of the Alert’s Heading within the document.
+   * The hierarchical level of the Heading within the document.
    * There is no default value; determine the correct level for each instance.
    * The size of the heading is fixed at level 3.
    */

--- a/packages/react/src/Breakout/BreakoutCell.tsx
+++ b/packages/react/src/Breakout/BreakoutCell.tsx
@@ -28,9 +28,15 @@ type BreakoutCellSpanAllProps = {
 }
 
 type BreakoutCellSpanAndStartProps = {
-  /** The amount of grid columns the cell spans. */
+  /**
+   * The amount of grid columns the cell spans.
+   * Accepts a number, an object of numbers per grid variant – narrow, medium, and wide – or ‘all’ to span the full width.
+   */
   readonly colSpan?: 'all' | GridColumnNumber | GridColumnNumbers
-  /** The index of the grid column the cell starts at. */
+  /**
+   * The index of the grid column the cell starts at.
+   * Accepts a number or an object of numbers per grid variant.
+   */
   readonly colStart?: GridColumnNumber | GridColumnNumbers
   /**
    * Marks that this cell contains a Figure.
@@ -40,9 +46,15 @@ type BreakoutCellSpanAndStartProps = {
 }
 
 type BreakoutCellRowSpanAndStartProps = {
-  /** The amount of grid rows the cell spans. */
+  /**
+   * The amount of grid rows the cell spans.
+   * Accepts a number or an object of numbers per grid variant.
+   */
   readonly rowSpan?: BreakoutRowNumber | BreakoutRowNumbers
-  /** The index of the grid row the cell starts at. */
+  /**
+   * The index of the grid row the cell starts at.
+   * Accepts a number or an object of numbers per grid variant.
+   */
   readonly rowStart?: BreakoutRowNumber | BreakoutRowNumbers
 }
 

--- a/packages/react/src/Breakout/BreakoutCell.tsx
+++ b/packages/react/src/Breakout/BreakoutCell.tsx
@@ -20,9 +20,10 @@ type BreakoutCellSpanAllProps = {
   /** Lets the cell span the full width of all grid variants. */
   readonly colSpan: 'all'
   readonly colStart?: never
-  /** The content of this cell.
-   * The Cell containing the Spotlight expands horizontally and vertically to cover the adjacent gaps and margins.
-   * The Cell containing the Image aligns itself to the bottom of the row, in case it is less tall than the text. */
+  /**
+   * Marks that this cell contains a Spotlight.
+   * The cell then expands horizontally and vertically to cover the adjacent gaps and margins.
+   */
   readonly has?: 'spotlight'
 }
 
@@ -31,6 +32,10 @@ type BreakoutCellSpanAndStartProps = {
   readonly colSpan?: 'all' | GridColumnNumber | GridColumnNumbers
   /** The index of the grid column the cell starts at. */
   readonly colStart?: GridColumnNumber | GridColumnNumbers
+  /**
+   * Marks that this cell contains a Figure.
+   * The cell then aligns itself to the bottom of the row, in case it is less tall than the text.
+   */
   readonly has?: 'figure'
 }
 
@@ -42,7 +47,10 @@ type BreakoutCellRowSpanAndStartProps = {
 }
 
 export type BreakoutCellProps = {
-  /** The HTML element to use. */
+  /**
+   * The HTML element to use.
+   * @default div
+   */
   readonly as?: BreakoutCellTag
 } & Readonly<BreakoutCellRowSpanAndStartProps> &
   Readonly<BreakoutCellSpanAllProps | BreakoutCellSpanAndStartProps> &

--- a/packages/react/src/Calendar/Calendar.tsx
+++ b/packages/react/src/Calendar/Calendar.tsx
@@ -13,14 +13,14 @@ import { CalendarBody } from './CalendarBody'
 import { CalendarHeader } from './CalendarHeader'
 
 export type CalendarProps = {
-  /** The text for the internal, visually hidden heading that gives the Calendar an accessible name. */
+  /** The text for the internal, visually hidden heading that gives the component an accessible name. */
   readonly accessibleName?: string
   /**
-   * Connects the Calendar with an internal element that defines its accessible name.
+   * Connects the component with an internal element that defines its accessible name.
    * Note: must be unique for the page.
    */
   readonly accessibleNameId?: string
-  /** The month shown when the Calendar first renders. Defaults to the current month. */
+  /** The month shown on first render. Defaults to the current month. */
   readonly defaultMonth?: Date
   /** The component to render each date link with. Defaults to a plain anchor. */
   readonly linkComponent?: ElementType

--- a/packages/react/src/Calendar/CalendarHeader.tsx
+++ b/packages/react/src/Calendar/CalendarHeader.tsx
@@ -15,10 +15,15 @@ import type { CalendarProps } from './Calendar'
 import { IconButton } from '../IconButton'
 
 export type CalendarHeaderProps = {
+  /** Navigates to the next month. */
   readonly goToNextMonth: () => void
+  /** Navigates to the next year. */
   readonly goToNextYear: () => void
+  /** Navigates to the previous month. */
   readonly goToPreviousMonth: () => void
+  /** Navigates to the previous year. */
   readonly goToPreviousYear: () => void
+  /** The currently displayed month. */
   readonly month: Date
 } & Pick<
   CalendarProps,

--- a/packages/react/src/DatePicker/DatePicker.tsx
+++ b/packages/react/src/DatePicker/DatePicker.tsx
@@ -23,7 +23,7 @@ export type DateRange = {
 }
 
 type DatePickerBaseProps = {
-  /** The month shown when the Date Picker first renders. Defaults to the current month. */
+  /** The month shown on first render. Defaults to the current month. */
   readonly defaultMonth?: Date
   /** Prevents selection of individual dates, e.g. dates that are unavailable. They remain reachable by keyboard. */
   readonly isDateDisabled?: (date: Date) => boolean

--- a/packages/react/src/DescriptionList/DescriptionList.tsx
+++ b/packages/react/src/DescriptionList/DescriptionList.tsx
@@ -18,7 +18,7 @@ type DescriptionListTermsWidth = (typeof descriptionListTermsWidths)[number]
 export type DescriptionListProps = {
   /** Changes the text colour for readability on a dark background. */
   readonly color?: 'inverse'
-  /* The width of the column containing the terms. */
+  /** The width of the column containing the terms. */
   readonly termsWidth?: DescriptionListTermsWidth
 } & Readonly<PropsWithChildren<HTMLAttributes<HTMLDListElement>>>
 

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -12,7 +12,7 @@ import { Heading } from '../Heading'
 import { IconButton } from '../IconButton'
 
 export type DialogProps = {
-  /** The label for the button that dismisses the Dialog. */
+  /** The label for the button that dismisses the dialog. */
   readonly closeButtonLabel?: string
   /** Content for the footer, often one Button or an Action Group containing more of them. */
   readonly footer?: ReactNode

--- a/packages/react/src/Field/Field.tsx
+++ b/packages/react/src/Field/Field.tsx
@@ -9,7 +9,7 @@ import { clsx } from 'clsx'
 import { forwardRef } from 'react'
 
 export type FieldProps = {
-  /** Whether the field has an input with a validation error */
+  /** Whether the field has an input with a validation error. */
   readonly invalid?: boolean
 } & Readonly<PropsWithChildren<HTMLAttributes<HTMLDivElement>>>
 

--- a/packages/react/src/FileList/FileListItem.tsx
+++ b/packages/react/src/FileList/FileListItem.tsx
@@ -15,7 +15,9 @@ import { formatFileType } from '../common/formatFileType'
 import { Icon } from '../Icon'
 
 export type FileListItemProps = {
+  /** The file to display. Shows its name, type, and size, and a thumbnail for images. */
   readonly file: File
+  /** A function to run when the user removes the file. Adds a delete button. */
   readonly onDelete?: () => void
 } & Readonly<HTMLAttributes<HTMLLIElement>>
 

--- a/packages/react/src/Grid/Grid.tsx
+++ b/packages/react/src/Grid/Grid.tsx
@@ -46,7 +46,10 @@ type GridPaddingTopAndBottomProps = {
 }
 
 export type GridProps = {
-  /** The HTML tag to use. */
+  /**
+   * The HTML tag to use.
+   * @default div
+   */
   readonly as?: GridTag
   /** The amount of space between rows. */
   readonly gapVertical?: GridGap

--- a/packages/react/src/Grid/GridCell.tsx
+++ b/packages/react/src/Grid/GridCell.tsx
@@ -25,9 +25,15 @@ type GridCellSpanAllProp = {
 }
 
 type GridCellSpanAndStartProps = {
-  /** The amount of grid columns the cell spans. */
+  /**
+   * The amount of grid columns the cell spans.
+   * Accepts a number, an object of numbers per grid variant – narrow, medium, and wide – or ‘all’ to span the full width.
+   */
   readonly span?: GridColumnNumber | GridColumnNumbers
-  /** The index of the grid column the cell starts at. */
+  /**
+   * The index of the grid column the cell starts at.
+   * Accepts a number or an object of numbers per grid variant.
+   */
   readonly start?: GridColumnNumber | GridColumnNumbers
 }
 
@@ -47,7 +53,10 @@ export type GridCellProps = {
    * @default div
    */
   readonly as?: GridCellTag
-  /** The amount of grid rows the cell spans. */
+  /**
+   * The amount of grid rows the cell spans.
+   * Accepts a number or an object of numbers per grid variant.
+   */
   readonly rowSpan?: GridRowNumber | GridRowNumbers
 } & Readonly<PropsWithChildren<HTMLAttributes<HTMLElement>>> &
   (GridCellSpanAllProp | GridCellSpanAndStartProps)

--- a/packages/react/src/Grid/GridCell.tsx
+++ b/packages/react/src/Grid/GridCell.tsx
@@ -33,7 +33,7 @@ type GridCellSpanAndStartProps = {
 
 export type GridCellProps = {
   /**
-   * Controls the background of the Grid Cell.
+   * Controls the background of the cell.
    *
    * In Compact Mode, cells have a background colour and padding to set them apart.
    * The flush variant removes the padding but keeps the background colour.
@@ -42,7 +42,10 @@ export type GridCellProps = {
    * In Spacious Mode, cells are always transparent and without padding; this prop has no effect.
    */
   readonly appearance?: GridCellAppearance
-  /** The HTML tag to use. */
+  /**
+   * The HTML tag to use.
+   * @default div
+   */
   readonly as?: GridCellTag
   /** The amount of grid rows the cell spans. */
   readonly rowSpan?: GridRowNumber | GridRowNumbers

--- a/packages/react/src/ImageSlider/ImageSlider.tsx
+++ b/packages/react/src/ImageSlider/ImageSlider.tsx
@@ -28,9 +28,9 @@ export type ImageSliderProps = {
   readonly imageLabel?: string
   /** The set of images to display. */
   readonly images: ImageSliderImageProps[]
-  /** The label for the ‘next’ button */
+  /** The label for the ‘next’ button. */
   readonly nextLabel?: string
-  /** The label for the ‘previous’ button */
+  /** The label for the ‘previous’ button. */
   readonly previousLabel?: string
 } & Readonly<HTMLAttributes<HTMLDivElement>>
 

--- a/packages/react/src/ImageSlider/ImageSliderThumbnails.tsx
+++ b/packages/react/src/ImageSlider/ImageSliderThumbnails.tsx
@@ -12,9 +12,13 @@ import type { ImageSliderProps } from './ImageSlider'
 import { generateAspectRatioClass } from '../Image/generateAspectRatioClass'
 
 export type ImageSliderThumbnailsProps = {
+  /** The index of the slide currently in view. */
   readonly currentSlideId: number
+  /** The label for an image, used in the accessible name of each thumbnail. */
   readonly imageLabel?: string
+  /** A function to run when a thumbnail is activated. Scrolls the slide with the provided index into view. */
   readonly scrollToSlide: (id: number) => void
+  /** The set of images to display thumbnails for. */
   readonly thumbnails: ImageSliderProps['images']
 } & Readonly<HTMLAttributes<HTMLElement>>
 

--- a/packages/react/src/InvalidFormAlert/InvalidFormAlert.tsx
+++ b/packages/react/src/InvalidFormAlert/InvalidFormAlert.tsx
@@ -27,7 +27,7 @@ export type InvalidFormAlertProps = {
   /** The list of error messages to display. */
   readonly errors: ErrorLink[]
   /**
-   * Whether the component receives focus on first render
+   * Whether the component receives focus on first render.
    * @default true
    */
   readonly focusOnRender?: boolean
@@ -37,7 +37,7 @@ export type InvalidFormAlertProps = {
    */
   readonly heading?: string
   /**
-   * The hierarchical level of the Invalid Form Alert’s Heading within the document.
+   * The hierarchical level of the Heading within the document.
    * There is no default value; determine the correct level for each instance.
    * The size of the heading is fixed at level 3.
    */

--- a/packages/react/src/Page/Page.tsx
+++ b/packages/react/src/Page/Page.tsx
@@ -9,7 +9,7 @@ import { clsx } from 'clsx'
 import { forwardRef } from 'react'
 
 export type PageProps = {
-  /*
+  /**
    * Whether the page contains a Menu component.
    * This requires the following class names on the appropriate children:
    *   - `ams-page__area--skip-link`

--- a/packages/react/src/PageFooter/PageFooterMenu.tsx
+++ b/packages/react/src/PageFooter/PageFooterMenu.tsx
@@ -20,7 +20,7 @@ export type PageFooterMenuProps = {
    */
   readonly heading?: string
   /**
-   * The hierarchical level of the Footer Menu’s Heading within the document.
+   * The hierarchical level of the Heading within the document.
    * The default value is 2. This will almost always be correct – but verify this yourself.
    */
   readonly headingLevel?: HeadingProps['level']

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -54,7 +54,7 @@ export type PageHeaderProps = {
    * @default Hoofdmenu
    */
   readonly navigationLabel?: string
-  /** Whether the menu button is visible on wide screens.  */
+  /** Hides the menu button on wide windows. */
   readonly noMenuButtonOnWideWindow?: boolean
 } & Readonly<HTMLAttributes<HTMLElement>>
 

--- a/packages/react/src/Pagination/Pagination.tsx
+++ b/packages/react/src/Pagination/Pagination.tsx
@@ -17,7 +17,7 @@ import { LinkItem } from './LinkItem'
 const DefaultLink = (props: AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...props} />
 
 export type PaginationProps = {
-  /** The accessible name for the Pagination component. */
+  /** The accessible name for the component. */
   readonly accessibleName?: string
   /**
    * Connects the component with an internal element that defines its accessible name.

--- a/packages/react/src/ProgressList/ProgressList.tsx
+++ b/packages/react/src/ProgressList/ProgressList.tsx
@@ -35,7 +35,7 @@ export type ProgressListProps = {
    */
   readonly currentAccessibleText?: string
   /**
-   * The hierarchical level of this Progress List’s Headings within the document.
+   * The hierarchical level of the step Headings within the document.
    * There is no default value; determine the correct level for this instance.
    */
   readonly headingLevel: ProgressListHeadingLevel

--- a/packages/react/src/Spotlight/Spotlight.tsx
+++ b/packages/react/src/Spotlight/Spotlight.tsx
@@ -15,7 +15,10 @@ export const spotlightColors = ['azure', 'green', 'lime', 'magenta', 'orange', '
 type SpotlightColor = (typeof spotlightColors)[number]
 
 export type SpotlightProps = {
-  /** The HTML element to use. */
+  /**
+   * The HTML element to use.
+   * @default div
+   */
   readonly as?: SpotlightTag
   /** The background colour. */
   readonly color?: SpotlightColor

--- a/packages/react/src/TableOfContents/TableOfContentsLink.tsx
+++ b/packages/react/src/TableOfContents/TableOfContentsLink.tsx
@@ -17,6 +17,7 @@ export type TableOfContentsLinkProps = {
   /**
    * Whether the nested list is initially expanded.
    * Ignored when the parent `TableOfContents` is not `collapsible` or when there is no nested list.
+   * @default false
    */
   readonly defaultExpanded?: boolean
   /** The text for the link. */

--- a/packages/react/src/Tabs/Tabs.tsx
+++ b/packages/react/src/Tabs/Tabs.tsx
@@ -16,7 +16,7 @@ import { TabsPanel } from './TabsPanel'
 export type TabsProps = {
   /** The identifier of the initially active Tab. Corresponds to its Panel `id` value. */
   readonly activeTab?: string
-  /* Provides the id of the activated Panel. */
+  /** A function to run when another Tab is activated. Provides the id of its Panel. */
   readonly onTabChange?: (panelId: string) => void
 } & Readonly<PropsWithChildren<HTMLAttributes<HTMLDivElement>>>
 

--- a/plop-templates/storybook.stories.tsx.hbs
+++ b/plop-templates/storybook.stories.tsx.hbs
@@ -8,10 +8,17 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { {{pascalCase name}} } from '@amsterdam/design-system-react/src'
 
 const meta = {
-  title: '{{titleCase name}}',
+  title: 'Components/TODO-ADD-GROUP/{{titleCase name}}',
   component: {{pascalCase name}},
   args: {
     children: 'Nieuw component',
+  },
+  // Configure controls following documentation/storybook.md.
+  argTypes: {
+    children: {
+      description: 'Any content for this component.',
+      table: { disable: false },
+    },
   },
 } satisfies Meta<typeof {{pascalCase name}}>
 

--- a/plop-templates/storybook.stories.tsx.hbs
+++ b/plop-templates/storybook.stories.tsx.hbs
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { {{pascalCase name}} } from '@amsterdam/design-system-react/src'
 
+import { childrenArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/TODO-ADD-GROUP/{{titleCase name}}',
   component: {{pascalCase name}},
@@ -15,10 +17,7 @@ const meta = {
   },
   // Configure controls following documentation/storybook.md.
   argTypes: {
-    children: {
-      description: 'Any content for this component.',
-      table: { disable: false },
-    },
+    children: childrenArgType('Any content for this component.'),
   },
 } satisfies Meta<typeof {{pascalCase name}}>
 

--- a/plop-templates/storybook.test.stories.tsx.hbs
+++ b/plop-templates/storybook.test.stories.tsx.hbs
@@ -12,7 +12,7 @@ import { default as {{camelCase name}}Meta } from './{{pascalCase name}}.stories
 
 const meta = {
   ...{{camelCase name}}Meta,
-  title: '{{titleCase name}}',
+  title: 'Components/TODO-ADD-GROUP/{{titleCase name}}',
 } satisfies Meta<typeof {{pascalCase name}}>
 
 export default meta

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -76,7 +76,30 @@ const formatDeprecatedProps: ArgTypesEnhancer = ({ component, argTypes }) => {
   )
 }
 
-export const argTypesEnhancers = [formatDeprecatedProps]
+// Show `@default` JSDoc tags in the ‘Default’ column of the controls tables, unless docgen already
+// derived a default value from the code itself.
+// The tags reach the docgen info through `shouldIncludePropTagMap` in main.ts.
+const formatDefaultValues: ArgTypesEnhancer = ({ component, argTypes }) => {
+  const docgenProps = (component as ComponentWithDocgen | null)?.__docgenInfo?.props
+
+  if (!docgenProps) {
+    return argTypes
+  }
+
+  return Object.fromEntries(
+    Object.entries(argTypes).map(([name, argType]) => {
+      const defaultValue = docgenProps[name]?.tags?.['default']
+
+      if (defaultValue === undefined || argType.table?.defaultValue !== undefined) {
+        return [name, argType]
+      }
+
+      return [name, { ...argType, table: { ...argType.table, defaultValue: { summary: defaultValue } } }]
+    }),
+  )
+}
+
+export const argTypesEnhancers = [formatDefaultValues, formatDeprecatedProps]
 
 // Set the page language and apply the page background overrides for Canvas and Stories.
 // Components that need a realistic Page or a width constraint add that themselves through a decorator.
@@ -126,6 +149,7 @@ const DocsContainerWithFooter = ({ children, ...props }: ComponentProps<typeof D
 export const parameters = {
   backgrounds: { disable: true },
   controls: {
+    expanded: true, // Shows the description and default columns in the Controls addon
     sort: 'alpha', // Sorts controls in the Controls addon
   },
   docs: {

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -6,6 +6,7 @@ import { DocsContainer } from '@storybook/addon-docs/blocks'
 import { withThemeByClassName } from '@storybook/addon-themes'
 import { clsx } from 'clsx'
 
+import { sortLiteralUnionValues } from './sortLiteralUnionValues'
 import { viewports } from './viewports'
 
 import '@amsterdam/design-system-tokens/dist/index.css'
@@ -99,7 +100,7 @@ const formatDefaultValues: ArgTypesEnhancer = ({ component, argTypes }) => {
   )
 }
 
-export const argTypesEnhancers = [formatDefaultValues, formatDeprecatedProps]
+export const argTypesEnhancers = [formatDefaultValues, formatDeprecatedProps, sortLiteralUnionValues]
 
 // Set the page language and apply the page background overrides for Canvas and Stories.
 // Components that need a realistic Page or a width constraint add that themselves through a decorator.

--- a/storybook/config/sortLiteralUnionValues.test.ts
+++ b/storybook/config/sortLiteralUnionValues.test.ts
@@ -35,6 +35,12 @@ describe('sortLiteralUnionValues', () => {
     expect(result?.type).toEqual({ name: 'enum', value: [1, 2, 3, 4] })
   })
 
+  it('tolerates an enum type without values', () => {
+    const result = enhance({ type: { name: 'enum' } as never })
+
+    expect(result?.type).toEqual({ name: 'enum' })
+  })
+
   it('orders a string type summary by the control’s options', () => {
     const result = enhance({
       options: [undefined, 'small', 'medium', 'large'],

--- a/storybook/config/sortLiteralUnionValues.test.ts
+++ b/storybook/config/sortLiteralUnionValues.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { InputType, StrictArgTypes } from 'storybook/internal/types'
+
+import { describe, expect, it } from 'vitest'
+
+import { sortLiteralUnionValues } from './sortLiteralUnionValues'
+
+const enhance = (argType: InputType) =>
+  (sortLiteralUnionValues as (context: { argTypes: Record<string, InputType> }) => StrictArgTypes)({
+    argTypes: { prop: argType },
+  })['prop']
+
+describe('sortLiteralUnionValues', () => {
+  it('sorts a scrambled numeric type summary', () => {
+    const result = enhance({ table: { type: { summary: '3 | 1 | 2 | 4' } } })
+
+    expect(result?.table?.type?.summary).toBe('1 | 2 | 3 | 4')
+  })
+
+  it('sorts a scrambled numeric type detail', () => {
+    const result = enhance({ table: { type: { detail: '3 | 1 | 2 | 4', summary: 'union' } } })
+
+    expect(result?.table?.type?.detail).toBe('1 | 2 | 3 | 4')
+    expect(result?.table?.type?.summary).toBe('union')
+  })
+
+  it('sorts numeric options and enum values', () => {
+    const result = enhance({ options: [3, 1, 2, 4], type: { name: 'enum', value: [3, 1, 2, 4] } })
+
+    expect(result?.options).toEqual([1, 2, 3, 4])
+    expect(result?.type).toEqual({ name: 'enum', value: [1, 2, 3, 4] })
+  })
+
+  it('orders a string type summary by the control’s options', () => {
+    const result = enhance({
+      options: [undefined, 'small', 'medium', 'large'],
+      table: { type: { summary: '"medium" | "large" | "small"' } },
+    })
+
+    expect(result?.table?.type?.summary).toBe('"small" | "medium" | "large"')
+  })
+
+  it('leaves a string type summary without options untouched', () => {
+    const result = enhance({ table: { type: { summary: '"medium" | "large" | "small"' } } })
+
+    expect(result?.table?.type?.summary).toBe('"medium" | "large" | "small"')
+  })
+
+  it('leaves a string type summary untouched if the options don’t offer every value', () => {
+    const result = enhance({
+      options: [undefined, 'small'],
+      table: { type: { summary: '"medium" | "large" | "small"' } },
+    })
+
+    expect(result?.table?.type?.summary).toBe('"medium" | "large" | "small"')
+  })
+
+  it('leaves options containing undefined unsorted', () => {
+    const result = enhance({ options: [undefined, 2, 3] })
+
+    expect(result?.options).toEqual([undefined, 2, 3])
+  })
+
+  it('leaves a type summary without a union untouched', () => {
+    const result = enhance({ table: { type: { summary: 'string' } } })
+
+    expect(result?.table?.type?.summary).toBe('string')
+  })
+})

--- a/storybook/config/sortLiteralUnionValues.ts
+++ b/storybook/config/sortLiteralUnionValues.ts
@@ -1,0 +1,70 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { ArgTypesEnhancer, StrictInputType } from 'storybook/internal/types'
+
+const compareNumbers = (a: unknown, b: unknown) => Number(a) - Number(b)
+
+const isNumeric = (value: unknown): boolean =>
+  (typeof value === 'number' || (typeof value === 'string' && value.trim() !== '')) && !Number.isNaN(Number(value))
+
+const unquote = (value: string) => value.replace(/"/g, '')
+
+/** Reorders the values of an `a | b | c` type text, numerically or following the control’s options. */
+const sortUnionText = (text: string, options?: readonly unknown[]) => {
+  if (!text.includes(' | ')) {
+    return text
+  }
+
+  const parts = text.split(' | ')
+
+  if (parts.every(isNumeric)) {
+    return [...parts].sort(compareNumbers).join(' | ')
+  }
+
+  const optionValues = options?.filter((option) => option !== undefined).map(String)
+
+  if (optionValues && parts.every((part) => optionValues.includes(unquote(part)))) {
+    return [...parts].sort((a, b) => optionValues.indexOf(unquote(a)) - optionValues.indexOf(unquote(b))).join(' | ')
+  }
+
+  return text
+}
+
+const sortArgType = (argType: StrictInputType): StrictInputType => {
+  const sorted = { ...argType }
+
+  if (Array.isArray(sorted.options) && sorted.options.length > 0 && sorted.options.every(isNumeric)) {
+    sorted.options = [...sorted.options].sort(compareNumbers)
+  }
+
+  if (typeof sorted.type === 'object' && sorted.type?.name === 'enum' && sorted.type.value.every(isNumeric)) {
+    sorted.type = { ...sorted.type, value: [...sorted.type.value].sort(compareNumbers) }
+  }
+
+  const { detail, summary } = sorted.table?.type ?? {}
+
+  if (typeof summary === 'string' || typeof detail === 'string') {
+    sorted.table = {
+      ...sorted.table,
+      type: {
+        ...sorted.table?.type,
+        ...(typeof summary === 'string' && { summary: sortUnionText(summary, sorted.options) }),
+        ...(typeof detail === 'string' && { detail: sortUnionText(detail, sorted.options) }),
+      },
+    }
+  }
+
+  return sorted
+}
+
+/**
+ * TypeScript interns the members of literal union types in the order it first encounters them
+ * anywhere in the program, so docgen may describe a prop typed `1 | 2 | 3 | 4` as `3 | 1 | 2 | 4`.
+ * Restore a natural order everywhere the controls tables show these values: numerically for
+ * numeric unions, and following the control’s options for unions whose values are all offered.
+ */
+export const sortLiteralUnionValues: ArgTypesEnhancer = ({ argTypes }) =>
+  Object.fromEntries(Object.entries(argTypes).map(([name, argType]) => [name, sortArgType(argType)]))

--- a/storybook/config/sortLiteralUnionValues.ts
+++ b/storybook/config/sortLiteralUnionValues.ts
@@ -40,7 +40,12 @@ const sortArgType = (argType: StrictInputType): StrictInputType => {
     sorted.options = [...sorted.options].sort(compareNumbers)
   }
 
-  if (typeof sorted.type === 'object' && sorted.type?.name === 'enum' && sorted.type.value.every(isNumeric)) {
+  if (
+    typeof sorted.type === 'object' &&
+    sorted.type?.name === 'enum' &&
+    Array.isArray(sorted.type.value) &&
+    sorted.type.value.every(isNumeric)
+  ) {
     sorted.type = { ...sorted.type, value: [...sorted.type.value].sort(compareNumbers) }
   }
 

--- a/storybook/src/_common/argTypes.ts
+++ b/storybook/src/_common/argTypes.ts
@@ -1,0 +1,81 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import * as Icons from '@amsterdam/design-system-react-icons'
+
+/** The native `checked` attribute of checkable inputs. */
+export const checkedArgType = {
+  description: 'Whether the control is checked.',
+} as const
+
+/** A colour prop offering `contrast` and `inverse` for readability on a light or dark background. */
+export const contrastInverseColorArgType = {
+  control: {
+    labels: { undefined: 'default' },
+    type: 'radio',
+  },
+  options: [undefined, 'contrast', 'inverse'],
+} as const
+
+/** An arg that updates automatically, e.g. through a decorator. Describe what drives its value. */
+export const derivedArgType = (description: string) =>
+  ({
+    control: false,
+    description,
+    table: { category: 'Derived', readonly: true },
+  }) as const
+
+/** The native `disabled` attribute of interactive elements. */
+export const disabledArgType = {
+  description: 'Prevents interaction. Avoid if possible.',
+} as const
+
+/** A heading level prop. Pass the levels the component accepts. */
+export const headingLevelArgType = (options: readonly number[] = [1, 2, 3, 4]) =>
+  ({
+    control: { type: 'radio' },
+    options: [...options],
+  }) as const
+
+/** The native `href` attribute of links. */
+export const hrefArgType = {
+  description: 'The url for the link.',
+} as const
+
+/** An optional icon prop. Offers all icons by name, labelling `undefined` as ‘none’. */
+export const iconArgType = {
+  control: {
+    labels: { undefined: 'none' },
+    type: 'select',
+  },
+  mapping: Icons,
+  options: [undefined, ...Object.keys(Icons)],
+} as const
+
+/** The native `id` attribute of form controls that generate one when it isn’t provided. */
+export const idArgType = {
+  description: 'The id of the input element. If not provided, a unique id will be generated.',
+} as const
+
+/** A colour prop offering `inverse` for readability on a dark background. */
+export const inverseColorArgType = {
+  control: {
+    labels: { undefined: 'default' },
+    type: 'radio',
+  },
+  options: [undefined, 'inverse'],
+} as const
+
+/** A `linkComponent` prop: a component type has no useful control, but the row is worth showing. */
+export const linkComponentArgType = {
+  control: false,
+} as const
+
+/** A required icon prop. Offers all icons by name. */
+export const requiredIconArgType = {
+  control: { type: 'select' },
+  mapping: Icons,
+  options: Object.keys(Icons),
+} as const

--- a/storybook/src/_common/argTypes.ts
+++ b/storybook/src/_common/argTypes.ts
@@ -21,10 +21,37 @@ export const asArgType = (tags: readonly string[]) => {
   }
 }
 
+/**
+ * A `children` prop whose content is a simple string.
+ * Unhides the globally hidden arg and offers a text control.
+ */
+export const childrenArgType = (description: string) =>
+  ({
+    control: 'text',
+    description,
+    table: { disable: false },
+  }) as const
+
 /** The native `checked` attribute of checkable inputs. */
 export const checkedArgType = {
   description: 'Whether the control is checked.',
 } as const
+
+/**
+ * A colour prop offering the component’s palette. Labels `undefined` with the default colour.
+ * Picks a radio or select control based on the number of options.
+ */
+export const colorArgType = (colors: readonly string[], defaultColor: string) => {
+  const options = [undefined, ...colors.filter((color) => color !== defaultColor)]
+
+  return {
+    control: {
+      labels: { undefined: `${defaultColor} (default)` },
+      type: options.length > 5 ? ('select' as const) : ('radio' as const),
+    },
+    options,
+  }
+}
 
 /** A colour prop offering `contrast` and `inverse` for readability on a light or dark background. */
 export const contrastInverseColorArgType = {

--- a/storybook/src/_common/argTypes.ts
+++ b/storybook/src/_common/argTypes.ts
@@ -3,7 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
-import * as Icons from '@amsterdam/design-system-react-icons'
+// Note: the icon arg types live in iconArgTypes.ts – they pull in the entire icon package.
 
 /**
  * An `as` prop offering the component’s allowed tags, which default to `div`.
@@ -93,19 +93,6 @@ export const hrefArgType = {
   description: 'The url for the link.',
 } as const
 
-/**
- * An optional icon prop. Offers all icons by name.
- * Labels `undefined` as ‘none’, or with the name of the default icon if one is passed.
- */
-export const iconArgType = (defaultIcon?: string) => ({
-  control: {
-    labels: { undefined: defaultIcon ? `${defaultIcon} (default)` : 'none' },
-    type: 'select' as const,
-  },
-  mapping: Icons,
-  options: [undefined, ...Object.keys(Icons).filter((name) => name !== defaultIcon)],
-})
-
 /** The native `id` attribute of form controls that generate one when it isn’t provided. */
 export const idArgType = {
   description: 'The id of the input element. If not provided, a unique id will be generated.',
@@ -134,10 +121,3 @@ export const textSizeArgType = (options: readonly (string | undefined)[]) =>
     },
     options: [...options],
   }) as const
-
-/** A required icon prop. Offers all icons by name. */
-export const requiredIconArgType = {
-  control: { type: 'select' },
-  mapping: Icons,
-  options: Object.keys(Icons),
-} as const

--- a/storybook/src/_common/argTypes.ts
+++ b/storybook/src/_common/argTypes.ts
@@ -75,27 +75,36 @@ export const disabledArgType = {
   description: 'Prevents interaction. Avoid if possible.',
 } as const
 
-/** A heading level prop. Pass the levels the component accepts. */
-export const headingLevelArgType = (options: readonly number[] = [1, 2, 3, 4]) =>
-  ({
-    control: { type: 'radio' },
-    options: [...options],
-  }) as const
+/**
+ * A heading level prop. Pass the levels the component accepts.
+ * For an optional prop, pass its default level as well; `undefined` then gets offered and labelled with it.
+ */
+export const headingLevelArgType = (options: readonly number[] = [1, 2, 3, 4], defaultLevel?: number) => ({
+  control: {
+    ...(defaultLevel !== undefined && { labels: { undefined: `${defaultLevel} (default)` } }),
+    type: 'radio' as const,
+  },
+  options:
+    defaultLevel === undefined ? [...options] : [undefined, ...options.filter((level) => level !== defaultLevel)],
+})
 
 /** The native `href` attribute of links. */
 export const hrefArgType = {
   description: 'The url for the link.',
 } as const
 
-/** An optional icon prop. Offers all icons by name, labelling `undefined` as ‘none’. */
-export const iconArgType = {
+/**
+ * An optional icon prop. Offers all icons by name.
+ * Labels `undefined` as ‘none’, or with the name of the default icon if one is passed.
+ */
+export const iconArgType = (defaultIcon?: string) => ({
   control: {
-    labels: { undefined: 'none' },
-    type: 'select',
+    labels: { undefined: defaultIcon ? `${defaultIcon} (default)` : 'none' },
+    type: 'select' as const,
   },
   mapping: Icons,
-  options: [undefined, ...Object.keys(Icons)],
-} as const
+  options: [undefined, ...Object.keys(Icons).filter((name) => name !== defaultIcon)],
+})
 
 /** The native `id` attribute of form controls that generate one when it isn’t provided. */
 export const idArgType = {
@@ -115,6 +124,16 @@ export const inverseColorArgType = {
 export const linkComponentArgType = {
   control: false,
 } as const
+
+/** A text size prop, whose default is medium. Pass the options in ascending order, `undefined` for medium. */
+export const textSizeArgType = (options: readonly (string | undefined)[]) =>
+  ({
+    control: {
+      labels: { undefined: 'medium (default)' },
+      type: 'radio',
+    },
+    options: [...options],
+  }) as const
 
 /** A required icon prop. Offers all icons by name. */
 export const requiredIconArgType = {

--- a/storybook/src/_common/argTypes.ts
+++ b/storybook/src/_common/argTypes.ts
@@ -5,6 +5,22 @@
 
 import * as Icons from '@amsterdam/design-system-react-icons'
 
+/**
+ * An `as` prop offering the component’s allowed tags, which default to `div`.
+ * Picks a radio or select control based on the number of options.
+ */
+export const asArgType = (tags: readonly string[]) => {
+  const options = [undefined, ...tags.filter((tag) => tag !== 'div')]
+
+  return {
+    control: {
+      labels: { undefined: 'div (default)' },
+      type: options.length > 5 ? ('select' as const) : ('radio' as const),
+    },
+    options,
+  }
+}
+
 /** The native `checked` attribute of checkable inputs. */
 export const checkedArgType = {
   description: 'Whether the control is checked.',

--- a/storybook/src/_common/iconArgTypes.ts
+++ b/storybook/src/_common/iconArgTypes.ts
@@ -1,0 +1,29 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import * as Icons from '@amsterdam/design-system-react-icons'
+
+// These arg types live in their own module because they pull in the entire icon package.
+// Import them only in stories that offer an icon control, so other stories don’t pay that cost.
+
+/**
+ * An optional icon prop. Offers all icons by name.
+ * Labels `undefined` as ‘none’, or with the name of the default icon if one is passed.
+ */
+export const iconArgType = (defaultIcon?: string) => ({
+  control: {
+    labels: { undefined: defaultIcon ? `${defaultIcon} (default)` : 'none' },
+    type: 'select' as const,
+  },
+  mapping: Icons,
+  options: [undefined, ...Object.keys(Icons).filter((name) => name !== defaultIcon)],
+})
+
+/** A required icon prop. Offers all icons by name. */
+export const requiredIconArgType = {
+  control: { type: 'select' },
+  mapping: Icons,
+  options: Object.keys(Icons),
+} as const

--- a/storybook/src/components/Accordion/Accordion.stories.tsx
+++ b/storybook/src/components/Accordion/Accordion.stories.tsx
@@ -8,6 +8,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Link, Paragraph } from '@amsterdam/design-system-react'
 import { Accordion } from '@amsterdam/design-system-react/src'
 
+import { headingLevelArgType } from '#storybook/_common/argTypes'
+
 const faqItems = [
   {
     content: (
@@ -45,6 +47,9 @@ const meta = {
   component: Accordion,
   args: {
     headingLevel: 3,
+  },
+  argTypes: {
+    headingLevel: headingLevelArgType([2, 3, 4]),
   },
 } satisfies Meta<typeof Accordion>
 

--- a/storybook/src/components/Alert/Alert.stories.tsx
+++ b/storybook/src/components/Alert/Alert.stories.tsx
@@ -8,6 +8,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Link, Paragraph } from '@amsterdam/design-system-react'
 import { Alert } from '@amsterdam/design-system-react/src'
 
+import { headingLevelArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Feedback/Alert',
   component: Alert,
@@ -17,9 +19,17 @@ const meta = {
     headingLevel: 2,
   },
   argTypes: {
+    closeButtonLabel: {
+      if: { arg: 'closeable' },
+    },
+    headingLevel: headingLevelArgType(),
+    onClose: {
+      control: false,
+    },
     severity: {
       control: {
-        labels: { undefined: 'information' },
+        labels: { undefined: 'information (default)' },
+        type: 'radio',
       },
       options: [undefined, 'success', 'warning', 'error'],
     },

--- a/storybook/src/components/Avatar/Avatar.stories.tsx
+++ b/storybook/src/components/Avatar/Avatar.stories.tsx
@@ -19,6 +19,7 @@ const meta = {
     color: {
       control: {
         labels: { undefined: 'purple (default)' },
+        type: 'select',
       },
       options: [undefined, ...avatarColors],
     },

--- a/storybook/src/components/Avatar/Avatar.stories.tsx
+++ b/storybook/src/components/Avatar/Avatar.stories.tsx
@@ -8,6 +8,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Avatar } from '@amsterdam/design-system-react/src'
 import { avatarColors } from '@amsterdam/design-system-react/src/Avatar/Avatar'
 
+import { colorArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Feedback/Avatar',
   component: Avatar,
@@ -16,13 +18,7 @@ const meta = {
     label: 'DS',
   },
   argTypes: {
-    color: {
-      control: {
-        labels: { undefined: 'purple (default)' },
-        type: 'select',
-      },
-      options: [undefined, ...avatarColors],
-    },
+    color: colorArgType(avatarColors, 'purple'),
   },
 } satisfies Meta<typeof Avatar>
 

--- a/storybook/src/components/Badge/Badge.stories.tsx
+++ b/storybook/src/components/Badge/Badge.stories.tsx
@@ -9,6 +9,8 @@ import * as Icons from '@amsterdam/design-system-react-icons'
 import { Badge } from '@amsterdam/design-system-react/src'
 import { badgeColors } from '@amsterdam/design-system-react/src/Badge/Badge'
 
+import { iconArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Feedback/Badge',
   component: Badge,
@@ -19,17 +21,11 @@ const meta = {
     color: {
       control: {
         labels: { undefined: 'green (default)' },
+        type: 'select',
       },
       options: [undefined, ...badgeColors],
     },
-    icon: {
-      control: {
-        labels: { undefined: 'none' },
-        type: 'select',
-      },
-      mapping: Icons,
-      options: [undefined, ...Object.keys(Icons)],
-    },
+    icon: iconArgType,
   },
 } satisfies Meta<typeof Badge>
 

--- a/storybook/src/components/Badge/Badge.stories.tsx
+++ b/storybook/src/components/Badge/Badge.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
   },
   argTypes: {
     color: colorArgType(badgeColors, 'green'),
-    icon: iconArgType,
+    icon: iconArgType(),
   },
 } satisfies Meta<typeof Badge>
 

--- a/storybook/src/components/Badge/Badge.stories.tsx
+++ b/storybook/src/components/Badge/Badge.stories.tsx
@@ -9,7 +9,8 @@ import * as Icons from '@amsterdam/design-system-react-icons'
 import { Badge } from '@amsterdam/design-system-react/src'
 import { badgeColors } from '@amsterdam/design-system-react/src/Badge/Badge'
 
-import { colorArgType, iconArgType } from '#storybook/_common/argTypes'
+import { colorArgType } from '#storybook/_common/argTypes'
+import { iconArgType } from '#storybook/_common/iconArgTypes'
 
 const meta = {
   title: 'Components/Feedback/Badge',

--- a/storybook/src/components/Badge/Badge.stories.tsx
+++ b/storybook/src/components/Badge/Badge.stories.tsx
@@ -9,7 +9,7 @@ import * as Icons from '@amsterdam/design-system-react-icons'
 import { Badge } from '@amsterdam/design-system-react/src'
 import { badgeColors } from '@amsterdam/design-system-react/src/Badge/Badge'
 
-import { iconArgType } from '#storybook/_common/argTypes'
+import { colorArgType, iconArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Feedback/Badge',
@@ -18,13 +18,7 @@ const meta = {
     label: 'Tip',
   },
   argTypes: {
-    color: {
-      control: {
-        labels: { undefined: 'green (default)' },
-        type: 'select',
-      },
-      options: [undefined, ...badgeColors],
-    },
+    color: colorArgType(badgeColors, 'green'),
     icon: iconArgType,
   },
 } satisfies Meta<typeof Badge>

--- a/storybook/src/components/Blockquote/Blockquote.stories.tsx
+++ b/storybook/src/components/Blockquote/Blockquote.stories.tsx
@@ -7,7 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Blockquote } from '@amsterdam/design-system-react/src'
 
-import { inverseColorArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, inverseColorArgType } from '#storybook/_common/argTypes'
 import { exampleQuote } from '#storybook/_common/exampleContent'
 
 const quote = exampleQuote()
@@ -19,10 +19,7 @@ const meta = {
     children: quote,
   },
   argTypes: {
-    children: {
-      description: 'The text for the quote.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The text for the quote.'),
     color: inverseColorArgType,
   },
 } satisfies Meta<typeof Blockquote>

--- a/storybook/src/components/Blockquote/Blockquote.stories.tsx
+++ b/storybook/src/components/Blockquote/Blockquote.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Blockquote } from '@amsterdam/design-system-react/src'
 
+import { inverseColorArgType } from '#storybook/_common/argTypes'
 import { exampleQuote } from '#storybook/_common/exampleContent'
 
 const quote = exampleQuote()
@@ -22,13 +23,7 @@ const meta = {
       description: 'The text for the quote.',
       table: { disable: false },
     },
-    color: {
-      control: {
-        labels: { undefined: 'default' },
-        type: 'radio',
-      },
-      options: [undefined, 'inverse'],
-    },
+    color: inverseColorArgType,
   },
 } satisfies Meta<typeof Blockquote>
 

--- a/storybook/src/components/Breadcrumb/BreadcrumbLink.stories.tsx
+++ b/storybook/src/components/Breadcrumb/BreadcrumbLink.stories.tsx
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Breadcrumb } from '@amsterdam/design-system-react/src'
 
+import { hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Navigation/Breadcrumb',
   component: Breadcrumb.Link,
@@ -16,6 +18,8 @@ const meta = {
       description: 'The link text.',
       table: { disable: false },
     },
+    href: hrefArgType,
+    linkComponent: linkComponentArgType,
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/Breadcrumb/BreadcrumbLink.stories.tsx
+++ b/storybook/src/components/Breadcrumb/BreadcrumbLink.stories.tsx
@@ -7,17 +7,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Breadcrumb } from '@amsterdam/design-system-react/src'
 
-import { hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Navigation/Breadcrumb',
   component: Breadcrumb.Link,
   argTypes: {
-    children: {
-      control: 'text',
-      description: 'The link text.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The link text.'),
     href: hrefArgType,
     linkComponent: linkComponentArgType,
   },

--- a/storybook/src/components/Breakout/Breakout.stories.tsx
+++ b/storybook/src/components/Breakout/Breakout.stories.tsx
@@ -7,7 +7,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Image, Paragraph, Spotlight } from '@amsterdam/design-system-react'
 import { Breakout } from '@amsterdam/design-system-react/src'
+import { gridTags } from '@amsterdam/design-system-react/src/Grid/Grid'
 
+import { asArgType } from '#storybook/_common/argTypes'
 import { wrapInPage } from '#storybook/_common/decorators'
 
 import { gridGapAndPaddingArgTypes } from '../Grid/Grid.argTypes'
@@ -15,7 +17,10 @@ import { gridGapAndPaddingArgTypes } from '../Grid/Grid.argTypes'
 const meta = {
   title: 'Components/Layout/Breakout',
   component: Breakout,
-  argTypes: gridGapAndPaddingArgTypes,
+  argTypes: {
+    ...gridGapAndPaddingArgTypes,
+    as: asArgType(gridTags),
+  },
   decorators: [wrapInPage],
 } satisfies Meta<typeof Breakout>
 

--- a/storybook/src/components/Breakout/BreakoutCell.stories.tsx
+++ b/storybook/src/components/Breakout/BreakoutCell.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
         labels: { undefined: 'div (default)' },
         type: 'radio',
       },
-      options: [undefined, ...breakoutCellTags],
+      options: [undefined, ...breakoutCellTags.filter((tag) => tag !== 'div')],
     },
     // The span and start props also take ‘all’ or an object of numbers per grid variant – the
     // number controls cover the common case, matching Grid Cell.

--- a/storybook/src/components/Breakout/BreakoutCell.stories.tsx
+++ b/storybook/src/components/Breakout/BreakoutCell.stories.tsx
@@ -6,6 +6,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Breakout } from '@amsterdam/design-system-react/src'
+import { breakoutCellTags } from '@amsterdam/design-system-react/src/Breakout/BreakoutCell'
 
 import { GridColumnsGuide } from '#storybook/_components/GridColumnsGuide/GridColumnsGuide'
 
@@ -14,20 +15,28 @@ const meta = {
   component: Breakout.Cell,
   argTypes: {
     as: {
-      control: { type: 'radio' },
-      options: ['article', 'div', 'section'],
+      control: {
+        labels: { undefined: 'div (default)' },
+        type: 'radio',
+      },
+      options: [undefined, ...breakoutCellTags],
     },
+    // The span and start props take a number, ‘all’, or an object of numbers per grid variant – no control expresses that.
     colSpan: {
-      control: { max: 12, min: 1, type: 'number' },
+      control: false,
     },
     colStart: {
-      control: { max: 12, min: 1, type: 'number' },
+      control: false,
+    },
+    // The allowed value differs per span variant – a control would mislead, the description explains it.
+    has: {
+      control: false,
     },
     rowSpan: {
-      control: { max: 4, min: 1, type: 'number' },
+      control: false,
     },
     rowStart: {
-      control: { max: 4, min: 1, type: 'number' },
+      control: false,
     },
   },
   decorators: [

--- a/storybook/src/components/Breakout/BreakoutCell.stories.tsx
+++ b/storybook/src/components/Breakout/BreakoutCell.stories.tsx
@@ -8,19 +8,14 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Breakout } from '@amsterdam/design-system-react/src'
 import { breakoutCellTags } from '@amsterdam/design-system-react/src/Breakout/BreakoutCell'
 
+import { asArgType } from '#storybook/_common/argTypes'
 import { GridColumnsGuide } from '#storybook/_components/GridColumnsGuide/GridColumnsGuide'
 
 const meta = {
   title: 'Components/Layout/Breakout',
   component: Breakout.Cell,
   argTypes: {
-    as: {
-      control: {
-        labels: { undefined: 'div (default)' },
-        type: 'radio',
-      },
-      options: [undefined, ...breakoutCellTags.filter((tag) => tag !== 'div')],
-    },
+    as: asArgType(breakoutCellTags),
     // The span and start props also take ‘all’ or an object of numbers per grid variant – the
     // number controls cover the common case, matching Grid Cell.
     colSpan: {

--- a/storybook/src/components/Breakout/BreakoutCell.stories.tsx
+++ b/storybook/src/components/Breakout/BreakoutCell.stories.tsx
@@ -21,22 +21,23 @@ const meta = {
       },
       options: [undefined, ...breakoutCellTags],
     },
-    // The span and start props take a number, ‘all’, or an object of numbers per grid variant – no control expresses that.
+    // The span and start props also take ‘all’ or an object of numbers per grid variant – the
+    // number controls cover the common case, matching Grid Cell.
     colSpan: {
-      control: false,
+      control: { max: 12, min: 1, type: 'number' },
     },
     colStart: {
-      control: false,
+      control: { max: 12, min: 1, type: 'number' },
     },
     // The allowed value differs per span variant – a control would mislead, the description explains it.
     has: {
       control: false,
     },
     rowSpan: {
-      control: false,
+      control: { max: 4, min: 1, type: 'number' },
     },
     rowStart: {
-      control: false,
+      control: { max: 4, min: 1, type: 'number' },
     },
   },
   decorators: [

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -25,7 +25,7 @@ const meta = {
   },
   argTypes: {
     disabled: disabledArgType,
-    icon: iconArgType,
+    icon: iconArgType(),
     iconBefore: {
       control: {
         type: 'boolean',

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -47,7 +47,7 @@ const meta = {
         labels: { undefined: 'primary (default)' },
         type: 'radio',
       },
-      options: [undefined, ...buttonVariants],
+      options: [undefined, ...buttonVariants.filter((variant) => variant !== 'primary')],
     },
   },
 } satisfies Meta<typeof Button>

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -9,8 +9,9 @@ import { CloseIcon } from '@amsterdam/design-system-react-icons'
 import { Button } from '@amsterdam/design-system-react/src'
 import { buttonVariants } from '@amsterdam/design-system-react/src/Button/Button'
 
-import { disabledArgType, iconArgType } from '#storybook/_common/argTypes'
+import { disabledArgType } from '#storybook/_common/argTypes'
 import { maximiseInlineSize } from '#storybook/_common/decorators'
+import { iconArgType } from '#storybook/_common/iconArgTypes'
 
 const meta = {
   title: 'Components/Buttons/Button',

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -6,9 +6,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { CloseIcon } from '@amsterdam/design-system-react-icons'
-import * as Icons from '@amsterdam/design-system-react-icons'
 import { Button } from '@amsterdam/design-system-react/src'
+import { buttonVariants } from '@amsterdam/design-system-react/src/Button/Button'
 
+import { disabledArgType, iconArgType } from '#storybook/_common/argTypes'
 import { maximiseInlineSize } from '#storybook/_common/decorators'
 
 const meta = {
@@ -23,17 +24,8 @@ const meta = {
     variant: 'primary',
   },
   argTypes: {
-    disabled: {
-      description: 'Prevents interaction. Avoid if possible.',
-    },
-    icon: {
-      control: {
-        labels: { undefined: 'none' },
-        type: 'select',
-      },
-      mapping: Icons,
-      options: [undefined, ...Object.keys(Icons)],
-    },
+    disabled: disabledArgType,
+    icon: iconArgType,
     iconBefore: {
       control: {
         type: 'boolean',
@@ -49,6 +41,13 @@ const meta = {
       if: {
         arg: 'icon',
       },
+    },
+    variant: {
+      control: {
+        labels: { undefined: 'primary (default)' },
+        type: 'radio',
+      },
+      options: [undefined, ...buttonVariants],
     },
   },
 } satisfies Meta<typeof Button>

--- a/storybook/src/components/CallToActionLink/CallToActionLink.stories.tsx
+++ b/storybook/src/components/CallToActionLink/CallToActionLink.stories.tsx
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { CallToActionLink } from '@amsterdam/design-system-react/src'
 
+import { hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Navigation/Call to Action Link',
   component: CallToActionLink,
@@ -19,11 +21,8 @@ const meta = {
       description: 'The link text.',
       table: { disable: false },
     },
-    href: {
-      description: 'The url for the link.',
-      name: 'href',
-      type: { name: 'string', required: false },
-    },
+    href: hrefArgType,
+    linkComponent: linkComponentArgType,
   },
 } satisfies Meta<typeof CallToActionLink>
 

--- a/storybook/src/components/CallToActionLink/CallToActionLink.stories.tsx
+++ b/storybook/src/components/CallToActionLink/CallToActionLink.stories.tsx
@@ -7,7 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { CallToActionLink } from '@amsterdam/design-system-react/src'
 
-import { hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Navigation/Call to Action Link',
@@ -17,10 +17,7 @@ const meta = {
     href: '#',
   },
   argTypes: {
-    children: {
-      description: 'The link text.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The link text.'),
     href: hrefArgType,
     linkComponent: linkComponentArgType,
   },

--- a/storybook/src/components/Card/Card.stories.tsx
+++ b/storybook/src/components/Card/Card.stories.tsx
@@ -73,9 +73,10 @@ export const WithImage: WithImageStory = {
     tagline: 'Nieuws',
     text: 'We bouwen een levendige, groene en duurzame woonbuurt tussen de Gooiseweg en het Nelson Mandelapark.',
   },
+  // These argTypes describe flattened args specific to this composed story; the meta cannot provide them.
   argTypes: {
     aspectRatio: {
-      control: { type: 'inline-radio' },
+      control: { type: 'select' },
       options: aspectRatioOptions,
     },
     date: { control: 'text' },

--- a/storybook/src/components/Card/CardHeading.stories.tsx
+++ b/storybook/src/components/Card/CardHeading.stories.tsx
@@ -7,14 +7,14 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Card } from '@amsterdam/design-system-react/src'
 
+import { headingLevelArgType, inverseColorArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Navigation/Card',
   component: Card.Heading,
   argTypes: {
-    level: {
-      control: { type: 'radio' },
-      options: [1, 2, 3, 4, 5, 6],
-    },
+    color: inverseColorArgType,
+    level: headingLevelArgType(),
     size: {
       control: {
         labels: { undefined: 'level-3 (default)' },

--- a/storybook/src/components/Card/CardHeading.stories.tsx
+++ b/storybook/src/components/Card/CardHeading.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
         labels: { undefined: 'level-3 (default)' },
         type: 'select',
       },
-      options: [undefined, 'level-1', 'level-2', 'level-3', 'level-4', 'level-5'],
+      options: [undefined, 'level-1', 'level-2', 'level-4', 'level-5'],
     },
   },
   decorators: [

--- a/storybook/src/components/Card/CardImage.stories.tsx
+++ b/storybook/src/components/Card/CardImage.stories.tsx
@@ -6,6 +6,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Card } from '@amsterdam/design-system-react/src'
+import { aspectRatioOptions } from '@amsterdam/design-system-react/src/common/types'
 
 const meta = {
   title: 'Components/Navigation/Card',
@@ -16,7 +17,7 @@ const meta = {
         labels: { undefined: 'none' },
         type: 'select',
       },
-      options: [undefined, '1:1', '4:3', '16:9', '16:5'],
+      options: [undefined, ...aspectRatioOptions],
     },
   },
   decorators: [

--- a/storybook/src/components/Card/CardLink.stories.tsx
+++ b/storybook/src/components/Card/CardLink.stories.tsx
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Card } from '@amsterdam/design-system-react/src'
 
+import { hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Navigation/Card',
   component: Card.Link,
@@ -16,6 +18,8 @@ const meta = {
       description: 'The link text.',
       table: { disable: false },
     },
+    href: hrefArgType,
+    linkComponent: linkComponentArgType,
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/Card/CardLink.stories.tsx
+++ b/storybook/src/components/Card/CardLink.stories.tsx
@@ -7,17 +7,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Card } from '@amsterdam/design-system-react/src'
 
-import { hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Navigation/Card',
   component: Card.Link,
   argTypes: {
-    children: {
-      control: 'text',
-      description: 'The link text.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The link text.'),
     href: hrefArgType,
     linkComponent: linkComponentArgType,
   },

--- a/storybook/src/components/CharacterCount/CharacterCount.stories.tsx
+++ b/storybook/src/components/CharacterCount/CharacterCount.stories.tsx
@@ -14,6 +14,14 @@ const meta = {
     length: 7,
     maxLength: 10,
   },
+  argTypes: {
+    length: {
+      control: { min: 0, type: 'number' },
+    },
+    maxLength: {
+      control: { min: 0, type: 'number' },
+    },
+  },
 } satisfies Meta<typeof CharacterCount>
 
 export default meta

--- a/storybook/src/components/Checkbox/Checkbox.stories.tsx
+++ b/storybook/src/components/Checkbox/Checkbox.stories.tsx
@@ -10,6 +10,8 @@ import { Column, ErrorMessage, FieldSet, Paragraph } from '@amsterdam/design-sys
 import { Checkbox } from '@amsterdam/design-system-react/src'
 import { useArgs } from 'storybook/preview-api'
 
+import { checkedArgType, disabledArgType, idArgType } from '#storybook/_common/argTypes'
+
 import CustomIcon from './CustomIcon'
 
 const meta = {
@@ -19,26 +21,19 @@ const meta = {
     checked: false,
     children: 'Checkbox label',
     disabled: false,
-    id: '',
     indeterminate: false,
     invalid: false,
   },
   argTypes: {
-    checked: {
-      description: 'Whether the control is checked.',
-    },
+    checked: checkedArgType,
     children: {
       description: 'The text for the label.',
       table: { disable: false },
     },
-    disabled: {
-      description: 'Prevents interaction. Avoid if possible.',
-    },
-    id: {
-      description: 'The id of the input element. If not provided, a unique id will be generated.',
-    },
+    disabled: disabledArgType,
+    id: idArgType,
     onChange: {
-      action: 'clicked',
+      action: 'changed',
       table: { disable: false },
     },
   },

--- a/storybook/src/components/Checkbox/Checkbox.stories.tsx
+++ b/storybook/src/components/Checkbox/Checkbox.stories.tsx
@@ -10,7 +10,7 @@ import { Column, ErrorMessage, FieldSet, Paragraph } from '@amsterdam/design-sys
 import { Checkbox } from '@amsterdam/design-system-react/src'
 import { useArgs } from 'storybook/preview-api'
 
-import { checkedArgType, disabledArgType, idArgType } from '#storybook/_common/argTypes'
+import { checkedArgType, childrenArgType, disabledArgType, idArgType } from '#storybook/_common/argTypes'
 
 import CustomIcon from './CustomIcon'
 
@@ -26,10 +26,7 @@ const meta = {
   },
   argTypes: {
     checked: checkedArgType,
-    children: {
-      description: 'The text for the label.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The text for the label.'),
     disabled: disabledArgType,
     id: idArgType,
     onChange: {

--- a/storybook/src/components/Column/Column.stories.tsx
+++ b/storybook/src/components/Column/Column.stories.tsx
@@ -7,7 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Card, Heading, Paragraph } from '@amsterdam/design-system-react'
 import { Column } from '@amsterdam/design-system-react/src'
-import { columnGapSizes } from '@amsterdam/design-system-react/src/Column/Column'
+import { columnGapSizes, columnTags } from '@amsterdam/design-system-react/src/Column/Column'
 import { crossAlignOptionsForColumn, mainAlignOptions } from '@amsterdam/design-system-react/src/common/types'
 
 const ThreeItems = [
@@ -26,22 +26,29 @@ const meta = {
   argTypes: {
     align: {
       control: {
-        labels: { undefined: 'start' },
-        type: 'radio',
+        labels: { undefined: 'start (default)' },
+        type: 'select',
       },
       options: [undefined, ...mainAlignOptions],
     },
     alignHorizontal: {
       control: {
-        labels: { undefined: 'stretch' },
+        labels: { undefined: 'stretch (default)' },
         type: 'radio',
       },
       options: [undefined, ...crossAlignOptionsForColumn],
     },
+    as: {
+      control: {
+        labels: { undefined: 'div (default)' },
+        type: 'radio',
+      },
+      options: [undefined, ...columnTags],
+    },
     gap: {
       control: {
-        labels: { undefined: 'medium' },
-        type: 'radio',
+        labels: { undefined: 'medium (default)' },
+        type: 'select',
       },
       options: [undefined, ...columnGapSizes],
     },

--- a/storybook/src/components/Column/Column.stories.tsx
+++ b/storybook/src/components/Column/Column.stories.tsx
@@ -10,6 +10,8 @@ import { Column } from '@amsterdam/design-system-react/src'
 import { columnGapSizes, columnTags } from '@amsterdam/design-system-react/src/Column/Column'
 import { crossAlignOptionsForColumn, mainAlignOptions } from '@amsterdam/design-system-react/src/common/types'
 
+import { asArgType } from '#storybook/_common/argTypes'
+
 const ThreeItems = [
   <div className="_ams-item" key={0} />,
   <div className="_ams-item" key={1} />,
@@ -38,13 +40,7 @@ const meta = {
       },
       options: [undefined, ...crossAlignOptionsForColumn],
     },
-    as: {
-      control: {
-        labels: { undefined: 'div (default)' },
-        type: 'radio',
-      },
-      options: [undefined, ...columnTags.filter((tag) => tag !== 'div')],
-    },
+    as: asArgType(columnTags),
     gap: {
       control: {
         labels: { undefined: 'medium (default)' },

--- a/storybook/src/components/Column/Column.stories.tsx
+++ b/storybook/src/components/Column/Column.stories.tsx
@@ -43,7 +43,7 @@ const meta = {
         labels: { undefined: 'div (default)' },
         type: 'radio',
       },
-      options: [undefined, ...columnTags],
+      options: [undefined, ...columnTags.filter((tag) => tag !== 'div')],
     },
     gap: {
       control: {

--- a/storybook/src/components/DateInput/DateInput.stories.tsx
+++ b/storybook/src/components/DateInput/DateInput.stories.tsx
@@ -6,7 +6,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Column, ErrorMessage, Field, FieldSet, Label, Paragraph, Row, TextInput } from '@amsterdam/design-system-react'
+import { dateInputTypes } from '@amsterdam/design-system-react/dist/DateInput/DateInput'
 import { DateInput } from '@amsterdam/design-system-react/src'
+
+import { disabledArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Forms/Date Input',
@@ -19,11 +22,16 @@ const meta = {
     defaultValue: {
       table: { disable: false },
     },
-    disabled: {
-      description: 'Prevents interaction. Avoid if possible.',
-    },
+    disabled: disabledArgType,
     onChange: {
       table: { disable: false },
+    },
+    type: {
+      control: {
+        labels: { undefined: 'date (default)' },
+        type: 'radio',
+      },
+      options: [undefined, ...dateInputTypes.filter((type) => type !== 'date')],
     },
   },
 } satisfies Meta<typeof DateInput>

--- a/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/storybook/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -9,6 +9,7 @@ import { Link, Paragraph, UnorderedList } from '@amsterdam/design-system-react'
 import { descriptionListTermsWidths } from '@amsterdam/design-system-react/dist/DescriptionList/DescriptionList'
 import { DescriptionList } from '@amsterdam/design-system-react/src'
 
+import { inverseColorArgType } from '#storybook/_common/argTypes'
 import { wrapInInlineSizeQueryContainer } from '#storybook/_common/decorators'
 
 const meta = {
@@ -29,16 +30,10 @@ const meta = {
     ],
   },
   argTypes: {
-    color: {
-      control: {
-        labels: { undefined: 'default' },
-        type: 'radio',
-      },
-      options: [undefined, 'inverse'],
-    },
+    color: inverseColorArgType,
     termsWidth: {
       control: {
-        labels: { undefined: 'auto' },
+        labels: { undefined: 'auto (default)' },
         type: 'radio',
       },
       options: [undefined, ...descriptionListTermsWidths],

--- a/storybook/src/components/Dialog/Dialog.stories.tsx
+++ b/storybook/src/components/Dialog/Dialog.stories.tsx
@@ -14,8 +14,8 @@ const meta = {
   component: Dialog,
   argTypes: {
     footer: { control: false }, // A React element has no usable controls panel widget.
-    heading: {
-      description: 'The text for the heading.',
+    id: {
+      description: 'The id of the dialog element. Use it to open the dialog.',
     },
     open: {
       description: 'Whether the dialog box is active and available for interaction.',

--- a/storybook/src/components/ErrorMessage/ErrorMessage.stories.tsx
+++ b/storybook/src/components/ErrorMessage/ErrorMessage.stories.tsx
@@ -8,6 +8,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { MegaphoneIcon } from '@amsterdam/design-system-react-icons'
 import { ErrorMessage } from '@amsterdam/design-system-react/src'
 
+import { childrenArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Forms/Error Message',
   component: ErrorMessage,
@@ -15,10 +17,7 @@ const meta = {
     children: 'Vul een geldig e-mailadres in, bijvoorbeeld naam@voorbeeld.nl.',
   },
   argTypes: {
-    children: {
-      description: 'The text content.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The text content.'),
     icon: { control: false }, // A component type has no usable controls panel widget.
   },
 } satisfies Meta<typeof ErrorMessage>

--- a/storybook/src/components/ErrorMessage/ErrorMessage.stories.tsx
+++ b/storybook/src/components/ErrorMessage/ErrorMessage.stories.tsx
@@ -16,8 +16,10 @@ const meta = {
   },
   argTypes: {
     children: {
+      description: 'The text content.',
       table: { disable: false },
     },
+    icon: { control: false }, // A component type has no usable controls panel widget.
   },
 } satisfies Meta<typeof ErrorMessage>
 

--- a/storybook/src/components/FieldSet/FieldSet.stories.tsx
+++ b/storybook/src/components/FieldSet/FieldSet.stories.tsx
@@ -26,7 +26,6 @@ const meta = {
   title: 'Components/Forms/Field Set',
   component: FieldSet,
   args: {
-    hint: '',
     invalid: false,
     legend: 'Wat is uw naam?',
   },

--- a/storybook/src/components/Figure/FigureCaption.stories.tsx
+++ b/storybook/src/components/Figure/FigureCaption.stories.tsx
@@ -8,18 +8,14 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Image } from '@amsterdam/design-system-react'
 import { Figure } from '@amsterdam/design-system-react/src'
 
-import { inverseColorArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, inverseColorArgType } from '#storybook/_common/argTypes'
 import { exampleCaption } from '#storybook/_common/exampleContent'
 
 const meta = {
   title: 'Components/Media/Figure',
   component: Figure.Caption,
   argTypes: {
-    children: {
-      control: 'text',
-      description: 'The text for the caption.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The text for the caption.'),
     color: inverseColorArgType,
   },
   render: ({ children, ...args }) => (

--- a/storybook/src/components/Figure/FigureCaption.stories.tsx
+++ b/storybook/src/components/Figure/FigureCaption.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Image } from '@amsterdam/design-system-react'
 import { Figure } from '@amsterdam/design-system-react/src'
 
+import { inverseColorArgType } from '#storybook/_common/argTypes'
 import { exampleCaption } from '#storybook/_common/exampleContent'
 
 const meta = {
@@ -19,13 +20,7 @@ const meta = {
       description: 'The text for the caption.',
       table: { disable: false },
     },
-    color: {
-      control: {
-        labels: { undefined: 'default' },
-        type: 'radio',
-      },
-      options: [undefined, 'inverse'],
-    },
+    color: inverseColorArgType,
   },
   render: ({ children, ...args }) => (
     <Figure>

--- a/storybook/src/components/FileInput/FileInput.stories.tsx
+++ b/storybook/src/components/FileInput/FileInput.stories.tsx
@@ -8,6 +8,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Field, Label, Paragraph } from '@amsterdam/design-system-react'
 import { FileInput } from '@amsterdam/design-system-react/src'
 
+import { disabledArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Forms/File Input',
   component: FileInput,
@@ -21,16 +23,11 @@ const meta = {
       control: {
         type: 'text',
       },
+      description: 'The file types that the user can select.',
     },
-    disabled: {
-      control: {
-        type: 'boolean',
-      },
-    },
+    disabled: disabledArgType,
     multiple: {
-      control: {
-        type: 'boolean',
-      },
+      description: 'Allows selecting more than one file.',
     },
     onChange: {
       table: { disable: false },

--- a/storybook/src/components/FileList/FileListItem.stories.tsx
+++ b/storybook/src/components/FileList/FileListItem.stories.tsx
@@ -12,6 +12,10 @@ const sampleFile = new File(['sample'], 'document.pdf', { lastModified: Date.now
 const meta = {
   title: 'Components/Forms/File List',
   component: FileList.Item,
+  argTypes: {
+    file: { control: false }, // A File object has no usable controls panel widget.
+    onDelete: { control: false },
+  },
   decorators: [
     (Story) => (
       <FileList>

--- a/storybook/src/components/Grid/Grid.stories.tsx
+++ b/storybook/src/components/Grid/Grid.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Paragraph } from '@amsterdam/design-system-react'
 import { Grid } from '@amsterdam/design-system-react/src'
+import { gridTags } from '@amsterdam/design-system-react/src/Grid/Grid'
 
 import { wrapInPage } from '#storybook/_common/decorators'
 import { GridColumnsGuide } from '#storybook/_components/GridColumnsGuide/GridColumnsGuide'
@@ -16,7 +17,16 @@ import { gridGapAndPaddingArgTypes } from './Grid.argTypes'
 const meta = {
   title: 'Components/Layout/Grid',
   component: Grid,
-  argTypes: gridGapAndPaddingArgTypes,
+  argTypes: {
+    ...gridGapAndPaddingArgTypes,
+    as: {
+      control: {
+        labels: { undefined: 'div (default)' },
+        type: 'select',
+      },
+      options: [undefined, ...gridTags],
+    },
+  },
   decorators: [wrapInPage],
   parameters: {
     layout: 'fullscreen',

--- a/storybook/src/components/Grid/Grid.stories.tsx
+++ b/storybook/src/components/Grid/Grid.stories.tsx
@@ -24,7 +24,7 @@ const meta = {
         labels: { undefined: 'div (default)' },
         type: 'select',
       },
-      options: [undefined, ...gridTags],
+      options: [undefined, ...gridTags.filter((tag) => tag !== 'div')],
     },
   },
   decorators: [wrapInPage],

--- a/storybook/src/components/Grid/Grid.stories.tsx
+++ b/storybook/src/components/Grid/Grid.stories.tsx
@@ -9,6 +9,7 @@ import { Paragraph } from '@amsterdam/design-system-react'
 import { Grid } from '@amsterdam/design-system-react/src'
 import { gridTags } from '@amsterdam/design-system-react/src/Grid/Grid'
 
+import { asArgType } from '#storybook/_common/argTypes'
 import { wrapInPage } from '#storybook/_common/decorators'
 import { GridColumnsGuide } from '#storybook/_components/GridColumnsGuide/GridColumnsGuide'
 
@@ -19,13 +20,7 @@ const meta = {
   component: Grid,
   argTypes: {
     ...gridGapAndPaddingArgTypes,
-    as: {
-      control: {
-        labels: { undefined: 'div (default)' },
-        type: 'select',
-      },
-      options: [undefined, ...gridTags.filter((tag) => tag !== 'div')],
-    },
+    as: asArgType(gridTags),
   },
   decorators: [wrapInPage],
   parameters: {

--- a/storybook/src/components/Grid/GridCell.stories.tsx
+++ b/storybook/src/components/Grid/GridCell.stories.tsx
@@ -6,6 +6,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Grid } from '@amsterdam/design-system-react/src'
+import { gridCellTags } from '@amsterdam/design-system-react/src/Grid/GridCell'
 
 import { GridColumnsGuide } from '#storybook/_components/GridColumnsGuide/GridColumnsGuide'
 
@@ -21,8 +22,11 @@ const meta = {
       options: [undefined, 'flush', 'transparent'],
     },
     as: {
-      control: { type: 'radio' },
-      options: ['article', 'div', 'section'],
+      control: {
+        labels: { undefined: 'div (default)' },
+        type: 'select',
+      },
+      options: [undefined, ...gridCellTags],
     },
     span: {
       control: { max: 12, min: 1, type: 'number' },

--- a/storybook/src/components/Grid/GridCell.stories.tsx
+++ b/storybook/src/components/Grid/GridCell.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Grid } from '@amsterdam/design-system-react/src'
 import { gridCellTags } from '@amsterdam/design-system-react/src/Grid/GridCell'
 
+import { asArgType } from '#storybook/_common/argTypes'
 import { GridColumnsGuide } from '#storybook/_components/GridColumnsGuide/GridColumnsGuide'
 
 const meta = {
@@ -21,13 +22,7 @@ const meta = {
       },
       options: [undefined, 'flush', 'transparent'],
     },
-    as: {
-      control: {
-        labels: { undefined: 'div (default)' },
-        type: 'select',
-      },
-      options: [undefined, ...gridCellTags.filter((tag) => tag !== 'div')],
-    },
+    as: asArgType(gridCellTags),
     span: {
       control: { max: 12, min: 1, type: 'number' },
     },

--- a/storybook/src/components/Grid/GridCell.stories.tsx
+++ b/storybook/src/components/Grid/GridCell.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
         labels: { undefined: 'div (default)' },
         type: 'select',
       },
-      options: [undefined, ...gridCellTags],
+      options: [undefined, ...gridCellTags.filter((tag) => tag !== 'div')],
     },
     span: {
       control: { max: 12, min: 1, type: 'number' },

--- a/storybook/src/components/Heading/Heading.stories.tsx
+++ b/storybook/src/components/Heading/Heading.stories.tsx
@@ -10,7 +10,7 @@ import { Column, Icon, Row } from '@amsterdam/design-system-react'
 import { MailIcon } from '@amsterdam/design-system-react-icons'
 import { Heading } from '@amsterdam/design-system-react/src'
 
-import { headingLevelArgType, inverseColorArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, headingLevelArgType, inverseColorArgType } from '#storybook/_common/argTypes'
 import { exampleHeading } from '#storybook/_common/exampleContent'
 
 const heading = exampleHeading()
@@ -23,10 +23,7 @@ const meta = {
     level: 1,
   },
   argTypes: {
-    children: {
-      description: 'The heading text.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The heading text.'),
     color: inverseColorArgType,
     level: headingLevelArgType(),
     size: {

--- a/storybook/src/components/Heading/Heading.stories.tsx
+++ b/storybook/src/components/Heading/Heading.stories.tsx
@@ -10,6 +10,7 @@ import { Column, Icon, Row } from '@amsterdam/design-system-react'
 import { MailIcon } from '@amsterdam/design-system-react-icons'
 import { Heading } from '@amsterdam/design-system-react/src'
 
+import { headingLevelArgType, inverseColorArgType } from '#storybook/_common/argTypes'
 import { exampleHeading } from '#storybook/_common/exampleContent'
 
 const heading = exampleHeading()
@@ -26,12 +27,14 @@ const meta = {
       description: 'The heading text.',
       table: { disable: false },
     },
-    color: {
+    color: inverseColorArgType,
+    level: headingLevelArgType(),
+    size: {
       control: {
-        labels: { undefined: 'default' },
-        type: 'radio',
+        labels: { undefined: 'matches level (default)' },
+        type: 'select',
       },
-      options: [undefined, 'inverse'],
+      options: [undefined, 'level-1', 'level-2', 'level-3', 'level-4', 'level-5'],
     },
   },
 } satisfies Meta<typeof Heading>
@@ -88,17 +91,6 @@ export const WithIcon: Story = {
   args: {
     children: 'Heading text',
     level: 3,
-  },
-  argTypes: {
-    level: {
-      options: [1, 2, 3, 4],
-    },
-    size: {
-      control: {
-        labels: { undefined: 'not set' },
-      },
-      options: [undefined, 'level-1', 'level-2', 'level-3', 'level-4', 'level-5'],
-    },
   },
   render: ({ children, ...args }) => {
     let iconSize

--- a/storybook/src/components/Icon/Icon.stories.tsx
+++ b/storybook/src/components/Icon/Icon.stories.tsx
@@ -10,7 +10,7 @@ import * as Icons from '@amsterdam/design-system-react-icons'
 import { Column, Icon, Paragraph, Row } from '@amsterdam/design-system-react/src'
 import { iconSizes } from '@amsterdam/design-system-react/src/Icon/Icon'
 
-const DEPRECATED_HEADING_SIZES = ['heading-0', 'heading-6']
+import { inverseColorArgType, requiredIconArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Media/Icon',
@@ -19,27 +19,15 @@ const meta = {
     svg: Icons.MailIcon,
   },
   argTypes: {
-    color: {
-      control: {
-        labels: { undefined: 'default' },
-        type: 'radio',
-      },
-      options: [undefined, 'inverse'],
-    },
+    color: inverseColorArgType,
     size: {
       control: {
-        labels: { undefined: 'default' },
+        labels: { undefined: 'medium body text (default)' },
         type: 'select',
       },
       options: [undefined, ...iconSizes],
     },
-    svg: {
-      control: {
-        type: 'select',
-      },
-      mapping: Icons,
-      options: Object.keys(Icons),
-    },
+    svg: requiredIconArgType,
   },
 } satisfies Meta<typeof Icon>
 
@@ -51,9 +39,11 @@ export const Default: Story = {}
 
 export const WithBodyText: Story = {
   argTypes: {
+    // This story pairs the Icon with body text, so it offers only the body text sizes, in ascending order.
     size: {
       control: {
         labels: { undefined: 'medium (default)' },
+        type: 'radio',
       },
       options: ['small', undefined, 'large'],
     },
@@ -81,8 +71,10 @@ export const WithAHeading: Story = {
     size: 'heading-3',
   },
   argTypes: {
+    // This story pairs the Icon with a Heading, so it offers only the heading sizes.
     size: {
-      options: [...iconSizes.filter((size) => size.startsWith('heading-') && !DEPRECATED_HEADING_SIZES.includes(size))],
+      control: { type: 'radio' },
+      options: iconSizes.filter((size) => size.startsWith('heading-')),
     },
   },
   render: (args) => {

--- a/storybook/src/components/Icon/Icon.stories.tsx
+++ b/storybook/src/components/Icon/Icon.stories.tsx
@@ -10,7 +10,8 @@ import * as Icons from '@amsterdam/design-system-react-icons'
 import { Column, Icon, Paragraph, Row } from '@amsterdam/design-system-react/src'
 import { iconSizes } from '@amsterdam/design-system-react/src/Icon/Icon'
 
-import { inverseColorArgType, requiredIconArgType } from '#storybook/_common/argTypes'
+import { inverseColorArgType } from '#storybook/_common/argTypes'
+import { requiredIconArgType } from '#storybook/_common/iconArgTypes'
 
 const meta = {
   title: 'Components/Media/Icon',

--- a/storybook/src/components/IconButton/IconButton.stories.tsx
+++ b/storybook/src/components/IconButton/IconButton.stories.tsx
@@ -9,6 +9,8 @@ import * as Icons from '@amsterdam/design-system-react-icons'
 import { IconButton } from '@amsterdam/design-system-react/src'
 import { iconSizes } from '@amsterdam/design-system-react/src/Icon/Icon'
 
+import { contrastInverseColorArgType, disabledArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Buttons/Icon Button',
   component: IconButton,
@@ -18,29 +20,23 @@ const meta = {
     size: undefined,
   },
   argTypes: {
-    color: {
-      control: {
-        labels: { undefined: 'default' },
-        type: 'radio',
-      },
-      options: [undefined, 'contrast', 'inverse'],
-    },
-    disabled: {
-      description: 'Prevents interaction. Avoid if possible.',
-    },
+    color: contrastInverseColorArgType,
+    disabled: disabledArgType,
     size: {
       control: {
-        labels: { undefined: 'default' },
+        labels: { undefined: 'medium body text (default)' },
         type: 'select',
       },
       options: [undefined, ...iconSizes],
     },
+    // The shared icon arg type doesn’t fit here: this prop defaults to an icon (CloseIcon) instead of none.
     svg: {
       control: {
+        labels: { undefined: 'CloseIcon (default)' },
         type: 'select',
       },
       mapping: Icons,
-      options: Object.keys(Icons),
+      options: [undefined, ...Object.keys(Icons)],
     },
   },
 } satisfies Meta<typeof IconButton>

--- a/storybook/src/components/IconButton/IconButton.stories.tsx
+++ b/storybook/src/components/IconButton/IconButton.stories.tsx
@@ -5,11 +5,10 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import * as Icons from '@amsterdam/design-system-react-icons'
 import { IconButton } from '@amsterdam/design-system-react/src'
 import { iconSizes } from '@amsterdam/design-system-react/src/Icon/Icon'
 
-import { contrastInverseColorArgType, disabledArgType } from '#storybook/_common/argTypes'
+import { contrastInverseColorArgType, disabledArgType, iconArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Buttons/Icon Button',
@@ -29,15 +28,7 @@ const meta = {
       },
       options: [undefined, ...iconSizes],
     },
-    // The shared icon arg type doesn’t fit here: this prop defaults to an icon (CloseIcon) instead of none.
-    svg: {
-      control: {
-        labels: { undefined: 'CloseIcon (default)' },
-        type: 'select',
-      },
-      mapping: Icons,
-      options: [undefined, ...Object.keys(Icons).filter((name) => name !== 'CloseIcon')],
-    },
+    svg: iconArgType('CloseIcon'),
   },
 } satisfies Meta<typeof IconButton>
 

--- a/storybook/src/components/IconButton/IconButton.stories.tsx
+++ b/storybook/src/components/IconButton/IconButton.stories.tsx
@@ -8,7 +8,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { IconButton } from '@amsterdam/design-system-react/src'
 import { iconSizes } from '@amsterdam/design-system-react/src/Icon/Icon'
 
-import { contrastInverseColorArgType, disabledArgType, iconArgType } from '#storybook/_common/argTypes'
+import { contrastInverseColorArgType, disabledArgType } from '#storybook/_common/argTypes'
+import { iconArgType } from '#storybook/_common/iconArgTypes'
 
 const meta = {
   title: 'Components/Buttons/Icon Button',

--- a/storybook/src/components/IconButton/IconButton.stories.tsx
+++ b/storybook/src/components/IconButton/IconButton.stories.tsx
@@ -36,7 +36,7 @@ const meta = {
         type: 'select',
       },
       mapping: Icons,
-      options: [undefined, ...Object.keys(Icons)],
+      options: [undefined, ...Object.keys(Icons).filter((name) => name !== 'CloseIcon')],
     },
   },
 } satisfies Meta<typeof IconButton>

--- a/storybook/src/components/Image/Image.stories.tsx
+++ b/storybook/src/components/Image/Image.stories.tsx
@@ -6,12 +6,28 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Image } from '@amsterdam/design-system-react/src'
+import { aspectRatioOptions } from '@amsterdam/design-system-react/src/common/types'
 
 import { maximiseInlineSize } from '#storybook/_common/decorators'
 
 const meta = {
   title: 'Components/Media/Image',
   component: Image,
+  argTypes: {
+    aspectRatio: {
+      control: {
+        labels: { undefined: 'none (default)' },
+        type: 'select',
+      },
+      options: [undefined, ...aspectRatioOptions],
+    },
+    src: {
+      description: 'The url for the image.',
+    },
+    srcSet: {
+      description: 'A set of candidate images.',
+    },
+  },
   decorators: [maximiseInlineSize('vi-medium')],
 } satisfies Meta<typeof Image>
 
@@ -23,17 +39,6 @@ export const Default: Story = {
   args: {
     alt: '',
     src: 'https://picsum.photos/640/360',
-  },
-  argTypes: {
-    alt: {
-      description: 'Describes the image for non-visual users.',
-    },
-    src: {
-      description: 'The url for the image.',
-    },
-    srcSet: {
-      description: 'A set of candidate images.',
-    },
   },
 }
 

--- a/storybook/src/components/InvalidFormAlert/InvalidFormAlert.stories.tsx
+++ b/storybook/src/components/InvalidFormAlert/InvalidFormAlert.stories.tsx
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { InvalidFormAlert } from '@amsterdam/design-system-react/src'
 
+import { headingLevelArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Forms/Invalid Form Alert',
   component: InvalidFormAlert,
@@ -17,6 +19,9 @@ const meta = {
     ],
     focusOnRender: false,
     headingLevel: 2,
+  },
+  argTypes: {
+    headingLevel: headingLevelArgType(),
   },
 } satisfies Meta<typeof InvalidFormAlert>
 

--- a/storybook/src/components/Label/Label.stories.tsx
+++ b/storybook/src/components/Label/Label.stories.tsx
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Label } from '@amsterdam/design-system-react/src'
 
+import { childrenArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Forms/Label',
   component: Label,
@@ -15,10 +17,7 @@ const meta = {
     optional: false,
   },
   argTypes: {
-    children: {
-      description: 'The text content.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The text content.'),
   },
 } satisfies Meta<typeof Label>
 

--- a/storybook/src/components/Label/Label.stories.tsx
+++ b/storybook/src/components/Label/Label.stories.tsx
@@ -12,7 +12,6 @@ const meta = {
   component: Label,
   args: {
     children: 'Label',
-    hint: '',
     optional: false,
   },
   argTypes: {

--- a/storybook/src/components/Link/Link.stories.tsx
+++ b/storybook/src/components/Link/Link.stories.tsx
@@ -8,6 +8,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Paragraph } from '@amsterdam/design-system-react'
 import { Link } from '@amsterdam/design-system-react/src'
 
+import { contrastInverseColorArgType, hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+
 type Story = StoryObj<typeof Link>
 
 const meta = {
@@ -22,18 +24,9 @@ const meta = {
       description: 'The link text.',
       table: { disable: false },
     },
-    color: {
-      control: {
-        labels: { undefined: 'default' },
-        type: 'radio',
-      },
-      options: [undefined, 'contrast', 'inverse'],
-    },
-    href: {
-      description: 'The url for the link.',
-      name: 'href',
-      type: { name: 'string', required: false },
-    },
+    color: contrastInverseColorArgType,
+    href: hrefArgType,
+    linkComponent: linkComponentArgType,
   },
   decorators: [
     (Story, { args }) => (

--- a/storybook/src/components/Link/Link.stories.tsx
+++ b/storybook/src/components/Link/Link.stories.tsx
@@ -8,7 +8,12 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Paragraph } from '@amsterdam/design-system-react'
 import { Link } from '@amsterdam/design-system-react/src'
 
-import { contrastInverseColorArgType, hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import {
+  childrenArgType,
+  contrastInverseColorArgType,
+  hrefArgType,
+  linkComponentArgType,
+} from '#storybook/_common/argTypes'
 
 type Story = StoryObj<typeof Link>
 
@@ -20,10 +25,7 @@ const meta = {
     href: '#',
   },
   argTypes: {
-    children: {
-      description: 'The link text.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The link text.'),
     color: contrastInverseColorArgType,
     href: hrefArgType,
     linkComponent: linkComponentArgType,

--- a/storybook/src/components/LinkList/LinkListLink.stories.tsx
+++ b/storybook/src/components/LinkList/LinkListLink.stories.tsx
@@ -8,7 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { HouseIcon } from '@amsterdam/design-system-react-icons'
 import { LinkList } from '@amsterdam/design-system-react/src'
 
-import { childrenArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, textSizeArgType } from '#storybook/_common/argTypes'
 import {
   contrastInverseColorArgType,
   hrefArgType,
@@ -23,22 +23,9 @@ const meta = {
     children: childrenArgType('The link text.'),
     color: contrastInverseColorArgType,
     href: hrefArgType,
-    icon: {
-      ...iconArgType,
-      control: {
-        labels: { undefined: 'ChevronForwardIcon (default)' },
-        type: 'select',
-      },
-      options: iconArgType.options.filter((option) => option !== 'ChevronForwardIcon'),
-    },
+    icon: iconArgType('ChevronForwardIcon'),
     linkComponent: linkComponentArgType,
-    size: {
-      control: {
-        labels: { undefined: 'medium (default)' },
-        type: 'radio',
-      },
-      options: ['small', undefined, 'large'],
-    },
+    size: textSizeArgType(['small', undefined, 'large']),
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/LinkList/LinkListLink.stories.tsx
+++ b/storybook/src/components/LinkList/LinkListLink.stories.tsx
@@ -12,10 +12,10 @@ import {
   childrenArgType,
   contrastInverseColorArgType,
   hrefArgType,
-  iconArgType,
   linkComponentArgType,
   textSizeArgType,
 } from '#storybook/_common/argTypes'
+import { iconArgType } from '#storybook/_common/iconArgTypes'
 
 const meta = {
   title: 'Components/Navigation/Link List',

--- a/storybook/src/components/LinkList/LinkListLink.stories.tsx
+++ b/storybook/src/components/LinkList/LinkListLink.stories.tsx
@@ -6,8 +6,14 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { HouseIcon } from '@amsterdam/design-system-react-icons'
-import * as Icons from '@amsterdam/design-system-react-icons'
 import { LinkList } from '@amsterdam/design-system-react/src'
+
+import {
+  contrastInverseColorArgType,
+  hrefArgType,
+  iconArgType,
+  linkComponentArgType,
+} from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Navigation/Link List',
@@ -18,24 +24,19 @@ const meta = {
       description: 'The link text.',
       table: { disable: false },
     },
-    color: {
-      control: {
-        labels: { undefined: 'default' },
-        type: 'radio',
-      },
-      options: [undefined, 'contrast', 'inverse'],
-    },
+    color: contrastInverseColorArgType,
+    href: hrefArgType,
     icon: {
+      ...iconArgType,
       control: {
-        labels: { undefined: 'none' },
+        labels: { undefined: 'ChevronForwardIcon (default)' },
         type: 'select',
       },
-      mapping: Icons,
-      options: [undefined, ...Object.keys(Icons)],
     },
+    linkComponent: linkComponentArgType,
     size: {
       control: {
-        labels: { undefined: 'medium' },
+        labels: { undefined: 'medium (default)' },
         type: 'radio',
       },
       options: ['small', undefined, 'large'],

--- a/storybook/src/components/LinkList/LinkListLink.stories.tsx
+++ b/storybook/src/components/LinkList/LinkListLink.stories.tsx
@@ -8,12 +8,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { HouseIcon } from '@amsterdam/design-system-react-icons'
 import { LinkList } from '@amsterdam/design-system-react/src'
 
-import { childrenArgType, textSizeArgType } from '#storybook/_common/argTypes'
 import {
+  childrenArgType,
   contrastInverseColorArgType,
   hrefArgType,
   iconArgType,
   linkComponentArgType,
+  textSizeArgType,
 } from '#storybook/_common/argTypes'
 
 const meta = {

--- a/storybook/src/components/LinkList/LinkListLink.stories.tsx
+++ b/storybook/src/components/LinkList/LinkListLink.stories.tsx
@@ -32,6 +32,7 @@ const meta = {
         labels: { undefined: 'ChevronForwardIcon (default)' },
         type: 'select',
       },
+      options: iconArgType.options.filter((option) => option !== 'ChevronForwardIcon'),
     },
     linkComponent: linkComponentArgType,
     size: {

--- a/storybook/src/components/LinkList/LinkListLink.stories.tsx
+++ b/storybook/src/components/LinkList/LinkListLink.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { HouseIcon } from '@amsterdam/design-system-react-icons'
 import { LinkList } from '@amsterdam/design-system-react/src'
 
+import { childrenArgType } from '#storybook/_common/argTypes'
 import {
   contrastInverseColorArgType,
   hrefArgType,
@@ -19,11 +20,7 @@ const meta = {
   title: 'Components/Navigation/Link List',
   component: LinkList.Link,
   argTypes: {
-    children: {
-      control: 'text',
-      description: 'The link text.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The link text.'),
     color: contrastInverseColorArgType,
     href: hrefArgType,
     icon: {

--- a/storybook/src/components/Logo/Logo.stories.tsx
+++ b/storybook/src/components/Logo/Logo.stories.tsx
@@ -7,12 +7,22 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { CSSProperties } from 'react'
 
 import { Logo } from '@amsterdam/design-system-react/src'
+import { logoBrands } from '@amsterdam/design-system-react/src/Logo/Logo'
 
 import ExampleLogo from './ExampleLogo'
 
 const meta = {
   title: 'Components/Media/Logo',
   component: Logo,
+  argTypes: {
+    brand: {
+      control: {
+        labels: { undefined: 'amsterdam (default)' },
+        type: 'select',
+      },
+      options: [undefined, ...logoBrands],
+    },
+  },
 } satisfies Meta<typeof Logo>
 
 export default meta

--- a/storybook/src/components/Logo/Logo.stories.tsx
+++ b/storybook/src/components/Logo/Logo.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
         labels: { undefined: 'amsterdam (default)' },
         type: 'select',
       },
-      options: [undefined, ...logoBrands],
+      options: [undefined, ...logoBrands.filter((brand) => brand !== 'amsterdam')],
     },
   },
 } satisfies Meta<typeof Logo>

--- a/storybook/src/components/Mark/Mark.stories.tsx
+++ b/storybook/src/components/Mark/Mark.stories.tsx
@@ -22,6 +22,7 @@ export const Default: Story = {
   args: {
     children: 'Wat vinden Amsterdammers belangrijk?',
   },
+  // Only this story renders a single Mark whose text the control drives – the other story composes many instances.
   argTypes: {
     children: {
       description: 'The text to mark.',

--- a/storybook/src/components/Mark/Mark.stories.tsx
+++ b/storybook/src/components/Mark/Mark.stories.tsx
@@ -9,6 +9,8 @@ import { Card, Grid, Heading, Paragraph, SearchField, UnorderedList } from '@ams
 import { Mark } from '@amsterdam/design-system-react/src'
 import { useState } from 'react'
 
+import { childrenArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Text/Mark',
   component: Mark,
@@ -24,10 +26,7 @@ export const Default: Story = {
   },
   // Only this story renders a single Mark whose text the control drives – the other story composes many instances.
   argTypes: {
-    children: {
-      description: 'The text to mark.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The text to mark.'),
   },
   render: ({ children }) => (
     <Paragraph>

--- a/storybook/src/components/Menu/Menu.stories.tsx
+++ b/storybook/src/components/Menu/Menu.stories.tsx
@@ -18,6 +18,8 @@ import { BREAKPOINTS } from '@amsterdam/design-system-react/src/common/useViewpo
 import { useEffect } from 'react'
 import { useArgs } from 'storybook/preview-api'
 
+import { derivedArgType } from '#storybook/_common/argTypes'
+
 const menuItems = [
   {
     href: '#',
@@ -74,11 +76,9 @@ const meta = {
     inWideWindow: false, // Initial value; will be overwritten when matchMedia runs.
   },
   argTypes: {
-    inWideWindow: {
-      control: false,
-      description: `This prop gets automatically updated in Storybook. It is \`true\` when the viewport is wider than ${BREAKPOINTS.wide}.`,
-      table: { category: 'Derived' },
-    },
+    inWideWindow: derivedArgType(
+      `This prop gets automatically updated in Storybook. It is \`true\` when the viewport is wider than ${BREAKPOINTS.wide}.`,
+    ),
   },
   decorators: [withInWideWindowArg],
   parameters: {

--- a/storybook/src/components/Menu/MenuLink.stories.tsx
+++ b/storybook/src/components/Menu/MenuLink.stories.tsx
@@ -8,17 +8,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { PieChartFillIcon } from '@amsterdam/design-system-react-icons'
 import { Menu } from '@amsterdam/design-system-react/src'
 
-import { hrefArgType, linkComponentArgType, requiredIconArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, hrefArgType, linkComponentArgType, requiredIconArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Navigation/Menu',
   component: Menu.Link,
   argTypes: {
-    children: {
-      control: 'text',
-      description: 'The link text.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The link text.'),
     href: hrefArgType,
     icon: requiredIconArgType,
     linkComponent: linkComponentArgType,

--- a/storybook/src/components/Menu/MenuLink.stories.tsx
+++ b/storybook/src/components/Menu/MenuLink.stories.tsx
@@ -8,7 +8,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { PieChartFillIcon } from '@amsterdam/design-system-react-icons'
 import { Menu } from '@amsterdam/design-system-react/src'
 
-import { childrenArgType, hrefArgType, linkComponentArgType, requiredIconArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { requiredIconArgType } from '#storybook/_common/iconArgTypes'
 
 const meta = {
   title: 'Components/Navigation/Menu',

--- a/storybook/src/components/Menu/MenuLink.stories.tsx
+++ b/storybook/src/components/Menu/MenuLink.stories.tsx
@@ -6,8 +6,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { PieChartFillIcon } from '@amsterdam/design-system-react-icons'
-import * as Icons from '@amsterdam/design-system-react-icons'
 import { Menu } from '@amsterdam/design-system-react/src'
+
+import { hrefArgType, linkComponentArgType, requiredIconArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Navigation/Menu',
@@ -18,11 +19,9 @@ const meta = {
       description: 'The link text.',
       table: { disable: false },
     },
-    icon: {
-      control: { type: 'select' },
-      mapping: Icons,
-      options: Object.keys(Icons),
-    },
+    href: hrefArgType,
+    icon: requiredIconArgType,
+    linkComponent: linkComponentArgType,
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/OrderedList/OrderedList.stories.tsx
+++ b/storybook/src/components/OrderedList/OrderedList.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Card, Paragraph } from '@amsterdam/design-system-react'
 import { OrderedList } from '@amsterdam/design-system-react/src'
 
+import { inverseColorArgType } from '#storybook/_common/argTypes'
 import { maximiseInlineSize } from '#storybook/_common/decorators'
 import { exampleOrderedList } from '#storybook/_common/exampleContent'
 
@@ -23,20 +24,14 @@ const meta = {
     start: undefined,
   },
   argTypes: {
-    color: {
-      control: {
-        labels: { undefined: 'default' },
-        type: 'radio',
-      },
-      options: [undefined, 'inverse'],
-    },
+    color: inverseColorArgType,
     reversed: {
       control: 'boolean',
       description: 'Numbers the items from the highest value down.',
     },
     size: {
       control: {
-        labels: { small: 'small', undefined: 'medium' },
+        labels: { undefined: 'medium (default)' },
         type: 'radio',
       },
       options: ['small', undefined],

--- a/storybook/src/components/OrderedList/OrderedList.stories.tsx
+++ b/storybook/src/components/OrderedList/OrderedList.stories.tsx
@@ -8,7 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Card, Paragraph } from '@amsterdam/design-system-react'
 import { OrderedList } from '@amsterdam/design-system-react/src'
 
-import { inverseColorArgType } from '#storybook/_common/argTypes'
+import { inverseColorArgType, textSizeArgType } from '#storybook/_common/argTypes'
 import { maximiseInlineSize } from '#storybook/_common/decorators'
 import { exampleOrderedList } from '#storybook/_common/exampleContent'
 
@@ -29,13 +29,7 @@ const meta = {
       control: 'boolean',
       description: 'Numbers the items from the highest value down.',
     },
-    size: {
-      control: {
-        labels: { undefined: 'medium (default)' },
-        type: 'radio',
-      },
-      options: ['small', undefined],
-    },
+    size: textSizeArgType(['small', undefined]),
     start: {
       control: 'number',
       description: 'The value for the first list item’s marker.',

--- a/storybook/src/components/Page/Page.stories.tsx
+++ b/storybook/src/components/Page/Page.stories.tsx
@@ -9,15 +9,15 @@ import { Grid, Heading, Menu, PageFooter, PageHeader, Paragraph, SkipLink } from
 import { SettingsFillIcon } from '@amsterdam/design-system-react-icons'
 import { Page } from '@amsterdam/design-system-react/src'
 
+import { derivedArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Containers/Page',
   component: Page,
   argTypes: {
-    withMenu: {
-      description:
-        'This prop updates automatically to prevent an invalid appearance: a Menu can only be used in Compact Mode.',
-      table: { readonly: true },
-    },
+    withMenu: derivedArgType(
+      'This prop updates automatically to prevent an invalid appearance: a Menu can only be used in Compact Mode.',
+    ),
   },
   parameters: {
     layout: 'fullscreen',

--- a/storybook/src/components/PageFooter/PageFooterMenu.stories.tsx
+++ b/storybook/src/components/PageFooter/PageFooterMenu.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
   component: PageFooter.Menu,
   argTypes: {
     // A level 1 heading never belongs in the footer, so this offers a subset of the allowed levels.
-    headingLevel: headingLevelArgType([2, 3, 4]),
+    headingLevel: headingLevelArgType([2, 3, 4], 2),
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/PageFooter/PageFooterMenu.stories.tsx
+++ b/storybook/src/components/PageFooter/PageFooterMenu.stories.tsx
@@ -7,14 +7,14 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { PageFooter } from '@amsterdam/design-system-react/src'
 
+import { headingLevelArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Containers/Page Footer',
   component: PageFooter.Menu,
   argTypes: {
-    headingLevel: {
-      control: { type: 'radio' },
-      options: [2, 3, 4],
-    },
+    // A level 1 heading never belongs in the footer, so this offers a subset of the allowed levels.
+    headingLevel: headingLevelArgType([2, 3, 4]),
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/PageFooter/PageFooterMenuLink.stories.tsx
+++ b/storybook/src/components/PageFooter/PageFooterMenuLink.stories.tsx
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { PageFooter } from '@amsterdam/design-system-react/src'
 
+import { hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Containers/Page Footer',
   component: PageFooter.MenuLink,
@@ -16,6 +18,8 @@ const meta = {
       description: 'The link text.',
       table: { disable: false },
     },
+    href: hrefArgType,
+    linkComponent: linkComponentArgType,
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/PageFooter/PageFooterMenuLink.stories.tsx
+++ b/storybook/src/components/PageFooter/PageFooterMenuLink.stories.tsx
@@ -7,17 +7,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { PageFooter } from '@amsterdam/design-system-react/src'
 
-import { hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Containers/Page Footer',
   component: PageFooter.MenuLink,
   argTypes: {
-    children: {
-      control: 'text',
-      description: 'The link text.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The link text.'),
     href: hrefArgType,
     linkComponent: linkComponentArgType,
   },

--- a/storybook/src/components/PageHeader/PageHeader.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeader.stories.tsx
@@ -11,8 +11,9 @@ import { LogInIcon, PlusIcon, SearchIcon } from '@amsterdam/design-system-react-
 import { PageHeader } from '@amsterdam/design-system-react/src'
 import { logoBrands } from '@amsterdam/design-system-react/src/Logo/Logo'
 
-import { iconArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { linkComponentArgType } from '#storybook/_common/argTypes'
 import { wrapInPage } from '#storybook/_common/decorators'
+import { iconArgType } from '#storybook/_common/iconArgTypes'
 
 import ExampleLogo from '../Logo/ExampleLogo'
 import { collapsibleMenuItems, headerMenuItems } from './content'

--- a/storybook/src/components/PageHeader/PageHeader.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeader.stories.tsx
@@ -9,7 +9,9 @@ import type { CSSProperties, ReactNode } from 'react'
 import { Grid, Heading, LinkList } from '@amsterdam/design-system-react'
 import { LogInIcon, PlusIcon, SearchIcon } from '@amsterdam/design-system-react-icons'
 import { PageHeader } from '@amsterdam/design-system-react/src'
+import { logoBrands } from '@amsterdam/design-system-react/src/Logo/Logo'
 
+import { iconArgType, linkComponentArgType } from '#storybook/_common/argTypes'
 import { wrapInPage } from '#storybook/_common/decorators'
 
 import ExampleLogo from '../Logo/ExampleLogo'
@@ -18,6 +20,24 @@ import { collapsibleMenuItems, headerMenuItems } from './content'
 const meta = {
   title: 'Components/Containers/Page Header',
   component: PageHeader,
+  argTypes: {
+    logoBrand: {
+      control: {
+        labels: { undefined: 'amsterdam (default)' },
+        type: 'select',
+      },
+      options: [undefined, ...logoBrands],
+    },
+    logoLinkComponent: linkComponentArgType,
+    menuButtonIcon: {
+      ...iconArgType,
+      control: {
+        labels: { undefined: 'default icon' },
+        type: 'select',
+      },
+    },
+    menuItems: { control: false },
+  },
   decorators: [wrapInPage],
 } satisfies Meta<typeof PageHeader>
 

--- a/storybook/src/components/PageHeader/PageHeader.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeader.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
         labels: { undefined: 'amsterdam (default)' },
         type: 'select',
       },
-      options: [undefined, ...logoBrands],
+      options: [undefined, ...logoBrands.filter((brand) => brand !== 'amsterdam')],
     },
     logoLinkComponent: linkComponentArgType,
     menuButtonIcon: {

--- a/storybook/src/components/PageHeader/PageHeader.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeader.stories.tsx
@@ -30,7 +30,7 @@ const meta = {
     },
     logoLinkComponent: linkComponentArgType,
     menuButtonIcon: {
-      ...iconArgType,
+      ...iconArgType(),
       control: {
         labels: { undefined: 'default icon' },
         type: 'select',

--- a/storybook/src/components/PageHeader/PageHeaderMenuLink.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeaderMenuLink.stories.tsx
@@ -7,17 +7,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { PageHeader } from '@amsterdam/design-system-react/src'
 
-import { hrefArgType, iconArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, hrefArgType, iconArgType, linkComponentArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Containers/Page Header',
   component: PageHeader.MenuLink,
   argTypes: {
-    children: {
-      control: 'text',
-      description: 'The link text.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The link text.'),
     href: hrefArgType,
     icon: iconArgType,
     linkComponent: linkComponentArgType,

--- a/storybook/src/components/PageHeader/PageHeaderMenuLink.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeaderMenuLink.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
   argTypes: {
     children: childrenArgType('The link text.'),
     href: hrefArgType,
-    icon: iconArgType,
+    icon: iconArgType(),
     linkComponent: linkComponentArgType,
   },
   decorators: [(Story) => <PageHeader menuItems={<Story />} />],

--- a/storybook/src/components/PageHeader/PageHeaderMenuLink.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeaderMenuLink.stories.tsx
@@ -5,8 +5,9 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import * as Icons from '@amsterdam/design-system-react-icons'
 import { PageHeader } from '@amsterdam/design-system-react/src'
+
+import { hrefArgType, iconArgType, linkComponentArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Containers/Page Header',
@@ -17,14 +18,9 @@ const meta = {
       description: 'The link text.',
       table: { disable: false },
     },
-    icon: {
-      control: {
-        labels: { undefined: 'none' },
-        type: 'select',
-      },
-      mapping: Icons,
-      options: [undefined, ...Object.keys(Icons)],
-    },
+    href: hrefArgType,
+    icon: iconArgType,
+    linkComponent: linkComponentArgType,
   },
   decorators: [(Story) => <PageHeader menuItems={<Story />} />],
   render: ({ children, ...args }) => <PageHeader.MenuLink {...args}>{children}</PageHeader.MenuLink>,

--- a/storybook/src/components/PageHeader/PageHeaderMenuLink.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeaderMenuLink.stories.tsx
@@ -7,7 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { PageHeader } from '@amsterdam/design-system-react/src'
 
-import { childrenArgType, hrefArgType, iconArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { iconArgType } from '#storybook/_common/iconArgTypes'
 
 const meta = {
   title: 'Components/Containers/Page Header',

--- a/storybook/src/components/Pagination/Pagination.stories.tsx
+++ b/storybook/src/components/Pagination/Pagination.stories.tsx
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Pagination } from '@amsterdam/design-system-react/src'
 
+import { linkComponentArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Navigation/Pagination',
   component: Pagination,
@@ -17,6 +19,13 @@ const meta = {
     totalPages: 10,
   },
   argTypes: {
+    linkComponent: linkComponentArgType,
+    maxVisiblePages: {
+      control: {
+        min: 5,
+        type: 'number',
+      },
+    },
     page: {
       control: {
         min: 1,

--- a/storybook/src/components/Paragraph/Paragraph.stories.tsx
+++ b/storybook/src/components/Paragraph/Paragraph.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { MailIcon } from '@amsterdam/design-system-react-icons'
 import { Icon, Paragraph, Row } from '@amsterdam/design-system-react/src'
 
+import { inverseColorArgType } from '#storybook/_common/argTypes'
 import { exampleParagraph } from '#storybook/_common/exampleContent'
 
 const paragraph = exampleParagraph()
@@ -23,16 +24,10 @@ const meta = {
       description: 'The paragraph text.',
       table: { disable: false },
     },
-    color: {
-      control: {
-        labels: { undefined: 'default' },
-        type: 'radio',
-      },
-      options: [undefined, 'inverse'],
-    },
+    color: inverseColorArgType,
     size: {
       control: {
-        labels: { large: 'large', small: 'small', undefined: 'medium' },
+        labels: { undefined: 'medium (default)' },
         type: 'radio',
       },
       options: ['small', undefined, 'large'],

--- a/storybook/src/components/Paragraph/Paragraph.stories.tsx
+++ b/storybook/src/components/Paragraph/Paragraph.stories.tsx
@@ -8,7 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { MailIcon } from '@amsterdam/design-system-react-icons'
 import { Icon, Paragraph, Row } from '@amsterdam/design-system-react/src'
 
-import { childrenArgType, inverseColorArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, inverseColorArgType, textSizeArgType } from '#storybook/_common/argTypes'
 import { exampleParagraph } from '#storybook/_common/exampleContent'
 
 const paragraph = exampleParagraph()
@@ -22,13 +22,7 @@ const meta = {
   argTypes: {
     children: childrenArgType('The paragraph text.'),
     color: inverseColorArgType,
-    size: {
-      control: {
-        labels: { undefined: 'medium (default)' },
-        type: 'radio',
-      },
-      options: ['small', undefined, 'large'],
-    },
+    size: textSizeArgType(['small', undefined, 'large']),
   },
 } satisfies Meta<typeof Paragraph>
 

--- a/storybook/src/components/Paragraph/Paragraph.stories.tsx
+++ b/storybook/src/components/Paragraph/Paragraph.stories.tsx
@@ -8,7 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { MailIcon } from '@amsterdam/design-system-react-icons'
 import { Icon, Paragraph, Row } from '@amsterdam/design-system-react/src'
 
-import { inverseColorArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, inverseColorArgType } from '#storybook/_common/argTypes'
 import { exampleParagraph } from '#storybook/_common/exampleContent'
 
 const paragraph = exampleParagraph()
@@ -20,10 +20,7 @@ const meta = {
     children: paragraph,
   },
   argTypes: {
-    children: {
-      description: 'The paragraph text.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The paragraph text.'),
     color: inverseColorArgType,
     size: {
       control: {

--- a/storybook/src/components/PasswordInput/PasswordInput.stories.tsx
+++ b/storybook/src/components/PasswordInput/PasswordInput.stories.tsx
@@ -8,6 +8,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { ErrorMessage, Field, Label, Paragraph } from '@amsterdam/design-system-react'
 import { PasswordInput } from '@amsterdam/design-system-react/src'
 
+import { disabledArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Forms/Password Input',
   component: PasswordInput,
@@ -19,9 +21,7 @@ const meta = {
     defaultValue: {
       table: { disable: false },
     },
-    disabled: {
-      description: 'Prevents interaction. Avoid if possible.',
-    },
+    disabled: disabledArgType,
     onChange: {
       table: { disable: false },
     },

--- a/storybook/src/components/PasswordInput/PasswordInput.stories.tsx
+++ b/storybook/src/components/PasswordInput/PasswordInput.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
       table: { disable: false },
     },
     size: {
-      control: { min: 0, type: 'number' },
+      control: { min: 1, type: 'number' },
       description: 'The width, expressed in the average number of characters.',
     },
   },

--- a/storybook/src/components/Radio/Radio.stories.tsx
+++ b/storybook/src/components/Radio/Radio.stories.tsx
@@ -10,6 +10,8 @@ import { Column, ErrorMessage, FieldSet, Paragraph } from '@amsterdam/design-sys
 import { Radio } from '@amsterdam/design-system-react/src'
 import { useArgs } from 'storybook/preview-api'
 
+import { checkedArgType, disabledArgType, idArgType } from '#storybook/_common/argTypes'
+
 import CustomIcon from './CustomIcon'
 
 const meta = {
@@ -19,29 +21,19 @@ const meta = {
     checked: false,
     children: 'Radio label',
     disabled: false,
-    id: '',
     invalid: false,
   },
   argTypes: {
-    checked: {
-      description: 'Whether the control is checked.',
-    },
+    checked: checkedArgType,
     children: {
       description: 'The text for the label.',
       table: { disable: false },
     },
-    disabled: {
-      description: 'Prevents interaction. Avoid if possible.',
-    },
+    disabled: disabledArgType,
     icon: { control: false }, // A React element has no usable controls panel widget.
-    id: {
-      description: 'The id of the input element. If not provided, a unique id will be generated.',
-    },
-    invalid: {
-      description: 'Whether the value fails a validation rule.',
-    },
+    id: idArgType,
     onChange: {
-      action: 'clicked',
+      action: 'changed',
       table: { disable: false },
     },
   },

--- a/storybook/src/components/Radio/Radio.stories.tsx
+++ b/storybook/src/components/Radio/Radio.stories.tsx
@@ -10,7 +10,7 @@ import { Column, ErrorMessage, FieldSet, Paragraph } from '@amsterdam/design-sys
 import { Radio } from '@amsterdam/design-system-react/src'
 import { useArgs } from 'storybook/preview-api'
 
-import { checkedArgType, disabledArgType, idArgType } from '#storybook/_common/argTypes'
+import { checkedArgType, childrenArgType, disabledArgType, idArgType } from '#storybook/_common/argTypes'
 
 import CustomIcon from './CustomIcon'
 
@@ -25,10 +25,7 @@ const meta = {
   },
   argTypes: {
     checked: checkedArgType,
-    children: {
-      description: 'The text for the label.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The text for the label.'),
     disabled: disabledArgType,
     icon: { control: false }, // A React element has no usable controls panel widget.
     id: idArgType,

--- a/storybook/src/components/Row/Row.stories.tsx
+++ b/storybook/src/components/Row/Row.stories.tsx
@@ -11,6 +11,8 @@ import { Row } from '@amsterdam/design-system-react/src'
 import { crossAlignOptions, mainAlignOptions } from '@amsterdam/design-system-react/src/common/types'
 import { rowGapSizes, rowTags } from '@amsterdam/design-system-react/src/Row/Row'
 
+import { asArgType } from '#storybook/_common/argTypes'
+
 const ThreeItems = [
   <div className="_ams-item" key={0} />,
   <div className="_ams-item" key={1} />,
@@ -40,13 +42,7 @@ const meta = {
       },
       options: [undefined, ...crossAlignOptions],
     },
-    as: {
-      control: {
-        labels: { undefined: 'div (default)' },
-        type: 'radio',
-      },
-      options: [undefined, ...rowTags.filter((tag) => tag !== 'div')],
-    },
+    as: asArgType(rowTags),
     gap: {
       control: {
         labels: { undefined: 'medium (default)' },

--- a/storybook/src/components/Row/Row.stories.tsx
+++ b/storybook/src/components/Row/Row.stories.tsx
@@ -9,7 +9,7 @@ import { Avatar, Heading, StandaloneLink } from '@amsterdam/design-system-react'
 import { PencilIcon } from '@amsterdam/design-system-react-icons'
 import { Row } from '@amsterdam/design-system-react/src'
 import { crossAlignOptions, mainAlignOptions } from '@amsterdam/design-system-react/src/common/types'
-import { rowGapSizes } from '@amsterdam/design-system-react/src/Row/Row'
+import { rowGapSizes, rowTags } from '@amsterdam/design-system-react/src/Row/Row'
 
 const ThreeItems = [
   <div className="_ams-item" key={0} />,
@@ -23,26 +23,34 @@ const meta = {
   args: {
     children: ThreeItems,
     className: '_ams-row',
+    wrap: false,
   },
   argTypes: {
     align: {
       control: {
-        labels: { undefined: 'start' },
-        type: 'radio',
+        labels: { undefined: 'start (default)' },
+        type: 'select',
       },
       options: [undefined, ...mainAlignOptions],
     },
     alignVertical: {
       control: {
-        labels: { undefined: 'stretch' },
+        labels: { undefined: 'stretch (default)' },
         type: 'radio',
       },
       options: [undefined, ...crossAlignOptions],
     },
+    as: {
+      control: {
+        labels: { undefined: 'div (default)' },
+        type: 'radio',
+      },
+      options: [undefined, ...rowTags],
+    },
     gap: {
       control: {
-        labels: { undefined: 'medium' },
-        type: 'radio',
+        labels: { undefined: 'medium (default)' },
+        type: 'select',
       },
       options: [undefined, ...rowGapSizes],
     },

--- a/storybook/src/components/Row/Row.stories.tsx
+++ b/storybook/src/components/Row/Row.stories.tsx
@@ -45,7 +45,7 @@ const meta = {
         labels: { undefined: 'div (default)' },
         type: 'radio',
       },
-      options: [undefined, ...rowTags],
+      options: [undefined, ...rowTags.filter((tag) => tag !== 'div')],
     },
     gap: {
       control: {

--- a/storybook/src/components/SearchField/SearchFieldButton.stories.tsx
+++ b/storybook/src/components/SearchField/SearchFieldButton.stories.tsx
@@ -7,15 +7,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { SearchField } from '@amsterdam/design-system-react/src'
 
+import { childrenArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Forms/Search Field',
   component: SearchField.Button,
   argTypes: {
-    children: {
-      control: 'text',
-      description: 'The accessible name of the button.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The accessible name of the button.'),
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/Select/Select.stories.tsx
+++ b/storybook/src/components/Select/Select.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { ErrorMessage, Field, Label, Paragraph } from '@amsterdam/design-system-react'
 import { Select } from '@amsterdam/design-system-react/src'
 
+import { disabledArgType } from '#storybook/_common/argTypes'
 import { districts } from '#storybook/_common/exampleContent'
 
 const optionList = [...districts, 'Westpoort'].sort().map((district) => (
@@ -28,9 +29,7 @@ const meta = {
     defaultValue: {
       table: { disable: false },
     },
-    disabled: {
-      description: 'Prevents interaction. Avoid if possible.',
-    },
+    disabled: disabledArgType,
     onChange: {
       table: { disable: false },
     },

--- a/storybook/src/components/SkipLink/SkipLink.stories.tsx
+++ b/storybook/src/components/SkipLink/SkipLink.stories.tsx
@@ -8,6 +8,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Paragraph } from '@amsterdam/design-system-react'
 import { SkipLink } from '@amsterdam/design-system-react/src'
 
+import { hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Navigation/Skip Link',
   component: SkipLink,
@@ -21,8 +23,9 @@ const meta = {
       table: { disable: false },
     },
     href: {
-      description: 'The url for the link. References an anchor on the current page.',
+      description: `${hrefArgType.description} References an anchor on the current page.`,
     },
+    linkComponent: linkComponentArgType,
   },
 } satisfies Meta<typeof SkipLink>
 

--- a/storybook/src/components/SkipLink/SkipLink.stories.tsx
+++ b/storybook/src/components/SkipLink/SkipLink.stories.tsx
@@ -8,7 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Paragraph } from '@amsterdam/design-system-react'
 import { SkipLink } from '@amsterdam/design-system-react/src'
 
-import { hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Navigation/Skip Link',
@@ -18,10 +18,7 @@ const meta = {
     href: '#',
   },
   argTypes: {
-    children: {
-      description: 'The text to attach the link to.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The text to attach the link to.'),
     href: {
       description: `${hrefArgType.description} References an anchor on the current page.`,
     },

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -7,7 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Blockquote, Grid, Heading, Paragraph, StandaloneLink } from '@amsterdam/design-system-react'
 import { Spotlight } from '@amsterdam/design-system-react/src'
-import { spotlightColors } from '@amsterdam/design-system-react/src/Spotlight/Spotlight'
+import { spotlightColors, spotlightTags } from '@amsterdam/design-system-react/src/Spotlight/Spotlight'
 
 import { wrapInPage } from '#storybook/_common/decorators'
 import { exampleQuote } from '#storybook/_common/exampleContent'
@@ -18,9 +18,17 @@ const meta = {
   title: 'Components/Containers/Spotlight',
   component: Spotlight,
   argTypes: {
+    as: {
+      control: {
+        labels: { undefined: 'div (default)' },
+        type: 'select',
+      },
+      options: [undefined, ...spotlightTags],
+    },
     color: {
       control: {
         labels: { undefined: 'purple (default)' },
+        type: 'select',
       },
       options: [undefined, ...spotlightColors],
     },

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
         labels: { undefined: 'div (default)' },
         type: 'select',
       },
-      options: [undefined, ...spotlightTags],
+      options: [undefined, ...spotlightTags.filter((tag) => tag !== 'div')],
     },
     color: {
       control: {

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -9,7 +9,7 @@ import { Blockquote, Grid, Heading, Paragraph, StandaloneLink } from '@amsterdam
 import { Spotlight } from '@amsterdam/design-system-react/src'
 import { spotlightColors, spotlightTags } from '@amsterdam/design-system-react/src/Spotlight/Spotlight'
 
-import { asArgType } from '#storybook/_common/argTypes'
+import { asArgType, colorArgType } from '#storybook/_common/argTypes'
 import { wrapInPage } from '#storybook/_common/decorators'
 import { exampleQuote } from '#storybook/_common/exampleContent'
 
@@ -20,13 +20,7 @@ const meta = {
   component: Spotlight,
   argTypes: {
     as: asArgType(spotlightTags),
-    color: {
-      control: {
-        labels: { undefined: 'purple (default)' },
-        type: 'select',
-      },
-      options: [undefined, ...spotlightColors],
-    },
+    color: colorArgType(spotlightColors, 'purple'),
   },
   decorators: [wrapInPage],
 } satisfies Meta<typeof Spotlight>

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -9,6 +9,7 @@ import { Blockquote, Grid, Heading, Paragraph, StandaloneLink } from '@amsterdam
 import { Spotlight } from '@amsterdam/design-system-react/src'
 import { spotlightColors, spotlightTags } from '@amsterdam/design-system-react/src/Spotlight/Spotlight'
 
+import { asArgType } from '#storybook/_common/argTypes'
 import { wrapInPage } from '#storybook/_common/decorators'
 import { exampleQuote } from '#storybook/_common/exampleContent'
 
@@ -18,13 +19,7 @@ const meta = {
   title: 'Components/Containers/Spotlight',
   component: Spotlight,
   argTypes: {
-    as: {
-      control: {
-        labels: { undefined: 'div (default)' },
-        type: 'select',
-      },
-      options: [undefined, ...spotlightTags.filter((tag) => tag !== 'div')],
-    },
+    as: asArgType(spotlightTags),
     color: {
       control: {
         labels: { undefined: 'purple (default)' },

--- a/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
+++ b/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
@@ -13,10 +13,10 @@ import {
   childrenArgType,
   contrastInverseColorArgType,
   hrefArgType,
-  iconArgType,
   linkComponentArgType,
 } from '#storybook/_common/argTypes'
 import { maximiseInlineSize } from '#storybook/_common/decorators'
+import { iconArgType } from '#storybook/_common/iconArgTypes'
 
 const meta = {
   title: 'Components/Navigation/Standalone Link',

--- a/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
+++ b/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
@@ -9,6 +9,7 @@ import { Heading, Paragraph } from '@amsterdam/design-system-react'
 import { DownloadIcon } from '@amsterdam/design-system-react-icons'
 import { StandaloneLink } from '@amsterdam/design-system-react/src'
 
+import { childrenArgType } from '#storybook/_common/argTypes'
 import {
   contrastInverseColorArgType,
   hrefArgType,
@@ -25,10 +26,7 @@ const meta = {
     href: '#',
   },
   argTypes: {
-    children: {
-      description: 'The link text.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The link text.'),
     color: contrastInverseColorArgType,
     href: hrefArgType,
     icon: {

--- a/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
+++ b/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
@@ -29,14 +29,7 @@ const meta = {
     children: childrenArgType('The link text.'),
     color: contrastInverseColorArgType,
     href: hrefArgType,
-    icon: {
-      ...iconArgType,
-      control: {
-        labels: { undefined: 'ChevronForwardIcon (default)' },
-        type: 'select',
-      },
-      options: iconArgType.options.filter((option) => option !== 'ChevronForwardIcon'),
-    },
+    icon: iconArgType('ChevronForwardIcon'),
     linkComponent: linkComponentArgType,
   },
 } satisfies Meta<typeof StandaloneLink>

--- a/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
+++ b/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
@@ -37,6 +37,7 @@ const meta = {
         labels: { undefined: 'ChevronForwardIcon (default)' },
         type: 'select',
       },
+      options: iconArgType.options.filter((option) => option !== 'ChevronForwardIcon'),
     },
     linkComponent: linkComponentArgType,
   },

--- a/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
+++ b/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
@@ -7,9 +7,14 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Heading, Paragraph } from '@amsterdam/design-system-react'
 import { DownloadIcon } from '@amsterdam/design-system-react-icons'
-import * as Icons from '@amsterdam/design-system-react-icons'
 import { StandaloneLink } from '@amsterdam/design-system-react/src'
 
+import {
+  contrastInverseColorArgType,
+  hrefArgType,
+  iconArgType,
+  linkComponentArgType,
+} from '#storybook/_common/argTypes'
 import { maximiseInlineSize } from '#storybook/_common/decorators'
 
 const meta = {
@@ -24,31 +29,16 @@ const meta = {
       description: 'The link text.',
       table: { disable: false },
     },
-    color: {
-      control: {
-        labels: { undefined: 'default' },
-        type: 'radio',
-      },
-      options: [undefined, 'contrast', 'inverse'],
-    },
-    href: {
-      description: 'The url for the link.',
-      name: 'href',
-      type: { name: 'string', required: false },
-    },
+    color: contrastInverseColorArgType,
+    href: hrefArgType,
     icon: {
+      ...iconArgType,
       control: {
-        labels: { undefined: 'none' },
+        labels: { undefined: 'ChevronForwardIcon (default)' },
         type: 'select',
       },
-      mapping: Icons,
-      options: [undefined, ...Object.keys(Icons)],
-      table: {
-        defaultValue: {
-          summary: 'ChevronForwardIcon',
-        },
-      },
     },
+    linkComponent: linkComponentArgType,
   },
 } satisfies Meta<typeof StandaloneLink>
 

--- a/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
+++ b/storybook/src/components/StandaloneLink/StandaloneLink.stories.tsx
@@ -9,8 +9,8 @@ import { Heading, Paragraph } from '@amsterdam/design-system-react'
 import { DownloadIcon } from '@amsterdam/design-system-react-icons'
 import { StandaloneLink } from '@amsterdam/design-system-react/src'
 
-import { childrenArgType } from '#storybook/_common/argTypes'
 import {
+  childrenArgType,
   contrastInverseColorArgType,
   hrefArgType,
   iconArgType,

--- a/storybook/src/components/Switch/Switch.stories.tsx
+++ b/storybook/src/components/Switch/Switch.stories.tsx
@@ -10,6 +10,8 @@ import { Label } from '@amsterdam/design-system-react'
 import { Switch } from '@amsterdam/design-system-react/src'
 import { useArgs } from 'storybook/preview-api'
 
+import { checkedArgType, disabledArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Forms/Switch',
   component: Switch,
@@ -18,14 +20,10 @@ const meta = {
     disabled: false,
   },
   argTypes: {
-    checked: {
-      description: 'Whether the control is initially checked.',
-    },
-    disabled: {
-      description: 'Prevents interaction. Avoid if possible.',
-    },
+    checked: checkedArgType,
+    disabled: disabledArgType,
     onChange: {
-      action: 'clicked',
+      action: 'changed',
       table: { disable: false },
     },
   },

--- a/storybook/src/components/TabNavigation/TabNavigation.stories.tsx
+++ b/storybook/src/components/TabNavigation/TabNavigation.stories.tsx
@@ -26,8 +26,11 @@ const meta = {
   component: TabNavigation,
   argTypes: {
     orientation: {
-      control: { type: 'inline-radio' },
-      options: ['horizontal', 'vertical'],
+      control: {
+        labels: { undefined: 'horizontal (default)' },
+        type: 'inline-radio',
+      },
+      options: [undefined, 'vertical'],
     },
   },
 } satisfies Meta<typeof TabNavigation>

--- a/storybook/src/components/TabNavigation/TabNavigationLink.stories.tsx
+++ b/storybook/src/components/TabNavigation/TabNavigationLink.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
   argTypes: {
     children: childrenArgType('The link text.'),
     href: hrefArgType,
-    icon: iconArgType,
+    icon: iconArgType(),
     linkComponent: linkComponentArgType,
   },
   decorators: [

--- a/storybook/src/components/TabNavigation/TabNavigationLink.stories.tsx
+++ b/storybook/src/components/TabNavigation/TabNavigationLink.stories.tsx
@@ -5,8 +5,9 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import * as Icons from '@amsterdam/design-system-react-icons'
 import { TabNavigation } from '@amsterdam/design-system-react/src'
+
+import { hrefArgType, iconArgType, linkComponentArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Navigation/Tab Navigation',
@@ -17,14 +18,9 @@ const meta = {
       description: 'The link text.',
       table: { disable: false },
     },
-    icon: {
-      control: {
-        labels: { undefined: 'none' },
-        type: 'select',
-      },
-      mapping: Icons,
-      options: [undefined, ...Object.keys(Icons)],
-    },
+    href: hrefArgType,
+    icon: iconArgType,
+    linkComponent: linkComponentArgType,
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/TabNavigation/TabNavigationLink.stories.tsx
+++ b/storybook/src/components/TabNavigation/TabNavigationLink.stories.tsx
@@ -7,7 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { TabNavigation } from '@amsterdam/design-system-react/src'
 
-import { childrenArgType, hrefArgType, iconArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { iconArgType } from '#storybook/_common/iconArgTypes'
 
 const meta = {
   title: 'Components/Navigation/Tab Navigation',

--- a/storybook/src/components/TabNavigation/TabNavigationLink.stories.tsx
+++ b/storybook/src/components/TabNavigation/TabNavigationLink.stories.tsx
@@ -7,17 +7,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { TabNavigation } from '@amsterdam/design-system-react/src'
 
-import { hrefArgType, iconArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+import { childrenArgType, hrefArgType, iconArgType, linkComponentArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Navigation/Tab Navigation',
   component: TabNavigation.Link,
   argTypes: {
-    children: {
-      control: 'text',
-      description: 'The link text.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The link text.'),
     href: hrefArgType,
     icon: iconArgType,
     linkComponent: linkComponentArgType,

--- a/storybook/src/components/Table/TableCell.stories.tsx
+++ b/storybook/src/components/Table/TableCell.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
   argTypes: {
     align: {
       control: {
-        labels: { undefined: 'start' },
+        labels: { undefined: 'start (default)' },
         type: 'radio',
       },
       options: [undefined, 'center', 'end'],

--- a/storybook/src/components/Table/TableCell.stories.tsx
+++ b/storybook/src/components/Table/TableCell.stories.tsx
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Table } from '@amsterdam/design-system-react/src'
 
+import { childrenArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Containers/Table',
   component: Table.Cell,
@@ -18,11 +20,7 @@ const meta = {
       },
       options: [undefined, 'center', 'end'],
     },
-    children: {
-      control: 'text',
-      description: 'The content of the cell.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The content of the cell.'),
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/Table/TableHeaderCell.stories.tsx
+++ b/storybook/src/components/Table/TableHeaderCell.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
   argTypes: {
     align: {
       control: {
-        labels: { undefined: 'start' },
+        labels: { undefined: 'start (default)' },
         type: 'radio',
       },
       options: [undefined, 'center', 'end'],

--- a/storybook/src/components/Table/TableHeaderCell.stories.tsx
+++ b/storybook/src/components/Table/TableHeaderCell.stories.tsx
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Table } from '@amsterdam/design-system-react/src'
 
+import { childrenArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Containers/Table',
   component: Table.HeaderCell,
@@ -18,11 +20,7 @@ const meta = {
       },
       options: [undefined, 'center', 'end'],
     },
-    children: {
-      control: 'text',
-      description: 'The text for the column header.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The text for the column header.'),
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/storybook/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { TableOfContents } from '@amsterdam/design-system-react/src'
 
+import { headingLevelArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Navigation/Table of Contents',
   component: TableOfContents,
@@ -25,6 +27,7 @@ const meta = {
     collapsible: {
       control: { type: 'boolean' },
     },
+    headingLevel: headingLevelArgType(),
     hideAccessibleLabel: {
       control: { type: 'text' },
     },

--- a/storybook/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/storybook/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -27,7 +27,7 @@ const meta = {
     collapsible: {
       control: { type: 'boolean' },
     },
-    headingLevel: headingLevelArgType(),
+    headingLevel: headingLevelArgType([1, 2, 3, 4], 2),
     hideAccessibleLabel: {
       control: { type: 'text' },
     },

--- a/storybook/src/components/TableOfContents/TableOfContentsLink.stories.tsx
+++ b/storybook/src/components/TableOfContents/TableOfContentsLink.stories.tsx
@@ -7,9 +7,15 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { TableOfContents } from '@amsterdam/design-system-react/src'
 
+import { hrefArgType, linkComponentArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Navigation/Table of Contents',
   component: TableOfContents.Link,
+  argTypes: {
+    href: hrefArgType,
+    linkComponent: linkComponentArgType,
+  },
   decorators: [
     (Story) => (
       <TableOfContents heading="Op deze pagina">

--- a/storybook/src/components/Tabs/Tabs.stories.tsx
+++ b/storybook/src/components/Tabs/Tabs.stories.tsx
@@ -15,8 +15,7 @@ const meta = {
   component: Tabs,
   argTypes: {
     onTabChange: {
-      action: 'clicked',
-      description: 'Provides the id of the activated tab.',
+      action: 'changed',
     },
   },
 } satisfies Meta<typeof Tabs>

--- a/storybook/src/components/Tabs/TabsButton.stories.tsx
+++ b/storybook/src/components/Tabs/TabsButton.stories.tsx
@@ -8,15 +8,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Paragraph } from '@amsterdam/design-system-react'
 import { Tabs } from '@amsterdam/design-system-react/src'
 
+import { childrenArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Containers/Tabs',
   component: Tabs.Button,
   argTypes: {
-    children: {
-      control: 'text',
-      description: 'The text for the tab.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The text for the tab.'),
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/TextArea/TextArea.stories.tsx
+++ b/storybook/src/components/TextArea/TextArea.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
   },
   argTypes: {
     cols: {
-      control: { min: 0, type: 'number' },
+      control: { min: 1, type: 'number' },
       description: 'The width, expressed in the average number of characters.',
     },
     defaultValue: {

--- a/storybook/src/components/TextArea/TextArea.stories.tsx
+++ b/storybook/src/components/TextArea/TextArea.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { ErrorMessage, Field, Label, Paragraph } from '@amsterdam/design-system-react'
 import { TextArea } from '@amsterdam/design-system-react/src'
 
+import { disabledArgType } from '#storybook/_common/argTypes'
 import { exampleParagraph } from '#storybook/_common/exampleContent'
 
 const paragraph = exampleParagraph()
@@ -22,32 +23,26 @@ const meta = {
   },
   argTypes: {
     cols: {
-      control: {
-        type: 'number',
-      },
+      control: { min: 0, type: 'number' },
       description: 'The width, expressed in the average number of characters.',
     },
     defaultValue: {
       table: { disable: false },
     },
-    disabled: {
-      description: 'Prevents interaction. Avoid if possible.',
-    },
+    disabled: disabledArgType,
     onChange: {
       table: { disable: false },
     },
     resize: {
       control: {
-        labels: { horizontal: 'horizontal', none: 'none', undefined: 'default', vertical: 'vertical' },
+        labels: { undefined: 'both (default)' },
         type: 'radio',
       },
       options: [undefined, 'none', 'horizontal', 'vertical'],
     },
     rows: {
-      control: {
-        type: 'number',
-      },
-      description: 'The number of lines to show',
+      control: { min: 0, type: 'number' },
+      description: 'The number of lines to show.',
     },
   },
 } satisfies Meta<typeof TextArea>

--- a/storybook/src/components/TextArea/TextArea.stories.tsx
+++ b/storybook/src/components/TextArea/TextArea.stories.tsx
@@ -41,7 +41,7 @@ const meta = {
       options: [undefined, 'none', 'horizontal', 'vertical'],
     },
     rows: {
-      control: { min: 0, type: 'number' },
+      control: { min: 1, type: 'number' },
       description: 'The number of lines to show.',
     },
   },

--- a/storybook/src/components/TextInput/TextInput.stories.tsx
+++ b/storybook/src/components/TextInput/TextInput.stories.tsx
@@ -28,7 +28,7 @@ const meta = {
       table: { disable: false },
     },
     size: {
-      control: { min: 0, type: 'number' },
+      control: { min: 1, type: 'number' },
       description: 'The width, expressed in the average number of characters.',
     },
     type: {

--- a/storybook/src/components/TextInput/TextInput.stories.tsx
+++ b/storybook/src/components/TextInput/TextInput.stories.tsx
@@ -9,6 +9,8 @@ import { ErrorMessage, Field, Label, Paragraph } from '@amsterdam/design-system-
 import { textInputTypes } from '@amsterdam/design-system-react/dist/TextInput/TextInput'
 import { TextInput } from '@amsterdam/design-system-react/src'
 
+import { disabledArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Forms/Text Input',
   component: TextInput,
@@ -21,12 +23,7 @@ const meta = {
     defaultValue: {
       table: { disable: false },
     },
-    disabled: {
-      description: 'Prevents interaction. Avoid if possible.',
-    },
-    invalid: {
-      description: 'Whether the value fails a validation rule.',
-    },
+    disabled: disabledArgType,
     onChange: {
       table: { disable: false },
     },

--- a/storybook/src/components/TimeInput/TimeInput.stories.tsx
+++ b/storybook/src/components/TimeInput/TimeInput.stories.tsx
@@ -8,6 +8,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { ErrorMessage, Field, Label, Paragraph } from '@amsterdam/design-system-react'
 import { TimeInput } from '@amsterdam/design-system-react/src'
 
+import { disabledArgType } from '#storybook/_common/argTypes'
+
 const meta = {
   title: 'Components/Forms/Time Input',
   component: TimeInput,
@@ -19,9 +21,7 @@ const meta = {
     defaultValue: {
       table: { disable: false },
     },
-    disabled: {
-      description: 'Prevents interaction. Avoid if possible.',
-    },
+    disabled: disabledArgType,
     onChange: {
       table: { disable: false },
     },

--- a/storybook/src/components/UnorderedList/UnorderedList.stories.tsx
+++ b/storybook/src/components/UnorderedList/UnorderedList.stories.tsx
@@ -8,7 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Card, Paragraph } from '@amsterdam/design-system-react'
 import { UnorderedList } from '@amsterdam/design-system-react/src'
 
-import { inverseColorArgType } from '#storybook/_common/argTypes'
+import { inverseColorArgType, textSizeArgType } from '#storybook/_common/argTypes'
 import { maximiseInlineSize } from '#storybook/_common/decorators'
 import { exampleUnorderedList } from '#storybook/_common/exampleContent'
 
@@ -25,13 +25,7 @@ const meta = {
   },
   argTypes: {
     color: inverseColorArgType,
-    size: {
-      control: {
-        labels: { undefined: 'medium (default)' },
-        type: 'radio',
-      },
-      options: ['small', undefined],
-    },
+    size: textSizeArgType(['small', undefined]),
   },
 } satisfies Meta<typeof UnorderedList>
 

--- a/storybook/src/components/UnorderedList/UnorderedList.stories.tsx
+++ b/storybook/src/components/UnorderedList/UnorderedList.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Card, Paragraph } from '@amsterdam/design-system-react'
 import { UnorderedList } from '@amsterdam/design-system-react/src'
 
+import { inverseColorArgType } from '#storybook/_common/argTypes'
 import { maximiseInlineSize } from '#storybook/_common/decorators'
 import { exampleUnorderedList } from '#storybook/_common/exampleContent'
 
@@ -23,9 +24,10 @@ const meta = {
     markers: undefined,
   },
   argTypes: {
+    color: inverseColorArgType,
     size: {
       control: {
-        labels: { small: 'small', undefined: 'medium' },
+        labels: { undefined: 'medium (default)' },
         type: 'radio',
       },
       options: ['small', undefined],

--- a/storybook/src/utils/AspectRatio/AspectRatio.stories.tsx
+++ b/storybook/src/utils/AspectRatio/AspectRatio.stories.tsx
@@ -18,8 +18,9 @@ const meta = {
     aspectRatio: '16:9',
   },
   argTypes: {
+    // The prop is optional, but without a ratio the demo element has no height, so `undefined` is not offered.
     aspectRatio: {
-      control: 'radio',
+      control: { type: 'select' },
       options: aspectRatioOptions,
     },
   },

--- a/storybook/src/utils/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/storybook/src/utils/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Paragraph } from '@amsterdam/design-system-react'
 
+import { childrenArgType } from '#storybook/_common/argTypes'
+
 import type { VisuallyHiddenProps } from './VisuallyHidden'
 
 import { VisuallyHidden } from './VisuallyHidden'
@@ -28,10 +30,7 @@ const meta = {
     children: 'Here is the paragraph that is visually hidden. A screen reader will pick it up and read it to its user.',
   },
   argTypes: {
-    children: {
-      description: 'The content to hide visually.',
-      table: { disable: false },
-    },
+    children: childrenArgType('The content to hide visually.'),
   },
 } satisfies Meta<typeof VisuallyHidden>
 

--- a/storybook/vitest.config.ts
+++ b/storybook/vitest.config.ts
@@ -7,6 +7,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts'],
+    include: ['config/**/*.test.ts', 'src/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## What

A consistency overhaul of the Controls experience across all component stories:

- Rewrite the controls sections of `documentation/storybook.md` into an explicit contract: control choice per prop shape, an ‘\<value\> (default)’ label convention for `undefined` options – removing the default value from the options themselves so it doesn’t appear twice – `control: false` (read-only row) versus `table.disable` (hidden row), a uniform pattern for derived args, action naming, and a JSDoc-first policy for prop descriptions.
- Expand the Controls addon to show the description and default columns, and surface `@default` JSDoc tags in the ‘Default’ column through an enhancer, mirroring the existing `@deprecated` one.
- Restore the natural order of literal union values in the tables through another enhancer. TypeScript interns these values in the order it first encounters them anywhere in the program, so docgen described Heading’s `level` as `3 | 1 | 2 | 4`.
- Build a vocabulary of fifteen shared arg types in `storybook/src/_common/argTypes.ts`: for `as` tags, string `children`, colour palettes, icons with and without a default, heading levels, text sizes, inverse and contrast colours, `linkComponent`, derived args, and recurring native-attribute descriptions. Each encodes at least one convention – the default-value label, filtering the default from the options, or the radio/select count rule – so violations can’t quietly return through new stories.
- Complete and correct the prop JSDoc in the React package so the new columns have something to show.
- Sweep every category’s stories to apply the conventions: Forms, Navigation, Text and Layout, and Media/Feedback/Buttons.
- Make scaffolded stories compliant from the start: the plop templates now use the shared children arg type, point to the guidelines, and pre-fill the title’s Components path.

## Why

Controls had drifted: implicit control types, option lists that didn’t match the prop types (Card Heading offered heading levels 5 and 6, which its type forbids), nine different labels for `undefined`, function props with junk controls, three competing mechanisms for derived args, and descriptions duplicated between JSDoc and argTypes. A consistent controls table teaches component APIs; an inconsistent one erodes trust in them.

## How

Documentation first, so the guidelines are the reviewable contract; then infrastructure; then the React package; then the stories per category; then the shared arg types extracted from the patterns the sweep settled. Some notable finds along the way:

- The JSDoc description of `noMenuButtonOnWideWindow` was inverted, and Breakout Cell’s `has` documentation described the wrong value.
- Missing controls added throughout: Heading `level`/`size`, Image `aspectRatio`, Logo and Page Header `logoBrand`, Date Input `type`, `as` for the layout components, and more. Table Of Contents and Page Footer Menu can now express their unset heading level, which defaults to 2.
- The span and start props of Grid Cell and Breakout Cell now describe the value shapes their number controls can’t express: an object of numbers per grid variant, or ‘all’.
- Args changes were kept out of rendering: only DOM-identical placeholder args were removed (empty-string `id`/`hint`). The variant matrices of the Chromatic Test stories derive from docgen types and `table.disable`, neither of which changed.

Verified with tsc, ESLint, unit tests for the new enhancer, and a full Storybook production build.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- A separate fix is underway for Breakout silently dropping its `as` prop, which this PR surfaced.
- Reviewing per commit is recommended; each step stands alone.
- The Controls panel of any component page in the branch deploy shows the new description and default columns.
