### PR TITLE
chore(docs): Add Deploy production Chromatic to the workflows README

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,12 +3,12 @@
 # GitHub Actions workflows
 
 This folder holds every continuous integration and delivery workflow for the design system.
-There are twelve of them, but they only do four kinds of work, and the file name now starts with the verb for that kind.
+There are thirteen of them, but they only do four kinds of work, and the file name now starts with the verb for that kind.
 Job ids and step names follow the same rule — a verb first, and a name that matches what actually happens — so keep new ones consistent with their neighbours rather than inventing a new style.
 Reading them by responsibility is the quickest way to understand the whole picture.
 
 - **Check** — quality gates that run on every pull request.
-- **Deploy** — build Storybook and deploy it to GitHub Pages.
+- **Deploy** — build Storybook and publish it to GitHub Pages and Chromatic.
 - **Publish** — publish the packages to npm.
 - **Remove** — delete preview deployments once a branch is gone.
 
@@ -17,20 +17,21 @@ Changes reach `main` through a release pull request, which is what triggers the 
 
 ## At a glance
 
-| Workflow                      | Runs when                                                      | Responsible for                                                                                                                    |
-| :---------------------------- | :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------- |
-| Check build and tests         | Every pull request; push to `main`                             | Build all packages, then run the linters and unit tests. The main quality gate.                                                    |
-| Check visual regressions      | Pull request opened or marked ready; `/chromatic test` comment | Visual regression snapshots through Chromatic.                                                                                     |
-| Check test coverage           | Every pull request                                             | Run the React tests with coverage and post a summary comment.                                                                      |
-| Check bundle size             | Every pull request                                             | Report the compressed size change of the published bundles.                                                                        |
-| Check PR title                | Pull request opened, edited, or synchronized                   | Enforce a Conventional Commit title (`feat`, `fix`, `chore`) so release-please can read it.                                        |
-| Deploy acceptance Storybook   | Push to any branch except `main`; pull request reopened        | Build Storybook and publish a per-branch preview to `gh-pages` under `demo-<branch>`. Records a GitHub Deployment and Environment. |
-| Deploy production Storybook   | Push to `main`                                                 | Build Storybook and publish the live documentation site to the `gh-pages` root.                                                    |
-| Publish packages              | After “Check build and tests” succeeds on `main`               | Run release-please; if it cuts a release, build and publish the packages to npm.                                                   |
-| Remove acceptance Storybook   | Pull request closed (base is not `main`)                       | Delete that branch’s `demo-<branch>` directory and deactivate its Deployment.                                                      |
-| Remove stale deployments      | Weekly, Sunday 05:00 UTC; manual                               | Delete GitHub Deployment records for `demo-*` whose branch no longer exists.                                                       |
-| Remove stale environments     | Weekly, Sunday 04:00 UTC; manual                               | Delete `demo-*` GitHub Environments whose branch no longer exists.                                                                 |
-| Remove stale demo directories | After a major release; manual                                  | Remove stale `demo-*` directories from the `gh-pages` branch.                                                                      |
+| Workflow                      | Runs when                                                      | Responsible for                                                                                                                            |
+| :---------------------------- | :------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------- |
+| Check build and tests         | Every pull request; push to `main`                             | Build all packages, then run the linters and unit tests. The main quality gate.                                                            |
+| Check visual regressions      | Pull request opened or marked ready; `/chromatic test` comment | Visual regression snapshots through Chromatic.                                                                                             |
+| Check test coverage           | Every pull request                                             | Run the React tests with coverage and post a summary comment.                                                                              |
+| Check bundle size             | Every pull request                                             | Report the compressed size change of the published bundles.                                                                                |
+| Check PR title                | Pull request opened, edited, or synchronized                   | Enforce a Conventional Commit title (`feat`, `fix`, `chore`) so release-please can read it.                                                |
+| Deploy acceptance Storybook   | Push to any branch except `main`; pull request reopened        | Build Storybook and publish a per-branch preview to `gh-pages` under `demo-<branch>`. Records a GitHub Deployment and Environment.         |
+| Deploy production Storybook   | Push to `main`                                                 | Build Storybook and publish the live documentation site to the `gh-pages` root.                                                            |
+| Deploy production Chromatic   | Push to `main`                                                 | Publish Storybook to Chromatic and auto-accept the snapshots as the new baseline, keeping the public permalink and its MCP server in sync. |
+| Publish packages              | After “Check build and tests” succeeds on `main`               | Run release-please; if it cuts a release, build and publish the packages to npm.                                                           |
+| Remove acceptance Storybook   | Pull request closed (base is not `main`)                       | Delete that branch’s `demo-<branch>` directory and deactivate its Deployment.                                                              |
+| Remove stale deployments      | Weekly, Sunday 05:00 UTC; manual                               | Delete GitHub Deployment records for `demo-*` whose branch no longer exists.                                                               |
+| Remove stale environments     | Weekly, Sunday 04:00 UTC; manual                               | Delete `demo-*` GitHub Environments whose branch no longer exists.                                                                         |
+| Remove stale demo directories | After a major release; manual                                  | Remove stale `demo-*` directories from the `gh-pages` branch.                                                                              |
 
 ## How a change flows through them
 
@@ -44,8 +45,9 @@ At the same time, **Deploy acceptance Storybook** publishes a live Storybook pre
 
 ### Merging to `main`
 
-A push to `main` runs two things in parallel.
+A push to `main` runs three things in parallel.
 **Deploy production Storybook** rebuilds Storybook and replaces the live documentation site at the `gh-pages` root, keeping all `demo-*` previews untouched.
+**Deploy production Chromatic** publishes the same Storybook to Chromatic and auto-accepts the snapshots as the new baseline, so the public permalink and its MCP server stay in sync with the latest released components.
 **Check build and tests** runs again on `main`, and its success is the signal that starts **Publish packages**.
 
 **Publish packages** runs release-please.


### PR DESCRIPTION
## What

Documents the `Deploy production Chromatic` workflow in the workflows README, which was missing from the reference even though its workflow file is present in the folder.

- Adds a row for it to the “At a glance” table, in the Deploy group alongside “Deploy production Storybook”.
- Updates the intro count from twelve to thirteen workflows.
- Notes that the Deploy group now publishes to Chromatic as well as GitHub Pages.
- Expands the “Merging to `main`” flow, which now covers all three workflows that run on a push to `main`.

## Why

The count sentence and the “At a glance” table were consistent with each other but never listed `deploy-production-chromatic.yml`, so anyone reading the reference would miss a workflow that runs on every push to `main`. The “Merging to `main`” section also claimed only two things run in parallel, when there are actually three.

## How

Described the workflow from its actual contents: it runs on a push to `main`, builds the packages and Storybook, and publishes to Chromatic with `autoAcceptChanges: "main"` so the public permalink and its MCP server track the latest released components. Kept the verb-first naming and one-sentence-per-line prose the rest of the README uses, then ran `prettier --write` so the table stays aligned.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Documentation-only change; no component, story, or export changes.
