### PR TITLE
feat(Calendar, Date Picker): Add props to configure the navigation icons

### DIFF
--- a/packages/react/src/Calendar/Calendar.tsx
+++ b/packages/react/src/Calendar/Calendar.tsx
@@ -8,6 +8,8 @@ import type { ElementType, ForwardedRef, HTMLAttributes } from 'react'
 import { clsx } from 'clsx'
 import { forwardRef, useId } from 'react'
 
+import type { IconProps } from '../Icon'
+
 import { useMonthNavigation } from '../common/useMonthNavigation'
 import { CalendarBody } from './CalendarBody'
 import { CalendarHeader } from './CalendarHeader'
@@ -29,20 +31,40 @@ export type CalendarProps = {
   /** BCP 47 language tag for the weekday names, month caption, and accessible date labels. Defaults to `'nl-NL'`. */
   readonly locale?: string
   /**
+   * The icon for the button that navigates to the next month.
+   * @default ChevronForwardIcon
+   */
+  readonly nextMonthButtonIcon?: IconProps['svg']
+  /**
    * The accessible label for the button that navigates to the next month.
    * @default Volgende maand
    */
   readonly nextMonthButtonLabel?: string
+  /**
+   * The icon for the button that navigates to the next year.
+   * @default ChevronDoubleForwardIcon
+   */
+  readonly nextYearButtonIcon?: IconProps['svg']
   /**
    * The accessible label for the button that navigates to the next year.
    * @default Volgend jaar
    */
   readonly nextYearButtonLabel?: string
   /**
+   * The icon for the button that navigates to the previous month.
+   * @default ChevronBackwardIcon
+   */
+  readonly previousMonthButtonIcon?: IconProps['svg']
+  /**
    * The accessible label for the button that navigates to the previous month.
    * @default Vorige maand
    */
   readonly previousMonthButtonLabel?: string
+  /**
+   * The icon for the button that navigates to the previous year.
+   * @default ChevronDoubleBackwardIcon
+   */
+  readonly previousYearButtonIcon?: IconProps['svg']
   /**
    * The accessible label for the button that navigates to the previous year.
    * @default Vorig jaar
@@ -65,9 +87,13 @@ export const Calendar = forwardRef(
       linkComponent,
       linkTemplate,
       locale = 'nl-NL',
+      nextMonthButtonIcon,
       nextMonthButtonLabel,
+      nextYearButtonIcon,
       nextYearButtonLabel,
+      previousMonthButtonIcon,
       previousMonthButtonLabel,
+      previousYearButtonIcon,
       previousYearButtonLabel,
       ...restProps
     }: CalendarProps,
@@ -90,9 +116,13 @@ export const Calendar = forwardRef(
           goToPreviousYear={goToPreviousYear}
           locale={locale}
           month={month}
+          nextMonthButtonIcon={nextMonthButtonIcon}
           nextMonthButtonLabel={nextMonthButtonLabel}
+          nextYearButtonIcon={nextYearButtonIcon}
           nextYearButtonLabel={nextYearButtonLabel}
+          previousMonthButtonIcon={previousMonthButtonIcon}
           previousMonthButtonLabel={previousMonthButtonLabel}
+          previousYearButtonIcon={previousYearButtonIcon}
           previousYearButtonLabel={previousYearButtonLabel}
         />
         <CalendarBody linkComponent={linkComponent} linkTemplate={linkTemplate} locale={locale} month={month} />

--- a/packages/react/src/Calendar/Calendar.tsx
+++ b/packages/react/src/Calendar/Calendar.tsx
@@ -32,6 +32,7 @@ export type CalendarProps = {
   readonly locale?: string
   /**
    * The icon for the button that navigates to the next month.
+   * Not for use within Amsterdam.
    * @default ChevronForwardIcon
    */
   readonly nextMonthButtonIcon?: IconProps['svg']
@@ -42,6 +43,7 @@ export type CalendarProps = {
   readonly nextMonthButtonLabel?: string
   /**
    * The icon for the button that navigates to the next year.
+   * Not for use within Amsterdam.
    * @default ChevronDoubleForwardIcon
    */
   readonly nextYearButtonIcon?: IconProps['svg']
@@ -52,6 +54,7 @@ export type CalendarProps = {
   readonly nextYearButtonLabel?: string
   /**
    * The icon for the button that navigates to the previous month.
+   * Not for use within Amsterdam.
    * @default ChevronBackwardIcon
    */
   readonly previousMonthButtonIcon?: IconProps['svg']
@@ -62,6 +65,7 @@ export type CalendarProps = {
   readonly previousMonthButtonLabel?: string
   /**
    * The icon for the button that navigates to the previous year.
+   * Not for use within Amsterdam.
    * @default ChevronDoubleBackwardIcon
    */
   readonly previousYearButtonIcon?: IconProps['svg']

--- a/packages/react/src/Calendar/CalendarHeader.test.tsx
+++ b/packages/react/src/Calendar/CalendarHeader.test.tsx
@@ -3,7 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { CalendarHeader } from './CalendarHeader'
@@ -76,5 +76,45 @@ describe('CalendarHeader', () => {
     expect(screen.getByRole('button', { name: 'Previous month' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Next month' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Next year' })).toBeInTheDocument()
+  })
+
+  it('renders directional default icons so they mirror in a right-to-left context', () => {
+    const { container } = render(
+      <CalendarHeader
+        goToNextMonth={noop}
+        goToNextYear={noop}
+        goToPreviousMonth={noop}
+        goToPreviousYear={noop}
+        locale="nl-NL"
+        month={june2026}
+      />,
+    )
+
+    // The default chevrons carry `data-directional`, so the Icon styles flip them under `dir="rtl"`.
+    expect(container.querySelectorAll('svg[data-directional="true"]')).toHaveLength(4)
+  })
+
+  it('uses custom navigation button icons', () => {
+    render(
+      <CalendarHeader
+        goToNextMonth={noop}
+        goToNextYear={noop}
+        goToPreviousMonth={noop}
+        goToPreviousYear={noop}
+        locale="nl-NL"
+        month={june2026}
+        nextMonthButtonIcon={<svg data-testid="next-month" />}
+        nextYearButtonIcon={<svg data-testid="next-year" />}
+        previousMonthButtonIcon={<svg data-testid="previous-month" />}
+        previousYearButtonIcon={<svg data-testid="previous-year" />}
+      />,
+    )
+
+    expect(within(screen.getByRole('button', { name: 'Vorig jaar' })).getByTestId('previous-year')).toBeInTheDocument()
+    expect(
+      within(screen.getByRole('button', { name: 'Vorige maand' })).getByTestId('previous-month'),
+    ).toBeInTheDocument()
+    expect(within(screen.getByRole('button', { name: 'Volgende maand' })).getByTestId('next-month')).toBeInTheDocument()
+    expect(within(screen.getByRole('button', { name: 'Volgend jaar' })).getByTestId('next-year')).toBeInTheDocument()
   })
 })

--- a/packages/react/src/Calendar/CalendarHeader.tsx
+++ b/packages/react/src/Calendar/CalendarHeader.tsx
@@ -27,7 +27,15 @@ export type CalendarHeaderProps = {
   readonly month: Date
 } & Pick<
   CalendarProps,
-  'locale' | 'nextMonthButtonLabel' | 'nextYearButtonLabel' | 'previousMonthButtonLabel' | 'previousYearButtonLabel'
+  | 'locale'
+  | 'nextMonthButtonIcon'
+  | 'nextMonthButtonLabel'
+  | 'nextYearButtonIcon'
+  | 'nextYearButtonLabel'
+  | 'previousMonthButtonIcon'
+  | 'previousMonthButtonLabel'
+  | 'previousYearButtonIcon'
+  | 'previousYearButtonLabel'
 >
 
 /**
@@ -42,19 +50,23 @@ export const CalendarHeader = ({
   goToPreviousYear,
   locale,
   month,
+  nextMonthButtonIcon = ChevronForwardIcon,
   nextMonthButtonLabel = 'Volgende maand',
+  nextYearButtonIcon = ChevronDoubleForwardIcon,
   nextYearButtonLabel = 'Volgend jaar',
+  previousMonthButtonIcon = ChevronBackwardIcon,
   previousMonthButtonLabel = 'Vorige maand',
+  previousYearButtonIcon = ChevronDoubleBackwardIcon,
   previousYearButtonLabel = 'Vorig jaar',
 }: CalendarHeaderProps) => (
   <div className="ams-calendar__header">
-    <IconButton label={previousYearButtonLabel} onClick={goToPreviousYear} svg={ChevronDoubleBackwardIcon} />
-    <IconButton label={previousMonthButtonLabel} onClick={goToPreviousMonth} svg={ChevronBackwardIcon} />
+    <IconButton label={previousYearButtonLabel} onClick={goToPreviousYear} svg={previousYearButtonIcon} />
+    <IconButton label={previousMonthButtonLabel} onClick={goToPreviousMonth} svg={previousMonthButtonIcon} />
     <span className="ams-calendar__caption">
       {new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(month)}
     </span>
-    <IconButton label={nextMonthButtonLabel} onClick={goToNextMonth} svg={ChevronForwardIcon} />
-    <IconButton label={nextYearButtonLabel} onClick={goToNextYear} svg={ChevronDoubleForwardIcon} />
+    <IconButton label={nextMonthButtonLabel} onClick={goToNextMonth} svg={nextMonthButtonIcon} />
+    <IconButton label={nextYearButtonLabel} onClick={goToNextYear} svg={nextYearButtonIcon} />
   </div>
 )
 

--- a/packages/react/src/DatePicker/DatePicker.tsx
+++ b/packages/react/src/DatePicker/DatePicker.tsx
@@ -37,6 +37,7 @@ type DatePickerBaseProps = {
   readonly minDate?: Date
   /**
    * The icon for the button that navigates to the next month.
+   * Not for use within Amsterdam.
    * @default ChevronForwardIcon
    */
   readonly nextMonthButtonIcon?: IconProps['svg']
@@ -47,6 +48,7 @@ type DatePickerBaseProps = {
   readonly nextMonthButtonLabel?: string
   /**
    * The icon for the button that navigates to the next year.
+   * Not for use within Amsterdam.
    * @default ChevronDoubleForwardIcon
    */
   readonly nextYearButtonIcon?: IconProps['svg']
@@ -57,6 +59,7 @@ type DatePickerBaseProps = {
   readonly nextYearButtonLabel?: string
   /**
    * The icon for the button that navigates to the previous month.
+   * Not for use within Amsterdam.
    * @default ChevronBackwardIcon
    */
   readonly previousMonthButtonIcon?: IconProps['svg']
@@ -67,6 +70,7 @@ type DatePickerBaseProps = {
   readonly previousMonthButtonLabel?: string
   /**
    * The icon for the button that navigates to the previous year.
+   * Not for use within Amsterdam.
    * @default ChevronDoubleBackwardIcon
    */
   readonly previousYearButtonIcon?: IconProps['svg']

--- a/packages/react/src/DatePicker/DatePicker.tsx
+++ b/packages/react/src/DatePicker/DatePicker.tsx
@@ -8,6 +8,8 @@ import type { ForwardedRef, HTMLAttributes, KeyboardEvent } from 'react'
 import { clsx } from 'clsx'
 import { forwardRef, useEffect, useId, useRef, useState } from 'react'
 
+import type { IconProps } from '../Icon'
+
 import { getDaysInMonth, isSameDay, isSameMonth, startOfDay } from '../common/dates'
 import { useMonthNavigation } from '../common/useMonthNavigation'
 import { DatePickerBody } from './DatePickerBody'
@@ -34,20 +36,40 @@ type DatePickerBaseProps = {
   /** The earliest selectable date. Also bounds month navigation. */
   readonly minDate?: Date
   /**
+   * The icon for the button that navigates to the next month.
+   * @default ChevronForwardIcon
+   */
+  readonly nextMonthButtonIcon?: IconProps['svg']
+  /**
    * The accessible label for the button that navigates to the next month.
    * @default Volgende maand
    */
   readonly nextMonthButtonLabel?: string
+  /**
+   * The icon for the button that navigates to the next year.
+   * @default ChevronDoubleForwardIcon
+   */
+  readonly nextYearButtonIcon?: IconProps['svg']
   /**
    * The accessible label for the button that navigates to the next year.
    * @default Volgend jaar
    */
   readonly nextYearButtonLabel?: string
   /**
+   * The icon for the button that navigates to the previous month.
+   * @default ChevronBackwardIcon
+   */
+  readonly previousMonthButtonIcon?: IconProps['svg']
+  /**
    * The accessible label for the button that navigates to the previous month.
    * @default Vorige maand
    */
   readonly previousMonthButtonLabel?: string
+  /**
+   * The icon for the button that navigates to the previous year.
+   * @default ChevronDoubleBackwardIcon
+   */
+  readonly previousYearButtonIcon?: IconProps['svg']
   /**
    * The accessible label for the button that navigates to the previous year.
    * @default Vorig jaar
@@ -114,10 +136,14 @@ export const DatePicker = forwardRef((props: DatePickerProps, ref: ForwardedRef<
     maxDate,
     minDate,
     mode,
+    nextMonthButtonIcon,
     nextMonthButtonLabel,
+    nextYearButtonIcon,
     nextYearButtonLabel,
     onChange,
+    previousMonthButtonIcon,
     previousMonthButtonLabel,
+    previousYearButtonIcon,
     previousYearButtonLabel,
     rangeEndAccessibleName = 'einddatum',
     rangeStartAccessibleName = 'startdatum',
@@ -249,9 +275,13 @@ export const DatePicker = forwardRef((props: DatePickerProps, ref: ForwardedRef<
         goToPreviousYear={goToPreviousYear}
         locale={locale}
         month={month}
+        nextMonthButtonIcon={nextMonthButtonIcon}
         nextMonthButtonLabel={nextMonthButtonLabel}
+        nextYearButtonIcon={nextYearButtonIcon}
         nextYearButtonLabel={nextYearButtonLabel}
+        previousMonthButtonIcon={previousMonthButtonIcon}
         previousMonthButtonLabel={previousMonthButtonLabel}
+        previousYearButtonIcon={previousYearButtonIcon}
         previousYearButtonLabel={previousYearButtonLabel}
       />
       <DatePickerBody

--- a/packages/react/src/DatePicker/DatePickerHeader.test.tsx
+++ b/packages/react/src/DatePicker/DatePickerHeader.test.tsx
@@ -3,7 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { DatePickerHeader } from './DatePickerHeader'
@@ -59,5 +59,31 @@ describe('DatePickerHeader', () => {
     render(<DatePickerHeader {...defaultProps} nextMonthButtonLabel="Volgende" />)
 
     expect(screen.getByRole('button', { name: 'Volgende' })).toBeInTheDocument()
+  })
+
+  it('renders directional default icons so they mirror in a right-to-left context', () => {
+    const { container } = render(<DatePickerHeader {...defaultProps} />)
+
+    // The default chevrons carry `data-directional`, so the Icon styles flip them under `dir="rtl"`.
+    expect(container.querySelectorAll('svg[data-directional="true"]')).toHaveLength(4)
+  })
+
+  it('uses custom navigation button icons', () => {
+    render(
+      <DatePickerHeader
+        {...defaultProps}
+        nextMonthButtonIcon={<svg data-testid="next-month" />}
+        nextYearButtonIcon={<svg data-testid="next-year" />}
+        previousMonthButtonIcon={<svg data-testid="previous-month" />}
+        previousYearButtonIcon={<svg data-testid="previous-year" />}
+      />,
+    )
+
+    expect(within(screen.getByRole('button', { name: 'Vorig jaar' })).getByTestId('previous-year')).toBeInTheDocument()
+    expect(
+      within(screen.getByRole('button', { name: 'Vorige maand' })).getByTestId('previous-month'),
+    ).toBeInTheDocument()
+    expect(within(screen.getByRole('button', { name: 'Volgende maand' })).getByTestId('next-month')).toBeInTheDocument()
+    expect(within(screen.getByRole('button', { name: 'Volgend jaar' })).getByTestId('next-year')).toBeInTheDocument()
   })
 })

--- a/packages/react/src/DatePicker/DatePickerHeader.tsx
+++ b/packages/react/src/DatePicker/DatePickerHeader.tsx
@@ -37,7 +37,15 @@ export type DatePickerHeaderProps = {
   readonly month: Date
 } & Pick<
   DatePickerProps,
-  'locale' | 'nextMonthButtonLabel' | 'nextYearButtonLabel' | 'previousMonthButtonLabel' | 'previousYearButtonLabel'
+  | 'locale'
+  | 'nextMonthButtonIcon'
+  | 'nextMonthButtonLabel'
+  | 'nextYearButtonIcon'
+  | 'nextYearButtonLabel'
+  | 'previousMonthButtonIcon'
+  | 'previousMonthButtonLabel'
+  | 'previousYearButtonIcon'
+  | 'previousYearButtonLabel'
 >
 
 export const DatePickerHeader = ({
@@ -52,9 +60,13 @@ export const DatePickerHeader = ({
   goToPreviousYear,
   locale,
   month,
+  nextMonthButtonIcon = ChevronForwardIcon,
   nextMonthButtonLabel = 'Volgende maand',
+  nextYearButtonIcon = ChevronDoubleForwardIcon,
   nextYearButtonLabel = 'Volgend jaar',
+  previousMonthButtonIcon = ChevronBackwardIcon,
   previousMonthButtonLabel = 'Vorige maand',
+  previousYearButtonIcon = ChevronDoubleBackwardIcon,
   previousYearButtonLabel = 'Vorig jaar',
 }: DatePickerHeaderProps) => (
   <div className="ams-date-picker__header">
@@ -62,13 +74,13 @@ export const DatePickerHeader = ({
       disabled={disablePreviousYear}
       label={previousYearButtonLabel}
       onClick={goToPreviousYear}
-      svg={ChevronDoubleBackwardIcon}
+      svg={previousYearButtonIcon}
     />
     <IconButton
       disabled={disablePreviousMonth}
       label={previousMonthButtonLabel}
       onClick={goToPreviousMonth}
-      svg={ChevronBackwardIcon}
+      svg={previousMonthButtonIcon}
     />
     <span className="ams-date-picker__caption" id={captionId}>
       {new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(month)}
@@ -77,13 +89,13 @@ export const DatePickerHeader = ({
       disabled={disableNextMonth}
       label={nextMonthButtonLabel}
       onClick={goToNextMonth}
-      svg={ChevronForwardIcon}
+      svg={nextMonthButtonIcon}
     />
     <IconButton
       disabled={disableNextYear}
       label={nextYearButtonLabel}
       onClick={goToNextYear}
-      svg={ChevronDoubleForwardIcon}
+      svg={nextYearButtonIcon}
     />
   </div>
 )

--- a/storybook/src/components/Calendar/Calendar.docs.mdx
+++ b/storybook/src/components/Calendar/Calendar.docs.mdx
@@ -94,7 +94,7 @@ const linkTemplate = (date: Date): string => `?date=${formatDate(date)}`
 
 ### Custom navigation icons
 
-Other [NL Design System](https://nldesignsystem.nl/) organisations can replace the navigation chevrons through the `*ButtonIcon` props, which each take the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
+Different navigation icons can be used through the `*ButtonIcon` props, which each take the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
 Websites for Amsterdam must use the default icons.
 For right-to-left scripts, give a custom icon a `data-directional="true"` attribute so it mirrors like the default chevrons; see the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs).
 

--- a/storybook/src/components/Calendar/Calendar.docs.mdx
+++ b/storybook/src/components/Calendar/Calendar.docs.mdx
@@ -41,7 +41,7 @@ The Calendar renders this name as a visually hidden heading and generates a uniq
 
 The Calendar renders weekday names, the month caption, and the accessible date labels in the language of `locale`, which defaults to `nl-NL`.
 It does not translate the rest: set `accessibleName`, `nextMonthButtonLabel`, `nextYearButtonLabel`, `previousMonthButtonLabel`, and `previousYearButtonLabel` in the same language, or they stay Dutch and screen readers announce a mix.
-For right-to-left scripts such as Arabic, also add `dir="rtl"`.
+For right-to-left scripts such as Arabic, also add `dir="rtl"`; this mirrors the layout and the navigation chevrons.
 Try the `locale` control above to preview each language; see the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs) for the tested locales.
 
 If your app uses Calendar in multiple places with the same language, a small wrapper component avoids repeating these props:
@@ -91,6 +91,17 @@ const formatDate = (date: Date) =>
 
 const linkTemplate = (date: Date): string => `?date=${formatDate(date)}`
 ```
+
+### Custom navigation icons
+
+By default, the month and year navigation buttons use the Amsterdam chevron icons, so Amsterdam websites need to set nothing.
+Other [NL Design System](https://nldesignsystem.nl/) organisations can match their own iconography with `previousYearButtonIcon`, `previousMonthButtonIcon`, `nextMonthButtonIcon`, and `nextYearButtonIcon`.
+Each accepts the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
+
+For a right-to-left script such as Arabic, the buttons need to point the other way.
+The default chevrons flip automatically because they carry a `data-directional="true"` attribute; the Icon styles mirror any icon with that attribute under `dir="rtl"`.
+Give your own icons the same attribute so they flip too.
+See the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs) for more on right-to-left support.
 
 ## Accessibility
 

--- a/storybook/src/components/Calendar/Calendar.docs.mdx
+++ b/storybook/src/components/Calendar/Calendar.docs.mdx
@@ -94,14 +94,9 @@ const linkTemplate = (date: Date): string => `?date=${formatDate(date)}`
 
 ### Custom navigation icons
 
-By default, the month and year navigation buttons use the Amsterdam chevron icons, so Amsterdam websites need to set nothing.
-Other [NL Design System](https://nldesignsystem.nl/) organisations can match their own iconography with `previousYearButtonIcon`, `previousMonthButtonIcon`, `nextMonthButtonIcon`, and `nextYearButtonIcon`.
-Each accepts the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
-
-For a right-to-left script such as Arabic, the buttons need to point the other way.
-The default chevrons flip automatically because they carry a `data-directional="true"` attribute; the Icon styles mirror any icon with that attribute under `dir="rtl"`.
-Give your own icons the same attribute so they flip too.
-See the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs) for more on right-to-left support.
+Other [NL Design System](https://nldesignsystem.nl/) organisations can replace the navigation chevrons through the `*ButtonIcon` props, which each take the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
+Websites for Amsterdam must use the default icons.
+For right-to-left scripts, give a custom icon a `data-directional="true"` attribute so it mirrors like the default chevrons; see the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs).
 
 ## Accessibility
 

--- a/storybook/src/components/Calendar/Calendar.stories.tsx
+++ b/storybook/src/components/Calendar/Calendar.stories.tsx
@@ -42,6 +42,10 @@ const meta = {
     defaultMonth: { control: false }, // Enabling the control breaks the story with an error.
     linkComponent: { control: false }, // Enabling the control breaks the story with an error.
     linkTemplate: { control: false }, // A function returning string or undefined has no usable controls panel widget.
+    nextMonthButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
+    nextYearButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
+    previousMonthButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
+    previousYearButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
   },
   decorators: [SyncLocaleArgs],
   parameters: { localeVariant: 'calendar' },

--- a/storybook/src/components/DatePicker/DatePicker.docs.mdx
+++ b/storybook/src/components/DatePicker/DatePicker.docs.mdx
@@ -128,14 +128,9 @@ Moving past the end of a month shows the adjacent month and keeps focus on the d
 
 ### Custom navigation icons
 
-By default, the month and year navigation buttons use the Amsterdam chevron icons, so Amsterdam websites need to set nothing.
-Other [NL Design System](https://nldesignsystem.nl/) organisations can match their own iconography with `previousYearButtonIcon`, `previousMonthButtonIcon`, `nextMonthButtonIcon`, and `nextYearButtonIcon`.
-Each accepts the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
-
-For a right-to-left script such as Arabic, the buttons need to point the other way.
-The default chevrons flip automatically because they carry a `data-directional="true"` attribute; the Icon styles mirror any icon with that attribute under `dir="rtl"`.
-Give your own icons the same attribute so they flip too.
-See the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs) for more on right-to-left support.
+Other [NL Design System](https://nldesignsystem.nl/) organisations can replace the navigation chevrons through the `*ButtonIcon` props, which each take the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
+Websites for Amsterdam must use the default icons.
+For right-to-left scripts, give a custom icon a `data-directional="true"` attribute so it mirrors like the default chevrons; see the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs).
 
 ## Accessibility
 

--- a/storybook/src/components/DatePicker/DatePicker.docs.mdx
+++ b/storybook/src/components/DatePicker/DatePicker.docs.mdx
@@ -128,7 +128,7 @@ Moving past the end of a month shows the adjacent month and keeps focus on the d
 
 ### Custom navigation icons
 
-Other [NL Design System](https://nldesignsystem.nl/) organisations can replace the navigation chevrons through the `*ButtonIcon` props, which each take the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
+Different navigation icons can be used through the `*ButtonIcon` props, which each take the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
 Websites for Amsterdam must use the default icons.
 For right-to-left scripts, give a custom icon a `data-directional="true"` attribute so it mirrors like the default chevrons; see the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs).
 

--- a/storybook/src/components/DatePicker/DatePicker.docs.mdx
+++ b/storybook/src/components/DatePicker/DatePicker.docs.mdx
@@ -48,7 +48,7 @@ The component does not clamp or validate the incoming value.
 The Date Picker renders weekday names, the month caption, and the accessible date labels in the language of `locale`, which defaults to `nl-NL`.
 It does not translate the rest: set `nextMonthButtonLabel`, `nextYearButtonLabel`, `previousMonthButtonLabel`, and `previousYearButtonLabel` in the same language, or they stay Dutch and screen readers announce a mix.
 In range mode, also localise `rangeStartAccessibleName` and `rangeEndAccessibleName`; they are appended to the start and end dates when those are announced.
-For right-to-left scripts such as Arabic, also add `dir="rtl"`.
+For right-to-left scripts such as Arabic, also add `dir="rtl"`; this mirrors the layout and the navigation chevrons.
 Try the `locale` control above to preview each language; see the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs) for the tested locales.
 
 If your app uses Date Picker in multiple places with the same language, a small wrapper component avoids repeating these props:
@@ -125,6 +125,17 @@ The day grid follows the [WAI-ARIA grid pattern](https://www.w3.org/WAI/ARIA/apg
 Arrow keys move between days, Home and End jump to the start and end of the week, and Page Up and Page Down move between months; hold Shift for years.
 Enter or Space selects the focused day.
 Moving past the end of a month shows the adjacent month and keeps focus on the day.
+
+### Custom navigation icons
+
+By default, the month and year navigation buttons use the Amsterdam chevron icons, so Amsterdam websites need to set nothing.
+Other [NL Design System](https://nldesignsystem.nl/) organisations can match their own iconography with `previousYearButtonIcon`, `previousMonthButtonIcon`, `nextMonthButtonIcon`, and `nextYearButtonIcon`.
+Each accepts the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
+
+For a right-to-left script such as Arabic, the buttons need to point the other way.
+The default chevrons flip automatically because they carry a `data-directional="true"` attribute; the Icon styles mirror any icon with that attribute under `dir="rtl"`.
+Give your own icons the same attribute so they flip too.
+See the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs) for more on right-to-left support.
 
 ## Accessibility
 

--- a/storybook/src/components/DatePicker/DatePicker.stories.tsx
+++ b/storybook/src/components/DatePicker/DatePicker.stories.tsx
@@ -46,7 +46,11 @@ const meta = {
     maxDate: { control: false }, // No usable Storybook control for Date objects; configured directly in each story.
     minDate: { control: false }, // No usable Storybook control for Date objects; configured directly in each story.
     mode: { table: { disable: true } }, // Owned by the story's state wrapper; not a user-configurable control.
+    nextMonthButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
+    nextYearButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
     onChange: { table: { disable: true } }, // Owned by the story's state wrapper; not a user-configurable control.
+    previousMonthButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
+    previousYearButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
     value: { table: { disable: true } }, // Owned by the story's state wrapper; not a user-configurable control.
   },
   decorators: [SyncLocaleArgs],

--- a/storybook/src/docs/developer-guide/localisation.docs.mdx
+++ b/storybook/src/docs/developer-guide/localisation.docs.mdx
@@ -97,8 +97,10 @@ For right-to-left languages like Arabic, also add `dir="rtl"` to the component o
 
 ### Mirror directional icons
 
-Some icons point in a direction — chevrons and arrows, for example — and must flip in a right-to-left context.
+Icons that imply a reading direction or depict movement that follows the reader’s natural flow flip in a right-to-left context.
+
 The design system’s own directional icons handle this automatically: each carries a `data-directional="true"` attribute on its root `<svg>`, and the [Icon](/docs/components-media-icon--docs) styles mirror any icon with that attribute under `dir="rtl"`.
+
 The [Calendar](/docs/components-navigation-calendar--docs) and [Date Picker](/docs/components-forms-date-picker--docs) navigation chevrons are one example.
 When you supply your own directional icon anywhere, give it the same attribute so it mirrors as well.
 

--- a/storybook/src/docs/developer-guide/localisation.docs.mdx
+++ b/storybook/src/docs/developer-guide/localisation.docs.mdx
@@ -95,6 +95,12 @@ For right-to-left languages like Arabic, also add `dir="rtl"` to the component o
 />
 ```
 
+### Mirror navigation icons
+
+In a right-to-left context, the Calendar and Date Picker navigation buttons must point the other way.
+Their default chevrons handle this on their own: each carries a `data-directional="true"` attribute on its root `<svg>`, and the [Icon](/docs/components-media-icon--docs) styles mirror any icon with that attribute under `dir="rtl"`.
+If you replace them through `previousYearButtonIcon`, `previousMonthButtonIcon`, `nextMonthButtonIcon`, or `nextYearButtonIcon`, give your own icons the same attribute so they flip as well.
+
 ## Relevant WCAG requirements
 
 - [WCAG 3.1.2](https://www.w3.org/TR/WCAG22/#language-of-parts): indicate the language of any passage or phrase that differs from the page’s default language

--- a/storybook/src/docs/developer-guide/localisation.docs.mdx
+++ b/storybook/src/docs/developer-guide/localisation.docs.mdx
@@ -95,11 +95,12 @@ For right-to-left languages like Arabic, also add `dir="rtl"` to the component o
 />
 ```
 
-### Mirror navigation icons
+### Mirror directional icons
 
-In a right-to-left context, the Calendar and Date Picker navigation buttons must point the other way.
-Their default chevrons handle this on their own: each carries a `data-directional="true"` attribute on its root `<svg>`, and the [Icon](/docs/components-media-icon--docs) styles mirror any icon with that attribute under `dir="rtl"`.
-If you replace them through `previousYearButtonIcon`, `previousMonthButtonIcon`, `nextMonthButtonIcon`, or `nextYearButtonIcon`, give your own icons the same attribute so they flip as well.
+Some icons point in a direction — chevrons and arrows, for example — and must flip in a right-to-left context.
+The design system’s own directional icons handle this automatically: each carries a `data-directional="true"` attribute on its root `<svg>`, and the [Icon](/docs/components-media-icon--docs) styles mirror any icon with that attribute under `dir="rtl"`.
+The [Calendar](/docs/components-navigation-calendar--docs) and [Date Picker](/docs/components-forms-date-picker--docs) navigation chevrons are one example.
+When you supply your own directional icon anywhere, give it the same attribute so it mirrors as well.
 
 ## Relevant WCAG requirements
 


### PR DESCRIPTION
## What

Adds four props to both Calendar and Date Picker for configuring the month and year navigation icons: `previousYearButtonIcon`, `previousMonthButtonIcon`, `nextMonthButtonIcon`, and `nextYearButtonIcon`.
Each accepts the same value as the Icon component’s `svg` prop and defaults to the Amsterdam chevron that button already used, so Amsterdam websites are unaffected.

## Why

Other NL Design System organisations want to adopt these components but were held back by the hardcoded Amsterdam chevrons.
These props let them supply their own iconography while our chevrons remain the default.

## How

- The props live on `CalendarProps` and `DatePickerProps`, are threaded through to the `…Header` components, and are applied to the matching `IconButton`. The chevron defaults sit in the headers, mirroring how the navigation labels already work.
- Right-to-left mirroring needs no new logic. It is driven by the existing `.ams-icon:dir(rtl) svg[data-directional="true"]` rule: the built-in chevrons carry that attribute, so a consumer’s custom icons flip the same way once they add `data-directional="true"` to their `<svg>` and set `dir="rtl"`. This is now spelled out in the Localisation developer guide and in a new “Custom navigation icons” section of each component’s docs.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Relevant stories: Components → Navigation → Calendar and Components → Forms → Date Picker; the developer guidance is under Docs → Developer Guide → Localisation.
- No dedicated demo story was added on purpose. The default chevrons already flip in the Arabic (`ar-MA`) case of the Calendar `Test` snapshot, and the configurable-icon behaviour is covered by unit tests and a docs example rather than a demo that would have to be built from other Amsterdam icons.
- No new exports: the props extend existing component APIs, so the `index.*` files are unchanged.
