### PR TITLE
chore(ci): Add Actionlint to lint workflow files

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 # GitHub Actions workflows
 
 This folder holds every continuous integration and delivery workflow for the design system.
-There are thirteen of them, but they only do four kinds of work, and the file name now starts with the verb for that kind.
+There are fourteen of them, but they only do four kinds of work, and the file name now starts with the verb for that kind.
 Job ids and step names follow the same rule — a verb first, and a name that matches what actually happens — so keep new ones consistent with their neighbours rather than inventing a new style.
 Reading them by responsibility is the quickest way to understand the whole picture.
 
@@ -24,6 +24,7 @@ Changes reach `main` through a release pull request, which is what triggers the 
 | Check test coverage           | Every pull request                                             | Run the React tests with coverage and post a summary comment.                                                                              |
 | Check bundle size             | Every pull request                                             | Report the compressed size change of the published bundles.                                                                                |
 | Check PR title                | Pull request opened, edited, or synchronized                   | Enforce a Conventional Commit title (`feat`, `fix`, `chore`) so release-please can read it.                                                |
+| Check workflows               | Every pull request                                             | Lint the Actions workflow files themselves with actionlint, including shellcheck on their `run:` scripts.                                  |
 | Deploy acceptance Storybook   | Push to any branch except `main`; pull request reopened        | Build Storybook and publish a per-branch preview to `gh-pages` under `demo-<branch>`. Records a GitHub Deployment and Environment.         |
 | Deploy production Storybook   | Push to `main`                                                 | Build Storybook and publish the live documentation site to the `gh-pages` root.                                                            |
 | Deploy production Chromatic   | Push to `main`                                                 | Publish Storybook to Chromatic and auto-accept the snapshots as the new baseline, keeping the public permalink and its MCP server in sync. |
@@ -40,6 +41,7 @@ Changes reach `main` through a release pull request, which is what triggers the 
 The **Check** workflows run together and gate the merge.
 **Check build and tests** builds the packages and runs the linters and unit tests.
 **Check visual regressions** takes Chromatic snapshots, the coverage and bundle-size workflows post their reports as comments, and the title check validates the pull request title.
+**Check workflows** lints the Actions workflow files themselves.
 
 At the same time, **Deploy acceptance Storybook** publishes a live Storybook preview for the branch at `demo-<branch>` on GitHub Pages.
 

--- a/.github/workflows/check-workflows.yml
+++ b/.github/workflows/check-workflows.yml
@@ -1,0 +1,30 @@
+name: Check workflows
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+# A new push to the PR makes the run in flight obsolete – cancel it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-workflows:
+    name: Lint workflow files
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Runs actionlint over .github/workflows. shellcheck ships on the runner,
+      # so run: scripts are linted too. The action is pinned by digest, but the
+      # actionlint binary it downloads is deliberately left unpinned: each run
+      # picks up the latest release, so new checks and fixes arrive without
+      # maintenance. Add `version: x.y.z` below if you need reproducible runs.
+      - name: Run actionlint
+        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0


### PR DESCRIPTION
## What

Adds a `Check workflows` workflow that runs [actionlint](https://github.com/rhysd/actionlint) on every pull request, linting all of our GitHub Actions workflow files. Because shellcheck ships on the runner, actionlint also lints the shell inside `run:` steps. The new Check is documented in the workflows README.

## Why

Until now nothing checked the workflow files themselves. actionlint catches the mistakes that are easy to miss in review — invalid syntax, bad `${{ }}` expressions, untrusted-input script-injection risks, and (through shellcheck) shell bugs in `run:` steps — before they land on `develop`. It’s a fast, cheap gate that sits naturally alongside the other `Check` workflows.

## How

- New `check-workflows.yml`, following the verb-first `Check` convention. It runs on `pull_request`, with `contents: read`, a short timeout, and the same cancel-superseded concurrency as the other pull-request checks. Linting workflow YAML only on pull requests is enough: anything reaching `main` was already linted on its `develop` PR.
- Uses `raven-actions/actionlint`, pinned by commit digest like every other action here, so the existing Dependabot `github-actions` updates keep it current.
- The actionlint binary itself is left unpinned (it floats to the latest release) to keep maintenance low; a comment in the file explains this and how to pin a version if reproducible runs are ever preferred.
- shellcheck runs automatically because it’s pre-installed on `ubuntu-latest` — no extra setup.

actionlint currently reports zero findings across all fourteen workflows.

## Checklist

- [ ] Add or update unit tests
- [x] Add or update documentation
- [ ] Add or update stories
- [ ] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

CI-only change; no product code, stories, or documentation site affected.
