### PR TITLE
feat(Table of Contents): Add controlled expanded prop to Link

### DIFF
--- a/packages/react/src/TableOfContents/TableOfContentsLink.test.tsx
+++ b/packages/react/src/TableOfContents/TableOfContentsLink.test.tsx
@@ -5,11 +5,26 @@
 
 import type { AnchorHTMLAttributes } from 'react'
 
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { createRef, forwardRef } from 'react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { TableOfContents } from './TableOfContents'
+
+const renderCollapsible = (linkProps = {}, { collapsible = true } = {}) =>
+  render(
+    <TableOfContents collapsible={collapsible}>
+      <TableOfContents.List>
+        <TableOfContents.Link href="#parent" label="Parent" {...linkProps}>
+          <TableOfContents.List>
+            <TableOfContents.Link href="#child" label="Child" />
+          </TableOfContents.List>
+        </TableOfContents.Link>
+      </TableOfContents.List>
+    </TableOfContents>,
+  )
+
+const getParentItem = () => screen.getByRole('button').closest('li') as HTMLLIElement
 
 describe('TableOfContentsLink', () => {
   it('renders', () => {
@@ -93,5 +108,178 @@ describe('TableOfContentsLink', () => {
     render(<TableOfContents.Link href="/test" label="Test" linkComponent={CustomLink} ref={ref} />)
 
     expect(ref.current).toBeNull()
+  })
+
+  describe('when collapsible', () => {
+    it('renders a toggle button for a link with a nested list', () => {
+      renderCollapsible()
+
+      expect(screen.getByRole('button', { name: /Parent/ })).toBeInTheDocument()
+    })
+
+    it('does not render a toggle button when the parent is not collapsible', () => {
+      renderCollapsible({}, { collapsible: false })
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+
+    it('does not render a toggle button for a link without a nested list', () => {
+      render(
+        <TableOfContents collapsible>
+          <TableOfContents.List>
+            <TableOfContents.Link href="#parent" label="Parent" />
+          </TableOfContents.List>
+        </TableOfContents>,
+      )
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+
+    it('is collapsed by default', () => {
+      renderCollapsible()
+
+      expect(getParentItem()).toHaveClass('ams-table-of-contents__item--collapsed')
+      expect(screen.getByRole('button', { name: /Parent/ })).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('expands initially when defaultExpanded is set', () => {
+      renderCollapsible({ defaultExpanded: true })
+
+      expect(getParentItem()).not.toHaveClass('ams-table-of-contents__item--collapsed')
+      expect(screen.getByRole('button', { name: /Parent/ })).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('links the toggle button to the nested list via aria-controls', () => {
+      renderCollapsible()
+
+      const button = screen.getByRole('button', { name: /Parent/ })
+      const nestedListId = button.getAttribute('aria-controls')
+      const nestedList = getParentItem().querySelector('.ams-table-of-contents__list')
+
+      expect(nestedListId).toBeTruthy()
+      expect(nestedList).toHaveAttribute('id', nestedListId)
+    })
+
+    it('toggles the expanded state when the button is clicked', () => {
+      renderCollapsible()
+
+      const item = getParentItem()
+      const button = screen.getByRole('button', { name: /Parent/ })
+
+      expect(item).toHaveClass('ams-table-of-contents__item--collapsed')
+
+      fireEvent.click(button)
+
+      expect(item).not.toHaveClass('ams-table-of-contents__item--collapsed')
+      expect(button).toHaveAttribute('aria-expanded', 'true')
+
+      fireEvent.click(button)
+
+      expect(item).toHaveClass('ams-table-of-contents__item--collapsed')
+    })
+
+    it('calls onToggle with the new expanded state when the button is clicked', () => {
+      const onToggle = vi.fn()
+      renderCollapsible({ onToggle })
+
+      const button = screen.getByRole('button', { name: /Parent/ })
+
+      fireEvent.click(button)
+
+      expect(onToggle).toHaveBeenCalledTimes(1)
+      expect(onToggle).toHaveBeenCalledWith(true)
+
+      fireEvent.click(button)
+
+      expect(onToggle).toHaveBeenLastCalledWith(false)
+    })
+
+    it('does not throw when onToggle is not provided', () => {
+      renderCollapsible()
+
+      const button = screen.getByRole('button', { name: /Parent/ })
+
+      expect(() => fireEvent.click(button)).not.toThrow()
+    })
+
+    it('respects the expanded prop when true', () => {
+      renderCollapsible({ expanded: true })
+
+      expect(getParentItem()).not.toHaveClass('ams-table-of-contents__item--collapsed')
+    })
+
+    it('respects the expanded prop when false', () => {
+      renderCollapsible({ expanded: false })
+
+      expect(getParentItem()).toHaveClass('ams-table-of-contents__item--collapsed')
+    })
+
+    it('ignores defaultExpanded when expanded is provided', () => {
+      renderCollapsible({ defaultExpanded: true, expanded: false })
+
+      expect(getParentItem()).toHaveClass('ams-table-of-contents__item--collapsed')
+    })
+
+    it('does not toggle internally when controlled', () => {
+      renderCollapsible({ expanded: false })
+
+      const item = getParentItem()
+      const button = screen.getByRole('button', { name: /Parent/ })
+
+      fireEvent.click(button)
+
+      expect(item).toHaveClass('ams-table-of-contents__item--collapsed')
+    })
+
+    it('calls onToggle in controlled mode with the desired next state', () => {
+      const onToggle = vi.fn()
+      renderCollapsible({ expanded: false, onToggle })
+
+      fireEvent.click(screen.getByRole('button', { name: /Parent/ }))
+
+      expect(onToggle).toHaveBeenCalledTimes(1)
+      expect(onToggle).toHaveBeenCalledWith(true)
+      expect(getParentItem()).toHaveClass('ams-table-of-contents__item--collapsed')
+    })
+
+    it('responds to controlled prop changes', () => {
+      const { rerender } = renderCollapsible({ expanded: false })
+
+      expect(getParentItem()).toHaveClass('ams-table-of-contents__item--collapsed')
+
+      rerender(
+        <TableOfContents collapsible>
+          <TableOfContents.List>
+            <TableOfContents.Link expanded href="#parent" label="Parent">
+              <TableOfContents.List>
+                <TableOfContents.Link href="#child" label="Child" />
+              </TableOfContents.List>
+            </TableOfContents.Link>
+          </TableOfContents.List>
+        </TableOfContents>,
+      )
+
+      expect(getParentItem()).not.toHaveClass('ams-table-of-contents__item--collapsed')
+    })
+
+    it('ignores the expanded prop when the parent is not collapsible', () => {
+      renderCollapsible({ expanded: true }, { collapsible: false })
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+
+    it('moves focus to the toggle button when a collapse hides the focused nested link', () => {
+      renderCollapsible({ defaultExpanded: true })
+
+      const button = screen.getByRole('button', { name: /Parent/ })
+      const childLink = screen.getByRole('link', { name: 'Child' })
+
+      childLink.focus()
+      expect(childLink).toHaveFocus()
+
+      fireEvent.click(button)
+
+      expect(button).toHaveFocus()
+    })
   })
 })

--- a/packages/react/src/TableOfContents/TableOfContentsLink.tsx
+++ b/packages/react/src/TableOfContents/TableOfContentsLink.tsx
@@ -16,10 +16,16 @@ import { useCollapsibleItem } from './useCollapsibleItem'
 export type TableOfContentsLinkProps = {
   /**
    * Whether the nested list is initially expanded.
-   * Ignored when the parent `TableOfContents` is not `collapsible` or when there is no nested list.
+   * Ignored when the parent `TableOfContents` is not `collapsible`, when there is no nested list, or when `expanded` is provided.
    * @default false
    */
   readonly defaultExpanded?: boolean
+  /**
+   * Whether the nested list is expanded.
+   * When provided, the component is controlled and internal state is ignored.
+   * Ignored when the parent `TableOfContents` is not `collapsible` or when there is no nested list.
+   */
+  readonly expanded?: boolean
   /** The text for the link. */
   readonly label: string
   /**
@@ -41,12 +47,21 @@ export type TableOfContentsLinkProps = {
  */
 export const TableOfContentsLink = forwardRef(
   (
-    { children, className, defaultExpanded, label, linkComponent, onToggle, ...restProps }: TableOfContentsLinkProps,
+    {
+      children,
+      className,
+      defaultExpanded,
+      expanded,
+      label,
+      linkComponent,
+      onToggle,
+      ...restProps
+    }: TableOfContentsLinkProps,
     ref: ForwardedRef<HTMLAnchorElement>,
   ) => {
     const { hideAccessibleLabel, showAccessibleLabel } = useContext(TableOfContentsContext)
     const { buttonRef, handleToggle, isExpandable, isExpanded, itemRef, nestedListId, renderedChildren } =
-      useCollapsibleItem({ children, defaultExpanded, onToggle })
+      useCollapsibleItem({ children, defaultExpanded, expanded, onToggle })
 
     const Tag = linkComponent || 'a'
 

--- a/packages/react/src/TableOfContents/useCollapsibleItem.tsx
+++ b/packages/react/src/TableOfContents/useCollapsibleItem.tsx
@@ -5,8 +5,9 @@
 
 import type { ReactElement, ReactNode } from 'react'
 
-import { Children, cloneElement, isValidElement, useContext, useId, useRef, useState } from 'react'
+import { Children, cloneElement, isValidElement, useContext, useId, useRef } from 'react'
 
+import { useCollapsible } from '../common/useCollapsible'
 import { TableOfContentsContext } from './TableOfContentsContext'
 import { TableOfContentsList } from './TableOfContentsList'
 
@@ -23,20 +24,21 @@ const findListChild = (children: ReactNode): ReactElement | undefined => {
 type UseCollapsibleItemProps = {
   children: ReactNode
   defaultExpanded?: boolean
+  expanded?: boolean
   onToggle?: (expanded: boolean) => void
 }
 
 /**
  * Drives the collapsible behaviour of a `TableOfContents.Link` that wraps a nested list: it tracks the
- * expanded state, links the toggle button to the nested list through a stable `aria-controls` id, and
- * restores focus to the toggle when collapsing a subtree that holds focus.
+ * expanded state (controlled via `expanded` or uncontrolled via `defaultExpanded`), links the toggle
+ * button to the nested list through a stable `aria-controls` id, and restores focus to the toggle when
+ * collapsing a subtree that holds focus.
  *
  * Returns the refs, state, and rendered children the link needs; it deliberately leaves the markup and
  * the accessible label text to the component.
  */
-export const useCollapsibleItem = ({ children, defaultExpanded, onToggle }: UseCollapsibleItemProps) => {
+export const useCollapsibleItem = ({ children, defaultExpanded, expanded, onToggle }: UseCollapsibleItemProps) => {
   const { collapsible } = useContext(TableOfContentsContext)
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded ?? false)
 
   const panelId = useId()
   const buttonRef = useRef<HTMLButtonElement>(null)
@@ -44,6 +46,14 @@ export const useCollapsibleItem = ({ children, defaultExpanded, onToggle }: UseC
 
   const listChild = findListChild(children)
   const isExpandable = collapsible && !!listChild
+
+  const [isExpanded, toggle] = useCollapsible({
+    defaultValue: defaultExpanded,
+    gate: isExpandable,
+    onToggle,
+    value: expanded,
+  })
+
   // Reuse a provided nested list id to keep aria-controls references stable, but ignore a blank
   // id so aria-controls never points at an empty string.
   const providedListId = (listChild?.props as { id?: string } | undefined)?.id
@@ -60,12 +70,10 @@ export const useCollapsibleItem = ({ children, defaultExpanded, onToggle }: UseC
     }
   }
 
-  // Toggles the local expanded state and emits the new expanded state
+  // Restore focus before the toggle hides the subtree, then toggle the (controlled or internal) state.
   const handleToggle = () => {
-    const nextIsExpanded = !isExpanded
-    moveFocusToToggleButton(nextIsExpanded)
-    setIsExpanded(nextIsExpanded)
-    onToggle?.(nextIsExpanded)
+    moveFocusToToggleButton(!isExpanded)
+    toggle()
   }
 
   // When expandable, clone the nested list so it receives the id referenced by aria-controls.

--- a/packages/react/src/common/useCollapsible.test.tsx
+++ b/packages/react/src/common/useCollapsible.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useCollapsible } from './useCollapsible'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useCollapsible', () => {
+  describe('uncontrolled', () => {
+    it('defaults to false', () => {
+      const { result } = renderHook(() => useCollapsible({}))
+
+      expect(result.current[0]).toBe(false)
+    })
+
+    it('uses fallback when no value or defaultValue is provided', () => {
+      const { result } = renderHook(() => useCollapsible({ fallback: true }))
+
+      expect(result.current[0]).toBe(true)
+    })
+
+    it('seeds the initial value from defaultValue', () => {
+      const { result } = renderHook(() => useCollapsible({ defaultValue: true }))
+
+      expect(result.current[0]).toBe(true)
+    })
+
+    it('prefers defaultValue over fallback', () => {
+      const { result } = renderHook(() => useCollapsible({ defaultValue: false, fallback: true }))
+
+      expect(result.current[0]).toBe(false)
+    })
+
+    it('toggles the internal value', () => {
+      const { result } = renderHook(() => useCollapsible({}))
+
+      act(() => result.current[1]())
+
+      expect(result.current[0]).toBe(true)
+
+      act(() => result.current[1]())
+
+      expect(result.current[0]).toBe(false)
+    })
+
+    it('fires onToggle with the next value', () => {
+      const onToggle = vi.fn()
+      const { result } = renderHook(() => useCollapsible({ onToggle }))
+
+      act(() => result.current[1]())
+
+      expect(onToggle).toHaveBeenCalledTimes(1)
+      expect(onToggle).toHaveBeenCalledWith(true)
+
+      act(() => result.current[1]())
+
+      expect(onToggle).toHaveBeenLastCalledWith(false)
+    })
+
+    it('ignores a later defaultValue change', () => {
+      const { rerender, result } = renderHook((props) => useCollapsible(props), {
+        initialProps: { defaultValue: false },
+      })
+
+      rerender({ defaultValue: true })
+
+      expect(result.current[0]).toBe(false)
+    })
+
+    it('reports that it is not controlled', () => {
+      const { result } = renderHook(() => useCollapsible({}))
+
+      expect(result.current[2]).toBe(false)
+    })
+  })
+
+  describe('controlled', () => {
+    it('reflects the controlled value and ignores defaultValue', () => {
+      const { result } = renderHook(() => useCollapsible({ defaultValue: false, value: true }))
+
+      expect(result.current[0]).toBe(true)
+      expect(result.current[2]).toBe(true)
+    })
+
+    it('does not mutate the value when toggled', () => {
+      const { result } = renderHook(() => useCollapsible({ value: true }))
+
+      act(() => result.current[1]())
+
+      expect(result.current[0]).toBe(true)
+    })
+
+    it('fires onToggle with the next value even though the value does not change', () => {
+      const onToggle = vi.fn()
+      const { result } = renderHook(() => useCollapsible({ onToggle, value: true }))
+
+      act(() => result.current[1]())
+
+      expect(onToggle).toHaveBeenCalledTimes(1)
+      expect(onToggle).toHaveBeenCalledWith(false)
+    })
+
+    it('responds to controlled value changes', () => {
+      const { rerender, result } = renderHook((props) => useCollapsible(props), {
+        initialProps: { value: true },
+      })
+
+      expect(result.current[0]).toBe(true)
+
+      rerender({ value: false })
+
+      expect(result.current[0]).toBe(false)
+    })
+  })
+
+  describe('gate', () => {
+    it('falls back to the internal value and ignores the controlled value when gated off', () => {
+      const { result } = renderHook(() => useCollapsible({ gate: false, value: true }))
+
+      expect(result.current[0]).toBe(false)
+      expect(result.current[2]).toBe(false)
+    })
+
+    it('does nothing and does not fire onToggle when gated off', () => {
+      const onToggle = vi.fn()
+      const { result } = renderHook(() => useCollapsible({ gate: false, onToggle }))
+
+      act(() => result.current[1]())
+
+      expect(result.current[0]).toBe(false)
+      expect(onToggle).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('controlled/uncontrolled switch warning', () => {
+    it('warns when switching from uncontrolled to controlled', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { rerender } = renderHook((props) => useCollapsible(props), {
+        initialProps: { value: undefined as boolean | undefined },
+      })
+
+      rerender({ value: true })
+
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('uncontrolled to controlled'))
+    })
+
+    it('warns when switching from controlled to uncontrolled', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { rerender } = renderHook((props) => useCollapsible(props), {
+        initialProps: { value: true as boolean | undefined },
+      })
+
+      rerender({ value: undefined })
+
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('controlled to uncontrolled'))
+    })
+
+    it('does not warn on stable rerenders', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { rerender } = renderHook((props) => useCollapsible(props), {
+        initialProps: { value: true },
+      })
+
+      rerender({ value: false })
+      rerender({ value: true })
+
+      expect(warn).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/react/src/common/useCollapsible.tsx
+++ b/packages/react/src/common/useCollapsible.tsx
@@ -1,0 +1,74 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { useEffect, useRef, useState } from 'react'
+
+type UseCollapsibleProps = {
+  /**
+   * The uncontrolled initial value. Read only when the component mounts, so later changes are ignored.
+   * Overridden by `value` when the component is controlled.
+   */
+  defaultValue?: boolean
+  /** The value to fall back to when neither `value` nor `defaultValue` is provided. */
+  fallback?: boolean
+  /**
+   * Whether the collapsible behaviour is active at all. When `false`, the state is inert:
+   * `value` is never read and `toggle` does nothing. Defaults to `true`.
+   */
+  gate?: boolean
+  /** Fired on every toggle with the next value. Fires in both controlled and uncontrolled modes. */
+  onToggle?: (next: boolean) => void
+  /** The controlled value. When provided (and `gate` is `true`), the component is controlled. */
+  value?: boolean
+}
+
+/**
+ * Drives the shared controlled/uncontrolled behaviour of a collapsible component.
+ *
+ * Pass `value` to control the component from a parent; leave it undefined to let the component
+ * hold its own state, seeded once by `defaultValue` (or `fallback`). `onToggle` always fires with
+ * the next value, so a controlled parent can update `value` and an uncontrolled consumer can observe
+ * changes. The internal state is only mutated when uncontrolled, so the two modes never fight.
+ *
+ * @returns A tuple of the current value, a toggle function, and whether the component is controlled.
+ */
+export const useCollapsible = ({
+  defaultValue,
+  fallback = false,
+  gate = true,
+  onToggle,
+  value,
+}: UseCollapsibleProps): readonly [boolean, () => void, boolean] => {
+  const isControlled = gate && value !== undefined
+  const [internalValue, setInternalValue] = useState(defaultValue ?? fallback)
+  const current = isControlled ? (value as boolean) : internalValue
+
+  // Warn once when the component flips between controlled and uncontrolled, mirroring React’s own
+  // guardrail for form inputs. Track the presence of `value` rather than `isControlled` so a change
+  // in `gate` alone (which the consumer does not choose per render) never trips the warning.
+  const isValueProvided = value !== undefined
+  const wasValueProvidedRef = useRef(isValueProvided)
+  useEffect(() => {
+    if (wasValueProvidedRef.current !== isValueProvided) {
+      console.warn(
+        `A collapsible component is changing from ${
+          wasValueProvidedRef.current ? 'controlled to uncontrolled' : 'uncontrolled to controlled'
+        }. Decide for its lifetime: pass a value for controlled, or leave it undefined for uncontrolled.`,
+      )
+      wasValueProvidedRef.current = isValueProvided
+    }
+  }, [isValueProvided])
+
+  const toggle = () => {
+    if (!gate) return
+
+    const next = !current
+    // Only mutate internal state when uncontrolled; a controlled parent owns the value.
+    if (!isControlled) setInternalValue(next)
+    onToggle?.(next)
+  }
+
+  return [current, toggle, isControlled] as const
+}

--- a/packages/react/src/common/useCollapsible.tsx
+++ b/packages/react/src/common/useCollapsible.tsx
@@ -15,7 +15,7 @@ type UseCollapsibleProps = {
   fallback?: boolean
   /**
    * Whether the collapsible behaviour is active at all. When `false`, the state is inert:
-   * `value` is never read and `toggle` does nothing. Defaults to `true`.
+   * `value` no longer affects the returned state and `toggle` does nothing. Defaults to `true`.
    */
   gate?: boolean
   /** Fired on every toggle with the next value. Fires in both controlled and uncontrolled modes. */

--- a/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
+++ b/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
@@ -27,6 +27,7 @@ The List has no props of its own; the ‘Multiple levels’ example shows how to
 
 Points to a section or page; provide its text through the `label` prop.
 Use `defaultExpanded` to initially show its nested list when the Table of Contents is collapsible.
+To drive the expanded state from your own code, pass `expanded` together with `onToggle` instead.
 
 <Canvas of={TableOfContentsLinkStories.Link} />
 
@@ -61,6 +62,14 @@ The toggle expands and collapses the nested list without following the link.
 Use `defaultExpanded` on a Link to pre-open its nested list when the component mounts, for example to show the ancestors of the current page.
 
 <Canvas of={TableOfContentsStories.Collapsible} />
+
+### Controlled
+
+Each Link manages its own expanded state by default.
+To drive that state yourself, pass `expanded` to a Link and update it from its `onToggle` callback.
+This example keeps a single branch open at a time by expanding the clicked branch and collapsing the others.
+
+<Canvas of={TableOfContentsStories.Controlled} />
 
 ## Accessibility
 

--- a/storybook/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/storybook/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -6,6 +6,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { TableOfContents } from '@amsterdam/design-system-react/src'
+import { useState } from 'react'
 
 import { headingLevelArgType } from '#storybook/_common/argTypes'
 
@@ -110,5 +111,46 @@ export const Collapsible: Story = {
     ),
     collapsible: true,
     heading: 'Inhoudsopgave',
+  },
+}
+
+export const Controlled: Story = {
+  args: {
+    collapsible: true,
+    heading: 'Inhoudsopgave',
+  },
+  render: (args) => {
+    const [expandedBranch, setExpandedBranch] = useState<string | null>('functies')
+
+    return (
+      <TableOfContents {...args}>
+        <TableOfContents.List>
+          <TableOfContents.Link href="#s1" label="Inleiding" />
+          <TableOfContents.Link
+            expanded={expandedBranch === 'functies'}
+            href="#s2"
+            label="Vaststellen en waarderen van functies"
+            onToggle={(expanded) => setExpandedBranch(expanded ? 'functies' : null)}
+          >
+            <TableOfContents.List>
+              <TableOfContents.Link href="#s2-1" label="Algemeen" />
+              <TableOfContents.Link href="#s2-2" label="Waardering van functies" />
+            </TableOfContents.List>
+          </TableOfContents.Link>
+          <TableOfContents.Link
+            expanded={expandedBranch === 'toelagen'}
+            href="#s3"
+            label="Salaristoelagen"
+            onToggle={(expanded) => setExpandedBranch(expanded ? 'toelagen' : null)}
+          >
+            <TableOfContents.List>
+              <TableOfContents.Link href="#s3-1" label="Functioneringstoelage" />
+              <TableOfContents.Link href="#s3-2" label="Arbeidsmarkttoelage" />
+            </TableOfContents.List>
+          </TableOfContents.Link>
+          <TableOfContents.Link href="#s4" label="Vergoedingen" />
+        </TableOfContents.List>
+      </TableOfContents>
+    )
   },
 }

--- a/storybook/src/components/TableOfContents/TableOfContents.test.stories.tsx
+++ b/storybook/src/components/TableOfContents/TableOfContents.test.stories.tsx
@@ -22,10 +22,11 @@ type Story = StoryObj<typeof meta>
 export const Test: Story = {
   play: async ({ canvas, userEvent }) => {
     const toggle = canvas.getByRole('button', { name: /Salaristoelagen/ })
-    const nestedLink = canvas.getByRole('link', { name: 'Functioneringstoelage' })
-
-    // The nested list is hidden with `display: none` until its toggle is clicked, so this asserts the
+    // The nested link starts hidden with `display: none`, so it is outside the accessibility tree and
+    // must be queried with `hidden: true`. Asserting visibility before and after the click covers the
     // real CSS show/hide contract that the class-name-only unit tests cannot reach.
+    const nestedLink = canvas.getByRole('link', { hidden: true, name: 'Functioneringstoelage' })
+
     await expect(nestedLink).not.toBeVisible()
 
     await userEvent.click(toggle)

--- a/storybook/src/components/TableOfContents/TableOfContents.test.stories.tsx
+++ b/storybook/src/components/TableOfContents/TableOfContents.test.stories.tsx
@@ -6,6 +6,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { TableOfContents } from '@amsterdam/design-system-react/src'
+import { expect } from 'storybook/test'
 
 import { default as tableOfContentsMeta } from './TableOfContents.stories'
 
@@ -19,6 +20,18 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
+  play: async ({ canvas, userEvent }) => {
+    const toggle = canvas.getByRole('button', { name: /Salaristoelagen/ })
+    const nestedLink = canvas.getByRole('link', { name: 'Functioneringstoelage' })
+
+    // The nested list is hidden with `display: none` until its toggle is clicked, so this asserts the
+    // real CSS show/hide contract that the class-name-only unit tests cannot reach.
+    await expect(nestedLink).not.toBeVisible()
+
+    await userEvent.click(toggle)
+
+    await expect(nestedLink).toBeVisible()
+  },
   render: () => (
     <div className="_ams-tests-stack">
       <TableOfContents heading="Op deze pagina">


### PR DESCRIPTION
## What

- Add a shared `useCollapsible` hook that captures the controlled/uncontrolled pattern for collapsible components, based on Progress List Step’s implementation.
- Add a controlled `expanded` prop to Table of Contents `Link`, alongside the existing uncontrolled `defaultExpanded`. Together with `onToggle`, a parent can now drive a Link’s expanded state — for example to keep a single branch open at a time.

## Why

- Table of Contents `Link` was uncontrolled only: `defaultExpanded` seeded the state at mount and there was no way to drive or override it afterwards.
- This is the first step of making all collapsible subcomponents controllable in a consistent way. Progress List Step already ships this pattern; extracting it into a shared hook lets Accordion and Progress List converge on the same implementation in follow-up PRs.

## How

- New `useCollapsible` hook (`packages/react/src/common`): it derives whether the component is controlled from the presence of the value each render, only mutates internal state when uncontrolled, and fires `onToggle` with the next value in both modes. It also takes a `gate` (so a non-expandable Link stays inert) and warns once if a component flips between controlled and uncontrolled, mirroring React’s own guardrail for form inputs.
- `useCollapsibleItem` now delegates its state to `useCollapsible`, passing `expanded`, `defaultExpanded`, and `isExpandable` as the gate. The existing focus-restoration behaviour on collapse is unchanged.
- The Link keeps the “expanded” vocabulary (matching `aria-expanded` and the existing `defaultExpanded`/`onToggle`), so nothing is renamed.

## Checklist

- [x] Add or update unit tests — new `useCollapsible.test.tsx`, and a “when collapsible” suite added to `TableOfContentsLink.test.tsx` covering toggling, `aria-expanded`/`aria-controls`, controlled mode, and focus restoration (this path had no tests before).
- [x] Add or update documentation — new “Controlled” section on the Table of Contents docs page.
- [x] Add or update stories — new `Controlled` story demonstrating single-open branches.
- [x] Add or update exports in index.\* files — not necessary; `expanded` rides on the already-exported `TableOfContentsLinkProps`, and `useCollapsible` is an internal hook like the other `common/` hooks.
- [x] Comment `/chromatic test` and verify visual regression tests pass — runs automatically on PR creation.
- [x] Start the PR title with a Conventional Commit prefix.

## Additional notes

- Part of a series making all collapsible subcomponents controllable; Accordion, Progress List alignment, and Page Header follow in separate branches and PRs.
- The new example lives under Components → Navigation → Table of Contents → Controlled.
- Known limitation for a follow-up: focus restoration runs on click-driven collapse. If a controlled parent collapses a branch that holds focus programmatically (not via the toggle button), focus is not yet moved to the toggle. This is worth handling alongside a future compound single-open mode.
