### PR TITLE
chore(Standalone Link): Fix test story title to remove stray sidebar entry

### DIFF
--- a/storybook/src/components/StandaloneLink/StandaloneLink.test.stories.tsx
+++ b/storybook/src/components/StandaloneLink/StandaloneLink.test.stories.tsx
@@ -13,7 +13,7 @@ import { default as standaloneLinkMeta } from './StandaloneLink.stories'
 
 const meta = {
   ...standaloneLinkMeta,
-  title: 'Components/StandaloneLink',
+  title: 'Components/Navigation/Standalone Link',
 } satisfies Meta<typeof StandaloneLink>
 
 export default meta


### PR DESCRIPTION
# Describe the pull request

## What

Corrects the meta title of the Standalone Link test story from `Components/StandaloneLink` to `Components/Navigation/Standalone Link`, matching the main stories file and every sibling test story.

## Why

The deviating title created a stray, uncategorised “StandaloneLink” entry in the Storybook index, next to the component’s regular entry under Navigation.
It also broke the `Components/<Category>/<Component Name>` title convention that all other stories follow.

## How

Restated the full title in the test story’s meta, as all other test stories do.
A full Storybook build confirms the fix: the index no longer contains `components-standalonelink`, and the test story id is now `components-navigation-standalone-link--test`.
The Chromatic run for this branch shows the same thing from its side: one “component” fewer than the previous run (95 → 94) with an unchanged number of stories, so the stray entry has merged into the regular one.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- The title has been off since the test stories were introduced in #2257.
- Visual regression coverage was not affected: a `**` in the `Components/**/**/Test` filter also matches zero path segments, so the old two-level title happened to match it as well.
  The Chromatic runs before and after this change both execute 76 tests and capture 152 snapshots.
  The story does move to a new name in Chromatic, so its baseline starts fresh there.
- The test story remains hidden from the sidebar (tags `!dev`), like all test stories; once the branch deploy is up it should be available at [this direct link](https://amsterdam.github.io/design-system/demo-standalone-link-test-story-title/?path=/story/components-navigation-standalone-link--test).
