### PR TITLE
feat(Accordion): Add an onToggle callback to Section

### DIFF
--- a/packages/react/src/Accordion/AccordionSection.test.tsx
+++ b/packages/react/src/Accordion/AccordionSection.test.tsx
@@ -53,6 +53,35 @@ describe('AccordionSection', () => {
     expect(sectionContent).not.toHaveClass('ams-accordion__panel--expanded')
   })
 
+  it('calls onToggle with the new expanded state when the button is clicked', () => {
+    const onToggle = vi.fn()
+
+    render(
+      <Accordion.Section label={testLabel} onToggle={onToggle}>
+        {testContent}
+      </Accordion.Section>,
+    )
+
+    const button = screen.getByRole('button', { name: testLabel })
+
+    fireEvent.click(button)
+
+    expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(onToggle).toHaveBeenCalledWith(true)
+
+    fireEvent.click(button)
+
+    expect(onToggle).toHaveBeenLastCalledWith(false)
+  })
+
+  it('does not throw when onToggle is not provided', () => {
+    render(<Accordion.Section label={testLabel}>{testContent}</Accordion.Section>)
+
+    const button = screen.getByRole('button', { name: testLabel })
+
+    expect(() => fireEvent.click(button)).not.toThrow()
+  })
+
   it('adds --expanded class when defaultExpanded prop is true', () => {
     const { getByText } = render(
       <Accordion.Section defaultExpanded label={testLabel}>

--- a/packages/react/src/Accordion/AccordionSection.tsx
+++ b/packages/react/src/Accordion/AccordionSection.tsx
@@ -7,10 +7,11 @@ import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 import { ChevronDownIcon } from '@amsterdam/design-system-react-icons'
 import { clsx } from 'clsx'
-import { forwardRef, useContext, useEffect, useId, useRef, useState } from 'react'
+import { forwardRef, useContext, useEffect, useId, useRef } from 'react'
 
 import type { IconProps } from '../Icon'
 
+import { useCollapsible } from '../common/useCollapsible'
 import { Heading } from '../Heading'
 import { Icon } from '../Icon'
 import { AccordionContext } from './AccordionContext'
@@ -28,6 +29,8 @@ export type AccordionSectionProps = {
   readonly expanded?: boolean
   /** The heading text. */
   readonly label: string
+  /** Callback fired when the section is expanded or collapsed. Receives the new expanded state. */
+  readonly onToggle?: (expanded: boolean) => void
 } & Readonly<PropsWithChildren<HTMLAttributes<HTMLElement>>>
 
 /**
@@ -37,11 +40,12 @@ export type AccordionSectionProps = {
  */
 export const AccordionSection = forwardRef(
   (
-    { children, className, defaultExpanded, expanded, label, ...restProps }: AccordionSectionProps,
+    { children, className, defaultExpanded, expanded, label, onToggle, ...restProps }: AccordionSectionProps,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
     const { headingLevel, sectionAs } = useContext(AccordionContext)
-    const [isExpanded, setIsExpanded] = useState(defaultExpanded ?? expanded ?? false)
+
+    const [isExpanded, toggle] = useCollapsible({ defaultValue: defaultExpanded ?? expanded, onToggle })
 
     // The deprecation warning fires once with the value passed on mount, so we read it through a ref to keep the effect dependency-free.
     const initialExpandedRef = useRef(expanded)
@@ -67,7 +71,7 @@ export const AccordionSection = forwardRef(
             aria-expanded={isExpanded}
             className="ams-accordion__button"
             id={buttonId}
-            onClick={() => setIsExpanded(!isExpanded)}
+            onClick={toggle}
             type="button"
           >
             <Icon className="ams-accordion__icon" size={iconSize} svg={ChevronDownIcon} />

--- a/storybook/src/components/Accordion/Accordion.docs.mdx
+++ b/storybook/src/components/Accordion/Accordion.docs.mdx
@@ -24,6 +24,7 @@ import * as AccordionSectionStories from "./AccordionSection.stories.tsx";
 
 Pairs a heading with collapsible content.
 Use `defaultExpanded` to show the content initially.
+Pass `onToggle` to be notified when the section opens or closes.
 
 <Canvas of={AccordionSectionStories.Section} />
 

--- a/storybook/src/components/Accordion/AccordionSection.stories.tsx
+++ b/storybook/src/components/Accordion/AccordionSection.stories.tsx
@@ -13,6 +13,9 @@ import { exampleAccordionHeading, exampleParagraph } from '#storybook/_common/ex
 const meta = {
   title: 'Components/Containers/Accordion',
   component: Accordion.Section,
+  argTypes: {
+    onToggle: { action: 'toggled' },
+  },
   decorators: [
     (Story) => (
       <Accordion headingLevel={3}>


### PR DESCRIPTION
## What

- Add an `onToggle` callback to Accordion Section, fired with the new expanded state when a section opens or closes.
- Route the section’s state through the shared `useCollapsible` hook (uncontrolled mode).

## Why

- Accordion Section had no callback, so a parent could not observe when a section opened or closed. `onToggle` matches the callback Table of Contents and Progress List already expose.
- This is Phase A of making Accordion Section controllable. The controlled `expanded` prop has to wait: the `expanded` name is currently a deprecated uncontrolled-default alias whose removal is published for on or after 2026-10-20, and repurposing it before then would silently change behaviour for existing `expanded` users. Adopting `useCollapsible` now makes Phase B a one-line change once the name frees up.

## How

- Add `onToggle?: (expanded: boolean) => void`.
- Replace the manual `useState` and toggle handler with `useCollapsible({ defaultValue: defaultExpanded ?? expanded, onToggle })`. Behaviour is unchanged.
- Leave the deprecated `expanded` prop and its warning in place.

## Checklist

- [x] Add or update unit tests – added `onToggle` tests (fires with the next state, does not throw when absent). The 20 existing tests still pass, so the refactor is behaviour-preserving. Accordion Section stays at 100% coverage.
- [x] Add or update documentation – noted `onToggle` on the Section docs.
- [x] Add or update stories – added an `onToggle` action to the Section story.
- [x] Add or update exports in index.\* files – not necessary; `onToggle` rides on the already-exported `AccordionSectionProps`.
- [x] Comment `/chromatic test` and verify visual regression tests pass – runs automatically on PR creation.
- [x] Start the PR title with a Conventional Commit prefix.

## Additional notes

- Phase A of Accordion Section’s controllability. Phase B (remove the deprecated `expanded`, add controlled `expanded` via `value: expanded`) follows on or after 2026-10-20, when the `expanded` name is free.
- Last of the collapsible series through Phase A, after Table of Contents (#2753), Page Header (#2754), and Progress List (#2755).
- A built-in single-open mode for the Accordion root is a separate, larger ticket, not part of this change.
