### PR TITLE
feat(Storybook): Add an MCP server for AI assistants

### DIFF
--- a/.github/workflows/deploy-production-chromatic.yml
+++ b/.github/workflows/deploy-production-chromatic.yml
@@ -1,0 +1,47 @@
+name: Deploy production Chromatic
+
+# Publishes Storybook to Chromatic on every push to main so the public
+# permalink (https://main--<appid>.chromatic.com) and its MCP server stay
+# in sync with the latest released components.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  chromatic:
+    name: Run Chromatic
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          cache: pnpm
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm --filter=!storybook -r run build
+
+      - name: Run Chromatic
+        uses: chromaui/action@94713c544284a14195de3b50ef24301579f1877e # v18.0.1
+        with:
+          # Changes reaching main are already reviewed on their PR, so accept
+          # them as the new baseline rather than leaving the build unreviewed.
+          autoAcceptChanges: "main"
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: storybook

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Our [Figma Library](https://www.figma.com/community/file/1530535540611888495/ams
 
 See the [getting started documentation for developers](https://designsystem.amsterdam/?path=/docs/docs-developer-guide-getting-started--docs) on how to use our React components.
 
+## AI assistance
+
+If you build with an AI coding assistant, connect it to our Model Context Protocol (MCP) server.
+Your assistant then works with real Amsterdam Design System components and their correct properties, instead of inventing markup.
+See [connecting AI assistants](https://designsystem.amsterdam/?path=/docs/docs-developer-guide-ai-assistance--docs) to set it up.
+
 ## Contributing
 
 See the [documentation for contributors](./CONTRIBUTING.md).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,6 +310,9 @@ importers:
       '@storybook/addon-links':
         specifier: 10.4.6
         version: 10.4.6(@types/react@18.3.31)(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@3.9.4)(react@18.3.1))
+      '@storybook/addon-mcp':
+        specifier: 0.6.0
+        version: 0.6.0(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@3.9.4)(react@18.3.1))(typescript@5.9.3)
       '@storybook/addon-themes':
         specifier: 10.4.6
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@3.9.4)(react@18.3.1))
@@ -1815,6 +1818,15 @@ packages:
       react:
         optional: true
 
+  '@storybook/addon-mcp@0.6.0':
+    resolution: {integrity: sha512-E79m2S7ik9wiF1AnI49fwbLQkrD03PicIZpCdeFhbbB19MF4tKFKyaQtbT3f6eaAP4EP2+COLDVLCQ7B3rGF4w==}
+    peerDependencies:
+      '@storybook/addon-vitest': ^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+      storybook: ^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+    peerDependenciesMeta:
+      '@storybook/addon-vitest':
+        optional: true
+
   '@storybook/addon-themes@10.4.6':
     resolution: {integrity: sha512-80d622oB9xWZs3VH4uywkLOA5L2DAx04lVouvCM4XH+pLnJElidoylOLm3i3ByvlGkRjCbB27OUVsW94IgyDrw==}
     peerDependencies:
