### PR TITLE
fix(ci): Remove non-functional image globs from asset aggregate

### DIFF
--- a/.github/workflows/check-bundle-size.yml
+++ b/.github/workflows/check-bundle-size.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           mkdir -p packages-proprietary/temp
           tar -czf packages-proprietary/temp/assets-fonts.tar.gz -C packages-proprietary/assets font
-          tar -czf packages-proprietary/temp/assets-others.tar.gz -C packages-proprietary/assets app-icons favicon icons logo manifest *.svg *.png *.jpg *.jpeg *.gif *.webp *.avif *.ico 2>/dev/null || true
+          tar -czf packages-proprietary/temp/assets-others.tar.gz -C packages-proprietary/assets app-icons favicon icons logo manifest
 
       - name: Report bundle size
         uses: preactjs/compressed-size-action@f322c295dde06a1cb7ccaef105732dd8a726d1d9 # v2.10.0


### PR DESCRIPTION
## What

Remove the trailing image globs (`*.svg *.png *.jpg *.jpeg *.gif *.webp *.avif *.ico`) and the `2>/dev/null || true` from the “Create asset aggregates” step in the bundle-size workflow.

## Why

Those globs never contributed anything to the `assets-others` aggregate. The shell expands them in the workflow’s working directory (the repo root) *before* `tar` runs, not in `packages-proprietary/assets` where `-C` points. There are no matching images at the root, so on the runner’s bash (`nullglob` off) each pattern stays literal, `tar` fails to find a file named `*.svg`, and the error is swallowed by `2>/dev/null || true`.

They were evidently meant as a safety net to catch any loose image sitting directly in `packages-proprietary/assets`, but no such file exists today and none has ever been tracked there — every asset lives in a named subdirectory (`app-icons`, `favicon`, `icons`, `logo`, `manifest`), all of which are already measured. So the net has never caught anything and doesn’t work regardless.

## How

Dropped the dead globs, leaving a clean one-liner that lists only the real subdirectories. Removing them also lets the `2>/dev/null || true` go — it only existed to hide the failing globs, so a genuine `tar` error will now surface instead of being silently ignored. The measured `assets-others` size is unchanged.

If a new top-level image category is ever added, it would get its own named entry here, the same as the existing subdirectories.

## Checklist

- [ ] Add or update unit tests
- [ ] Add or update documentation
- [ ] Add or update stories
- [ ] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

CI-only change; no product code, stories, or docs affected.
