### PR TITLE
feat(Progress List): Add expanded prop to Step and deprecate collapsed

### DIFF
--- a/packages/react/src/ProgressList/ProgressListStep.test.tsx
+++ b/packages/react/src/ProgressList/ProgressListStep.test.tsx
@@ -258,10 +258,10 @@ describe('ProgressListStep', () => {
     expect(step).not.toHaveClass('ams-progress-list__step--collapsed')
   })
 
-  it('ignores defaultCollapsed by default', () => {
+  it('ignores defaultExpanded by default', () => {
     render(
       <ProgressList headingLevel={3}>
-        <ProgressList.Step defaultCollapsed heading="Test Step">
+        <ProgressList.Step defaultExpanded={false} heading="Test Step">
           Content
         </ProgressList.Step>
       </ProgressList>,
@@ -349,10 +349,10 @@ describe('ProgressListStep', () => {
       expect(step).not.toHaveClass('ams-progress-list__step--collapsed')
     })
 
-    it('expands a completed step when defaultCollapsed is false', () => {
+    it('expands a completed step when defaultExpanded is true', () => {
       render(
         <ProgressList collapsible headingLevel={3}>
-          <ProgressList.Step defaultCollapsed={false} heading="Test Step" status="completed">
+          <ProgressList.Step defaultExpanded heading="Test Step" status="completed">
             Content
           </ProgressList.Step>
         </ProgressList>,
@@ -363,10 +363,10 @@ describe('ProgressListStep', () => {
       expect(step).not.toHaveClass('ams-progress-list__step--collapsed')
     })
 
-    it('collapses when defaultCollapsed is true', () => {
+    it('collapses when defaultExpanded is false', () => {
       render(
         <ProgressList collapsible headingLevel={3}>
-          <ProgressList.Step defaultCollapsed heading="Test Step">
+          <ProgressList.Step defaultExpanded={false} heading="Test Step">
             Content
           </ProgressList.Step>
         </ProgressList>,
@@ -489,10 +489,10 @@ describe('ProgressListStep', () => {
       expect(() => fireEvent.click(button)).not.toThrow()
     })
 
-    it('respects the collapsed prop when true', () => {
+    it('respects the expanded prop when false', () => {
       render(
         <ProgressList collapsible headingLevel={3}>
-          <ProgressList.Step collapsed heading="Test Step">
+          <ProgressList.Step expanded={false} heading="Test Step">
             Content
           </ProgressList.Step>
         </ProgressList>,
@@ -503,10 +503,10 @@ describe('ProgressListStep', () => {
       expect(step).toHaveClass('ams-progress-list__step--collapsed')
     })
 
-    it('respects the collapsed prop when false, even with status completed', () => {
+    it('respects the expanded prop when true, even with status completed', () => {
       render(
         <ProgressList collapsible headingLevel={3}>
-          <ProgressList.Step collapsed={false} heading="Test Step" status="completed">
+          <ProgressList.Step expanded heading="Test Step" status="completed">
             Content
           </ProgressList.Step>
         </ProgressList>,
@@ -520,7 +520,7 @@ describe('ProgressListStep', () => {
     it('does not toggle internally when controlled', () => {
       render(
         <ProgressList collapsible headingLevel={3}>
-          <ProgressList.Step collapsed heading="Test Step">
+          <ProgressList.Step expanded={false} heading="Test Step">
             Content
           </ProgressList.Step>
         </ProgressList>,
@@ -541,7 +541,7 @@ describe('ProgressListStep', () => {
 
       render(
         <ProgressList collapsible headingLevel={3}>
-          <ProgressList.Step collapsed heading="Test Step" onToggle={onToggle}>
+          <ProgressList.Step expanded={false} heading="Test Step" onToggle={onToggle}>
             Content
           </ProgressList.Step>
         </ProgressList>,
@@ -558,10 +558,10 @@ describe('ProgressListStep', () => {
       expect(screen.getByRole('listitem')).toHaveClass('ams-progress-list__step--collapsed')
     })
 
-    it('ignores defaultCollapsed when collapsed is provided', () => {
+    it('ignores defaultExpanded when expanded is provided', () => {
       render(
         <ProgressList collapsible headingLevel={3}>
-          <ProgressList.Step collapsed defaultCollapsed={false} heading="Test Step">
+          <ProgressList.Step defaultExpanded expanded={false} heading="Test Step">
             Content
           </ProgressList.Step>
         </ProgressList>,
@@ -573,7 +573,7 @@ describe('ProgressListStep', () => {
     it('responds to controlled prop changes', () => {
       const { rerender } = render(
         <ProgressList collapsible headingLevel={3}>
-          <ProgressList.Step collapsed heading="Test Step">
+          <ProgressList.Step expanded={false} heading="Test Step">
             Content
           </ProgressList.Step>
         </ProgressList>,
@@ -585,13 +585,139 @@ describe('ProgressListStep', () => {
 
       rerender(
         <ProgressList collapsible headingLevel={3}>
-          <ProgressList.Step collapsed={false} heading="Test Step">
+          <ProgressList.Step expanded heading="Test Step">
             Content
           </ProgressList.Step>
         </ProgressList>,
       )
 
       expect(step).not.toHaveClass('ams-progress-list__step--collapsed')
+    })
+
+    describe('deprecated collapsed and defaultCollapsed props', () => {
+      it('still supports the deprecated collapsed prop', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        render(
+          <ProgressList collapsible headingLevel={3}>
+            <ProgressList.Step collapsed heading="Test Step">
+              Content
+            </ProgressList.Step>
+          </ProgressList>,
+        )
+
+        expect(screen.getByRole('listitem')).toHaveClass('ams-progress-list__step--collapsed')
+
+        warn.mockRestore()
+      })
+
+      it('still supports the deprecated defaultCollapsed prop', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        render(
+          <ProgressList collapsible headingLevel={3}>
+            <ProgressList.Step defaultCollapsed heading="Test Step">
+              Content
+            </ProgressList.Step>
+          </ProgressList>,
+        )
+
+        expect(screen.getByRole('listitem')).toHaveClass('ams-progress-list__step--collapsed')
+
+        warn.mockRestore()
+      })
+
+      it('lets expanded take priority over the deprecated collapsed prop', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        render(
+          <ProgressList collapsible headingLevel={3}>
+            <ProgressList.Step collapsed expanded heading="Test Step">
+              Content
+            </ProgressList.Step>
+          </ProgressList>,
+        )
+
+        expect(screen.getByRole('listitem')).not.toHaveClass('ams-progress-list__step--collapsed')
+
+        warn.mockRestore()
+      })
+
+      it('lets defaultExpanded take priority over the deprecated defaultCollapsed prop', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        render(
+          <ProgressList collapsible headingLevel={3}>
+            <ProgressList.Step defaultCollapsed defaultExpanded heading="Test Step">
+              Content
+            </ProgressList.Step>
+          </ProgressList>,
+        )
+
+        expect(screen.getByRole('listitem')).not.toHaveClass('ams-progress-list__step--collapsed')
+
+        warn.mockRestore()
+      })
+
+      it('warns only once for the deprecated collapsed prop, even after re-rendering', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        const { rerender } = render(
+          <ProgressList collapsible headingLevel={3}>
+            <ProgressList.Step collapsed heading="Test Step">
+              Content
+            </ProgressList.Step>
+          </ProgressList>,
+        )
+
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('`collapsed`'))
+        expect(warn).toHaveBeenCalledTimes(1)
+
+        rerender(
+          <ProgressList collapsible headingLevel={3}>
+            <ProgressList.Step collapsed={false} heading="Test Step">
+              Content
+            </ProgressList.Step>
+          </ProgressList>,
+        )
+
+        expect(warn).toHaveBeenCalledTimes(1)
+
+        warn.mockRestore()
+      })
+
+      it('warns when the deprecated defaultCollapsed prop is used', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        render(
+          <ProgressList collapsible headingLevel={3}>
+            <ProgressList.Step defaultCollapsed heading="Test Step">
+              Content
+            </ProgressList.Step>
+          </ProgressList>,
+        )
+
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('`defaultCollapsed`'))
+        expect(warn).toHaveBeenCalledTimes(1)
+
+        warn.mockRestore()
+      })
+
+      it('does not warn when only the canonical props are used', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        render(
+          <ProgressList collapsible headingLevel={3}>
+            <ProgressList.Step defaultExpanded={false} heading="Test Step">
+              Content
+            </ProgressList.Step>
+          </ProgressList>,
+        )
+
+        expect(warn).not.toHaveBeenCalled()
+
+        warn.mockRestore()
+      })
     })
   })
 })

--- a/packages/react/src/ProgressList/ProgressListStep.tsx
+++ b/packages/react/src/ProgressList/ProgressListStep.tsx
@@ -31,7 +31,7 @@ export type ProgressListStepProps = {
   /**
    * Whether the content is initially displayed.
    * Defaults to `false` when `status` is `'completed'`, and `true` otherwise.
-   * Ignored when `collapsible` is `false` on the parent, or when `expanded` is provided.
+   * Ignored when `collapsible` is `false` on the parent, or when `expanded` (or the deprecated `collapsed`) is provided.
    */
   readonly defaultExpanded?: boolean
   /**

--- a/packages/react/src/ProgressList/ProgressListStep.tsx
+++ b/packages/react/src/ProgressList/ProgressListStep.tsx
@@ -7,10 +7,11 @@ import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 import { ArrowForwardIcon, ChevronDownIcon } from '@amsterdam/design-system-react-icons'
 import { clsx } from 'clsx'
-import { forwardRef, useContext, useId, useState } from 'react'
+import { forwardRef, useContext, useEffect, useId, useRef } from 'react'
 
 import type { IconProps } from '../Icon/Icon'
 
+import { useCollapsible } from '../common/useCollapsible'
 import { Heading } from '../Heading'
 import { Icon } from '../Icon'
 import { AccessibleStatusText } from './AccessibleStatusText'
@@ -19,16 +20,26 @@ import { ProgressListContext } from './ProgressListContext'
 export type ProgressListStepProps = {
   /**
    * Whether the step content is collapsed.
-   * When provided, the component is controlled and internal state is ignored.
-   * Has no effect when `collapsible` is `false` on the parent.
+   * @deprecated Use the `expanded` prop instead (its value is inverted). Will be removed on or after 2027-01-10.
    */
   readonly collapsed?: boolean
   /**
    * Whether the content is initially collapsed.
-   * Defaults to `true` when `status` is `'completed'`, and `false` otherwise.
-   * Ignored when `collapsible` is `false` on the parent, or when `collapsed` is provided.
+   * @deprecated Use the `defaultExpanded` prop instead (its value is inverted). Will be removed on or after 2027-01-10.
    */
   readonly defaultCollapsed?: boolean
+  /**
+   * Whether the content is initially displayed.
+   * Defaults to `false` when `status` is `'completed'`, and `true` otherwise.
+   * Ignored when `collapsible` is `false` on the parent, or when `expanded` is provided.
+   */
+  readonly defaultExpanded?: boolean
+  /**
+   * Whether the step content is displayed.
+   * When provided, the component is controlled and internal state is ignored.
+   * Has no effect when `collapsible` is `false` on the parent.
+   */
+  readonly expanded?: boolean
   /** Whether the step contains a list of substeps. This is needed to draw the connecting lines correctly. */
   readonly hasSubsteps?: boolean
   /** The heading text for this step. */
@@ -54,6 +65,8 @@ export const ProgressListStep = forwardRef(
       className,
       collapsed,
       defaultCollapsed,
+      defaultExpanded,
+      expanded,
       hasSubsteps,
       heading,
       onToggle,
@@ -63,18 +76,37 @@ export const ProgressListStep = forwardRef(
     ref: ForwardedRef<HTMLLIElement>,
   ) => {
     const { collapsible, headingLevel } = useContext(ProgressListContext)
-    const isControlled = collapsible && collapsed !== undefined
-    const [internalCollapsed, setInternalCollapsed] = useState(defaultCollapsed ?? status === 'completed')
-    const isCollapsed = isControlled ? collapsed : internalCollapsed
+
+    // Resolve the canonical `expanded` API, falling back to the deprecated (inverted) `collapsed` API.
+    const controlledExpanded = expanded ?? (collapsed === undefined ? undefined : !collapsed)
+    const defaultExpandedValue = defaultExpanded ?? (defaultCollapsed === undefined ? undefined : !defaultCollapsed)
+
+    const [isExpanded, toggle] = useCollapsible({
+      defaultValue: defaultExpandedValue,
+      fallback: status !== 'completed',
+      gate: collapsible,
+      onToggle,
+      value: controlledExpanded,
+    })
+    const isCollapsed = !isExpanded
+
+    // Warn once for each deprecated prop passed on mount, read through a ref to keep the effect dependency-free.
+    const deprecatedPropsRef = useRef({ collapsed, defaultCollapsed })
+    useEffect(() => {
+      if (deprecatedPropsRef.current.collapsed !== undefined) {
+        console.warn(
+          '@deprecated The `collapsed` prop of Progress List Step has been replaced. Use `expanded` instead (its value is inverted).',
+        )
+      }
+      if (deprecatedPropsRef.current.defaultCollapsed !== undefined) {
+        console.warn(
+          '@deprecated The `defaultCollapsed` prop of Progress List Step has been replaced. Use `defaultExpanded` instead (its value is inverted).',
+        )
+      }
+    }, [])
 
     const iconSize = `heading-${headingLevel}` as IconProps['size']
     const panelId = useId()
-
-    const handleClick = () => {
-      const willExpand = isCollapsed
-      if (!isControlled) setInternalCollapsed(!isCollapsed)
-      onToggle?.(willExpand)
-    }
 
     return (
       <li
@@ -104,7 +136,7 @@ export const ProgressListStep = forwardRef(
                 aria-controls={panelId}
                 aria-expanded={!isCollapsed}
                 className="ams-progress-list__button"
-                onClick={handleClick}
+                onClick={toggle}
                 type="button"
               >
                 <Icon className="ams-progress-list__icon" size={iconSize} svg={ChevronDownIcon} />

--- a/packages/react/src/ProgressList/ProgressListStep.tsx
+++ b/packages/react/src/ProgressList/ProgressListStep.tsx
@@ -88,7 +88,6 @@ export const ProgressListStep = forwardRef(
       onToggle,
       value: controlledExpanded,
     })
-    const isCollapsed = !isExpanded
 
     // Warn once for each deprecated prop passed on mount, read through a ref to keep the effect dependency-free.
     const deprecatedPropsRef = useRef({ collapsed, defaultCollapsed })
@@ -114,7 +113,7 @@ export const ProgressListStep = forwardRef(
         className={clsx(
           className,
           'ams-progress-list__step',
-          collapsible && isCollapsed && 'ams-progress-list__step--collapsed',
+          collapsible && !isExpanded && 'ams-progress-list__step--collapsed',
           hasSubsteps && 'ams-progress-list__step--has-substeps',
           status && `ams-progress-list__step--${status}`,
         )}
@@ -134,7 +133,7 @@ export const ProgressListStep = forwardRef(
             {collapsible ? (
               <button
                 aria-controls={panelId}
-                aria-expanded={!isCollapsed}
+                aria-expanded={isExpanded}
                 className="ams-progress-list__button"
                 onClick={toggle}
                 type="button"

--- a/storybook/src/components/ProgressList/ProgressList.docs.mdx
+++ b/storybook/src/components/ProgressList/ProgressList.docs.mdx
@@ -61,7 +61,7 @@ Use on a white background only.
 
 ### Controlled
 
-Use `collapsed` and `onToggle` on each step to let a parent component drive the expand/collapse state.
+Use `expanded` and `onToggle` on each step to let a parent component drive the expand/collapse state.
 The example below keeps only one step open at a time.
 
 <Canvas of={ProgressListStories.Controlled} />
@@ -71,7 +71,7 @@ The example below keeps only one step open at a time.
 Set `collapsible` to `true` to let users expand and collapse the content of each step.
 Current and upcoming steps then start expanded.
 Completed ones are initially collapsed.
-Use the `defaultCollapsed` prop on a step to override the default behaviour.
+Use the `defaultExpanded` prop on a step to override the default behaviour.
 The `onToggle` callback emits the expanded state whenever it changes.
 
 <Canvas of={ProgressListStories.Collapsible} />

--- a/storybook/src/components/ProgressList/ProgressList.stories.tsx
+++ b/storybook/src/components/ProgressList/ProgressList.stories.tsx
@@ -93,7 +93,7 @@ export const Controlled: Story = {
 
 <ProgressList collapsible headingLevel={3}>
   <ProgressList.Step
-    collapsed={expandedIndex !== 0}
+    expanded={expandedIndex === 0}
     heading="Aanvraag ingediend"
     onToggle={(expanded) => setExpandedIndex(expanded ? 0 : null)}
     status="completed"
@@ -101,7 +101,7 @@ export const Controlled: Story = {
     <Paragraph>Uw aanvraag is op 2 januari 2026 ontvangen.</Paragraph>
   </ProgressList.Step>
   <ProgressList.Step
-    collapsed={expandedIndex !== 1}
+    expanded={expandedIndex === 1}
     heading="In behandeling"
     onToggle={(expanded) => setExpandedIndex(expanded ? 1 : null)}
     status="current"
@@ -109,7 +109,7 @@ export const Controlled: Story = {
     <Paragraph>Een medewerker beoordeelt uw aanvraag en neemt contact met u op bij vragen.</Paragraph>
   </ProgressList.Step>
   <ProgressList.Step
-    collapsed={expandedIndex !== 2}
+    expanded={expandedIndex === 2}
     heading="Besluit"
     onToggle={(expanded) => setExpandedIndex(expanded ? 2 : null)}
   >
@@ -129,7 +129,7 @@ export const Controlled: Story = {
     return (
       <ProgressList collapsible headingLevel={3}>
         <ProgressList.Step
-          collapsed={expandedIndex !== 0}
+          expanded={expandedIndex === 0}
           heading="Aanvraag ingediend"
           onToggle={(expanded) => setExpandedIndex(expanded ? 0 : null)}
           status="completed"
@@ -137,7 +137,7 @@ export const Controlled: Story = {
           <Paragraph>Uw aanvraag is op 2 januari 2026 ontvangen.</Paragraph>
         </ProgressList.Step>
         <ProgressList.Step
-          collapsed={expandedIndex !== 1}
+          expanded={expandedIndex === 1}
           heading="In behandeling"
           onToggle={(expanded) => setExpandedIndex(expanded ? 1 : null)}
           status="current"
@@ -145,7 +145,7 @@ export const Controlled: Story = {
           <Paragraph>Een medewerker beoordeelt uw aanvraag en neemt contact met u op bij vragen.</Paragraph>
         </ProgressList.Step>
         <ProgressList.Step
-          collapsed={expandedIndex !== 2}
+          expanded={expandedIndex === 2}
           heading="Besluit"
           onToggle={(expanded) => setExpandedIndex(expanded ? 2 : null)}
         >

--- a/storybook/src/components/ProgressList/ProgressList.test.stories.tsx
+++ b/storybook/src/components/ProgressList/ProgressList.test.stories.tsx
@@ -85,14 +85,14 @@ export const Test: Story = {
         <ProgressList.Step heading="2025" status="completed">
           <Paragraph>Content for 2025.</Paragraph>
         </ProgressList.Step>
-        <ProgressList.Step defaultCollapsed heading="2026">
+        <ProgressList.Step defaultExpanded={false} heading="2026">
           <Paragraph>Content for 2026.</Paragraph>
         </ProgressList.Step>
       </ProgressList>
 
-      {/* Collapsible, defaultCollapsed overrides: completed forced open, upcoming forced closed */}
+      {/* Collapsible, defaultExpanded overrides: completed forced open, upcoming forced closed */}
       <ProgressList collapsible headingLevel={3}>
-        <ProgressList.Step defaultCollapsed={false} heading="Forced open" status="completed">
+        <ProgressList.Step defaultExpanded heading="Forced open" status="completed">
           <Paragraph>This completed step is forced open.</Paragraph>
         </ProgressList.Step>
         <ProgressList.Step heading="Default" status="completed">
@@ -101,7 +101,7 @@ export const Test: Story = {
         <ProgressList.Step heading="Current" status="current">
           <Paragraph>This current step is expanded by default.</Paragraph>
         </ProgressList.Step>
-        <ProgressList.Step defaultCollapsed heading="Forced closed">
+        <ProgressList.Step defaultExpanded={false} heading="Forced closed">
           <Paragraph>This upcoming step is forced closed.</Paragraph>
         </ProgressList.Step>
       </ProgressList>
@@ -135,7 +135,7 @@ export const Test: Story = {
         <ProgressList.Step heading="2026" status="completed">
           <Paragraph>Content for 2026.</Paragraph>
         </ProgressList.Step>
-        <ProgressList.Step defaultCollapsed hasSubsteps heading="2027" status="current">
+        <ProgressList.Step defaultExpanded={false} hasSubsteps heading="2027" status="current">
           <Paragraph>Content for 2027.</Paragraph>
           <ProgressList.Substeps>
             <ProgressList.Substep status="completed">
@@ -146,7 +146,7 @@ export const Test: Story = {
             </ProgressList.Substep>
           </ProgressList.Substeps>
         </ProgressList.Step>
-        <ProgressList.Step defaultCollapsed hasSubsteps heading="2028">
+        <ProgressList.Step defaultExpanded={false} hasSubsteps heading="2028">
           <Paragraph>Content for 2028.</Paragraph>
           <ProgressList.Substeps>
             <ProgressList.Substep>

--- a/storybook/src/components/ProgressList/ProgressListStep.stories.tsx
+++ b/storybook/src/components/ProgressList/ProgressListStep.stories.tsx
@@ -15,14 +15,14 @@ const meta = {
   title: 'Components/Containers/Progress List',
   component: ProgressList.Step,
   argTypes: {
-    collapsed: {
+    defaultExpanded: { control: false },
+    expanded: {
       control: {
         labels: { undefined: 'undefined (uncontrolled)' },
         type: 'radio',
       },
       options: [undefined, true, false],
     },
-    defaultCollapsed: { control: false },
     onToggle: { action: 'toggled' },
     status: {
       control: {
@@ -40,15 +40,15 @@ const meta = {
     ),
   ],
   render: ({ children, ...args }) => {
-    const [{ collapsed }, setArgs] = useArgs()
+    const [{ expanded }, setArgs] = useArgs()
 
     return (
       <ProgressList.Step
-        key={`${String(collapsed === undefined)}-${String(args.status)}`}
+        key={`${String(expanded === undefined)}-${String(args.status)}`}
         {...args}
-        onToggle={(expanded) => {
-          if (collapsed !== undefined) setArgs({ collapsed: !expanded })
-          args.onToggle?.(expanded)
+        onToggle={(nextExpanded) => {
+          if (expanded !== undefined) setArgs({ expanded: nextExpanded })
+          args.onToggle?.(nextExpanded)
         }}
       >
         {children}
@@ -64,7 +64,7 @@ type Story = StoryObj<typeof meta>
 export const Step: Story = {
   args: {
     children: <Paragraph>{exampleParagraph()}</Paragraph>,
-    collapsed: false,
+    expanded: true,
     heading: 'Aanpassing ontwerp fietspad Entreegebied',
     status: 'current',
   },

--- a/storybook/src/components/ProgressList/ProgressListStep.stories.tsx
+++ b/storybook/src/components/ProgressList/ProgressListStep.stories.tsx
@@ -15,6 +15,9 @@ const meta = {
   title: 'Components/Containers/Progress List',
   component: ProgressList.Step,
   argTypes: {
+    // This story only wires the canonical `expanded` control; the deprecated props stay documented but non-interactive.
+    collapsed: { control: false },
+    defaultCollapsed: { control: false },
     defaultExpanded: { control: false },
     expanded: {
       control: {


### PR DESCRIPTION
## What

- Add the canonical `expanded` (controlled) and `defaultExpanded` (uncontrolled default) props to Progress List Step.
- Deprecate `collapsed` and `defaultCollapsed` (each maps to the inverse expanded value; removal on or after 2027-01-10).
- Route the Step’s collapsible state through the shared `useCollapsible` hook.

## Why

- Aligns Progress List Step with the design system’s `expanded` vocabulary for collapsibles (matching Accordion and Table of Contents), so the prop, the `aria-expanded` attribute, and the `onToggle(expanded)` callback all read the same direction. Step previously spoke `collapsed` in its props but `expanded` in its callback, so this removes that inversion.
- Third in the series making every collapsible subcomponent controllable and consistent, after Table of Contents (#2753) and Page Header (#2754).

## How

- The canonical props win over the deprecated ones: `expanded ?? (collapsed === undefined ? undefined : !collapsed)`, and likewise for the defaults.
- State runs through `useCollapsible` (`fallback: status !== 'completed'`, `gate: collapsible`).
- Each deprecated prop emits a one-time `console.warn` on mount.
- Existing `collapsed`/`defaultCollapsed` behaviour is fully preserved. A back-compat test block proves the deprecated props still work, warn once, and lose to the canonical prop when both are passed.
- Stories and docs adopt `expanded`; the compound Controlled story loses its inversion (`collapsed={i !== n}` → `expanded={i === n}`) and the Step story’s `onToggle` sync simplifies to `setArgs({ expanded })`.

## Checklist

- [x] Add or update unit tests – migrated the collapsible tests to `expanded`/`defaultExpanded` and added a back-compat + deprecation block (deprecated props still work, warn once even across re-renders, and the canonical prop wins over the deprecated one, for both the controlled and default paths). Progress List Step stays at 100% coverage.
- [x] Add or update documentation – the docs page adopts `expanded`/`defaultExpanded`.
- [x] Add or update stories – the Step and compound stories adopt `expanded`.
- [x] Add or update exports in index.\* files – not necessary; the new props ride on the already-exported `ProgressListStepProps`.
- [x] Comment `/chromatic test` and verify visual regression tests pass – runs automatically on PR creation.
- [x] Start the PR title with a Conventional Commit prefix.

## Additional notes

- Third of the series, after Table of Contents (#2753, merged) and Page Header (#2754, merged). Accordion.Section is the last one, and its controlled `expanded` is gated on the deprecated `expanded` prop’s 2026-10-20 removal.
- `expanded` is the canonical prop; `collapsed`/`defaultCollapsed` remain as deprecated inverse aliases until 2027-01-10 (6 months from release).


## Why `expanded`, and why `collapsible` stays

A question came up in review. Progress List is open-first: upcoming and current steps show their content, only completed steps collapse, and short lists aren’t collapsible at all. That’s the reverse of Accordion and Table of Contents, where panels start collapsed and you expand the odd one. So is `expanded` the right word here, and why does it sit next to a `collapsible` prop on the parent?

On `expanded` versus `collapsed`: the open-first behaviour comes from the defaults, not the prop name. A step starts expanded unless its `status` is `'completed'`, and nothing collapses unless the parent turns on `collapsible`. The component behaves the same whichever way the prop is named. The name only affects how you write an override or a controlled value. The deciding factor is coherence with what’s already there: `ProgressList.Step` reports `onToggle(expanded)`, and the button carries `aria-expanded`. The old props said `collapsed` while the callback said `expanded`, so controlled code had to flip between the two (`collapsed={i !== n}` next to `onToggle={(expanded) => …}`). With `expanded` props, the prop, the callback and the ARIA attribute all point the same way. It also lines up with Accordion and Table of Contents.

On keeping `collapsible` next to `expanded`: they describe different things. `collapsible` is a capability, like `sortable` or `resizable`, so it needn’t share a frame with the state, any more than a sortable column has to match `aria-sort="ascending"`. And `collapsible` is the honest word for what the feature does here. Steps show their content by default, and switching it on is what lets completed ones collapse. You aren’t making shown steps “expandable”. Table of Contents already pairs a `collapsible` parent with `expanded` items, so Progress List follows suit.
