### PR TITLE
feat(Page Header): Add controlled open prop to the mega menu

### DIFF
--- a/packages/react/src/PageHeader/PageHeader.test.tsx
+++ b/packages/react/src/PageHeader/PageHeader.test.tsx
@@ -385,6 +385,28 @@ describe('PageHeader', () => {
     expect(container.querySelector('.ams-page-header__mega-menu')).not.toHaveClass('ams-page-header__mega-menu--closed')
   })
 
+  it('does not open on mount with defaultOpen when the menu button is hidden on a wide window', () => {
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = vi.fn().mockReturnValue({
+      addEventListener: vi.fn(),
+      matches: true, // wide window
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList)
+
+    try {
+      const { container } = render(
+        <PageHeader defaultOpen noMenuButtonOnWideWindow>
+          Test
+        </PageHeader>,
+      )
+
+      // There is no menu button on a wide window, so the menu must not start open.
+      expect(container.querySelector('.ams-page-header__mega-menu')).toHaveClass('ams-page-header__mega-menu--closed')
+    } finally {
+      window.matchMedia = originalMatchMedia
+    }
+  })
+
   it('fires onOpenChange when the open mega menu is force-closed on a wide window', async () => {
     let changeListener: (() => void) | undefined
     const mediaQueryList = {

--- a/packages/react/src/PageHeader/PageHeader.test.tsx
+++ b/packages/react/src/PageHeader/PageHeader.test.tsx
@@ -211,6 +211,24 @@ describe('PageHeader', () => {
     expect(openMegaMenu).not.toHaveClass('ams-page-header__mega-menu--closed')
   })
 
+  it('gives each mega menu a unique id that its own button controls', () => {
+    const { container } = render(
+      <>
+        <PageHeader>Menu one</PageHeader>
+        <PageHeader>Menu two</PageHeader>
+      </>,
+    )
+
+    const megaMenus = container.querySelectorAll('.ams-page-header__mega-menu')
+    const menuButtons = container.querySelectorAll('.ams-page-header__mega-menu-button')
+
+    expect(megaMenus).toHaveLength(2)
+    expect(megaMenus[0].id).toBeTruthy()
+    expect(megaMenus[0].id).not.toBe(megaMenus[1].id)
+    expect(menuButtons[0]).toHaveAttribute('aria-controls', megaMenus[0].id)
+    expect(menuButtons[1]).toHaveAttribute('aria-controls', megaMenus[1].id)
+  })
+
   it('updates the menu button text for screen readers when the menu is opened and closed', async () => {
     const user = userEvent.setup()
 

--- a/packages/react/src/PageHeader/PageHeader.test.tsx
+++ b/packages/react/src/PageHeader/PageHeader.test.tsx
@@ -359,4 +359,199 @@ describe('PageHeader', () => {
     expect(component).toHaveAttribute('id', 'id')
     expect(component).toHaveAttribute('data-test', 'data-test')
   })
+
+  it('calls onOpenChange with the new state when the menu button is clicked', async () => {
+    const onOpenChange = vi.fn()
+    const user = userEvent.setup()
+
+    const { container } = render(<PageHeader onOpenChange={onOpenChange}>Test</PageHeader>)
+
+    const menuButton = screen.getByRole('button', { hidden: true, name: 'Laat navigatiemenu zien' })
+
+    await user.click(menuButton)
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1)
+    expect(onOpenChange).toHaveBeenCalledWith(true)
+    expect(container.querySelector('.ams-page-header__mega-menu')).not.toHaveClass('ams-page-header__mega-menu--closed')
+
+    await user.click(menuButton)
+
+    expect(onOpenChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('opens the mega menu on mount when defaultOpen is set', () => {
+    const { container } = render(<PageHeader defaultOpen>Test</PageHeader>)
+
+    expect(container.querySelector('.ams-page-header__mega-menu')).not.toHaveClass('ams-page-header__mega-menu--closed')
+  })
+
+  it('fires onOpenChange when the open mega menu is force-closed on a wide window', async () => {
+    let changeListener: (() => void) | undefined
+    const mediaQueryList = {
+      addEventListener: vi.fn((_event: string, listener: () => void) => {
+        changeListener = listener
+      }),
+      matches: false,
+      removeEventListener: vi.fn(),
+    }
+
+    const originalMatchMedia = window.matchMedia
+    window.matchMedia = vi.fn().mockReturnValue(mediaQueryList as unknown as MediaQueryList)
+
+    try {
+      const onOpenChange = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <PageHeader noMenuButtonOnWideWindow onOpenChange={onOpenChange}>
+          Test
+        </PageHeader>,
+      )
+
+      const menuButton = screen.getByRole('button', { hidden: true, name: 'Laat navigatiemenu zien' })
+      await user.click(menuButton)
+
+      expect(onOpenChange).toHaveBeenLastCalledWith(true)
+
+      // Simulate the viewport crossing the 'wide' breakpoint: the button hides and the menu force-closes.
+      mediaQueryList.matches = true
+      act(() => {
+        changeListener?.()
+      })
+
+      expect(onOpenChange).toHaveBeenLastCalledWith(false)
+    } finally {
+      window.matchMedia = originalMatchMedia
+    }
+  })
+
+  describe('when controlled', () => {
+    it('renders the mega menu open when open is true', () => {
+      const { container } = render(<PageHeader open>Test</PageHeader>)
+
+      expect(container.querySelector('.ams-page-header__mega-menu')).not.toHaveClass(
+        'ams-page-header__mega-menu--closed',
+      )
+      expect(screen.getByRole('button', { hidden: true })).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('renders the mega menu closed when open is false', () => {
+      const { container } = render(<PageHeader open={false}>Test</PageHeader>)
+
+      expect(container.querySelector('.ams-page-header__mega-menu')).toHaveClass('ams-page-header__mega-menu--closed')
+    })
+
+    it('does not toggle internally when controlled', async () => {
+      const user = userEvent.setup()
+
+      const { container } = render(<PageHeader open={false}>Test</PageHeader>)
+
+      const menuButton = screen.getByRole('button', { hidden: true, name: 'Laat navigatiemenu zien' })
+
+      await user.click(menuButton)
+
+      expect(container.querySelector('.ams-page-header__mega-menu')).toHaveClass('ams-page-header__mega-menu--closed')
+    })
+
+    it('calls onOpenChange with the desired next state without changing itself', async () => {
+      const onOpenChange = vi.fn()
+      const user = userEvent.setup()
+
+      const { container } = render(
+        <PageHeader onOpenChange={onOpenChange} open={false}>
+          Test
+        </PageHeader>,
+      )
+
+      await user.click(screen.getByRole('button', { hidden: true, name: 'Laat navigatiemenu zien' }))
+
+      expect(onOpenChange).toHaveBeenCalledTimes(1)
+      expect(onOpenChange).toHaveBeenCalledWith(true)
+      expect(container.querySelector('.ams-page-header__mega-menu')).toHaveClass('ams-page-header__mega-menu--closed')
+    })
+
+    it('responds to open prop changes', () => {
+      const { container, rerender } = render(<PageHeader open={false}>Test</PageHeader>)
+
+      expect(container.querySelector('.ams-page-header__mega-menu')).toHaveClass('ams-page-header__mega-menu--closed')
+
+      rerender(<PageHeader open>Test</PageHeader>)
+
+      expect(container.querySelector('.ams-page-header__mega-menu')).not.toHaveClass(
+        'ams-page-header__mega-menu--closed',
+      )
+    })
+
+    it('ignores defaultOpen when open is provided', () => {
+      const { container } = render(
+        <PageHeader defaultOpen open={false}>
+          Test
+        </PageHeader>,
+      )
+
+      expect(container.querySelector('.ams-page-header__mega-menu')).toHaveClass('ams-page-header__mega-menu--closed')
+    })
+
+    it('notifies but does not change itself when force-closed on a wide window', () => {
+      let changeListener: (() => void) | undefined
+      const mediaQueryList = {
+        addEventListener: vi.fn((_event: string, listener: () => void) => {
+          changeListener = listener
+        }),
+        matches: false,
+        removeEventListener: vi.fn(),
+      }
+
+      const originalMatchMedia = window.matchMedia
+      window.matchMedia = vi.fn().mockReturnValue(mediaQueryList as unknown as MediaQueryList)
+
+      try {
+        const onOpenChange = vi.fn()
+        const { container } = render(
+          <PageHeader noMenuButtonOnWideWindow onOpenChange={onOpenChange} open>
+            Test
+          </PageHeader>,
+        )
+
+        // Cross the 'wide' breakpoint so the button hides while the parent still controls `open` as true.
+        mediaQueryList.matches = true
+        act(() => {
+          changeListener?.()
+        })
+
+        // The component requests a close via the callback but leaves the visual state to the parent.
+        expect(onOpenChange).toHaveBeenCalledWith(false)
+        expect(container.querySelector('.ams-page-header__mega-menu')).not.toHaveClass(
+          'ams-page-header__mega-menu--closed',
+        )
+      } finally {
+        window.matchMedia = originalMatchMedia
+      }
+    })
+  })
+
+  describe('controlled/uncontrolled switch warning', () => {
+    it('warns when switching from uncontrolled to controlled', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const { rerender } = render(<PageHeader>Test</PageHeader>)
+
+      rerender(<PageHeader open>Test</PageHeader>)
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('uncontrolled to controlled'))
+
+      warn.mockRestore()
+    })
+
+    it('warns when switching from controlled to uncontrolled', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const { rerender } = render(<PageHeader open>Test</PageHeader>)
+
+      rerender(<PageHeader>Test</PageHeader>)
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('controlled to uncontrolled'))
+
+      warn.mockRestore()
+    })
+  })
 })

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -98,8 +98,6 @@ const PageHeaderRoot = forwardRef(
     ref: ForwardedRef<HTMLElement>,
   ) => {
     const isControlled = open !== undefined
-    const [internalOpen, setInternalOpen] = useState(defaultOpen ?? false)
-    const isOpen = isControlled ? open : internalOpen
 
     const viewportHasMinWidth = useViewportHasMinWidth('wide')
     const accessibleLabelId = useId()
@@ -107,6 +105,10 @@ const PageHeaderRoot = forwardRef(
     const hasMegaMenu = Boolean(children)
     const hasMegaMenuOnWideWindow = hasMegaMenu && viewportHasMinWidth
     const menuButtonHidden = noMenuButtonOnWideWindow && hasMegaMenuOnWideWindow
+
+    // Don't start open when the menu button is hidden on a wide window: there would then be no control to close it.
+    const [internalOpen, setInternalOpen] = useState((defaultOpen ?? false) && !menuButtonHidden)
+    const isOpen = isControlled ? open : internalOpen
 
     // Warn once when the component flips between controlled and uncontrolled, mirroring React’s guardrail for inputs.
     const wasControlledRef = useRef(isControlled)

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -103,6 +103,7 @@ const PageHeaderRoot = forwardRef(
 
     const viewportHasMinWidth = useViewportHasMinWidth('wide')
     const accessibleLabelId = useId()
+    const megaMenuId = useId()
     const hasMegaMenu = Boolean(children)
     const hasMegaMenuOnWideWindow = hasMegaMenu && viewportHasMinWidth
     const menuButtonHidden = noMenuButtonOnWideWindow && hasMegaMenuOnWideWindow
@@ -184,7 +185,7 @@ const PageHeaderRoot = forwardRef(
                   hidden // Hide the list item containing the menu button until its CSS loads. If it doesn't load, the menu will always be visible.
                 >
                   <button
-                    aria-controls="ams-page-header-mega-menu"
+                    aria-controls={megaMenuId}
                     aria-expanded={isOpen}
                     className="ams-page-header__mega-menu-button"
                     onClick={handleMenuButtonClick}
@@ -213,7 +214,7 @@ const PageHeaderRoot = forwardRef(
             {hasMegaMenu && (
               <div
                 className={clsx('ams-page-header__mega-menu', !isOpen && 'ams-page-header__mega-menu--closed')}
-                id="ams-page-header-mega-menu"
+                id={megaMenuId}
               >
                 {children}
               </div>

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -6,7 +6,7 @@
 import type { AnchorHTMLAttributes, ElementType, ForwardedRef, HTMLAttributes, ReactNode } from 'react'
 
 import { clsx } from 'clsx'
-import { forwardRef, useId, useState } from 'react'
+import { forwardRef, useEffect, useId, useRef, useState } from 'react'
 
 import type { IconProps } from '../Icon'
 import type { LogoBrand } from '../Logo'
@@ -29,6 +29,12 @@ export type PageHeaderProps = {
    * Provide this only together with a `brandName`.
    */
   readonly brandNameShort?: string
+  /**
+   * Whether the mega menu is open initially.
+   * Ignored when `open` is provided.
+   * @default false
+   */
+  readonly defaultOpen?: boolean
   /** The accessible name of the logo. */
   readonly logoAccessibleName?: string
   /** The name of the brand for which to display the logo. */
@@ -56,6 +62,13 @@ export type PageHeaderProps = {
   readonly navigationLabel?: string
   /** Hides the menu button on wide windows. */
   readonly noMenuButtonOnWideWindow?: boolean
+  /** Callback fired when the mega menu is opened or closed. Receives the new open state. */
+  readonly onOpenChange?: (open: boolean) => void
+  /**
+   * Whether the mega menu is open.
+   * When provided, the component is controlled and internal state is ignored.
+   */
+  readonly open?: boolean
 } & Readonly<HTMLAttributes<HTMLElement>>
 
 const PageHeaderRoot = forwardRef(
@@ -65,6 +78,7 @@ const PageHeaderRoot = forwardRef(
       brandNameShort,
       children,
       className,
+      defaultOpen,
       logoAccessibleName,
       logoBrand = 'amsterdam',
       logoLink = '/',
@@ -77,11 +91,15 @@ const PageHeaderRoot = forwardRef(
       menuItems,
       navigationLabel = 'Hoofdmenu',
       noMenuButtonOnWideWindow,
+      onOpenChange,
+      open,
       ...restProps
     }: PageHeaderProps,
     ref: ForwardedRef<HTMLElement>,
   ) => {
-    const [open, setOpen] = useState(false)
+    const isControlled = open !== undefined
+    const [internalOpen, setInternalOpen] = useState(defaultOpen ?? false)
+    const isOpen = isControlled ? open : internalOpen
 
     const viewportHasMinWidth = useViewportHasMinWidth('wide')
     const accessibleLabelId = useId()
@@ -89,14 +107,45 @@ const PageHeaderRoot = forwardRef(
     const hasMegaMenuOnWideWindow = hasMegaMenu && viewportHasMinWidth
     const menuButtonHidden = noMenuButtonOnWideWindow && hasMegaMenuOnWideWindow
 
-    // Close the menu when its button is hidden, and keep it closed when the button returns: there is then no control to reopen it.
+    // Warn once when the component flips between controlled and uncontrolled, mirroring React’s guardrail for inputs.
+    const wasControlledRef = useRef(isControlled)
+    useEffect(() => {
+      if (wasControlledRef.current !== isControlled) {
+        console.warn(
+          `PageHeader is changing from ${
+            wasControlledRef.current ? 'controlled to uncontrolled' : 'uncontrolled to controlled'
+          }. Decide for its lifetime: pass \`open\` for controlled, or leave it undefined for uncontrolled.`,
+        )
+        wasControlledRef.current = isControlled
+      }
+    }, [isControlled])
+
+    // Close the menu when its button hides on a wide window, and keep it closed when the button returns: there is then
+    // no control to reopen it. Adjusting state while rendering is the recommended pattern for this internal reset.
     const [menuButtonWasHidden, setMenuButtonWasHidden] = useState(menuButtonHidden)
     if (menuButtonHidden !== menuButtonWasHidden) {
       setMenuButtonWasHidden(menuButtonHidden)
-      /* v8 ignore next -- setState above causes React to discard and retry this render; v8 cannot track the false branch across the retry */
-      if (menuButtonHidden) {
-        setOpen(false)
+      if (menuButtonHidden && isOpen && !isControlled) {
+        setInternalOpen(false)
       }
+    }
+
+    // Notify a listening parent when hiding the button force-closes the menu. This runs in an effect so it never
+    // updates a controlled parent during render; the refs capture the hide transition and the prior open state.
+    const wasMenuButtonHiddenRef = useRef(menuButtonHidden)
+    const wasOpenRef = useRef(isOpen)
+    useEffect(() => {
+      if (!wasMenuButtonHiddenRef.current && menuButtonHidden && wasOpenRef.current) {
+        onOpenChange?.(false)
+      }
+      wasMenuButtonHiddenRef.current = menuButtonHidden
+      wasOpenRef.current = isOpen
+    }, [isOpen, menuButtonHidden, onOpenChange])
+
+    const handleMenuButtonClick = () => {
+      const nextOpen = !isOpen
+      if (!isControlled) setInternalOpen(nextOpen)
+      onOpenChange?.(nextOpen)
     }
 
     const LogoLink = logoLinkComponent
@@ -136,20 +185,22 @@ const PageHeaderRoot = forwardRef(
                 >
                   <button
                     aria-controls="ams-page-header-mega-menu"
-                    aria-expanded={open}
+                    aria-expanded={isOpen}
                     className="ams-page-header__mega-menu-button"
-                    onClick={() => setOpen((wasOpen) => !wasOpen)}
+                    onClick={handleMenuButtonClick}
                     type="button"
                   >
                     <span aria-hidden="true" className="ams-page-header__mega-menu-button-label">
                       {menuButtonText}
                     </span>
-                    <span className="ams-visually-hidden">{open ? menuButtonTextForHide : menuButtonTextForShow}</span>
+                    <span className="ams-visually-hidden">
+                      {isOpen ? menuButtonTextForHide : menuButtonTextForShow}
+                    </span>
                     <Icon
                       svg={
                         menuButtonIcon ?? (
                           <PageHeaderMenuIcon
-                            className={clsx('ams-page-header__menu-icon', open && 'ams-page-header__menu-icon--open')}
+                            className={clsx('ams-page-header__menu-icon', isOpen && 'ams-page-header__menu-icon--open')}
                           />
                         )
                       }
@@ -161,7 +212,7 @@ const PageHeaderRoot = forwardRef(
 
             {hasMegaMenu && (
               <div
-                className={clsx('ams-page-header__mega-menu', !open && 'ams-page-header__mega-menu--closed')}
+                className={clsx('ams-page-header__mega-menu', !isOpen && 'ams-page-header__mega-menu--closed')}
                 id="ams-page-header-mega-menu"
               >
                 {children}

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -99,15 +99,15 @@ const PageHeaderRoot = forwardRef(
   ) => {
     const isControlled = open !== undefined
 
-    const viewportHasMinWidth = useViewportHasMinWidth('wide')
+    const isWideViewport = useViewportHasMinWidth('wide')
     const accessibleLabelId = useId()
     const megaMenuId = useId()
     const hasMegaMenu = Boolean(children)
-    const hasMegaMenuOnWideWindow = hasMegaMenu && viewportHasMinWidth
-    const menuButtonHidden = noMenuButtonOnWideWindow && hasMegaMenuOnWideWindow
+    const hasMegaMenuOnWideWindow = hasMegaMenu && isWideViewport
+    const isMenuButtonHidden = noMenuButtonOnWideWindow && hasMegaMenuOnWideWindow
 
     // Don't start open when the menu button is hidden on a wide window: there would then be no control to close it.
-    const [internalOpen, setInternalOpen] = useState((defaultOpen ?? false) && !menuButtonHidden)
+    const [internalOpen, setInternalOpen] = useState((defaultOpen ?? false) && !isMenuButtonHidden)
     const isOpen = isControlled ? open : internalOpen
 
     // Warn once when the component flips between controlled and uncontrolled, mirroring React’s guardrail for inputs.
@@ -125,25 +125,25 @@ const PageHeaderRoot = forwardRef(
 
     // Close the menu when its button hides on a wide window, and keep it closed when the button returns: there is then
     // no control to reopen it. Adjusting state while rendering is the recommended pattern for this internal reset.
-    const [menuButtonWasHidden, setMenuButtonWasHidden] = useState(menuButtonHidden)
-    if (menuButtonHidden !== menuButtonWasHidden) {
-      setMenuButtonWasHidden(menuButtonHidden)
-      if (menuButtonHidden && isOpen && !isControlled) {
+    const [wasMenuButtonHidden, setWasMenuButtonHidden] = useState(isMenuButtonHidden)
+    if (isMenuButtonHidden !== wasMenuButtonHidden) {
+      setWasMenuButtonHidden(isMenuButtonHidden)
+      if (isMenuButtonHidden && isOpen && !isControlled) {
         setInternalOpen(false)
       }
     }
 
     // Notify a listening parent when hiding the button force-closes the menu. This runs in an effect so it never
     // updates a controlled parent during render; the refs capture the hide transition and the prior open state.
-    const wasMenuButtonHiddenRef = useRef(menuButtonHidden)
+    const wasMenuButtonHiddenRef = useRef(isMenuButtonHidden)
     const wasOpenRef = useRef(isOpen)
     useEffect(() => {
-      if (!wasMenuButtonHiddenRef.current && menuButtonHidden && wasOpenRef.current) {
+      if (!wasMenuButtonHiddenRef.current && isMenuButtonHidden && wasOpenRef.current) {
         onOpenChange?.(false)
       }
-      wasMenuButtonHiddenRef.current = menuButtonHidden
+      wasMenuButtonHiddenRef.current = isMenuButtonHidden
       wasOpenRef.current = isOpen
-    }, [isOpen, menuButtonHidden, onOpenChange])
+    }, [isOpen, isMenuButtonHidden, onOpenChange])
 
     const handleMenuButtonClick = () => {
       const nextOpen = !isOpen

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -99,11 +99,11 @@ const PageHeaderRoot = forwardRef(
   ) => {
     const isControlled = open !== undefined
 
-    const isWideViewport = useViewportHasMinWidth('wide')
+    const isWideWindow = useViewportHasMinWidth('wide')
     const accessibleLabelId = useId()
     const megaMenuId = useId()
     const hasMegaMenu = Boolean(children)
-    const hasMegaMenuOnWideWindow = hasMegaMenu && isWideViewport
+    const hasMegaMenuOnWideWindow = hasMegaMenu && isWideWindow
     const isMenuButtonHidden = noMenuButtonOnWideWindow && hasMegaMenuOnWideWindow
 
     // Don't start open when the menu button is hidden on a wide window: there would then be no control to close it.

--- a/storybook/src/components/PageHeader/PageHeader.docs.mdx
+++ b/storybook/src/components/PageHeader/PageHeader.docs.mdx
@@ -90,7 +90,31 @@ If the collapsible menu contains [Headings](/docs/components-text-heading--docs)
 
 By default the Page Header keeps track of whether the collapsible menu is open.
 Set `defaultOpen` to have it open on the first render.
-To control it yourself – for example to close the menu when the route changes – pass `open` and update it from the `onOpenChange` callback.
+
+To control the menu yourself, pass `open` and update it from the `onOpenChange` callback.
+This matters most in a single-page app: the Page Header stays mounted while navigating, so the menu would otherwise stay open after someone follows a link inside it.
+Keep the open state in your own component and close it whenever the route changes:
+
+{/* prettier-ignore */}
+```tsx
+function Header() {
+  const { pathname } = useLocation() // The current route from your router
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [previousPathname, setPreviousPathname] = useState(pathname)
+
+  // Close the collapsible menu whenever the route changes
+  if (pathname !== previousPathname) {
+    setPreviousPathname(pathname)
+    setMenuOpen(false)
+  }
+
+  return (
+    <PageHeader onOpenChange={setMenuOpen} open={menuOpen}>
+      {/* Collapsible menu content */}
+    </PageHeader>
+  )
+}
+```
 
 ## Examples
 

--- a/storybook/src/components/PageHeader/PageHeader.docs.mdx
+++ b/storybook/src/components/PageHeader/PageHeader.docs.mdx
@@ -86,6 +86,12 @@ Don’t add whitespace to the Grid in the collapsible menu – its container alr
 
 If the collapsible menu contains [Headings](/docs/components-text-heading--docs), give them level 2 and a size of ‘level-3’.
 
+#### Controlling the menu
+
+By default the Page Header keeps track of whether the collapsible menu is open.
+Set `defaultOpen` to have it open on the first render.
+To control it yourself – for example to close the menu when the route changes – pass `open` and update it from the `onOpenChange` callback.
+
 ## Examples
 
 ### With moving links

--- a/storybook/src/components/PageHeader/PageHeader.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeader.stories.tsx
@@ -10,6 +10,7 @@ import { Grid, Heading, LinkList } from '@amsterdam/design-system-react'
 import { LogInIcon, PlusIcon, SearchIcon } from '@amsterdam/design-system-react-icons'
 import { PageHeader } from '@amsterdam/design-system-react/src'
 import { logoBrands } from '@amsterdam/design-system-react/src/Logo/Logo'
+import { useState } from 'react'
 
 import { linkComponentArgType } from '#storybook/_common/argTypes'
 import { wrapInPage } from '#storybook/_common/decorators'
@@ -41,6 +42,28 @@ const meta = {
     onOpenChange: { action: 'openChange' },
   },
   decorators: [wrapInPage],
+  // Control the mega menu so these example links can close it on click, the way an app would on navigation.
+  render: (args) => {
+    const [open, setOpen] = useState(false)
+
+    return (
+      <PageHeader
+        {...args}
+        onClick={(event) => {
+          // The mega menu links are placeholders; keep them from navigating and close the menu instead.
+          if ((event.target as HTMLElement).closest('.ams-page-header__mega-menu a')) {
+            event.preventDefault()
+            setOpen(false)
+          }
+        }}
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen)
+          args.onOpenChange?.(nextOpen)
+        }}
+        open={open}
+      />
+    )
+  },
 } satisfies Meta<typeof PageHeader>
 
 export default meta

--- a/storybook/src/components/PageHeader/PageHeader.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeader.stories.tsx
@@ -43,8 +43,9 @@ const meta = {
   },
   decorators: [wrapInPage],
   // Control the mega menu so these example links can close it on click, the way an app would on navigation.
+  // Seed from `defaultOpen` and defer to a provided `open` arg so the public API still drives the story.
   render: (args) => {
-    const [open, setOpen] = useState(false)
+    const [open, setOpen] = useState(args.defaultOpen ?? false)
 
     return (
       <PageHeader
@@ -52,7 +53,7 @@ const meta = {
         onClick={(event) => {
           // The links are placeholders; keep any Page Header link (logo, inline menu, mega menu) from
           // navigating, and close the mega menu the way an app would on navigation.
-          if ((event.target as HTMLElement).closest('a')) {
+          if (event.target instanceof Element && event.target.closest('a')) {
             event.preventDefault()
             setOpen(false)
           }
@@ -61,7 +62,7 @@ const meta = {
           setOpen(nextOpen)
           args.onOpenChange?.(nextOpen)
         }}
-        open={open}
+        open={args.open ?? open}
       />
     )
   },

--- a/storybook/src/components/PageHeader/PageHeader.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeader.stories.tsx
@@ -50,8 +50,9 @@ const meta = {
       <PageHeader
         {...args}
         onClick={(event) => {
-          // The mega menu links are placeholders; keep them from navigating and close the menu instead.
-          if ((event.target as HTMLElement).closest('.ams-page-header__mega-menu a')) {
+          // The links are placeholders; keep any Page Header link (logo, inline menu, mega menu) from
+          // navigating, and close the mega menu the way an app would on navigation.
+          if ((event.target as HTMLElement).closest('a')) {
             event.preventDefault()
             setOpen(false)
           }

--- a/storybook/src/components/PageHeader/PageHeader.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeader.stories.tsx
@@ -38,6 +38,7 @@ const meta = {
       },
     },
     menuItems: { control: false },
+    onOpenChange: { action: 'openChange' },
   },
   decorators: [wrapInPage],
 } satisfies Meta<typeof PageHeader>

--- a/storybook/src/components/PageHeader/PageHeader.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeader.stories.tsx
@@ -23,6 +23,9 @@ const meta = {
   title: 'Components/Containers/Page Header',
   component: PageHeader,
   argTypes: {
+    // The render below controls the mega menu, so live `open`/`defaultOpen` controls can't behave like the
+    // real uncontrolled props. Disable them; a story can still set either through its `args`.
+    defaultOpen: { control: false },
     logoBrand: {
       control: {
         labels: { undefined: 'amsterdam (default)' },
@@ -40,10 +43,11 @@ const meta = {
     },
     menuItems: { control: false },
     onOpenChange: { action: 'openChange' },
+    open: { control: false },
   },
   decorators: [wrapInPage],
   // Control the mega menu so these example links can close it on click, the way an app would on navigation.
-  // Seed from `defaultOpen` and defer to a provided `open` arg so the public API still drives the story.
+  // Seed from `defaultOpen` and defer to a provided `open` arg so a story can still set them through args.
   render: (args) => {
     const [open, setOpen] = useState(args.defaultOpen ?? false)
 

--- a/storybook/src/components/PageHeader/PageHeader.test.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeader.test.stories.tsx
@@ -58,6 +58,13 @@ export const Test: Story = {
     expect(exampleChildren).toBeVisible()
     await userEvent.click(canvas.getByTestId('mega-menu-link'))
     expect(exampleChildren).not.toBeVisible()
+
+    // Every link’s default is prevented, so clicking the logo never navigates the story away.
+    const logoLink = pageHeader.querySelector('a')
+    if (logoLink) {
+      await userEvent.click(logoLink)
+    }
+    expect(menuButton).toBeInTheDocument()
   },
   render: (args) => {
     const [open, setOpen] = useState(false)
@@ -69,7 +76,8 @@ export const Test: Story = {
           data-testid="interaction-test"
           {...args}
           onClick={(event) => {
-            if ((event.target as HTMLElement).closest('.ams-page-header__mega-menu a')) {
+            // Keep any Page Header link (logo, inline menu, mega menu) from navigating, and close the menu.
+            if ((event.target as HTMLElement).closest('a')) {
               event.preventDefault()
               setOpen(false)
             }

--- a/storybook/src/components/PageHeader/PageHeader.test.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeader.test.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { LogInIcon } from '@amsterdam/design-system-react-icons'
 import { PageHeader } from '@amsterdam/design-system-react/src'
 import { logoBrands } from '@amsterdam/design-system-react/src/Logo/Logo'
+import { useState } from 'react'
 import { expect } from 'storybook/test'
 
 import type { PageHeaderStory } from './PageHeader.stories'
@@ -46,43 +47,69 @@ export const Test: Story = {
 
     if (!menuButton) return
 
+    // Open and close the mega menu with the menu button.
     await userEvent.click(menuButton)
     expect(exampleChildren).toBeVisible()
     await userEvent.click(menuButton)
     expect(exampleChildren).not.toBeVisible()
+
+    // Reopen, then close it by clicking a link inside the mega menu (controlled close, no navigation).
+    await userEvent.click(menuButton)
+    expect(exampleChildren).toBeVisible()
+    await userEvent.click(canvas.getByTestId('mega-menu-link'))
+    expect(exampleChildren).not.toBeVisible()
   },
-  render: (args) => (
-    <>
-      {/* Interaction test */}
-      <PageHeader data-testid="interaction-test" {...args}>
-        <ul>
-          <li data-testid="children">English</li>
-        </ul>
-      </PageHeader>
+  render: (args) => {
+    const [open, setOpen] = useState(false)
 
-      {/* All public stories, sorted by key for deterministic order */}
-      {Object.keys(pageHeaderStories)
-        .filter((key) => key !== '__namedExportsOrder') // This gets added by babel-plugin-named-exports-order
-        .sort()
-        .map((key) => {
-          const story = pageHeaderStories[key]
-          return story ? <PageHeader key={key} {...story.args} /> : null
-        })}
-
-      {/* All logo brands */}
-      {logoBrands.map((brand) => (
+    return (
+      <>
+        {/* Interaction test: controlled open so a mega-menu link can close the menu instead of navigating */}
         <PageHeader
-          brandName="Voorbeeld"
-          key={brand}
-          logoBrand={brand}
-          menuItems={
-            <PageHeader.MenuLink fixed href="#" icon={LogInIcon}>
-              Inloggen
-            </PageHeader.MenuLink>
-          }
-        />
-      ))}
-    </>
-  ),
+          data-testid="interaction-test"
+          {...args}
+          onClick={(event) => {
+            if ((event.target as HTMLElement).closest('.ams-page-header__mega-menu a')) {
+              event.preventDefault()
+              setOpen(false)
+            }
+          }}
+          onOpenChange={setOpen}
+          open={open}
+        >
+          <ul>
+            <li data-testid="children">
+              <a data-testid="mega-menu-link" href="#/should-not-navigate">
+                English
+              </a>
+            </li>
+          </ul>
+        </PageHeader>
+
+        {/* All public stories, sorted by key for deterministic order */}
+        {Object.keys(pageHeaderStories)
+          .filter((key) => key !== '__namedExportsOrder') // This gets added by babel-plugin-named-exports-order
+          .sort()
+          .map((key) => {
+            const story = pageHeaderStories[key]
+            return story ? <PageHeader key={key} {...story.args} /> : null
+          })}
+
+        {/* All logo brands */}
+        {logoBrands.map((brand) => (
+          <PageHeader
+            brandName="Voorbeeld"
+            key={brand}
+            logoBrand={brand}
+            menuItems={
+              <PageHeader.MenuLink fixed href="#" icon={LogInIcon}>
+                Inloggen
+              </PageHeader.MenuLink>
+            }
+          />
+        ))}
+      </>
+    )
+  },
   tags: ['!dev', '!autodocs'],
 }

--- a/storybook/src/components/PageHeader/PageHeader.test.stories.tsx
+++ b/storybook/src/components/PageHeader/PageHeader.test.stories.tsx
@@ -77,7 +77,7 @@ export const Test: Story = {
           {...args}
           onClick={(event) => {
             // Keep any Page Header link (logo, inline menu, mega menu) from navigating, and close the menu.
-            if ((event.target as HTMLElement).closest('a')) {
+            if (event.target instanceof Element && event.target.closest('a')) {
               event.preventDefault()
               setOpen(false)
             }


### PR DESCRIPTION
## What

- Add controlled `open`, uncontrolled `defaultOpen`, and `onOpenChange` props to the Page Header mega menu, so a parent can drive or observe whether it is open.
- Fix a pre-existing bug where the mega menu panel used a hard-coded id, which collides when two Page Headers appear on one page. It now uses a generated id.

## Why

- The mega menu was uncontrolled only: its open state lived entirely in internal state, with no way to drive or observe it.
- Third in the series that makes every collapsible subcomponent controllable. Page Header is a menu/overlay, so it keeps the `open` vocabulary rather than the `expanded` vocabulary used by the disclosures.

## How

- Bespoke controlled/uncontrolled state (`isControlled`, `internalOpen`, `isOpen`), matching the pattern used by Progress List Step and Table of Contents Link. Page Header does not use the shared `useCollapsible` hook because its viewport force-close must set the state to a specific value, which a toggle-only hook cannot express.
- The viewport force-close (closing the menu when its button hides on a wide window) keeps resetting internal state during render – the React-recommended, flash-free pattern – but now also fires `onOpenChange(false)` from an effect, so a controlled parent learns about the automatic close without the component updating a parent mid-render.
- A one-time warning fires if the component flips between controlled and uncontrolled, mirroring React’s guardrail for form inputs.
- The mega menu panel id now comes from `useId`.

## Checklist

- [x] Add or update unit tests – 12 new tests covering controlled rendering, no internal toggle when controlled, responding to prop changes, `defaultOpen`, `onOpenChange` on click and on force-close (both modes), and the switch warning. Page Header stays at 100% coverage.
- [x] Add or update documentation – a new “Controlling the menu” section on the docs page.
- [x] Add or update stories – added an `onOpenChange` action. A dedicated controlled story was not added because externally controlling a mega menu is a niche pattern that would only mirror the uncontrolled behaviour.
- [x] Add or update exports in index.\* files – not necessary; the new props ride on the already-exported `PageHeaderProps`.
- [x] Comment `/chromatic test` and verify visual regression tests pass – runs automatically on PR creation.
- [x] Start the PR title with a Conventional Commit prefix.

## Additional notes

- Third of the series making collapsibles controllable, after Table of Contents (#2753). Progress List alignment and Accordion follow in their own branches and PRs.
- The controlled `open` behaviour and the `useId` fix are separate commits.
