### PR TITLE
chore(Storybook): Add code-panel comments and tidy page template markup

### DIFF
--- a/storybook/src/pages/internal/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/internal/HomePage/HomePage.stories.tsx
@@ -42,4 +42,42 @@ const meta = {
 
 export default meta
 
-export const Default: StoryObj = {}
+export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        code: `<Grid paddingBottom="x-large" paddingTop="large">
+  {/*
+   * appearance="transparent" removes the cell’s background and padding, so the page title sits directly
+   * on the page instead of looking like one of the content blocks the other cells form.
+   */}
+  <Grid.Cell appearance="transparent" span="all">
+    <Heading level={1}>Titel van de pagina</Heading>
+  </Grid.Cell>
+  {/*
+   * This is a layout demo: the empty cells stand in for content blocks. Their blockSize only gives them
+   * a height to show here – on a real page the content sets the height. What matters is the responsive
+   * span: how many of the grid’s columns a cell fills at narrow, medium, and wide widths. That is what
+   * makes the cells reflow into different rows as the window changes.
+   */}
+  <Grid.Cell span={{ narrow: 4, medium: 5, wide: 8 }} style={{ blockSize: '12rem' }} />
+  <Grid.Cell span={{ narrow: 1, medium: 3, wide: 4 }} style={{ blockSize: '10rem' }} />
+  <Grid.Cell span={{ narrow: 3, medium: 3, wide: 3 }}>
+    <Paragraph>Voorbeeldtekst in een contentblok.</Paragraph>
+  </Grid.Cell>
+  <Grid.Cell span={{ narrow: 4, medium: 5, wide: 9 }}>
+    <Paragraph>Voorbeeldtekst in een contentblok.</Paragraph>
+  </Grid.Cell>
+  <Grid.Cell span={{ narrow: 2, medium: 3, wide: 6 }} style={{ blockSize: '8rem' }} />
+  <Grid.Cell span={{ narrow: 2, medium: 3, wide: 6 }} style={{ blockSize: '8rem' }} />
+  <Grid.Cell span={{ narrow: 3, medium: 2, wide: 4 }} style={{ blockSize: '6rem' }} />
+  <Grid.Cell span={{ narrow: 1, medium: 4, wide: 4 }} style={{ blockSize: '8rem' }} />
+  <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }} style={{ blockSize: '6rem' }} />
+</Grid>`,
+        language: 'tsx',
+      },
+    },
+  },
+}

--- a/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
@@ -110,4 +110,72 @@ const meta = {
 
 export default meta
 
-export const Default: StoryObj = {}
+export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments and resolves the interactive state. Provide the source by hand so the guidance stays
+        // visible and the layout reads the way a developer would write it.
+        code: `<Grid paddingVertical="x-large">
+  <Grid.Cell appearance="transparent" span="all">
+    <Breadcrumb>
+      <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+      <Breadcrumb.Link href="#">Projecten</Breadcrumb.Link>
+    </Breadcrumb>
+    <Heading level={1}>Naam van het project</Heading>
+  </Grid.Cell>
+  {/*
+   * The main project navigation. rowSpan={2} lets this one cell sit beside both the subnavigation and
+   * the content below it; appearance="flush" drops the cell padding so the tabs align with the grid.
+   * accessibleName labels the nav for screen readers, and aria-current="page" marks the active link.
+   */}
+  <Grid.Cell appearance="flush" rowSpan={2} span={{ narrow: 4, medium: 2, wide: 2 }}>
+    <TabNavigation accessibleName="Navigatie voor dit project" orientation="vertical">
+      <TabNavigation.List>
+        {menuItems.map(({ icon, label, slug }) => (
+          <TabNavigation.Link
+            aria-current={currentMenuSlug === slug ? 'page' : undefined}
+            href={\`/projecten/42/\${slug}\`}
+            icon={icon}
+            key={slug}
+            onClick={(e) => handleMenuItemClick(e, slug)}
+          >
+            {label}
+          </TabNavigation.Link>
+        ))}
+      </TabNavigation.List>
+    </TabNavigation>
+  </Grid.Cell>
+  {/*
+   * The subnavigation scrolls sideways when it overflows. Keep a ref to its list so selecting another
+   * main menu item can reset the scroll back to the start (see handleMenuItemClick).
+   */}
+  <Grid.Cell appearance="flush" span={{ narrow: 4, medium: 6, wide: 10 }} start={{ narrow: 1, medium: 3, wide: 3 }}>
+    <TabNavigation accessibleName="Subnavigatie voor dit project">
+      <TabNavigation.List ref={subMenuListRef}>
+        {subMenuItems.map(({ label, slug }) => (
+          <TabNavigation.Link
+            aria-current={currentSubMenuSlug === slug ? 'page' : undefined}
+            href={\`/projecten/42/\${currentMenuSlug}/\${slug}\`}
+            key={slug}
+            onClick={(e) => handleSubMenuItemClick(e, slug)}
+          >
+            {label}
+          </TabNavigation.Link>
+        ))}
+      </TabNavigation.List>
+    </TabNavigation>
+  </Grid.Cell>
+  {/* The content area, start-aligned next to the vertical navigation. Its cells stand in for content. */}
+  <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 3, wide: 3 }}>
+    <Heading className="ams-mb-s" level={2}>{currentMenu.label}</Heading>
+    <Heading className="ams-mb-m" level={3}>{currentSubMenu.label}</Heading>
+  </Grid.Cell>
+  <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }} start={{ narrow: 1, medium: 3, wide: 10 }} />
+</Grid>`,
+        language: 'tsx',
+      },
+    },
+  },
+}