@@ -1857,6 +1869,9 @@ packages:
     resolution: {integrity: sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/mcp@0.7.0':
+    resolution: {integrity: sha512-Pr4E61tM5e7aDzqgNOL/Ylw8CGdb+BIDGOf3vbmFfkR8ZnXjPxaV/vhTEsiXynnIpjQWCzySCxOU1icxZsgjrA==}
 
   '@storybook/mdx2-csf@1.1.0':
     resolution: {integrity: sha512-TXJJd5RAKakWx4BtpwvSNdgTDkKM6RkXU8GK34S/LhidQ5Pjz3wcnqb0TxEkfhK/ztbP8nKHqXFwLfa2CYkvQw==}
@@ -2013,6 +2028,26 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@tmcp/adapter-valibot@0.1.6':
+    resolution: {integrity: sha512-drirZeNinhYLiRSMksN+m//u0ImFxtGRk1Vp425Xp/7CbBXFQdjAG+f7grssyHAukbVTGzmWsMMP6ejrGVErUA==}
+    peerDependencies:
+      tmcp: ^1.17.0
+      valibot: ^1.1.0
+
+  '@tmcp/session-manager@0.2.2':
+    resolution: {integrity: sha512-UrCRpTsxh5XnMbplspvftEYboiZWgAiXqqAUbyFTHoHMJ0LoNDy8bQd0+7qtxtT4S5Qsnv650gvs/Nbec5NTCQ==}
+    peerDependencies:
+      tmcp: ^1.16.3
+
+  '@tmcp/transport-http@0.8.6':
+    resolution: {integrity: sha512-iLcxu+tEMbkVHbhFfyXQhxfPDDTfm+F0kEw8Xg/a1rm29s4cBg1vwcpbtk02XTxsdDh8RJ1AZkQwF9WDGeb/IA==}
+    peerDependencies:
+      '@tmcp/auth': ^0.3.3 || ^0.4.0
+      tmcp: ^1.18.0
+    peerDependenciesMeta:
+      '@tmcp/auth':
+        optional: true
 
   '@tootallnate/once@3.0.1':
     resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
@@ -2394,6 +2429,11 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@valibot/to-json-schema@1.7.1':
+    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
+    peerDependencies:
+      valibot: ^1.4.0
 
   '@vitejs/plugin-react@6.0.3':
     resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
@@ -3420,6 +3460,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4219,6 +4262,9 @@ packages:
   json-parse-even-better-errors@3.0.2:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  json-rpc-2.0@1.7.1:
+    resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -5121,6 +5167,9 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picoquery@2.5.0:
+    resolution: {integrity: sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g==}
+
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
@@ -5629,6 +5678,9 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
+  sqids@0.3.0:
+    resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
+
   ssri@10.0.6:
     resolution: {integrity: sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -5927,6 +5979,9 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
+  tmcp@1.19.4:
+    resolution: {integrity: sha512-fMoUJ3Gef9iA0yKZNeW2SQCCKTluCwghUyOz/qxPS8XxrQk6Jlw4lgql3S+s6L//FteLeSJ7erKxMWl727mZoQ==}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -6115,6 +6170,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  uri-template-matcher@1.1.2:
+    resolution: {integrity: sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ==}
+
   url@0.11.4:
     resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
     engines: {node: '>= 0.4'}
@@ -6136,6 +6194,14 @@ packages:
   v8flags@4.0.1:
     resolution: {integrity: sha512-fcRLaS4H/hrZk9hYwbdRM35D0U8IYMfEClhXxCivOojl+yTRAZH3Zy2sSy6qVCiGbV9YAtPssP6jaChqC9vPCg==}
     engines: {node: '>= 10.13.0'}
+
+  valibot@1.2.0:
+    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -7733,6 +7799,19 @@ snapshots:
       '@types/react': 18.3.31
       react: 18.3.1
 
+  '@storybook/addon-mcp@0.6.0(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@3.9.4)(react@18.3.1))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/mcp': 0.7.0(typescript@5.9.3)
+      '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
+      '@tmcp/transport-http': 0.8.6(tmcp@1.19.4(typescript@5.9.3))
+      picoquery: 2.5.0
+      storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@3.9.4)(react@18.3.1)
+      tmcp: 1.19.4(typescript@5.9.3)
+      valibot: 1.2.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@tmcp/auth'
+      - typescript
+
   '@storybook/addon-themes@10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@3.9.4)(react@18.3.1))':
     dependencies:
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@18.3.31)(prettier@3.9.4)(react@18.3.1)
@@ -7768,6 +7847,16 @@ snapshots:
   '@storybook/icons@2.1.0(react@18.3.1)':
     dependencies:
       react: 18.3.1
+
+  '@storybook/mcp@0.7.0(typescript@5.9.3)':
+    dependencies:
+      '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
+      '@tmcp/transport-http': 0.8.6(tmcp@1.19.4(typescript@5.9.3))
+      tmcp: 1.19.4(typescript@5.9.3)
+      valibot: 1.2.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@tmcp/auth'
+      - typescript
 
   '@storybook/mdx2-csf@1.1.0': {}
 
@@ -7954,6 +8043,23 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
+
+  '@tmcp/adapter-valibot@0.1.6(tmcp@1.19.4(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@valibot/to-json-schema': 1.7.1(valibot@1.2.0(typescript@5.9.3))
+      tmcp: 1.19.4(typescript@5.9.3)
+      valibot: 1.2.0(typescript@5.9.3)
+
+  '@tmcp/session-manager@0.2.2(tmcp@1.19.4(typescript@5.9.3))':
+    dependencies:
+      tmcp: 1.19.4(typescript@5.9.3)
+
+  '@tmcp/transport-http@0.8.6(tmcp@1.19.4(typescript@5.9.3))':
+    dependencies:
+      '@tmcp/session-manager': 0.2.2(tmcp@1.19.4(typescript@5.9.3))
+      esm-env: 1.2.2
+      tmcp: 1.19.4(typescript@5.9.3)
 
   '@tootallnate/once@3.0.1': {}
 
@@ -8351,6 +8457,10 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@valibot/to-json-schema@1.7.1(valibot@1.2.0(typescript@5.9.3))':
+    dependencies:
+      valibot: 1.2.0(typescript@5.9.3)
 
   '@vitejs/plugin-react@6.0.3(vite@8.1.3(@types/node@25.7.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))':
     dependencies:
@@ -9559,6 +9669,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@10.4.0:
     dependencies:
       acorn: 8.16.0
@@ -10372,6 +10484,8 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-parse-even-better-errors@3.0.2: {}
+
+  json-rpc-2.0@1.7.1: {}
 
   json-schema-traverse@0.4.1: {}
 
@@ -11724,6 +11838,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picoquery@2.5.0: {}
+
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
@@ -12339,6 +12455,8 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
+  sqids@0.3.0: {}
+
   ssri@10.0.6:
     dependencies:
       minipass: 7.1.3
@@ -12725,6 +12843,16 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
+  tmcp@1.19.4(typescript@5.9.3):
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      json-rpc-2.0: 1.7.1
+      sqids: 0.3.0
+      uri-template-matcher: 1.1.2
+      valibot: 1.2.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -12979,6 +13107,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  uri-template-matcher@1.1.2: {}
+
   url@0.11.4:
     dependencies:
       punycode: 1.4.1
@@ -13003,6 +13133,10 @@ snapshots:
       which-typed-array: 1.1.22
 
   v8flags@4.0.1: {}
+
+  valibot@1.2.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/storybook/AGENTS.md
+++ b/storybook/AGENTS.md
@@ -82,4 +82,4 @@ Utility functions in `src/_common/` have unit tests (`*.test.ts`) run by Vitest 
 
 The `@storybook/addon-mcp` addon (registered in `config/main.ts`) serves a Model Context Protocol endpoint at `http://localhost:6006/mcp` while `pnpm run watch:storybook` is running; the URL follows the dev-server port.
 It exposes the components, props, stories, and docs of the design system to MCP-capable AI agents such as GitHub Copilot, so agents reuse existing components instead of inventing markup.
-No single MCP config file works across editors, so we do not commit editor-specific config; per-tool connection steps live in the AI assistance developer-guide page (`src/docs/developer-guide/ai-assistance.docs.mdx`).
+No single MCP config file works across editors, so we do not commit editor-specific config; connection guidance lives in the AI assistance developer-guide page (`src/docs/developer-guide/ai-assistance.docs.mdx`).

--- a/storybook/AGENTS.md
+++ b/storybook/AGENTS.md
@@ -77,3 +77,9 @@ Utility functions in `src/_common/` have unit tests (`*.test.ts`) run by Vitest 
 
 - Global styles and package imports: `config/preview.tsx`
 - Static assets (`packages-proprietary/assets`) and Chromatic pseudo-state setup: `config/main.ts`
+
+## MCP server
+
+The `@storybook/addon-mcp` addon (registered in `config/main.ts`) serves a Model Context Protocol endpoint at `http://localhost:6006/mcp` while `pnpm run watch:storybook` is running; the URL follows the dev-server port.
+It exposes the components, props, stories, and docs of the design system to MCP-capable AI agents such as GitHub Copilot, so agents reuse existing components instead of inventing markup.
+No single MCP config file works across editors, so we do not commit editor-specific config; per-tool connection steps live in the AI assistance developer-guide page (`src/docs/developer-guide/ai-assistance.docs.mdx`).

--- a/storybook/config/main.ts
+++ b/storybook/config/main.ts
@@ -29,6 +29,7 @@ const config: StorybookConfig = {
       },
     },
     '@linus_janns/storybook-addon-html',
+    '@storybook/addon-mcp',
     ...(process.env['IS_CHROMATIC'] || process.env['NODE_ENV'] === 'development'
       ? ['storybook-addon-pseudo-states']
       : []),

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -35,6 +35,7 @@
     "@storybook/addon-a11y": "10.4.6",
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-links": "10.4.6",
+    "@storybook/addon-mcp": "0.6.0",
     "@storybook/addon-themes": "10.4.6",
     "@storybook/mdx2-csf": "1.1.0",
     "@storybook/react-vite": "10.4.6",

--- a/storybook/src/docs/developer-guide/ai-assistance.docs.mdx
+++ b/storybook/src/docs/developer-guide/ai-assistance.docs.mdx
@@ -6,21 +6,14 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 # AI assistance
 
-Many teams now build interfaces with an AI coding assistant.
-We run a Model Context Protocol (MCP) server so your assistant can work with the real Amsterdam Design System: our components, their properties, our stories, and our documentation.
-With it connected, the assistant reuses existing components with the correct properties, variants, and accessibility patterns, instead of inventing markup that only looks similar.
+We run a MCP server to let your assistant work with the real Amsterdam Design System.
 
 ## Why connect your assistant
 
-Without this context, an assistant guesses.
-It writes generic HTML, invents property names, and misses our accessibility and language conventions.
+This server exposes our components and their features, as well as our stories and documentation.
+Without this context, an assistant guesses: it writes generic HTML, invents property names, and misses our accessibility and language conventions.
 
-With it connected, the assistant:
-
-- reaches for an existing component instead of rebuilding one;
-- uses the correct properties and variants, taken from the current release;
-- follows our accessibility patterns and Dutch-language defaults.
-
+With it, the assistant builds with existing components, using the correct properties, variants, and accessibility patterns from the current release.
 This keeps what you ship consistent with the rest of the City’s services, with less review and rework.
 
 ## What the server exposes
@@ -33,21 +26,16 @@ The hosted server gives your assistant a small set of tools, which it calls on i
 
 You simply ask for what you want to build.
 
-Contributors who run Storybook locally also get tools to preview stories and follow our story-writing conventions.
-
 ## The endpoint
 
-The server speaks the Model Context Protocol over Streamable HTTP, at the path `/mcp`.
-
-Most people should use the hosted endpoint.
-It needs no setup, tracks our `main` branch, and is public, so any tool can connect without signing in:
+Our hosted endpoint needs no setup, tracks our `main` branch, and is public, so any tool can connect:
 
 {/* prettier-ignore */}
 ```sh
 https://main--68db9df886b46f139748c074.chromatic.com/mcp
 ```
 
-Contributors working on the design system itself can instead use the local endpoint, available while `pnpm run watch:storybook` is running:
+Contributors can use the local endpoint while `pnpm run watch:storybook` is running:
 
 {/* prettier-ignore */}
 ```sh
@@ -58,73 +46,11 @@ The local URL follows your Storybook port; if you run it on another port, change
 
 ## Connect your tool
 
-The snippets below use the hosted endpoint.
+Any MCP-capable assistant can connect.
+Use your tool’s MCP settings to add a server over Streamable HTTP at the hosted endpoint above.
 Contributors can swap in `http://localhost:6006/mcp` to use a local Storybook.
 
-One thing to watch: Visual Studio Code uses the key `servers`, while most other tools use `mcpServers`.
-Use the snippet that matches your tool.
-
-### GitHub Copilot
-
-In Visual Studio Code, add a workspace file `.vscode/mcp.json`:
-
-{/* prettier-ignore */}
-```json
-{
-  "servers": {
-    "amsterdam-design-system": {
-      "type": "http",
-      "url": "https://main--68db9df886b46f139748c074.chromatic.com/mcp"
-    }
-  }
-}
-```
-
-In a JetBrains IDE such as WebStorm, open the GitHub Copilot plugin’s settings and add an MCP server with the URL above.
-Connecting Copilot to MCP servers in JetBrains IDEs is newer than in Visual Studio Code; if you do not see the option, update the plugin and check its release notes.
-
-### JetBrains AI Assistant or Junie
-
-For AI Assistant (WebStorm or IntelliJ 2025.2 and later), go to Settings → Tools → AI Assistant → Model Context Protocol (MCP) and add a server with the URL above.
-
-For Junie, add a project file `.junie/mcp/mcp.json`:
-
-{/* prettier-ignore */}
-```json
-{
-  "mcpServers": {
-    "amsterdam-design-system": {
-      "url": "https://main--68db9df886b46f139748c074.chromatic.com/mcp"
-    }
-  }
-}
-```
-
-### Cursor
-
-Add a project file `.cursor/mcp.json`:
-
-{/* prettier-ignore */}
-```json
-{
-  "mcpServers": {
-    "amsterdam-design-system": {
-      "url": "https://main--68db9df886b46f139748c074.chromatic.com/mcp"
-    }
-  }
-}
-```
-
-### Claude Code
-
-Run:
-
-{/* prettier-ignore */}
-```sh
-claude mcp add --transport http amsterdam-design-system https://main--68db9df886b46f139748c074.chromatic.com/mcp
-```
-
-Or add a project file `.mcp.json`:
+Many tools read this configuration from a JSON file, and most accept this shape:
 
 {/* prettier-ignore */}
 ```json
@@ -138,36 +64,21 @@ Or add a project file `.mcp.json`:
 }
 ```
 
-### Another tool
-
-Any MCP-capable assistant can connect.
-Use your tool’s own MCP settings to add a server over Streamable HTTP at the endpoint above.
-Most tools accept this shape:
-
-{/* prettier-ignore */}
-```json
-{
-  "mcpServers": {
-    "amsterdam-design-system": {
-      "type": "http",
-      "url": "https://main--68db9df886b46f139748c074.chromatic.com/mcp"
-    }
-  }
-}
-```
+The exact key, file name, and file location differ per tool; check your tool’s MCP documentation for the specifics.
 
 ## Example prompts
 
 Once connected, ask for what you want in plain language:
 
-- “Build a contact form with the Amsterdam Design System: a name field, an email field, and a submit button.”
+- “Build a contact form with ADS: a name and email field and a submit button.”
 - “Show me the properties and variants of the Alert component.”
 - “Replace this hand-built card with the design system’s Card component.”
 - “Lay out this page with Grid and Column from the design system.”
+- “Should I use a Button or a Link component for this interaction?”
 
 ## Good to know
 
-- The hosted endpoint tracks the `main` branch, so your assistant works with our latest released components and properties.
+- The hosted endpoint tracks the `main` branch, so your assistant works with our latest released API.
 - It draws on our stories and documentation, so richer stories lead to better answers.
 - Component support starts with React; other technologies follow as the Storybook MCP server adds them.
 - This page always lists the current endpoint; if a connection stops working, check here for the latest address.

--- a/storybook/src/docs/developer-guide/ai-assistance.docs.mdx
+++ b/storybook/src/docs/developer-guide/ai-assistance.docs.mdx
@@ -6,7 +6,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 # AI assistance
 
-We run a MCP server to let your assistant work with the real Amsterdam Design System.
+We run an MCP server to let your assistant work with the real Amsterdam Design System.
 
 ## Why connect your assistant
 

--- a/storybook/src/docs/developer-guide/ai-assistance.docs.mdx
+++ b/storybook/src/docs/developer-guide/ai-assistance.docs.mdx
@@ -1,0 +1,174 @@
+{/* @license CC0-1.0 */}
+
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Docs/Developer Guide/AI assistance" />
+
+# AI assistance
+
+Many teams now build interfaces with an AI coding assistant.
+We run a Model Context Protocol (MCP) server so your assistant can work with the real Amsterdam Design System: our components, their properties, our stories, and our documentation.
+With it connected, the assistant reuses existing components with the correct properties, variants, and accessibility patterns, instead of inventing markup that only looks similar.
+
+## Why connect your assistant
+
+Without this context, an assistant guesses.
+It writes generic HTML, invents property names, and misses our accessibility and language conventions.
+
+With it connected, the assistant:
+
+- reaches for an existing component instead of rebuilding one;
+- uses the correct properties and variants, taken from the current release;
+- follows our accessibility patterns and Dutch-language defaults.
+
+This keeps what you ship consistent with the rest of the City’s services, with less review and rework.
+
+## What the server exposes
+
+The hosted server gives your assistant a small set of tools, which it calls on its own:
+
+- **list-all-documentation** lists every component and documentation page, so the assistant knows what exists.
+- **get-documentation** returns a component’s full documentation, properties, and code examples.
+- **get-documentation-for-story** returns the documentation for one specific story variant.
+
+You simply ask for what you want to build.
+
+Contributors who run Storybook locally also get tools to preview stories and follow our story-writing conventions.
+
+## The endpoint
+
+The server speaks the Model Context Protocol over Streamable HTTP, at the path `/mcp`.
+
+Most people should use the hosted endpoint.
+It needs no setup, tracks our `main` branch, and is public, so any tool can connect without signing in:
+
+{/* prettier-ignore */}
+```sh
+https://main--68db9df886b46f139748c074.chromatic.com/mcp
+```
+
+Contributors working on the design system itself can instead use the local endpoint, available while `pnpm run watch:storybook` is running:
+
+{/* prettier-ignore */}
+```sh
+http://localhost:6006/mcp
+```
+
+The local URL follows your Storybook port; if you run it on another port, change the number to match.
+
+## Connect your tool
+
+The snippets below use the hosted endpoint.
+Contributors can swap in `http://localhost:6006/mcp` to use a local Storybook.
+
+One thing to watch: Visual Studio Code uses the key `servers`, while most other tools use `mcpServers`.
+Use the snippet that matches your tool.
+
+### GitHub Copilot
+
+In Visual Studio Code, add a workspace file `.vscode/mcp.json`:
+
+{/* prettier-ignore */}
+```json
+{
+  "servers": {
+    "amsterdam-design-system": {
+      "type": "http",
+      "url": "https://main--68db9df886b46f139748c074.chromatic.com/mcp"
+    }
+  }
+}
+```
+
+In a JetBrains IDE such as WebStorm, open the GitHub Copilot plugin’s settings and add an MCP server with the URL above.
+Connecting Copilot to MCP servers in JetBrains IDEs is newer than in Visual Studio Code; if you do not see the option, update the plugin and check its release notes.
+
+### JetBrains AI Assistant or Junie
+
+For AI Assistant (WebStorm or IntelliJ 2025.2 and later), go to Settings → Tools → AI Assistant → Model Context Protocol (MCP) and add a server with the URL above.
+
+For Junie, add a project file `.junie/mcp/mcp.json`:
+
+{/* prettier-ignore */}
+```json
+{
+  "mcpServers": {
+    "amsterdam-design-system": {
+      "url": "https://main--68db9df886b46f139748c074.chromatic.com/mcp"
+    }
+  }
+}
+```
+
+### Cursor
+
+Add a project file `.cursor/mcp.json`:
+
+{/* prettier-ignore */}
+```json
+{
+  "mcpServers": {
+    "amsterdam-design-system": {
+      "url": "https://main--68db9df886b46f139748c074.chromatic.com/mcp"
+    }
+  }
+}
+```
+
+### Claude Code
+
+Run:
+
+{/* prettier-ignore */}
+```sh
+claude mcp add --transport http amsterdam-design-system https://main--68db9df886b46f139748c074.chromatic.com/mcp
+```
+
+Or add a project file `.mcp.json`:
+
+{/* prettier-ignore */}
+```json
+{
+  "mcpServers": {
+    "amsterdam-design-system": {
+      "type": "http",
+      "url": "https://main--68db9df886b46f139748c074.chromatic.com/mcp"
+    }
+  }
+}
+```
+
+### Another tool
+
+Any MCP-capable assistant can connect.
+Use your tool’s own MCP settings to add a server over Streamable HTTP at the endpoint above.
+Most tools accept this shape:
+
+{/* prettier-ignore */}
+```json
+{
+  "mcpServers": {
+    "amsterdam-design-system": {
+      "type": "http",
+      "url": "https://main--68db9df886b46f139748c074.chromatic.com/mcp"
+    }
+  }
+}
+```
+
+## Example prompts
+
+Once connected, ask for what you want in plain language:
+
+- “Build a contact form with the Amsterdam Design System: a name field, an email field, and a submit button.”
+- “Show me the properties and variants of the Alert component.”
+- “Replace this hand-built card with the design system’s Card component.”
+- “Lay out this page with Grid and Column from the design system.”
+
+## Good to know
+
+- The hosted endpoint tracks the `main` branch, so your assistant works with our latest released components and properties.
+- It draws on our stories and documentation, so richer stories lead to better answers.
+- Component support starts with React; other technologies follow as the Storybook MCP server adds them.
+- This page always lists the current endpoint; if a connection stops working, check here for the latest address.
+- If a component you need does not exist yet, [request it or contribute](https://github.com/Amsterdam/design-system/blob/develop/CONTRIBUTING.md) rather than having your assistant build a one-off.


### PR DESCRIPTION
## What

Adds a Model Context Protocol (MCP) server to Storybook, so AI coding assistants can build with the real Amsterdam Design System — our components, their properties, our stories, and our documentation — instead of guessing.

- Installs and registers `@storybook/addon-mcp`, which serves an MCP endpoint at `/mcp` from the Storybook dev server.
- Publishes the server publicly through Chromatic (the `main` permalink) and adds a workflow that republishes on every push to `main`, so the endpoint tracks releases.
- Adds a Developer Guide page, “AI assistance”, with per-tool connection steps (GitHub Copilot, JetBrains AI Assistant/Junie, Cursor, Claude Code, and a generic option) and example prompts, plus a short pointer from the README.

## Why

A growing share of developers building on the design system work through AI assistants.
Without this context, an assistant invents generic markup and property names and misses our accessibility and language conventions.
With the MCP server connected, it reuses our components with the correct properties and patterns — the adoption and consistency the design system exists to provide, now extended to AI-assisted workflows across the City and the wider NL Design System community.

## How

- `@storybook/addon-mcp` is registered in `storybook/config/main.ts`; the endpoint follows the dev-server port (`http://localhost:6006/mcp`).
- The hosted endpoint is Chromatic’s published Storybook.
  The new “Deploy production Chromatic” workflow runs a Chromatic build on every push to `main` (changes auto-accepted, since they’re reviewed on their PR) to keep it current.
  The data — the component and docs manifests — is produced by `storybook build` and published as static JSON, so the server holds no database and no secrets.
- No single MCP config file works across editors, so we document the endpoint and per-tool setup rather than committing an editor-specific file.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Relates to DES-1918.
- Supersedes #2757: the same MCP server and documentation, reworked as a smaller change.
  It deliberately omits that PR’s Storybook‑Vitest/Playwright component-testing integration — four heavy dependencies and browser infrastructure for a tool (`run-story-tests`) that the hosted endpoint doesn’t expose, duplicating our existing unit tests and Chromatic checks.
- The hosted MCP endpoint is public and anonymous: `https://main--68db9df886b46f139748c074.chromatic.com/mcp`.
  The new “AI assistance” page (Docs → Developer Guide) documents how to connect each tool; see it in this branch’s feature deploy.
- MCP support currently covers React; other technologies will follow as the Storybook MCP server adds them.
