### PR TITLE
chore: Check staged YAML with Prettier

### DIFF
--- a/.nano-staged.json
+++ b/.nano-staged.json
@@ -2,5 +2,6 @@
   "composer.json": "composer validate",
   "package.json": "npmPkgJsonLint --allowEmptyTargets",
   "*.{md,js,json,jsx,mdx,ts,tsx}": ["eslint --no-error-on-unmatched-pattern", "prettier --check"],
-  "*.{css,scss}": ["stylelint --allow-empty-input", "prettier --check"]
+  "*.{css,scss}": ["stylelint --allow-empty-input", "prettier --check"],
+  "*.{yml,yaml}": "prettier --check"
 }


### PR DESCRIPTION
## What

Add `*.{yml,yaml}` to the nano-staged config so Prettier checks YAML at commit time. This covers the GitHub Actions workflows, the issue-template config, and the Dependabot config.

## Why

YAML was the one file type in the repo with no formatting gate — it was neither linted nor formatted. Workflow YAML in particular changed regularly without any consistency check. This closes that gap and makes YAML behave like every other file type we format (Markdown, JS/TS, JSON, CSS/SCSS), all of which already run through Prettier in nano-staged.

## How

A single entry in `.nano-staged.json`:

```json
"*.{yml,yaml}": "prettier --check"
```

Prettier runs in `--check` mode, so it flags unformatted YAML at commit time without rewriting it. All existing YAML already conforms, so nothing needed reformatting. `pnpm-lock.yaml` is left alone — it’s already in `.prettierignore`, so pnpm keeps ownership of its indentation.

Scope is deliberately formatting only. This doesn’t validate workflow schemas or GitHub Actions expressions; that would be a separate tool (such as actionlint) if we decide we want it later.

## Checklist

- [ ] Add or update unit tests
- [ ] Add or update documentation
- [ ] Add or update stories
- [ ] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Formatting only for now, per discussion; workflow/schema validation (actionlint) can be a follow-up if desired.