--- a/storybook/src/pages/internal/TablePage/TablePage.stories.tsx
+++ b/storybook/src/pages/internal/TablePage/TablePage.stories.tsx
@@ -56,7 +56,7 @@ export const SortingWithSelect: StoryObj = {
         // The Code Panel regenerates a `render` story’s source from the rendered tree, dropping JSX
         // comments and expanding the map. Provide the source by hand so the guidance stays in the panel.
         code: `<Grid paddingBottom="x-large" paddingTop="large">
-  <Grid.Cell className="ams-grid__cell--transparent" span="all">
+  <Grid.Cell appearance="transparent" span="all">
     <Heading level={1}>Vergunninghouders 2026/2027</Heading>
   </Grid.Cell>
   <Grid.Cell span="all">
@@ -96,7 +96,7 @@ export const SortingWithSelect: StoryObj = {
 
     return (
       <Grid paddingBottom="x-large" paddingTop="large">
-        <Grid.Cell className="ams-grid__cell--transparent" span="all">
+        <Grid.Cell appearance="transparent" span="all">
           <Heading level={1}>Vergunninghouders 2026/2027</Heading>
         </Grid.Cell>
         <Grid.Cell span="all">
@@ -200,7 +200,7 @@ export const WithPagination = () => {
 
   return (
     <Grid paddingBottom="x-large" paddingTop="large">
-      <Grid.Cell className="ams-grid__cell--transparent" span="all">
+      <Grid.Cell appearance="transparent" span="all">
         <Heading level={1}>Vergunninghouders 2026/2027</Heading>
       </Grid.Cell>
       <Grid.Cell span="all">
@@ -233,7 +233,7 @@ WithPagination.parameters = {
       // The Code Panel regenerates a `render` story’s source from the rendered tree, dropping JSX
       // comments. Provide the source by hand so the guidance below stays visible in the panel.
       code: `<Grid paddingBottom="x-large" paddingTop="large">
-  <Grid.Cell className="ams-grid__cell--transparent" span="all">
+  <Grid.Cell appearance="transparent" span="all">
     <Heading level={1}>Vergunninghouders 2026/2027</Heading>
   </Grid.Cell>
   <Grid.Cell span="all">

--- a/storybook/src/pages/internal/TablePage/TablePage.stories.tsx
+++ b/storybook/src/pages/internal/TablePage/TablePage.stories.tsx
@@ -50,6 +50,46 @@ const sortSelectOptions = sortOptions.map(({ label, value }) => (
 ))
 
 export const SortingWithSelect: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, dropping JSX
+        // comments and expanding the map. Provide the source by hand so the guidance stays in the panel.
+        code: `<Grid paddingBottom="x-large" paddingTop="large">
+  <Grid.Cell className="ams-grid__cell--transparent" span="all">
+    <Heading level={1}>Vergunninghouders 2026/2027</Heading>
+  </Grid.Cell>
+  <Grid.Cell span="all">
+    {/* Position the Heading and Select next to each other to save space. */}
+    <Row align="between" alignVertical="center" className="ams-mb-m" wrap>
+      {/* Use a Heading instead of a Caption to allow a form in between. */}
+      <Heading level={2}>Gegevens per adres</Heading>
+      <form onSubmit={handleSortSubmit}>
+        <Row alignVertical="center" wrap>
+          <Label htmlFor="sort">Sorteren op</Label>
+          {/* Submitting the form on change avoids a separate submit button (see handleSortChange). */}
+          <Select defaultValue={sortOrder} id="sort" name="sort" onChange={handleSortChange}>
+            {sortOptions.map(({ label, value }) => (
+              <Select.Option key={value} value={value}>{label}</Select.Option>
+            ))}
+          </Select>
+        </Row>
+      </form>
+    </Row>
+    <Table>
+      {/* Repeat the heading non-visually in the Caption for accessibility. */}
+      <Table.Caption className="ams-visually-hidden">Gegevens per adres</Table.Caption>
+      <Table.Header>
+        <AddressTableHeaderRow />
+      </Table.Header>
+      <AddressTableBody addresses={addresses} />
+    </Table>
+  </Grid.Cell>
+</Grid>`,
+        language: 'tsx',
+      },
+    },
+  },
   render: () => {
     const sortOrder = (params.get('sort') ?? 'straat-asc') as SortOrder
     const addresses = sortAddresses(bagAddresses.slice(0, 30), sortOrder)
@@ -185,4 +225,44 @@ export const WithPagination = () => {
       </Grid.Cell>
     </Grid>
   )
+}
+
+WithPagination.parameters = {
+  docs: {
+    source: {
+      // The Code Panel regenerates a `render` story’s source from the rendered tree, dropping JSX
+      // comments. Provide the source by hand so the guidance below stays visible in the panel.
+      code: `<Grid paddingBottom="x-large" paddingTop="large">
+  <Grid.Cell className="ams-grid__cell--transparent" span="all">
+    <Heading level={1}>Vergunninghouders 2026/2027</Heading>
+  </Grid.Cell>
+  <Grid.Cell span="all">
+    <Table className="ams-mb-l">
+      {/* If nothing sits between the Heading and the Table, wrap the Heading in the Caption. */}
+      <Table.Caption className="ams-mb-m">
+        <Heading level={2}>Gegevens per adres</Heading>
+      </Table.Caption>
+      <Table.Header>
+        <AddressTableHeaderRow />
+      </Table.Header>
+      <AddressTableBody addresses={paginatedAddresses} firstRow={firstRow} />
+    </Table>
+    <Row align="center">
+      {/*
+       * Pagination renders links, so pages stay shareable and open in a new tab. linkTemplate builds each
+       * href; linkComponent lets you pass your router’s link. Here a small wrapper keeps navigation inside
+       * Storybook rather than reloading the iframe – see PaginationLink and handlePaginationClick.
+       */}
+      <Pagination
+        linkComponent={PaginationLink}
+        linkTemplate={paginationLinkTemplate}
+        page={page}
+        totalPages={totalPaginationPages}
+      />
+    </Row>
+  </Grid.Cell>
+</Grid>`,
+      language: 'tsx',
+    },
+  },
 }

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -183,4 +183,144 @@ const meta = {
 
 export default meta
 
-export const Default: StoryObj = {}
+export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        code: `<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+        <Breadcrumb.Link href="#">Nieuws</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  <main id="inhoud">
+    <Grid paddingBottom="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-s" level={1}>Met korting van A naar B op de deelscooter of -bakfiets</Heading>
+        <Paragraph className="ams-mb-xl">29 juli 2025</Paragraph>
+        <Paragraph size="large">
+          Woont of werkt u in Amsterdam? Dan maakt u tot en met oktober met korting gebruik van deelscooters
+          en -bakfietsen.
+        </Paragraph>
+      </Grid.Cell>
+    </Grid>
+    {/*
+     * A full-width hero image. srcSet lets the browser pick a size for the viewport, loading="lazy" defers
+     * loading until it is near the viewport, and aspectRatio reserves its space so the layout does not jump.
+     */}
+    <Image
+      alt=""
+      aspectRatio="16:5"
+      loading="lazy"
+      src="https://picsum.photos/1440/450"
+      srcSet="https://picsum.photos/640/200 640w, https://picsum.photos/1280/400 1280w, https://picsum.photos/1440/450 1440w"
+    />
+    <Grid paddingVertical="x-large">
+      {/* ams-prose applies article typography and vertical rhythm to the headings, paragraphs, and links. */}
+      <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+        <Paragraph>
+          U kunt gebruikmaken van de kortingsacties via Amsterdam Bereikbaar. De actie geldt voor
+          Amsterdammers en forenzen van en naar Amsterdam, en is te activeren tot 6 oktober.
+        </Paragraph>
+        <Heading level={2}>Meer deelvervoer</Heading>
+        <Paragraph>
+          Het gebruik van deelvervoer groeit snel. Vanwege de grote vraag is besloten het aantal
+          deelscooters te verhogen van 1.200 naar 1.500 stuks. Op de{' '}
+          <Link href="https://kaart.amsterdam.nl/deelvervoer">Kaart deelvervoer Amsterdam</Link> ziet u waar
+          bij u in de buurt deelvervoer wordt aangeboden.
+        </Paragraph>
+        <Heading level={2}>Evenementen in de stad</Heading>
+        <Paragraph>
+          Deelvervoer is ook handig tijdens evenementen. Zo werden er op 21 juni, de dag van het festival Op
+          de Ring, bijna 12.000 ritten gemaakt met de deelscooter en deelbakfiets.
+        </Paragraph>
+        <Heading level={2}>Verkeershinder ontwijken</Heading>
+        <Paragraph>
+          Daarnaast kunt u met deelscooters en -bakfietsen verkeershinder omzeilen. Deze zomer vinden er veel
+          werkzaamheden plaats in en rond de stad, waaronder op grote delen van de ring A10.
+        </Paragraph>
+        <Heading level={2}>Meer weten</Heading>
+        <Paragraph>
+          Gebruikmaken van de kortingsacties? Kijk dan op{' '}
+          <Link href="https://www.amsterdambereikbaar.nl">Amsterdam Bereikbaar</Link>. Wilt u meer weten over
+          deelvervoer in de stad? Ga dan naar <Link href="https://www.amsterdam.nl/deelvervoer/">Deelvervoer</Link>.
+        </Paragraph>
+        <Heading level={2}>Lees ook</Heading>
+        <LinkList>
+          <LinkList.Link href="#">Sociale huurders kunnen gratis e-bike uitproberen</LinkList.Link>
+          <LinkList.Link href="#">Amstelveenseweg ruim 5 weken dicht voor gemotoriseerd verkeer</LinkList.Link>
+          <LinkList.Link href="#">Groot onderhoud A4 vanaf 11 juli: houd rekening met flinke vertraging</LinkList.Link>
+        </LinkList>
+      </Grid.Cell>
+    </Grid>
+  </main>
+  {/* A newsletter call-out set apart as a labelled aside (aria-labelledby) on a green Spotlight. */}
+  <Spotlight aria-labelledby="blijf-op-de-hoogte" as="aside" color="green">
+    <Grid paddingVertical="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+        {/* color="inverse" adapts the heading, text, and link to the dark Spotlight background. */}
+        <Heading className="ams-mb-s" color="inverse" id="blijf-op-de-hoogte" level={2} size="level-3">
+          Blijf op de hoogte!
+        </Heading>
+        <Paragraph className="ams-mb-m" color="inverse">
+          Schrijf u nu in voor de Nieuwsbrief Amsterdam en ontvang wekelijks nieuws, tips en mooie verhalen.
+        </Paragraph>
+        <StandaloneLink color="inverse" href="#">Ik wil de nieuwsbrief</StandaloneLink>
+      </Grid.Cell>
+    </Grid>
+  </Spotlight>
+  {/* Related articles in their own labelled aside, outside the article’s <main>. */}
+  <aside aria-labelledby="meer-nieuws">
+    <Grid gapVertical="large" paddingVertical="x-large">
+      <Grid.Cell span="all">
+        <Heading id="meer-nieuws" level={2} size="level-1">Meer nieuws</Heading>
+      </Grid.Cell>
+      <Grid.Cell span={4}>
+        <Card>
+          <Card.Image alt="" src="https://picsum.photos/640/360?random=1" />
+          <Card.HeadingGroup tagline="Nieuws">
+            <Card.Heading level={3}>
+              <Card.Link href="#">Waarom we op zoek zijn naar vleermuizen</Card.Link>
+            </Card.Heading>
+          </Card.HeadingGroup>
+          <Paragraph>
+            U kunt 's avonds ecologen in oranje hesjes tegenkomen. Zij zijn op zoek naar vleermuizen.
+          </Paragraph>
+        </Card>
+      </Grid.Cell>
+      <Grid.Cell span={4}>
+        <Card>
+          <Card.Image alt="" src="https://picsum.photos/640/360?random=2" />
+          <Card.HeadingGroup tagline="Nieuws">
+            <Card.Heading level={3}>
+              <Card.Link href="#">Meer aandacht voor voetgangers, een jaar lang</Card.Link>
+            </Card.Heading>
+          </Card.HeadingGroup>
+          <Paragraph>We gaan de veiligheid voor voetgangers verbeteren en meer ruimte maken.</Paragraph>
+        </Card>
+      </Grid.Cell>
+      <Grid.Cell span={4}>
+        <Card>
+          <Card.Image alt="" src="https://picsum.photos/640/360?random=3" />
+          <Card.HeadingGroup tagline="Nieuws">
+            <Card.Heading level={3}>
+              <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>
+            </Card.Heading>
+          </Card.HeadingGroup>
+          <Paragraph>Afvalboten, bakfietsen en ondergrondse containers in het centrum.</Paragraph>
+        </Card>
+      </Grid.Cell>
+    </Grid>
+  </aside>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
+}

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -40,7 +40,9 @@ const meta = {
             <Heading className="ams-mb-s" level={1}>
               Met korting van A naar B op de deelscooter of -bakfiets
             </Heading>
-            <Paragraph className="ams-mb-xl">29 juli 2025</Paragraph>
+            <Paragraph className="ams-mb-xl">
+              <time dateTime="2025-07-29">29 juli 2025</time>
+            </Paragraph>
             <Paragraph size="large">
               Woont of werkt u in Amsterdam? Dan maakt u tot en met oktober met korting gebruik van deelscooters en
               -bakfietsen. Zo kunt u de auto laten staan en de werkzaamheden in en rond de stad vermijden.
@@ -127,56 +129,54 @@ const meta = {
           </Grid.Cell>
         </Grid>
       </Spotlight>
-      <aside aria-labelledby="meer-nieuws">
-        <Grid gapVertical="large" paddingVertical="x-large">
-          <Grid.Cell span="all">
-            <Heading id="meer-nieuws" level={2} size="level-1">
-              Meer nieuws
-            </Heading>
-          </Grid.Cell>
-          <Grid.Cell span={4}>
-            <Card>
-              <Card.Image alt="" src="https://picsum.photos/640/360?random=1" />
-              <Card.HeadingGroup tagline="Nieuws">
-                <Card.Heading level={3}>
-                  <Card.Link href="#">Waarom we op zoek zijn naar vleermuizen</Card.Link>
-                </Card.Heading>
-              </Card.HeadingGroup>
-              <Paragraph>
-                U kunt &apos;s avonds ecologen in oranje hesjes tegenkomen. Zij zijn op zoek naar vleermuizen. Dat heeft
-                te maken met het verduurzamen van woningen.
-              </Paragraph>
-            </Card>
-          </Grid.Cell>
-          <Grid.Cell span={4}>
-            <Card>
-              <Card.Image alt="" src="https://picsum.photos/640/360?random=2" />
-              <Card.HeadingGroup tagline="Nieuws">
-                <Card.Heading level={3}>
-                  <Card.Link href="#">Meer aandacht voor voetgangers, een jaar lang</Card.Link>
-                </Card.Heading>
-              </Card.HeadingGroup>
-              <Paragraph>
-                We gaan de veiligheid voor voetgangers verbeteren, meer ruimte maken, en lopen en wandelen stimuleren.
-              </Paragraph>
-            </Card>
-          </Grid.Cell>
-          <Grid.Cell span={4}>
-            <Card>
-              <Card.Image alt="" src="https://picsum.photos/640/360?random=3" />
-              <Card.HeadingGroup tagline="Nieuws">
-                <Card.Heading level={3}>
-                  <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>
-                </Card.Heading>
-              </Card.HeadingGroup>
-              <Paragraph>
-                Afvalboten, bakfietsen en ondergrondse containers. We experimenteren met nieuwe manieren om afval op te
-                halen in het centrum.
-              </Paragraph>
-            </Card>
-          </Grid.Cell>
-        </Grid>
-      </aside>
+      <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="large" paddingVertical="x-large">
+        <Grid.Cell span="all">
+          <Heading id="meer-nieuws" level={2} size="level-1">
+            Meer nieuws
+          </Heading>
+        </Grid.Cell>
+        <Grid.Cell span={4}>
+          <Card>
+            <Card.Image alt="" src="https://picsum.photos/640/360?random=1" />
+            <Card.HeadingGroup tagline="Nieuws">
+              <Card.Heading level={3}>
+                <Card.Link href="#">Waarom we op zoek zijn naar vleermuizen</Card.Link>
+              </Card.Heading>
+            </Card.HeadingGroup>
+            <Paragraph>
+              U kunt &apos;s avonds ecologen in oranje hesjes tegenkomen. Zij zijn op zoek naar vleermuizen. Dat heeft
+              te maken met het verduurzamen van woningen.
+            </Paragraph>
+          </Card>
+        </Grid.Cell>
+        <Grid.Cell span={4}>
+          <Card>
+            <Card.Image alt="" src="https://picsum.photos/640/360?random=2" />
+            <Card.HeadingGroup tagline="Nieuws">
+              <Card.Heading level={3}>
+                <Card.Link href="#">Meer aandacht voor voetgangers, een jaar lang</Card.Link>
+              </Card.Heading>
+            </Card.HeadingGroup>
+            <Paragraph>
+              We gaan de veiligheid voor voetgangers verbeteren, meer ruimte maken, en lopen en wandelen stimuleren.
+            </Paragraph>
+          </Card>
+        </Grid.Cell>
+        <Grid.Cell span={4}>
+          <Card>
+            <Card.Image alt="" src="https://picsum.photos/640/360?random=3" />
+            <Card.HeadingGroup tagline="Nieuws">
+              <Card.Heading level={3}>
+                <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>
+              </Card.Heading>
+            </Card.HeadingGroup>
+            <Paragraph>
+              Afvalboten, bakfietsen en ondergrondse containers. We experimenteren met nieuwe manieren om afval op te
+              halen in het centrum.
+            </Paragraph>
+          </Card>
+        </Grid.Cell>
+      </Grid>
     </>
   ),
 } satisfies Meta
@@ -203,7 +203,9 @@ export const Default: StoryObj = {
     <Grid paddingBottom="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading className="ams-mb-s" level={1}>Met korting van A naar B op de deelscooter of -bakfiets</Heading>
-        <Paragraph className="ams-mb-xl">29 juli 2025</Paragraph>
+        <Paragraph className="ams-mb-xl">
+          <time dateTime="2025-07-29">29 juli 2025</time>
+        </Paragraph>
         <Paragraph size="large">
           Woont of werkt u in Amsterdam? Dan maakt u tot en met oktober met korting gebruik van deelscooters
           en -bakfietsen.
@@ -275,49 +277,47 @@ export const Default: StoryObj = {
       </Grid.Cell>
     </Grid>
   </Spotlight>
-  {/* Related articles in their own labelled aside, outside the article’s <main>. */}
-  <aside aria-labelledby="meer-nieuws">
-    <Grid gapVertical="large" paddingVertical="x-large">
-      <Grid.Cell span="all">
-        <Heading id="meer-nieuws" level={2} size="level-1">Meer nieuws</Heading>
-      </Grid.Cell>
-      <Grid.Cell span={4}>
-        <Card>
-          <Card.Image alt="" src="https://picsum.photos/640/360?random=1" />
-          <Card.HeadingGroup tagline="Nieuws">
-            <Card.Heading level={3}>
-              <Card.Link href="#">Waarom we op zoek zijn naar vleermuizen</Card.Link>
-            </Card.Heading>
-          </Card.HeadingGroup>
-          <Paragraph>
-            U kunt 's avonds ecologen in oranje hesjes tegenkomen. Zij zijn op zoek naar vleermuizen.
-          </Paragraph>
-        </Card>
-      </Grid.Cell>
-      <Grid.Cell span={4}>
-        <Card>
-          <Card.Image alt="" src="https://picsum.photos/640/360?random=2" />
-          <Card.HeadingGroup tagline="Nieuws">
-            <Card.Heading level={3}>
-              <Card.Link href="#">Meer aandacht voor voetgangers, een jaar lang</Card.Link>
-            </Card.Heading>
-          </Card.HeadingGroup>
-          <Paragraph>We gaan de veiligheid voor voetgangers verbeteren en meer ruimte maken.</Paragraph>
-        </Card>
-      </Grid.Cell>
-      <Grid.Cell span={4}>
-        <Card>
-          <Card.Image alt="" src="https://picsum.photos/640/360?random=3" />
-          <Card.HeadingGroup tagline="Nieuws">
-            <Card.Heading level={3}>
-              <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>
-            </Card.Heading>
-          </Card.HeadingGroup>
-          <Paragraph>Afvalboten, bakfietsen en ondergrondse containers in het centrum.</Paragraph>
-        </Card>
-      </Grid.Cell>
-    </Grid>
-  </aside>
+  {/* Related articles as a labelled aside (Grid as="aside"), outside the article’s <main>. */}
+  <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="large" paddingVertical="x-large">
+    <Grid.Cell span="all">
+      <Heading id="meer-nieuws" level={2} size="level-1">Meer nieuws</Heading>
+    </Grid.Cell>
+    <Grid.Cell span={4}>
+      <Card>
+        <Card.Image alt="" src="https://picsum.photos/640/360?random=1" />
+        <Card.HeadingGroup tagline="Nieuws">
+          <Card.Heading level={3}>
+            <Card.Link href="#">Waarom we op zoek zijn naar vleermuizen</Card.Link>
+          </Card.Heading>
+        </Card.HeadingGroup>
+        <Paragraph>
+          U kunt 's avonds ecologen in oranje hesjes tegenkomen. Zij zijn op zoek naar vleermuizen.
+        </Paragraph>
+      </Card>
+    </Grid.Cell>
+    <Grid.Cell span={4}>
+      <Card>
+        <Card.Image alt="" src="https://picsum.photos/640/360?random=2" />
+        <Card.HeadingGroup tagline="Nieuws">
+          <Card.Heading level={3}>
+            <Card.Link href="#">Meer aandacht voor voetgangers, een jaar lang</Card.Link>
+          </Card.Heading>
+        </Card.HeadingGroup>
+        <Paragraph>We gaan de veiligheid voor voetgangers verbeteren en meer ruimte maken.</Paragraph>
+      </Card>
+    </Grid.Cell>
+    <Grid.Cell span={4}>
+      <Card>
+        <Card.Image alt="" src="https://picsum.photos/640/360?random=3" />
+        <Card.HeadingGroup tagline="Nieuws">
+          <Card.Heading level={3}>
+            <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>
+          </Card.Heading>
+        </Card.HeadingGroup>
+        <Paragraph>Afvalboten, bakfietsen en ondergrondse containers in het centrum.</Paragraph>
+      </Card>
+    </Grid.Cell>
+  </Grid>
 </>`,
         language: 'tsx',
       },

