### PR TITLE
chore(storybook): Narrow staticDirs to the individual asset folders

### DIFF
--- a/storybook/config/main.ts
+++ b/storybook/config/main.ts
@@ -47,7 +47,16 @@ const config: StorybookConfig = {
     options: {},
   },
 
-  staticDirs: ['../../packages-proprietary/assets'],
+  // Mount the individual asset folders rather than the package root: the package
+  // also holds infrastructure (node_modules, configs) that must not be published.
+  staticDirs: [
+    { from: '../../packages-proprietary/assets/app-icons', to: '/app-icons' },
+    { from: '../../packages-proprietary/assets/favicon', to: '/favicon' },
+    { from: '../../packages-proprietary/assets/font', to: '/font' },
+    { from: '../../packages-proprietary/assets/icons', to: '/icons' },
+    { from: '../../packages-proprietary/assets/logo', to: '/logo' },
+    { from: '../../packages-proprietary/assets/manifest', to: '/manifest' },
+  ],
   stories: ['../src/**/*.docs.mdx', '../src/**/*.stories.@(ts|tsx)'],
 
   typescript: {


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## What

Narrows Storybook’s `staticDirs` from the root of the assets package to its six individual asset folders: `app-icons`, `favicon`, `font`, `icons`, `logo`, and `manifest`.

## Why

Mounting the package root copies its infrastructure – `node_modules`, `package.json`, configs, and Markdown files – into every Storybook build, so it all gets published along with the actual assets.

## How

Each asset folder is now mounted as a `{ from, to }` entry, keeping the same URLs as before. Verified with a full Storybook build: all six folders end up in the output with their contents, the paths referenced from the docs (`favicon/…`, `app-icons/…`) resolve, and the package infrastructure is no longer copied.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

This change was part of #2757 and deliberately left out of #2760 to keep that PR focused on the MCP server.
