### PR TITLE
chore(docs): Describe handling deprecated props in Storybook stories

### DIFF
--- a/documentation/component-docs.md
+++ b/documentation/component-docs.md
@@ -163,6 +163,23 @@ Omit the section if the component has no meaningful accessibility behaviour to d
 **See also** is the exit point at the bottom of the body.
 List a handful of alternatives or companions, with a one-line reason for each.
 
+## Deprecated props
+
+Storybook surfaces `@deprecated` props on its own: the `formatDeprecatedProps` enhancer in `storybook/config/preview.tsx` leads a prop’s Controls description with a bold ‘Deprecated.’ notice and moves it into a ‘Deprecated’ category at the bottom of the table.
+
+When a story’s render only wires the canonical prop, such as a controlled wrapper that syncs `expanded`, set `control: false` on each deprecated prop in its `argTypes`.
+This keeps them listed with their deprecation notice but stops Storybook from offering a control that does nothing when toggled.
+
+```tsx
+const meta = {
+  argTypes: {
+    collapsed: { control: false },
+    defaultCollapsed: { control: false },
+  },
+  // …
+};
+```
+
 ## Reference components
 
 These three components are worked examples of the content model.


### PR DESCRIPTION
## What

Add a ‘Deprecated props’ section to the documentation guidelines, describing how Storybook surfaces `@deprecated` props and when to disable their controls.

## Why

Components now carry deprecated props (for example Progress List Step’s `collapsed` and `defaultCollapsed`), and there was no guidance on handling them in stories.

## How

Documents that the `formatDeprecatedProps` enhancer surfaces deprecated props on its own, and that a story whose render only wires the canonical prop should set `control: false` on the deprecated ones so they stay listed but non-interactive.

## Checklist

- [x] Add or update unit tests — not necessary (documentation only).
- [x] Add or update documentation — this PR is the documentation.
- [x] Add or update stories — not necessary.
- [x] Add or update exports in index.\* files — not necessary.
- [x] Comment `/chromatic test` and verify visual regression tests pass — not necessary; no component or story change to snapshot.
- [x] Start the PR title with a Conventional Commit prefix.

## Additional notes

Follows the deprecation handling introduced in the Progress List PR (#2755).
