### PR TITLE
fix(Page Header): Crop the logo a bit wider to prevent cut-offs from sub-pixel rounding

### DIFF
--- a/packages/css/src/components/page-header/page-header.scss
+++ b/packages/css/src/components/page-header/page-header.scss
@@ -66,10 +66,11 @@
   flex-shrink: 0;
 
   /* Crops the logo to its emblem (the three Saint Andrew's crosses), hiding the wordmark that follows it.
-  0.875rem sits roughly midway between the emblem's right edge (~0.735rem) and the wordmark's left edge
-  (~1.027rem) in the logo's own coordinate space, so the crop has margin on both sides and doesn't depend
-  on sub-pixel rounding to land in the right place. */
-  inline-size: 0.875rem;
+  0.881rem is the midpoint between the emblem's right edge (0.735rem) and the wordmark's left edge
+  (1.027rem) in the logo's own coordinate space (rounded to 4 decimals, our stylelint precision limit),
+  so the crop has equal margin on both sides and doesn't depend on sub-pixel rounding to land in the
+  right place. */
+  inline-size: 0.881rem;
   overflow: hidden;
 
   @media (min-width: $ams-breakpoint-medium) {

--- a/packages/css/src/components/page-header/page-header.scss
+++ b/packages/css/src/components/page-header/page-header.scss
@@ -64,7 +64,12 @@
 
 .ams-page-header__logo-container {
   flex-shrink: 0;
-  inline-size: 0.75rem;
+
+  /* Crops the logo to its emblem (the three Saint Andrew's crosses), hiding the wordmark that follows it.
+  0.875rem sits roughly midway between the emblem's right edge (~0.735rem) and the wordmark's left edge
+  (~1.027rem) in the logo's own coordinate space, so the crop has margin on both sides and doesn't depend
+  on sub-pixel rounding to land in the right place. */
+  inline-size: 0.875rem;
   overflow: hidden;
 
   @media (min-width: $ams-breakpoint-medium) {

--- a/packages/css/src/components/page-header/page-header.scss
+++ b/packages/css/src/components/page-header/page-header.scss
@@ -66,10 +66,9 @@
   flex-shrink: 0;
 
   /* Crops the logo to its emblem (the three Saint Andrew's crosses), hiding the wordmark that follows it.
-  0.881rem is the midpoint between the emblem's right edge (0.735rem) and the wordmark's left edge
-  (1.027rem) in the logo's own coordinate space (rounded to 4 decimals, our stylelint precision limit),
-  so the crop has equal margin on both sides and doesn't depend on sub-pixel rounding to land in the
-  right place. */
+  0.881rem is the midpoint between the emblem's right edge (0.735rem) and the wordmark's left edge (1.027rem)
+  in the logo's coordinate space, so the crop has equal margin on both sides and doesn't depend on sub-pixel
+  rounding to land in the right place. */
   inline-size: 0.881rem;
   overflow: hidden;
 


### PR DESCRIPTION
# Give the logo crop margin so it doesn't rely on sub-pixel rounding

## What

The Page Header crops the Amsterdam logo down to just its emblem (the three Saint Andrew’s crosses) by giving `.ams-page-header__logo-container` a fixed `inline-size` and hiding the overflow. That width was `0.75rem`, and this PR changes it to `0.881rem`.

## Why

The emblem’s right edge sits at `0.735rem` in the logo’s own coordinate space, and the wordmark that follows it starts at `1.027rem`. The old crop width of `0.75rem` left only about `0.24px` of margin past the emblem — well within rounding-error territory. A different rendering engine, or a fractional browser zoom or OS display-scaling factor, could tip that margin the wrong way and either clip the last cross or reveal a sliver of the wordmark. It wasn’t reproducible in a battery of headless-Chromium screenshots across zoom levels and device-pixel ratios, but a margin that thin shouldn’t depend on one engine rounding consistently in its favor.

## How

I parsed the logo SVG’s path data to get the emblem’s exact bounding box and the wordmark’s starting position, then set the crop width to the midpoint between them (rounded to four decimals, our stylelint `number-max-precision` limit). That gives roughly `2.3px` of margin on both sides instead of `0.24px` on one. Verified with static headless-Chromium screenshots (real compiled CSS and the real logo SVG, no Storybook needed) that the visible result is unchanged — still only the three crosses are shown, with no wordmark leaking through — across zoom levels from 67% to 200% and device-pixel ratios from 1× to 3×.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- Implements DES-1869.
- This only touches one SCSS value and its explanatory comment; no markup or component API changes.