--- a/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
+++ b/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
@@ -50,6 +50,41 @@ export const LandingPage: StoryObj = {
       </Page>
     ),
   ],
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        code: `<Grid as="main" id="inhoud" paddingBottom="2x-large" paddingTop="large">
+  <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+    <Heading className="ams-mb-m" level={1}>Waar u dit formulier voor gebruikt</Heading>
+    <Paragraph size="large">
+      Met dit formulier maakt u een afspraak bij een Stadsloket in Amsterdam of Weesp.
+    </Paragraph>
+  </Grid.Cell>
+  <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+    {/* Show the steps up front so people know what to expect before they start. */}
+    <Heading className="ams-mb-s" level={2}>De stappen in dit formulier</Heading>
+    <OrderedList className="ams-mb-l">
+      <OrderedList.Item>
+        <strong>Afspraak</strong> - Kies waarvoor u een afspraak wilt maken. Kies ook waar u de afspraak
+        wilt hebben. En wanneer.
+      </OrderedList.Item>
+      <OrderedList.Item>
+        <strong>Uw gegevens</strong> - Vul uw contactgegevens in.
+      </OrderedList.Item>
+      <OrderedList.Item>
+        <strong>Controleren</strong> - Controleer de gegevens die u heeft ingevuld. Verstuur de aanvraag.
+      </OrderedList.Item>
+    </OrderedList>
+    {/* A single, prominent call to action that starts the form. */}
+    <CallToActionLink href="#">Start het formulier</CallToActionLink>
+  </Grid.Cell>
+</Grid>`,
+        language: 'tsx',
+      },
+    },
+  },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <Grid as="main" id="inhoud" paddingBottom="2x-large" paddingTop="large">
@@ -91,6 +126,71 @@ export const SingleQuestion: StoryObj = {
       </FormLayout>
     ),
   ],
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the accessibility guidance below stays in the panel.
+        code: `<>
+  {/* The back link is in its own Grid, because it should be outside of the main section. */}
+  <Grid className="ams-mb-xl">
+    <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+      {/*
+       * A back link lets users move between form pages without worrying about losing their progress. The
+       * browser back button should keep progress too, but users do not always trust it. Use a link, not a
+       * button: multiple submit buttons in a form can cause unexpected behaviour.
+       * See https://design-system.service.gov.uk/components/back-link/ and
+       * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+       */}
+      <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
+    </Grid.Cell>
+  </Grid>
+  <Grid as="main" paddingBottom="2x-large">
+    <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+      {/*
+       * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
+       * an extra entry to the heading hierarchy – and it stays clearly labelled if CSS fails to load.
+       */}
+      <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
+        <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
+        {/*
+         * First test the form without a progress indicator to see whether it is simple enough to go without
+         * one. If not, use a plain one like this.
+         * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
+         */}
+        <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
+      </header>
+      {/*
+       * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
+       * the user too little. Validate on the server and return the result, or use client-side validation.
+       * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/
+       */}
+      <form noValidate onSubmit={(e) => e.preventDefault()}>
+        {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
+        <FieldSet
+          aria-required="true"
+          className="ams-mb-xl"
+          legend="Kies waar u voor wilt langskomen op het Stadsloket"
+          // When a page is a single question, treat its legend as the main page heading (h1).
+          legendIsPageHeading
+          role="radiogroup"
+        >
+          <Column gap="x-small">
+            <Radio aria-required="true" name="reasonForVisit" value="passport-id-driving-license">Paspoort / ID / Rijbewijs</Radio>
+            <Radio aria-required="true" name="reasonForVisit" value="permits">Vergunningen</Radio>
+            <Radio aria-required="true" name="reasonForVisit" value="social-counter">Sociaal loket</Radio>
+            <Radio aria-required="true" name="reasonForVisit" value="other">Overig</Radio>
+          </Column>
+        </FieldSet>
+        <Button type="submit">Volgende vraag</Button>
+      </form>
+    </Grid.Cell>
+  </Grid>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
@@ -176,6 +276,71 @@ export const SingleQuestionWithSubquestions: StoryObj = {
       </FormLayout>
     ),
   ],
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the accessibility guidance below stays in the panel.
+        code: `<>
+  {/* The back link is in its own Grid, because it should be outside of the main section. */}
+  <Grid className="ams-mb-xl">
+    <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+      {/*
+       * A back link lets users move between form pages without worrying about losing their progress. Use a
+       * link, not a button: multiple submit buttons in a form can cause unexpected behaviour.
+       * See https://design-system.service.gov.uk/components/back-link/
+       */}
+      <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
+    </Grid.Cell>
+  </Grid>
+  <Grid as="main" paddingBottom="2x-large">
+    <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+      {/*
+       * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
+       * an extra entry to the heading hierarchy – and it stays labelled if CSS fails to load.
+       */}
+      <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
+        <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
+        <Paragraph>Stap 2 van 3: Uw gegevens</Paragraph>
+      </header>
+      {/* Do not rely on HTML5 form validation; validate on the server or client-side and return clear errors. */}
+      <form noValidate onSubmit={(e) => e.preventDefault()}>
+        {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
+        <FieldSet legend="Contactgegevens" legendIsPageHeading>
+          <Field>
+            <Label htmlFor="email-input" inFieldSet optional>E-mailadres</Label>
+            <TextInput
+              autoComplete="email"
+              autoCorrect="off"
+              id="email-input"
+              name="email"
+              // A generous size, per https://design-system.service.gov.uk/patterns/email-addresses/
+              size={30}
+              spellCheck="false"
+              type="email"
+            />
+          </Field>
+          <Field className="ams-mb-xl">
+            <Label htmlFor="tel-input" inFieldSet optional>Telefoonnummer</Label>
+            <TextInput
+              autoComplete="tel"
+              id="tel-input"
+              name="phone"
+              // Phone numbers are at most 15 characters (E.164): https://en.wikipedia.org/wiki/E.164
+              size={15}
+              type="tel"
+            />
+          </Field>
+        </FieldSet>
+        <Button type="submit">Volgende vraag</Button>
+      </form>
+    </Grid.Cell>
+  </Grid>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
@@ -266,6 +431,52 @@ export const MultipleQuestions: StoryObj = {
       </FormLayout>
     ),
   ],
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the accessibility guidance below stays in the panel.
+        code: `<>
+  {/* The back link is in its own Grid, because it should be outside of the main section. */}
+  <Grid className="ams-mb-xl">
+    <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+      {/*
+       * A back link lets users move between form pages without worrying about losing their progress. Use a
+       * link, not a button: multiple submit buttons in a form can cause unexpected behaviour.
+       * See https://design-system.service.gov.uk/components/back-link/
+       */}
+      <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
+    </Grid.Cell>
+  </Grid>
+  <Grid as="main" paddingBottom="2x-large">
+    <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+      {/* A form with multiple questions has a level 1 heading before it that describes the whole group. */}
+      <Heading className="ams-mb-xl" level={1}>Inschrijven</Heading>
+      {/* Do not rely on HTML5 form validation; validate on the server or client-side and return clear errors. */}
+      <form noValidate onSubmit={(e) => e.preventDefault()}>
+        {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
+        <Field className="ams-mb-l">
+          <Label htmlFor="name-input">Naam</Label>
+          <TextInput autoComplete="name" autoCorrect="off" id="name-input" name="name" spellCheck="false" type="text" />
+        </Field>
+        <Field className="ams-mb-l">
+          <Label htmlFor="tel-input" optional>Telefoonnummer</Label>
+          {/* Phone numbers are at most 15 characters (E.164): https://en.wikipedia.org/wiki/E.164 */}
+          <TextInput autoComplete="tel" id="tel-input" name="tel" size={15} type="tel" />
+        </Field>
+        <Field className="ams-mb-xl">
+          <Label htmlFor="date">Datum</Label>
+          <DateInput id="date" />
+        </Field>
+        <Button type="submit">Volgende vraag</Button>
+      </form>
+    </Grid.Cell>
+  </Grid>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
@@ -343,6 +554,70 @@ export const WithValidationError: StoryObj = {
       </FormLayout>
     ),
   ],
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the error-handling guidance below stays in the panel.
+        code: `<>
+  {/* The back link is in its own Grid, because it should be outside of the main section. */}
+  <Grid className="ams-mb-xl">
+    <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+      <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
+    </Grid.Cell>
+  </Grid>
+  <Grid as="main" paddingBottom="2x-large">
+    <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+      {/*
+       * Notifying a user of errors is threefold:
+       * - Add the error count to the document title, so a screen reader announces it first.
+       * - Show the Invalid Form Alert at the top of the main container.
+       * - Add error messages next to the relevant form fields.
+       * See https://designsystem.amsterdam/?path=/docs/components-forms-invalid-form-alert--docs
+       */}
+      <InvalidFormAlert
+        className="ams-mb-m"
+        errors={[{ id: '#passport-id-driving-license', label: 'Geef aan waar u voor wilt langskomen.' }]}
+        headingLevel={2}
+      />
+      {/*
+       * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
+       * an extra entry to the heading hierarchy – and it stays labelled if CSS fails to load.
+       */}
+      <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
+        <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
+        <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
+      </header>
+      {/* Do not rely on HTML5 form validation; validate on the server or client-side and return clear errors. */}
+      <form noValidate onSubmit={(e) => e.preventDefault()}>
+        <FieldSet
+          // Only link the error message to the field set while the message is in the DOM. Referencing a
+          // non-existent element can trip up accessibility evaluation tools.
+          aria-describedby="error"
+          aria-required="true"
+          className="ams-mb-xl"
+          invalid
+          legend="Kies waar u voor wilt langskomen op het Stadsloket"
+          legendIsPageHeading
+          role="radiogroup"
+        >
+          <ErrorMessage id="error">Geef aan waar u voor wilt langskomen.</ErrorMessage>
+          <Column gap="x-small">
+            <Radio aria-required="true" id="passport-id-driving-license" invalid name="reasonForVisit" value="passport-id-driving-license">Paspoort / ID / Rijbewijs</Radio>
+            <Radio aria-required="true" invalid name="reasonForVisit" value="permits">Vergunningen</Radio>
+            <Radio aria-required="true" invalid name="reasonForVisit" value="social-counter">Sociaal loket</Radio>
+            <Radio aria-required="true" invalid name="reasonForVisit" value="other">Overig</Radio>
+          </Column>
+        </FieldSet>
+        <Button type="submit">Volgende vraag</Button>
+      </form>
+    </Grid.Cell>
+  </Grid>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -79,4 +79,72 @@ const meta = {
 
 export default meta
 
-export const Default: StoryObj = {}
+export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments and expands each `map` into repeated blocks. Provide the source by hand so the
+        // guidance stays visible and the `map` pattern reads the way a developer would write it.
+        code: `<main id="inhoud">
+  {/*
+   * The homepage’s visible headings start at the section level, so give the page one visually hidden
+   * h1. Screen readers still announce a page title and the heading outline keeps a single top level.
+   */}
+  <h1 className="ams-visually-hidden">Homepage van de gemeente Amsterdam</h1>
+  {/* A hero that overlaps a full-width image with the block beneath it – see the Overlap component. */}
+  <Overlap>{/* … */}</Overlap>
+  <Grid gapVertical="large" paddingVertical="x-large">
+    <Grid.Cell span="all">
+      {/* Second level in the outline (the hidden h1 is first), shown at the largest size. */}
+      <Heading level={2} size="level-1">{topTaskSection.title}</Heading>
+    </Grid.Cell>
+    {topTaskSection.tasks.map(({ title, description }) => (
+      <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
+        <Card>
+          {/* Card.Link stretches over the whole Card, so the entire card is one clickable link. */}
+          <Card.Heading level={3}>
+            <Card.Link href="#">{title}</Card.Link>
+          </Card.Heading>
+          <Paragraph>{description}</Paragraph>
+        </Card>
+      </Grid.Cell>
+    ))}
+  </Grid>
+  <Spotlight>
+    <Grid paddingVertical="x-large">
+      {spotlightSections.map(({ title, description, link }) => (
+        <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 6 }}>
+          {/* On the dark Spotlight, color="inverse" switches text and links to their light variant. */}
+          <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">{title}</Heading>
+          <Paragraph className="ams-mb-m" color="inverse">{description}</Paragraph>
+          <StandaloneLink color="inverse" href="#">{link}</StandaloneLink>
+        </Grid.Cell>
+      ))}
+    </Grid>
+  </Spotlight>
+  <Grid gapVertical="large" paddingVertical="x-large">
+    <Grid.Cell span="all">
+      <Heading level={2} size="level-1">{newsSection.title}</Heading>
+    </Grid.Cell>
+    {newsSection.items.map(({ title, description, image }) => (
+      <Grid.Cell key={title} span={4}>
+        <Card>
+          <Card.Image alt="" src={image} />
+          {/* Card.HeadingGroup adds a short tagline above the card’s heading. */}
+          <Card.HeadingGroup tagline="Nieuws">
+            <Card.Heading level={3}>
+              <Card.Link href="#">{title}</Card.Link>
+            </Card.Heading>
+          </Card.HeadingGroup>
+          <Paragraph>{description}</Paragraph>
+        </Card>
+      </Grid.Cell>
+    ))}
+  </Grid>
+</main>`,
+        language: 'tsx',
+      },
+    },
+  },
+}

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -417,7 +417,7 @@ export const WithImageGallery: StoryObj = {
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
         <Heading className="ams-mb-s" level={2} size="level-3">Coalitieakkoord</Heading>
         <Paragraph className="ams-mb-s">
-          In dit akkoord staan de plannen en visie van de coalitie Pvda, GroenLinks en D66 voor 2022-2026.
+          In dit akkoord staan de plannen en visie van de coalitie PvdA, GroenLinks en D66 voor 2022-2026.
         </Paragraph>
         <StandaloneLink href="#">Coalitieakkoord en Uitvoeringsagenda</StandaloneLink>
       </Grid.Cell>

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -277,7 +277,7 @@ export const WithInteractiveElement: StoryObj = {
           <Heading className="ams-mb-m" color="inverse" level={2} size="level-3">Parkeertarieven</Heading>
           {/* An interactive element in the page: a search field. On the dark Spotlight, its links take color="inverse". */}
           <SearchField className="ams-mb-m">
-            <SearchField.Input placeholder="Zoek op adres" />
+            <SearchField.Input label="Zoek op adres" placeholder="Zoek op adres" />
             <SearchField.Button />
           </SearchField>
           <LinkList>
@@ -334,7 +334,7 @@ export const WithInteractiveElement: StoryObj = {
                 Parkeertarieven
               </Heading>
               <SearchField className="ams-mb-m">
-                <SearchField.Input placeholder="Zoek op adres" />
+                <SearchField.Input label="Zoek op adres" placeholder="Zoek op adres" />
                 <SearchField.Button />
               </SearchField>
               <LinkList>
@@ -492,7 +492,7 @@ export const WithImageGallery: StoryObj = {
           </Breadcrumb>
         </Grid.Cell>
       </Grid>
-      <main id="inhoud" key={2}>
+      <main id="inhoud">
         <Grid paddingBottom="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
             <Heading className="ams-mb-m" level={1}>

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -47,6 +47,51 @@ const getLinks = (links: string[]) =>
   )
 
 export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments and expands each `map`. Provide the source by hand so the guidance stays visible and
+        // the `map` and `getLinks` patterns read the way a developer would write them.
+        code: `// getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
+
+<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  <Grid as="main" id="inhoud" paddingBottom="x-large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Heading className="ams-mb-m" level={1}>Burgerzaken</Heading>
+      <Paragraph size="large">
+        Heeft u een paspoort, rijbewijs of uittreksel nodig? Of wilt u een verhuizing doorgeven of een
+        geboorte aangeven? Op deze pagina vindt u alle informatie en regelzaken rondom Burgerzaken.
+      </Paragraph>
+    </Grid.Cell>
+    {/*
+     * Two columns of link groups. On the even-indexed cells, start pins them to the content column; the
+     * odd-indexed cells (start undefined) fall in beside them.
+     */}
+    {burgerzakenLinks.map(({ heading, links }, index) => (
+      <Grid.Cell
+        key={heading}
+        span={{ narrow: 4, medium: 4, wide: 5 }}
+        start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
+      >
+        <Heading className="ams-mb-s" level={2} size="level-3">{heading}</Heading>
+        {getLinks(links)}
+      </Grid.Cell>
+    ))}
+  </Grid>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
@@ -85,6 +130,61 @@ export const Default: StoryObj = {
 }
 
 export const WithTopTasks: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `// getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
+
+<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  <Grid as="main" id="inhoud" paddingBottom="x-large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Heading className="ams-mb-m" level={1}>Leefomgeving</Heading>
+    </Grid.Cell>
+    {/* The two most important tasks get a full Card each; the groups below are plain heading + links. */}
+    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Card>
+        <Card.Heading level={2}>
+          <Card.Link href="/">Doe een melding</Card.Link>
+        </Card.Heading>
+        <Paragraph>
+          Meld overlast van geluid of afval op straat. U kunt ook kapotte dingen melden of iets dat we
+          moeten opruimen.
+        </Paragraph>
+      </Card>
+    </Grid.Cell>
+    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
+      <Card>
+        <Card.Heading level={2}>
+          <Card.Link href="/">Kondig een demonstratie of manifestatie aan</Card.Link>
+        </Card.Heading>
+        <Paragraph>Een demonstratie of manifestatie meldt u vooraf bij de gemeente.</Paragraph>
+      </Card>
+    </Grid.Cell>
+    {/* start pins the even-indexed cells to the content column; odd-indexed cells fall in beside them. */}
+    {topTaskLinks.map(({ heading, links }, index) => (
+      <Grid.Cell
+        key={heading}
+        span={{ narrow: 4, medium: 4, wide: 5 }}
+        start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
+      >
+        <Heading className="ams-mb-s" level={2} size="level-3">{heading}</Heading>
+        {getLinks(links)}
+      </Grid.Cell>
+    ))}
+  </Grid>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
@@ -138,6 +238,62 @@ export const WithTopTasks: StoryObj = {
 }
 
 export const WithInteractiveElement: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `// getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
+
+<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  <main id="inhoud">
+    <Grid paddingBottom="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-m" level={1}>Parkeren</Heading>
+        <Paragraph className="ams-mb-m" size="large">
+          Vind informatie over parkeervergunningen, parkeertarieven en betaald parkeren in Amsterdam.
+        </Paragraph>
+      </Grid.Cell>
+      {parkerenLinks.map(({ heading, links }, index) => (
+        <Grid.Cell
+          key={heading}
+          span={{ narrow: 4, medium: 4, wide: 5 }}
+          start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
+        >
+          <Heading className="ams-mb-s" level={2} size="level-3">{heading}</Heading>
+          {getLinks(links)}
+        </Grid.Cell>
+      ))}
+    </Grid>
+    <Spotlight>
+      <Grid paddingVertical="large">
+        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+          <Heading className="ams-mb-m" color="inverse" level={2} size="level-3">Parkeertarieven</Heading>
+          {/* An interactive element in the page: a search field. On the dark Spotlight, its links take color="inverse". */}
+          <SearchField className="ams-mb-m">
+            <SearchField.Input placeholder="Zoek op adres" />
+            <SearchField.Button />
+          </SearchField>
+          <LinkList>
+            <LinkList.Link color="inverse" href="#">Tarieven stadsgebied Weesp</LinkList.Link>
+            <LinkList.Link color="inverse" href="#">Parkeren op feestdagen</LinkList.Link>
+          </LinkList>
+        </Grid.Cell>
+      </Grid>
+    </Spotlight>
+    <Image alt="" aspectRatio="16:9" className="ams-mb-2xl" src="https://picsum.photos/id/133/1440/810" />
+  </main>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
@@ -199,6 +355,132 @@ export const WithInteractiveElement: StoryObj = {
 }
 
 export const WithImageGallery: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+        <Breadcrumb.Link href="#">Bestuur en Organisatie</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  <main id="inhoud">
+    <Grid paddingBottom="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-m" level={1}>College van burgemeester en wethouders</Heading>
+        <Paragraph size="large">
+          Het college van burgemeester en wethouders is verantwoordelijk voor het dagelijks bestuur van de
+          gemeente Amsterdam.
+        </Paragraph>
+      </Grid.Cell>
+    </Grid>
+    {/* A full-width banner image spans all columns; aspectRatio keeps it from shifting the layout. */}
+    <Image alt="" aspectRatio="16:5" src="https://picsum.photos/1440/450" />
+    <Grid paddingVertical="x-large">
+      {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }}>
+        <Heading className="ams-mb-s" level={2}>Burgemeester en wethouders</Heading>
+        <Paragraph>
+          Het college bestaat uit de burgemeester en 9 wethouders en wordt ambtelijk ondersteund door de
+          gemeentesecretaris.
+        </Paragraph>
+      </Grid.Cell>
+      {/*
+       * The image gallery. Each card spans 4 columns; the computed start lays them out two per row on
+       * medium ([1, 5]) and three per row on wide ([1, 5, 9]) screens.
+       */}
+      {persons.map(({ imageSource, name, role }, index) => (
+        <Grid.Cell
+          key={name}
+          span={4}
+          start={{ narrow: 1, medium: [1, 5][index % 2], wide: [1, 5, 9][index % 3] }}
+        >
+          <Card>
+            <Card.Image alt="" src={imageSource} />
+            <Card.Heading level={3}>
+              <Card.Link href="#">{role} {name}</Card.Link>
+            </Card.Heading>
+          </Card>
+        </Grid.Cell>
+      ))}
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-s" level={2} size="level-3">Portefeuilleverdeling</Heading>
+        <Paragraph className="ams-mb-s">
+          Een alfabetisch overzicht van de portefeuilles van burgemeester en wethouders.
+        </Paragraph>
+        <StandaloneLink href="#">Portefeuilleverdeling</StandaloneLink>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
+        <Heading className="ams-mb-s" level={2} size="level-3">Coalitieakkoord</Heading>
+        <Paragraph className="ams-mb-s">
+          In dit akkoord staan de plannen en visie van de coalitie Pvda, GroenLinks en D66 voor 2022-2026.
+        </Paragraph>
+        <StandaloneLink href="#">Coalitieakkoord en Uitvoeringsagenda</StandaloneLink>
+      </Grid.Cell>
+    </Grid>
+    <Spotlight>
+      <Grid paddingVertical="x-large">
+        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+          {/* On the dark Spotlight, color="inverse" switches the heading and links to their light variant. */}
+          <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Persberichten en nieuws</Heading>
+          <LinkList className="ams-mb-m">
+            <LinkList.Link color="inverse" href="#">
+              Proef elektrische fietsen voor sociale huurders op Strandeiland en Centrumeiland
+            </LinkList.Link>
+            <LinkList.Link color="inverse" href="#">Definitief ontwerp voor nieuwe Jaap Eden IJshal</LinkList.Link>
+            <LinkList.Link color="inverse" href="#">Meer persberichten</LinkList.Link>
+          </LinkList>
+        </Grid.Cell>
+        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
+          <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Besluiten B en W</Heading>
+          <LinkList className="ams-mb-m">
+            <LinkList.Link color="inverse" href="#">Nieuws uit B en W 9 juli 2025</LinkList.Link>
+            <LinkList.Link color="inverse" href="#">Nieuws uit B en W 2 juli 2025</LinkList.Link>
+            <LinkList.Link color="inverse" href="#">Nieuws uit B en W 25 juni 2025</LinkList.Link>
+            <LinkList.Link color="inverse" href="#">Meer besluiten B en W</LinkList.Link>
+          </LinkList>
+        </Grid.Cell>
+      </Grid>
+    </Spotlight>
+    <Grid paddingVertical="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-s" level={2} size="level-3">Pers en woordvoering</Heading>
+        <Paragraph className="ams-mb-s">Voor vragen van journalisten aan de afdeling Bestuursvoorlichting.</Paragraph>
+        <StandaloneLink href="#">Pers en woordvoering</StandaloneLink>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
+        <Heading className="ams-mb-s" level={2} size="level-3">Meer over het college</Heading>
+        <LinkList className="ams-mb-m">
+          <LinkList.Link href="#">Vervangingsregeling en locoburgemeesters</LinkList.Link>
+          <LinkList.Link href="#">Gedragscode</LinkList.Link>
+          <LinkList.Link href="#">Declaraties en dienstreizen</LinkList.Link>
+          <LinkList.Link href="#">Geschenkenregister college van B&W</LinkList.Link>
+        </LinkList>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-s" level={2} size="level-3">Contact</Heading>
+        <Paragraph className="ams-mb-s">Een bericht voor het college van burgemeester en wethouders kunt u:</Paragraph>
+        <UnorderedList>
+          <UnorderedList.Item>sturen naar Postbus 202, 1000 AE Amsterdam</UnorderedList.Item>
+          <UnorderedList.Item>afgeven bij 1 van de <Link href="#">stadsloketten</Link></UnorderedList.Item>
+          <UnorderedList.Item>mailen met het <Link href="#">contactformulier</Link></UnorderedList.Item>
+        </UnorderedList>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
+        <Heading className="ams-mb-s" level={2} size="level-3">Rechtenvrije foto’s</Heading>
+        <Image alt="" src="https://picsum.photos/640/360" />
+      </Grid.Cell>
+    </Grid>
+  </main>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
@@ -357,6 +639,105 @@ export const WithImageGallery: StoryObj = {
 }
 
 export const SubnavigationPage: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `// getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
+
+<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+        <Breadcrumb.Link href="#">Onderwerp</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  <main id="inhoud">
+    <Grid paddingBottom="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-m" level={1}>Onderwerp</Heading>
+        <Paragraph size="large">
+          Amsterdam wil een nieuwe traditie starten om met oud en nieuw naar een centrale nieuwjaarsviering
+          te gaan in plaats van zelf vuurwerk af te steken.
+        </Paragraph>
+      </Grid.Cell>
+    </Grid>
+    <Image alt="" aspectRatio="16:5" src="https://picsum.photos/1440/450" />
+    <Grid paddingVertical="large">
+      {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-s" level={2}>L2 Paragraaf titel</Heading>
+        <Paragraph>Voorbeeldtekst bij dit onderwerp.</Paragraph>
+      </Grid.Cell>
+      {/* start pins the even-indexed cells to the content column; odd-indexed cells fall in beside them. */}
+      {burgerzakenLinks.slice(0, 6).map(({ heading, links }, index) => (
+        <Grid.Cell
+          key={heading}
+          span={{ narrow: 4, medium: 4, wide: 5 }}
+          start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
+        >
+          <Heading className="ams-mb-s" level={3}>{heading}</Heading>
+          {getLinks(links)}
+        </Grid.Cell>
+      ))}
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-s" level={3}>Titel</Heading>
+        <Paragraph className="ams-mb-m">Voorbeeldtekst bij dit onderwerp.</Paragraph>
+        <StandaloneLink href="#">Lees meer</StandaloneLink>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
+        <Heading className="ams-mb-s" level={3}>Titel</Heading>
+        <Paragraph className="ams-mb-m">Voorbeeldtekst bij dit onderwerp.</Paragraph>
+        <StandaloneLink href="#">Lees meer</StandaloneLink>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-s" level={3}>Titel</Heading>
+        <Paragraph className="ams-mb-m">Voorbeeldtekst bij dit onderwerp.</Paragraph>
+        <StandaloneLink href="#">Lees meer</StandaloneLink>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
+        <Heading className="ams-mb-s" level={3}>Titel</Heading>
+        <Paragraph className="ams-mb-m">Voorbeeldtekst bij dit onderwerp.</Paragraph>
+        <StandaloneLink href="#">Lees meer</StandaloneLink>
+      </Grid.Cell>
+    </Grid>
+    <Spotlight color="magenta">
+      <Grid paddingVertical="large">
+        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+          <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Titel</Heading>
+          <Paragraph color="inverse">Voorbeeldtekst bij dit onderwerp.</Paragraph>
+        </Grid.Cell>
+        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
+          <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Titel</Heading>
+          <Paragraph color="inverse">Voorbeeldtekst bij dit onderwerp.</Paragraph>
+        </Grid.Cell>
+      </Grid>
+    </Spotlight>
+    <Grid paddingVertical="large">
+      {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-s" level={2}>L2 Paragraaf titel</Heading>
+        <Paragraph>Voorbeeldtekst bij dit onderwerp.</Paragraph>
+      </Grid.Cell>
+      {burgerzakenLinks.slice(4, 8).map(({ heading, links }, index) => (
+        <Grid.Cell
+          key={heading}
+          span={{ narrow: 4, medium: 4, wide: 5 }}
+          start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
+        >
+          <Heading className="ams-mb-s" level={3}>{heading}</Heading>
+          {getLinks(links)}
+        </Grid.Cell>
+      ))}
+    </Grid>
+  </main>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>

--- a/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
+++ b/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
@@ -151,4 +151,115 @@ const meta = {
 
 export default meta
 
-export const Default: StoryObj = {}
+export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        code: `<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+        <Breadcrumb.Link href="#">Stadspas</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  <Grid as="main" id="inhoud" paddingBottom="x-large">
+    {/* The title and lead span the wide intro column. */}
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Heading className="ams-mb-xl" level={1}>Gratis laptop of tablet voor de basisschool aanvragen</Heading>
+      <Paragraph size="large">
+        U krijgt per huishouden 1 keer per 5 schooljaren een gratis laptop of tablet op de basisschool.
+      </Paragraph>
+    </Grid.Cell>
+    {/* The body sits in a narrower cell, indented one column on wider screens, for a comfortable reading measure. */}
+    <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+      <Heading className="ams-mb-s" level={2}>Voorwaarden</Heading>
+      <UnorderedList className="ams-mb-xl">
+        <UnorderedList.Item>U woont in Amsterdam of Weesp.</UnorderedList.Item>
+        <UnorderedList.Item>U heeft een <Link href="#">laag inkomen en weinig vermogen</Link>.</UnorderedList.Item>
+        <UnorderedList.Item>U ontvangt kinderbijslag of pleegoudervergoeding voor uw kind.</UnorderedList.Item>
+        <UnorderedList.Item>Uw kind gaat naar de basisschool.</UnorderedList.Item>
+        <UnorderedList.Item>Uw kind is nu 10, 11 of 12 jaar.</UnorderedList.Item>
+        <UnorderedList.Item>Uw kind woont bij u in huis.</UnorderedList.Item>
+        <UnorderedList.Item>
+          Uw huishouden heeft de afgelopen 4 schooljaren geen gratis laptop of tablet voor een kind op de
+          basisschool gehad.
+        </UnorderedList.Item>
+        <UnorderedList.Item>Uw kind doet eerst een computercursus.</UnorderedList.Item>
+      </UnorderedList>
+
+      <Heading className="ams-mb-s" level={2}>Aanvragen</Heading>
+      <Paragraph className="ams-mb-m">
+        Doe de check en kijk of u in aanmerking komt voor een gratis laptop of tablet voor uw kind of andere
+        regelingen.
+      </Paragraph>
+      <UnorderedList className="ams-mb-xl">
+        <UnorderedList.Item>Ontdek welke regelingen u hier kunt aanvragen.</UnorderedList.Item>
+        <UnorderedList.Item>Kies welke regelingen u wilt aanvragen voor u en uw gezinsleden.</UnorderedList.Item>
+        <UnorderedList.Item>Hierna moet u inloggen met uw DigiD.</UnorderedList.Item>
+      </UnorderedList>
+      {/* A prominent call to action for the main task on the page. */}
+      <CallToActionLink className="ams-mb-xl" href="#">Start de check en vraag aan</CallToActionLink>
+
+      <Heading className="ams-mb-s" level={2}>Geen DigiD?</Heading>
+      <UnorderedList className="ams-mb-xl">
+        <UnorderedList.Item>Ga naar <Link href="#">www.digid.nl</Link> en vraag uw DigID aan.</UnorderedList.Item>
+        <UnorderedList.Item>
+          {/* download hints the browser to save the PDF rather than open it in a new tab. */}
+          Lees eerst{' '}
+          <Link download href="#">Toelichting Gratis laptop of tablet basisschool Schooljaar 2024-2025.pdf</Link>{' '}
+          en{' '}
+          <Link download href="#">Aanvraag gratis laptop of tablet basisschool schooljaar 2024-2025.pdf</Link>.
+        </UnorderedList.Item>
+        <UnorderedList.Item>
+          Of: bel <Link href="tel:+31202526000">020 252 6000</Link> en vraag een formulier aan per post.
+        </UnorderedList.Item>
+      </UnorderedList>
+
+      <Heading className="ams-mb-s" level={2}>Vragen?</Heading>
+      <UnorderedList className="ams-mb-xl">
+        <UnorderedList.Item>Bel ons op 020 252 6000.</UnorderedList.Item>
+        <UnorderedList.Item>Hulp nodig bij het aanvragen? Ga naar Buurtteam Amsterdam.</UnorderedList.Item>
+      </UnorderedList>
+
+      <Heading className="ams-mb-s" level={2}>Zo lang duurt het</Heading>
+      <Paragraph className="ams-mb-xl">
+        Na de aanvraag krijgt u binnen 8 weken een reactie. We vertellen u dan of u recht hebt op de regeling
+        of niet. Het kan dus even duren voor u van ons hoort.
+      </Paragraph>
+
+      <Heading className="ams-mb-s" level={2}>Zonder computerles geen laptop</Heading>
+      <Paragraph className="ams-mb-xl">
+        Als uw kind recht heeft op een laptop, moet het een computerles volgen. De les is verplicht, ook als
+        uw kind in het verleden al zo’n les heeft gedaan.
+      </Paragraph>
+
+      <Heading className="ams-mb-s" level={2}>Maak binnen 2 weken een afspraak</Heading>
+      <Paragraph className="ams-mb-m">
+        U krijgt een brief met een aanmeldcode om aan te melden en een afspraak te maken. Bewaar deze brief
+        goed. Ga naar <Link href="#">Aanmelden Cyberschool</Link>. Vul de aanmeldcode in en kies zelf uw
+        stadsdeel, datum en tijd. U hebt een e-mailadres of telefoonnummer nodig. U krijgt een bevestiging
+        van uw afspraak.
+      </Paragraph>
+      <Paragraph className="ams-mb-xl">
+        Als u geen afspraak maakt, deelt de gemeente u in. U krijgt dan wel een uitnodiging. Na de
+        computerles krijgt u een code om in de webshop een laptop of tablet uit te kiezen.
+      </Paragraph>
+
+      <Heading className="ams-mb-s" level={2}>Afspraak aanpassen</Heading>
+      <Paragraph>
+        Pas uw afspraak aan als u niet kunt of als u de les gemist heeft. Bel hiervoor met Cybersoek:{' '}
+        <Link href="tel:+31206934582">020 6934 582</Link>.
+      </Paragraph>
+    </Grid.Cell>
+  </Grid>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
+}

--- a/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
+++ b/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
@@ -11,6 +11,7 @@ import {
   Grid,
   Heading,
   Link,
+  OrderedList,
   Paragraph,
   UnorderedList,
 } from '@amsterdam/design-system-react'
@@ -67,11 +68,11 @@ const meta = {
             Doe de check en kijk of u in aanmerking komt voor een gratis laptop of tablet voor uw kind of andere
             regelingen.
           </Paragraph>
-          <UnorderedList className="ams-mb-xl">
-            <UnorderedList.Item>Ontdek welke regelingen u hier kunt aanvragen.</UnorderedList.Item>
-            <UnorderedList.Item>Kies welke regelingen u wilt aanvragen voor u en uw gezinsleden.</UnorderedList.Item>
-            <UnorderedList.Item>Hierna moet u inloggen met uw DigiD.</UnorderedList.Item>
-          </UnorderedList>
+          <OrderedList className="ams-mb-xl">
+            <OrderedList.Item>Ontdek welke regelingen u hier kunt aanvragen.</OrderedList.Item>
+            <OrderedList.Item>Kies welke regelingen u wilt aanvragen voor u en uw gezinsleden.</OrderedList.Item>
+            <OrderedList.Item>Hierna moet u inloggen met uw DigiD.</OrderedList.Item>
+          </OrderedList>
           <CallToActionLink className="ams-mb-xl" href="#">
             Start de check en vraag aan
           </CallToActionLink>
@@ -197,11 +198,11 @@ export const Default: StoryObj = {
         Doe de check en kijk of u in aanmerking komt voor een gratis laptop of tablet voor uw kind of andere
         regelingen.
       </Paragraph>
-      <UnorderedList className="ams-mb-xl">
-        <UnorderedList.Item>Ontdek welke regelingen u hier kunt aanvragen.</UnorderedList.Item>
-        <UnorderedList.Item>Kies welke regelingen u wilt aanvragen voor u en uw gezinsleden.</UnorderedList.Item>
-        <UnorderedList.Item>Hierna moet u inloggen met uw DigiD.</UnorderedList.Item>
-      </UnorderedList>
+      <OrderedList className="ams-mb-xl">
+        <OrderedList.Item>Ontdek welke regelingen u hier kunt aanvragen.</OrderedList.Item>
+        <OrderedList.Item>Kies welke regelingen u wilt aanvragen voor u en uw gezinsleden.</OrderedList.Item>
+        <OrderedList.Item>Hierna moet u inloggen met uw DigiD.</OrderedList.Item>
+      </OrderedList>
       {/* A prominent call to action for the main task on the page. */}
       <CallToActionLink className="ams-mb-xl" href="#">Start de check en vraag aan</CallToActionLink>
 

--- a/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
+++ b/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
@@ -208,7 +208,7 @@ export const Default: StoryObj = {
 
       <Heading className="ams-mb-s" level={2}>Geen DigiD?</Heading>
       <UnorderedList className="ams-mb-xl">
-        <UnorderedList.Item>Ga naar <Link href="#">www.digid.nl</Link> en vraag uw DigID aan.</UnorderedList.Item>
+        <UnorderedList.Item>Ga naar <Link href="#">www.digid.nl</Link> en vraag uw DigiD aan.</UnorderedList.Item>
         <UnorderedList.Item>
           {/* download hints the browser to save the PDF rather than open it in a new tab. */}
           Lees eerst{' '}

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -331,4 +331,161 @@ const meta = {
 
 export default meta
 
-export const Default: StoryObj = {}
+export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the guidance below stays visible in the panel. Repetitive
+        // sections are shortened with `{/* … */}` markers to keep the timeline and grid patterns readable.
+        code: `<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+        <Breadcrumb.Link href="#">Bouwprojecten en verkeersprojecten</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  <Grid as="main" id="inhoud" paddingBottom="x-large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Heading level={1}>Centrumeiland: hét zelfbouweiland van Amsterdam</Heading>
+    </Grid.Cell>
+    <Grid.Cell span="all">
+      {/* ImageSlider takes an array of images; each entry has an alt text, an aspectRatio, and a src. */}
+      <ImageSlider images={images} />
+    </Grid.Cell>
+    <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+      <Heading className="ams-mb-s" level={2}>Wat</Heading>
+      <Paragraph className="ams-mb-m">
+        Centrumeiland is hét zelfbouweiland van de stad en maakt deel uit van <Link href="#">IJburg</Link>.
+        Er komen zo’n 1.500 tot 1.700 woningen, waarvan 60 tot 70 procent zelfbouw.
+      </Paragraph>
+      <StandaloneLink className="ams-mb-xl" href="#">Lees meer over Centrumeiland</StandaloneLink>
+      <Heading className="ams-mb-s" level={2}>Waar</Heading>
+      <Paragraph className="ams-mb-xl">
+        Centrumeiland ligt op IJburg aan de oostkant van Amsterdam, in het IJmeer. Het is het vierde eiland
+        van IJburg en ligt tussen Haveneiland en Strandeiland.
+      </Paragraph>
+      <Heading className="ams-mb-s" level={2}>Wanneer</Heading>
+      <Paragraph className="ams-mb-l">
+        De bouwwerkzaamheden op Centrumeiland zijn in volle gang. We verwachten dat bijna alle woningen en
+        voorzieningen klaar zijn in 2028.
+      </Paragraph>
+      {/*
+       * A ProgressList shows a timeline. status="completed" marks a finished step, status="current" the one
+       * in progress, and a step with no status is still to come. hasSubsteps nests a ProgressList.Substeps.
+       */}
+      <ProgressList headingLevel={3}>
+        <ProgressList.Step hasSubsteps heading="2021" status="completed">
+          <ProgressList.Substeps>
+            <ProgressList.Substep status="completed">
+              <Paragraph>Landmaken voor de Noordoever en Noordpunt, start oktober.</Paragraph>
+            </ProgressList.Substep>
+          </ProgressList.Substeps>
+        </ProgressList.Step>
+        {/* … more completed years (2022–2025), each a Step with completed Substeps … */}
+        <ProgressList.Step hasSubsteps heading="2026" status="current">
+          <ProgressList.Substeps>
+            <ProgressList.Substep>
+              <Paragraph>Oplevering Zuidoever (ecologische oever).</Paragraph>
+            </ProgressList.Substep>
+          </ProgressList.Substeps>
+        </ProgressList.Step>
+        <ProgressList.Step hasSubsteps heading="2029">
+          <ProgressList.Substeps>
+            <ProgressList.Substep>
+              <Paragraph>Waarschijnlijk zijn bijna alle woningen en voorzieningen klaar.</Paragraph>
+            </ProgressList.Substep>
+          </ProgressList.Substeps>
+        </ProgressList.Step>
+      </ProgressList>
+    </Grid.Cell>
+    {/* Two link lists side by side, each start-aligned to its own half of the grid. */}
+    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Heading className="ams-mb-s" level={2} size="level-3">Nieuws</Heading>
+      <LinkList>
+        <LinkList.Link href="#">Werkzaamheden Bert Haanstrakade en Pampuslaan (27 november 2025)</LinkList.Link>
+        <LinkList.Link href="#">17 november: bijeenkomst over Strandeiland (11 november 2025)</LinkList.Link>
+      </LinkList>
+    </Grid.Cell>
+    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
+      <Heading className="ams-mb-s" level={2} size="level-3">Werk aan de weg</Heading>
+      <LinkList>
+        <LinkList.Link href="#">Bert Haanstrakade, omleiding</LinkList.Link>
+        <LinkList.Link href="#">Straten Centrumeiland, afsluitingen</LinkList.Link>
+      </LinkList>
+    </Grid.Cell>
+  </Grid>
+  <Spotlight color="azure">
+    <Grid paddingVertical="x-large">
+      <Grid.Cell span="all">
+        <Heading color="inverse" level={2}>Zelfbouw</Heading>
+      </Grid.Cell>
+      {/* Four equal columns of promo links; on the azure Spotlight, color="inverse" adapts their content. */}
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
+        <Paragraph className="ams-mb-s" color="inverse">
+          Meer over de verschillende vormen van zelfbouw vindt u op:
+        </Paragraph>
+        <StandaloneLink color="inverse" href="#">Zelfbouw</StandaloneLink>
+      </Grid.Cell>
+      {/* … three more columns (Aanbod kavels, Prikbord, Nieuwsbrief zelfbouw) … */}
+    </Grid>
+  </Spotlight>
+  <Grid paddingVertical="x-large">
+    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Heading className="ams-mb-s" level={2} size="level-3">Meer informatie</Heading>
+      <LinkList>
+        <LinkList.Link href="#">Blok 16: Amsterdams nabuurschap, een nieuwe vorm van zelfbouw</LinkList.Link>
+        <LinkList.Link href="#">Woningaanbod Centrumeiland</LinkList.Link>
+        <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
+      </LinkList>
+    </Grid.Cell>
+    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
+      <Heading className="ams-mb-m" level={2} size="level-3">Ontwikkeling Centrumeiland, herfst 2025</Heading>
+      <Image alt="" className="ams-mb-m" src="https://picsum.photos/id/385/640/360" />
+      <StandaloneLink href="#">Meer video’s</StandaloneLink>
+    </Grid.Cell>
+    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Heading className="ams-mb-s" level={2} size="level-3">Blijf op de hoogte</Heading>
+      <LinkList>
+        <LinkList.Link href="#">Nieuwsbrief ontwikkeling IJburg</LinkList.Link>
+        <LinkList.Link href="#">Hallo Centrumeiland: praat mee</LinkList.Link>
+      </LinkList>
+    </Grid.Cell>
+  </Grid>
+  <Spotlight>
+    <Grid paddingVertical="x-large">
+      <Grid.Cell span="all">
+        <Heading className="ams-mb-s" color="inverse" level={2}>Contact</Heading>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+        <Paragraph className="ams-mb-m" color="inverse">
+          Vragen over zelfbouw op Centrumeiland:{' '}
+          <Link color="inverse" href="mailto:zelfbouwcentrumeiland@amsterdam.nl">zelfbouwcentrumeiland@amsterdam.nl</Link>
+        </Paragraph>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+        {/* <br /> holds a contact block’s lines together inside one Paragraph. */}
+        <Paragraph color="inverse">
+          Maud van Esch
+          <br />
+          Omgevingsmanager IJburg
+          <br />
+          <Link color="inverse" href="mailto:m.van.esch@amsterdam.nl">m.van.esch@amsterdam.nl</Link>
+        </Paragraph>
+      </Grid.Cell>
+    </Grid>
+  </Spotlight>
+  <Grid paddingVertical="x-large">
+    <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Image alt="" src="https://picsum.photos/1280/720" />
+    </Grid.Cell>
+  </Grid>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
+}


### PR DESCRIPTION
## What

Two changes to the page template examples in Storybook:

1. Every page template now provides its own `docs.source.code`, so the Code Panel shows curated comments that explain the subtle, easy-to-miss parts of each example.
2. A handful of small markup improvements to the examples themselves.

## Why

The Code Panel builds a `render` story’s source with react-element-to-jsx-string, which drops JSX comments and expands each `map` into repeated blocks. That means the guidance we write in the render — why a heading is visually hidden, how the collapsible Table of Contents remounts, why a back link is a link and not a button — never reaches the reader. Providing the source by hand keeps that guidance visible, and lets the code read the way a developer would actually write it (a `map` instead of six identical blocks).

While going through every template, a few bits of markup were worth tightening.

## How

- Added `parameters.docs.source.code` (the same approach as the Loading Page) to the internal Home, Navigation and Table pages, and the public Home, Navigation, Product, Article and Project pages and the Form Flow. The comments cover the pieces that are easy to miss or need specific knowledge; a couple of long, repetitive sections are shortened with visible `{/* … */}` markers so it’s clear nothing was dropped by accident.
- Markup tidy-ups:
  - **Article Page** — the publication date is a `<time>` element, and the ‘Meer nieuws’ aside is folded into its Grid with `as="aside"` rather than a wrapper.
  - **Product Page** — the ‘Aanvragen’ steps are a sequence, so they use an `OrderedList`.
  - **Navigation Page** — the search field gets a `label` that matches its placeholder, and a leftover `key` on `<main>` is removed.
  - **Table Page** — uses the `appearance="transparent"` prop instead of the raw grid-cell class.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- The Handbook Page gets the same code-panel treatment on its own branch (`feat/DES-1819-handbook-page`), since that page doesn’t exist on develop yet.
- Switching the Product Page steps to an `OrderedList` is an intended visual change (numbers instead of bullets), so expect a Chromatic diff there.
- I considered wrapping the Project Page contact block in `<address>`, but left it as a `Paragraph`: the element is italic by default and we don’t have a home for element-level resets in the design system yet.
