### PR TITLE
feat(Storybook): Tidy the Code Panel source for Page stories

### DIFF
--- a/storybook/config/collapseInlineObjects.test.ts
+++ b/storybook/config/collapseInlineObjects.test.ts
@@ -52,6 +52,15 @@ describe('collapseInlineObjects', () => {
     expect(result).toContain('<Component\n')
   })
 
+  it('leaves a multi-line function prop untouched', () => {
+    const input = `<Button onClick={(event) => {
+  event.preventDefault()
+  submit()
+}} />`
+
+    expect(collapseInlineObjects(input)).toBe(input)
+  })
+
   it('does not treat a `>` inside an arrow function or string as the end of the tag', () => {
     const input = `<Field onSubmit={() => {}} label="a > b" data={[
   1,

--- a/storybook/config/collapseInlineObjects.test.ts
+++ b/storybook/config/collapseInlineObjects.test.ts
@@ -52,6 +52,15 @@ describe('collapseInlineObjects', () => {
     expect(result).toContain('<Component\n')
   })
 
+  it('leaves a multi-line tag without object or array props untouched', () => {
+    const input = `<Alert
+  heading="Let op"
+  severity="warning"
+>`
+
+    expect(collapseInlineObjects(input)).toBe(input)
+  })
+
   it('leaves a multi-line function prop untouched', () => {
     const input = `<Button onClick={(event) => {
   event.preventDefault()

--- a/storybook/config/collapseInlineObjects.test.ts
+++ b/storybook/config/collapseInlineObjects.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { collapseInlineObjects } from './collapseInlineObjects'
+
+describe('collapseInlineObjects', () => {
+  it('collapses a multi-line object prop and re-joins its opening tag', () => {
+    const input = `<Grid.Cell
+  span={{
+    medium: 6,
+    narrow: 4,
+    wide: 6
+  }}
+>`
+
+    expect(collapseInlineObjects(input)).toBe('<Grid.Cell span={{ medium: 6, narrow: 4, wide: 6 }}>')
+  })
+
+  it('collapses a multi-line array prop', () => {
+    const input = `<List
+  items={[
+    1,
+    2
+  ]}
+/>`
+
+    expect(collapseInlineObjects(input)).toBe('<List items={[ 1, 2 ]} />')
+  })
+
+  it('leaves already inline code untouched', () => {
+    const input = '<SearchField.Input defaultValue="woningbouw" label="Zoek op de website" name="search" />'
+
+    expect(collapseInlineObjects(input)).toBe(input)
+  })
+
+  it('keeps a tag wrapped when collapsing would exceed the line-length budget', () => {
+    const input = `<Component
+  alpha="one"
+  charlie={{
+    delta: 1
+  }}
+  overflow="a value long enough to push the whole single line past one hundred and twenty columns in total"
+>`
+
+    const result = collapseInlineObjects(input)
+
+    expect(result).toContain('charlie={{ delta: 1 }}')
+    expect(result).toContain('<Component\n')
+  })
+
+  it('does not treat a `>` inside an arrow function or string as the end of the tag', () => {
+    const input = `<Field onSubmit={() => {}} label="a > b" data={[
+  1,
+  2
+]} />`
+
+    expect(collapseInlineObjects(input)).toBe('<Field onSubmit={() => {}} label="a > b" data={[ 1, 2 ]} />')
+  })
+})

--- a/storybook/config/collapseInlineObjects.ts
+++ b/storybook/config/collapseInlineObjects.ts
@@ -130,7 +130,23 @@ const hasNestedNewline = (tag: string): boolean => {
   return false
 }
 
-// Re-join opening tags that only wrapped because a value did – but keep tags that genuinely overflow.
+// Does the opening tag carry an object or array prop (`name={{…}}` / `name={[…]}`)? Those are the tags
+// the source generator wrapped only because it always expands such values, so those are the ones worth
+// re-joining. A tag a story author wrapped by hand in `docs.source.code` carries no such prop and is left
+// alone.
+const hasObjectOrArrayProp = (tag: string): boolean => {
+  for (let i = 0; i < tag.length; i++) {
+    if (tag[i] === '=' && tag[i + 1] === '{' && ['[', '{'].includes(firstNonSpaceAt(tag, i + 2))) {
+      return true
+    }
+  }
+
+  return false
+}
+
+// Re-join an opening tag only when it wrapped because an object or array value forced it multi-line,
+// recognised by the tag still carrying such a prop. Tags that genuinely overflow, that hold a nested
+// multi-line expression, or that an author wrapped by hand are left as they are.
 const collapseTags = (code: string): string => {
   let out = ''
   let i = 0
@@ -142,7 +158,7 @@ const collapseTags = (code: string): string => {
       if (end !== -1) {
         const tag = code.slice(i, end + 1)
 
-        if (tag.includes('\n') && !hasNestedNewline(tag)) {
+        if (tag.includes('\n') && !hasNestedNewline(tag) && hasObjectOrArrayProp(tag)) {
           const indent = out.length - out.lastIndexOf('\n') - 1
           const collapsed = collapseWhitespace(tag)
             .replace(/\s+>$/, '>')

--- a/storybook/config/collapseInlineObjects.ts
+++ b/storybook/config/collapseInlineObjects.ts
@@ -10,7 +10,11 @@
 // collapse each multi-line attribute value onto one line, then re-join the opening tags that only
 // wrapped because of it – unless the result would exceed the line-length budget.
 
-const maxWidth = 120
+/**
+ * Line-length budget for the Code Panel. Also fed to `parameters.jsx.maxInlineAttributesLineLength` in
+ * preview, so the source generator’s attribute wrapping and this transform’s tag re-joining agree.
+ */
+export const maxInlineWidth = 120
 
 // Walk from an opening bracket (`{` or `[`) to its match, skipping over string contents.
 const matchBracket = (code: string, openIndex: number): number => {
@@ -144,7 +148,7 @@ const collapseTags = (code: string): string => {
             .replace(/\s+>$/, '>')
             .replace(/\s+\/>$/, ' />')
 
-          if (indent + collapsed.length <= maxWidth) {
+          if (indent + collapsed.length <= maxInlineWidth) {
             out += collapsed
             i = end + 1
             continue

--- a/storybook/config/collapseInlineObjects.ts
+++ b/storybook/config/collapseInlineObjects.ts
@@ -38,13 +38,23 @@ const matchBracket = (code: string, openIndex: number): number => {
 
 const collapseWhitespace = (text: string) => text.replace(/\s*\n\s*/g, ' ')
 
-// Collapse each multi-line attribute value (`name={…}`) onto a single line.
+// Return the first non-whitespace character at or after `index`, or '' at the end of the input.
+const firstNonSpaceAt = (code: string, index: number): string => {
+  let i = index
+  while (i < code.length && /\s/.test(code[i] ?? '')) i++
+  return code[i] ?? ''
+}
+
+// Collapse multi-line object and array attribute values (`name={{…}}` / `name={[…]}`) onto a single
+// line. Other expression props are left alone, so a multi-line function body is not flattened into an
+// unreadable single line.
 const collapseValues = (code: string): string => {
   let out = ''
   let i = 0
 
   while (i < code.length) {
-    if (code[i] === '=' && code[i + 1] === '{') {
+    // `code[i + 1]` is the expression container brace; peek past it for an object or array literal.
+    if (code[i] === '=' && code[i + 1] === '{' && ['[', '{'].includes(firstNonSpaceAt(code, i + 2))) {
       const end = matchBracket(code, i + 1)
 
       if (end !== -1) {
@@ -90,6 +100,32 @@ const findTagEnd = (code: string, ltIndex: number): number => {
   return -1
 }
 
+// Does a newline sit inside a bracketed expression or string (depth > 0), as in a multi-line function
+// body? Such tags are left as they are so their inner formatting is not flattened onto one line.
+const hasNestedNewline = (tag: string): boolean => {
+  let depth = 0
+  let quote: string | null = null
+
+  for (let i = 0; i < tag.length; i++) {
+    const character = tag[i]
+
+    if (character === '\n' && (depth > 0 || quote)) {
+      return true
+    } else if (quote) {
+      if (character === '\\') i++
+      else if (character === quote) quote = null
+    } else if (character === '"' || character === "'" || character === '`') {
+      quote = character
+    } else if (character === '{' || character === '[') {
+      depth++
+    } else if (character === '}' || character === ']') {
+      depth--
+    }
+  }
+
+  return false
+}
+
 // Re-join opening tags that only wrapped because a value did – but keep tags that genuinely overflow.
 const collapseTags = (code: string): string => {
   let out = ''
@@ -102,7 +138,7 @@ const collapseTags = (code: string): string => {
       if (end !== -1) {
         const tag = code.slice(i, end + 1)
 
-        if (tag.includes('\n')) {
+        if (tag.includes('\n') && !hasNestedNewline(tag)) {
           const indent = out.length - out.lastIndexOf('\n') - 1
           const collapsed = collapseWhitespace(tag)
             .replace(/\s+>$/, '>')

--- a/storybook/config/collapseInlineObjects.ts
+++ b/storybook/config/collapseInlineObjects.ts
@@ -1,0 +1,128 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+// The Code Panel generates the source for `render`-function stories with react-element-to-jsx-string.
+// That library always prints object and array props on multiple lines for block-level elements, which
+// scatters short props like `span={{ narrow: 4, medium: 4, wide: 4 }}` across four lines. There is no
+// option to change this, so we post-process the generated code through `docs.source.transform`:
+// collapse each multi-line attribute value onto one line, then re-join the opening tags that only
+// wrapped because of it – unless the result would exceed the line-length budget.
+
+const maxWidth = 120
+
+// Walk from an opening bracket (`{` or `[`) to its match, skipping over string contents.
+const matchBracket = (code: string, openIndex: number): number => {
+  let depth = 0
+  let quote: string | null = null
+
+  for (let i = openIndex; i < code.length; i++) {
+    const character = code[i]
+
+    if (quote) {
+      if (character === '\\') i++
+      else if (character === quote) quote = null
+    } else if (character === '"' || character === "'" || character === '`') {
+      quote = character
+    } else if (character === '{' || character === '[') {
+      depth++
+    } else if (character === '}' || character === ']') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+
+  return -1
+}
+
+const collapseWhitespace = (text: string) => text.replace(/\s*\n\s*/g, ' ')
+
+// Collapse each multi-line attribute value (`name={…}`) onto a single line.
+const collapseValues = (code: string): string => {
+  let out = ''
+  let i = 0
+
+  while (i < code.length) {
+    if (code[i] === '=' && code[i + 1] === '{') {
+      const end = matchBracket(code, i + 1)
+
+      if (end !== -1) {
+        const group = code.slice(i + 1, end + 1)
+        out += '=' + (group.includes('\n') ? collapseWhitespace(group) : group)
+        i = end + 1
+        continue
+      }
+    }
+
+    out += code[i]
+    i++
+  }
+
+  return out
+}
+
+// Find the `>` that closes an opening tag starting at `<`, skipping strings and bracketed expressions
+// (so a `>` inside an arrow function or a string does not end the tag early). Returns -1 if malformed.
+const findTagEnd = (code: string, ltIndex: number): number => {
+  let depth = 0
+  let quote: string | null = null
+
+  for (let i = ltIndex + 1; i < code.length; i++) {
+    const character = code[i]
+
+    if (quote) {
+      if (character === '\\') i++
+      else if (character === quote) quote = null
+    } else if (character === '"' || character === "'" || character === '`') {
+      quote = character
+    } else if (character === '{' || character === '[') {
+      depth++
+    } else if (character === '}' || character === ']') {
+      depth--
+    } else if (depth === 0 && character === '>') {
+      return i
+    } else if (depth === 0 && character === '<') {
+      return -1
+    }
+  }
+
+  return -1
+}
+
+// Re-join opening tags that only wrapped because a value did – but keep tags that genuinely overflow.
+const collapseTags = (code: string): string => {
+  let out = ''
+  let i = 0
+
+  while (i < code.length) {
+    if (code[i] === '<' && /[A-Za-z]/.test(code[i + 1] ?? '')) {
+      const end = findTagEnd(code, i)
+
+      if (end !== -1) {
+        const tag = code.slice(i, end + 1)
+
+        if (tag.includes('\n')) {
+          const indent = out.length - out.lastIndexOf('\n') - 1
+          const collapsed = collapseWhitespace(tag)
+            .replace(/\s+>$/, '>')
+            .replace(/\s+\/>$/, ' />')
+
+          if (indent + collapsed.length <= maxWidth) {
+            out += collapsed
+            i = end + 1
+            continue
+          }
+        }
+      }
+    }
+
+    out += code[i]
+    i++
+  }
+
+  return out
+}
+
+/** Collapses the multi-line object and array props that the Code Panel’s source generator expands. */
+export const collapseInlineObjects = (code: string): string => collapseTags(collapseValues(code))

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -6,6 +6,7 @@ import { DocsContainer } from '@storybook/addon-docs/blocks'
 import { withThemeByClassName } from '@storybook/addon-themes'
 import { clsx } from 'clsx'
 
+import { collapseInlineObjects } from './collapseInlineObjects'
 import { sortLiteralUnionValues } from './sortLiteralUnionValues'
 import { viewports } from './viewports'
 
@@ -159,12 +160,22 @@ export const parameters = {
     controls: {
       sort: 'alpha', // Sorts controls in the Controls doc block – https://github.com/storybookjs/storybook/issues/25386#issuecomment-1905468177
     },
+    source: {
+      // Collapse the multi-line object and array props that the source generator expands (see the module).
+      transform: collapseInlineObjects,
+    },
     toc: {
       headingSelector: 'h2, h3',
     },
   },
   html: {
     root: '.ams-body',
+  },
+  // Widen the Code Panel’s line budget. Without this, react-element-to-jsx-string – which generates the
+  // source for stories with a `render` function – puts every element with more than one attribute onto
+  // multiple lines. Keeping attributes inline until a line reaches this length shows more code at once.
+  jsx: {
+    maxInlineAttributesLineLength: 120,
   },
   options: {
     storySort: {

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -6,7 +6,7 @@ import { DocsContainer } from '@storybook/addon-docs/blocks'
 import { withThemeByClassName } from '@storybook/addon-themes'
 import { clsx } from 'clsx'
 
-import { collapseInlineObjects } from './collapseInlineObjects'
+import { collapseInlineObjects, maxInlineWidth } from './collapseInlineObjects'
 import { sortLiteralUnionValues } from './sortLiteralUnionValues'
 import { viewports } from './viewports'
 
@@ -175,7 +175,7 @@ export const parameters = {
   // source for stories with a `render` function – puts every element with more than one attribute onto
   // multiple lines. Keeping attributes inline until a line reaches this length shows more code at once.
   jsx: {
-    maxInlineAttributesLineLength: 120,
+    maxInlineAttributesLineLength: maxInlineWidth,
   },
   options: {
     storySort: {

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -23,12 +23,8 @@ import { commonMeta } from '../common/config'
 const meta = {
   ...commonMeta,
   title: 'Pages/Public/Article Page',
-} satisfies Meta
-
-export default meta
-
-export const Default: StoryObj = {
-  render: () => (
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  render: (args) => (
     <>
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -183,4 +179,8 @@ export const Default: StoryObj = {
       </aside>
     </>
   ),
-}
+} satisfies Meta
+
+export default meta
+
+export const Default: StoryObj = {}


### PR DESCRIPTION
## What

Two changes that make the Storybook Code Panel easier to read, especially for the Page stories:

- Widen the generated source and keep object and array props on a single line. The panel’s source generator (`react-element-to-jsx-string`) previously put every element with more than one attribute — and every object or array prop — on its own line, so short props like `span={{ narrow: 4, medium: 4, wide: 4 }}` were scattered across four lines.
- Move the Article Page render to its meta so it renders through the same source path as the other public Page stories.

## Why

The Code Panel was wrapping so aggressively that only a fraction of an example was in view at once, and simple objects were broken across several lines for no benefit.

Article Page was a special case. Because its render lived on the `Default` story as a zero-argument arrow (`render: () => …`), Storybook treated it as a non-args story and showed the re-printed story object — `{ render: () => … }` wrapper and all, with props split across lines — instead of the clean generated markup its siblings show. The other public Page stories (Home, Product, Project) already give `render` a throwaway `args` parameter for exactly this reason; Article Page was the lone exception.

## How

- Set `parameters.jsx.maxInlineAttributesLineLength` to 120 so attributes stay inline until a line reaches that width.
- Add a `parameters.docs.source.transform` (`collapseInlineObjects`) that post-processes the generated source: it collapses the multi-line object and array props the generator expands, then re-joins the opening tags that only wrapped because of them — while leaving genuinely long tags wrapped so nothing overflows the panel. It is string- and brace-aware, so a `>` inside an arrow function or a string doesn’t confuse it. Covered by unit tests.
- Move Article Page’s render to its meta with the same `args` idiom the sibling pages use, and leave `Default` empty.

This only affects how the source is presented in the Code Panel; the rendered pages are unchanged.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Table Page is intentionally left as is. Its two stories are genuinely stateful and interactive (pagination, URL sync, `useState`), so routing them through the generated source path would dump every expanded table row into the panel rather than clean markup.
- No visual changes are expected, so this is a good candidate for a quick Chromatic pass.
