### PR TITLE
chore: Insert scaffolded index entries in sorted order

### DIFF
--- a/plopfile.mjs
+++ b/plopfile.mjs
@@ -1,3 +1,31 @@
+/**
+ * Inserts a line at its sorted position in the list that follows the ‘Append here’ marker.
+ * This keeps generated index files in the order that our lint rules require.
+ */
+const insertLineSorted = (contents, line) => {
+  const lines = contents.split('\n')
+
+  if (lines.includes(line)) {
+    return contents
+  }
+
+  const markerIndex = lines.indexOf('/* Append here */')
+
+  if (markerIndex === -1) {
+    throw new Error('Marker /* Append here */ not found')
+  }
+
+  let index = markerIndex + 1
+
+  while (index < lines.length && lines[index] !== '' && lines[index].toLowerCase() < line.toLowerCase()) {
+    index += 1
+  }
+
+  lines.splice(index, 0, line)
+
+  return lines.join('\n')
+}
+
 export default function (plop) {
   // component generator
   plop.setGenerator('component', {
@@ -14,9 +42,9 @@ export default function (plop) {
       },
       {
         path: 'packages/css/src/components/index.scss',
-        pattern: `/* Append here */`,
-        template: `@use "{{kebabCase name}}/{{kebabCase name}}";`,
-        type: 'append',
+        transform: (contents, answers) =>
+          insertLineSorted(contents, plop.renderString(`@use "{{kebabCase name}}/{{kebabCase name}}";`, answers)),
+        type: 'modify',
       },
       {
         path: 'packages/react/src/{{pascalCase name}}/{{pascalCase name}}.tsx',
@@ -35,9 +63,9 @@ export default function (plop) {
       },
       {
         path: 'packages/react/src/index.ts',
-        pattern: `/* Append here */`,
-        template: `export * from './{{pascalCase name}}'`,
-        type: 'append',
+        transform: (contents, answers) =>
+          insertLineSorted(contents, plop.renderString(`export * from './{{pascalCase name}}'`, answers)),
+        type: 'modify',
       },
       {
         data: { curlyBefore: '{' },


### PR DESCRIPTION
# Describe the pull request

## What

Makes the plop component generator insert the new `export` line in `packages/react/src/index.ts` and the new `@use` line in `packages/css/src/components/index.scss` at their alphabetical position, instead of appending them directly below the `/* Append here */` marker.

## Why

The marker sits at the top of both lists.
Any component whose name sorts after ‘Accordion’ therefore failed `perfectionist/sort-exports` immediately after scaffolding, and needed a manual lint fix before it could be committed.
Freshly scaffolded components should pass lint as-is.

## How

The two `append` actions became `modify` actions with a `transform` that renders the same template and inserts the line at its sorted position in the list below the marker.
The comparison is case-insensitive, matching the natural sort order of our Perfectionist rules.
The insert is also idempotent: if the line already exists, the file stays unchanged.

Verified by scaffolding components named ‘Aardvark’, ‘Test’, and ‘Zebra’ to cover the top, middle, and end of the lists: both index files received their lines at the correct position and passed ESLint and Stylelint.
The throwaway scaffolds were removed afterwards; only `plopfile.mjs` changes.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

The ‘Append here’ markers remain in both index files; they now mark where the sorted list starts.
