### PR TITLE
chore: Use JSX boolean shorthand and string values for aria-hidden

### DIFF
--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -25,7 +25,7 @@ const AvatarContent = ({ imageSrc, initials }: AvatarContentProps) => {
   }
 
   if (initials.length) {
-    return <span aria-hidden={true}>{initials}</span>
+    return <span aria-hidden="true">{initials}</span>
   }
 
   return <Icon size="small" svg={PersonFillIcon} />

--- a/packages/react/src/Breadcrumb/Breadcrumb.tsx
+++ b/packages/react/src/Breadcrumb/Breadcrumb.tsx
@@ -30,7 +30,7 @@ const BreadcrumbRoot = forwardRef(
 
     return (
       <nav {...restProps} aria-labelledby={labelId} className={clsx('ams-breadcrumb', className)} ref={ref}>
-        <h2 aria-hidden={true} className="ams-visually-hidden" id={labelId}>
+        <h2 aria-hidden="true" className="ams-visually-hidden" id={labelId}>
           {accessibleName || 'Kruimelpad'}
         </h2>
         <ol className="ams-breadcrumb__list">{children}</ol>

--- a/packages/react/src/Calendar/Calendar.tsx
+++ b/packages/react/src/Calendar/Calendar.tsx
@@ -110,7 +110,7 @@ export const Calendar = forwardRef(
 
     return (
       <nav {...restProps} aria-labelledby={labelId} className={clsx('ams-calendar', className)} ref={ref}>
-        <h2 aria-hidden={true} className="ams-visually-hidden" id={labelId}>
+        <h2 aria-hidden="true" className="ams-visually-hidden" id={labelId}>
           {accessibleName || 'Kalender'}
         </h2>
         <CalendarHeader

--- a/packages/react/src/Calendar/CalendarBody.tsx
+++ b/packages/react/src/Calendar/CalendarBody.tsx
@@ -34,13 +34,13 @@ export const CalendarBody = ({ linkComponent, linkTemplate, locale, month }: Cal
         const weekday = weekdayFormatter.format(date)
 
         return (
-          <span aria-hidden={true} className="ams-calendar__weekday" key={`weekday-${index}`}>
+          <span aria-hidden="true" className="ams-calendar__weekday" key={`weekday-${index}`}>
             {weekday}
           </span>
         )
       })}
       {Array.from({ length: firstWeekday }).map((_, index) => (
-        <span aria-hidden={true} key={`offset-${index}`} />
+        <span aria-hidden="true" key={`offset-${index}`} />
       ))}
       {Array.from({ length: daysInMonth }).map((_, index) => {
         const date = new Date(year, monthIndex, index + 1)

--- a/packages/react/src/Calendar/CalendarDay.tsx
+++ b/packages/react/src/Calendar/CalendarDay.tsx
@@ -46,7 +46,7 @@ export const CalendarDay = ({ date, isCurrent, linkComponent, linkTemplate, loca
 
   const content = (
     <>
-      <span aria-hidden={true}>{formatDayNumber(date, locale)}</span>
+      <span aria-hidden="true">{formatDayNumber(date, locale)}</span>
       <span className="ams-visually-hidden">{formatAccessibleDate(date, locale)}</span>
     </>
   )

--- a/packages/react/src/DatePicker/DatePickerDay.tsx
+++ b/packages/react/src/DatePicker/DatePickerDay.tsx
@@ -75,7 +75,7 @@ export const DatePickerDay = ({
       tabIndex={isFocused ? 0 : -1}
       type="button"
     >
-      <span aria-hidden={true}>{formatDayNumber(date, locale)}</span>
+      <span aria-hidden="true">{formatDayNumber(date, locale)}</span>
       <span className="ams-visually-hidden">{formatAccessibleDate(date, locale, boundaryLabel)}</span>
     </button>
   </div>

--- a/packages/react/src/FieldSet/FieldSet.test.tsx
+++ b/packages/react/src/FieldSet/FieldSet.test.tsx
@@ -78,7 +78,7 @@ describe('FieldSet', () => {
   })
 
   it('renders the provided hint text after the legend when both `optional` and `hint` props are used', () => {
-    render(<FieldSet hint="not required" legend="Legend" optional={true} />)
+    render(<FieldSet hint="not required" legend="Legend" optional />)
 
     const component = screen.getByRole('group', { name: 'Legend (not required)' })
 

--- a/packages/react/src/Hint/Hint.test.tsx
+++ b/packages/react/src/Hint/Hint.test.tsx
@@ -54,7 +54,7 @@ describe('Hint', () => {
   })
 
   it('renders the default hint text', () => {
-    const { container } = render(<Hint optional={true} />)
+    const { container } = render(<Hint optional />)
 
     const component = container.querySelector(':only-child')
 
@@ -62,7 +62,7 @@ describe('Hint', () => {
   })
 
   it('renders the provided hint text when `optional` is set to `false`', () => {
-    const { container } = render(<Hint hint="not required" optional={true} />)
+    const { container } = render(<Hint hint="not required" optional />)
 
     const component = container.querySelector(':only-child')
 

--- a/packages/react/src/Hint/Hint.test.tsx
+++ b/packages/react/src/Hint/Hint.test.tsx
@@ -61,7 +61,7 @@ describe('Hint', () => {
     expect(component).toHaveTextContent('(niet verplicht)')
   })
 
-  it('renders the provided hint text when `optional` is set to `false`', () => {
+  it('renders the provided hint text when `optional` is set to `true`', () => {
     const { container } = render(<Hint hint="not required" optional />)
 
     const component = container.querySelector(':only-child')

--- a/packages/react/src/Label/Label.test.tsx
+++ b/packages/react/src/Label/Label.test.tsx
@@ -105,7 +105,7 @@ describe('Label', () => {
 
   it('renders the default hint text after the label', () => {
     const { container } = render(
-      <Label htmlFor="form-control" optional={true}>
+      <Label htmlFor="form-control" optional>
         Label
       </Label>,
     )
@@ -117,7 +117,7 @@ describe('Label', () => {
 
   it('renders the provided hint text after the label when `optional` is set to `false`', () => {
     const { container } = render(
-      <Label hint="not required" htmlFor="form-control" optional={true}>
+      <Label hint="not required" htmlFor="form-control" optional>
         Label
       </Label>,
     )
@@ -163,7 +163,7 @@ describe('Label', () => {
 
   it('passes additional props', () => {
     const { container } = render(
-      <Label aria-hidden="false" data-test="data-test" htmlFor="form-control" id="id" optional={true} />,
+      <Label aria-hidden="false" data-test="data-test" htmlFor="form-control" id="id" optional />,
     )
     const component = container.querySelector(':only-child')
 

--- a/packages/react/src/Label/Label.test.tsx
+++ b/packages/react/src/Label/Label.test.tsx
@@ -115,7 +115,7 @@ describe('Label', () => {
     expect(label).toHaveTextContent('Label (niet verplicht)')
   })
 
-  it('renders the provided hint text after the label when `optional` is set to `false`', () => {
+  it('renders the provided hint text after the label when `optional` is set to `true`', () => {
     const { container } = render(
       <Label hint="not required" htmlFor="form-control" optional>
         Label

--- a/packages/react/src/TabNavigation/TabNavigation.tsx
+++ b/packages/react/src/TabNavigation/TabNavigation.tsx
@@ -38,7 +38,7 @@ const TabNavigationRoot = forwardRef(
         className={clsx('ams-tab-navigation', orientation === 'vertical' && 'ams-tab-navigation--vertical', className)}
         ref={ref}
       >
-        <h2 aria-hidden={true} className="ams-visually-hidden" id={labelId}>
+        <h2 aria-hidden="true" className="ams-visually-hidden" id={labelId}>
           {accessibleName || 'Navigatie'}
         </h2>
         {children}

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -92,7 +92,7 @@ const meta = {
             ontwikkelaars, bouwgroepen en zelfbouwers ook met de bouw van hun nieuwe woningen. We verwachten dat bijna
             alle woningen en voorzieningen klaar zijn in 2028. Het laatste woonblok wordt opgeleverd in 2029.
           </Paragraph>
-          <ProgressList collapsible={true} headingLevel={3}>
+          <ProgressList collapsible headingLevel={3}>
             <ProgressList.Step hasSubsteps heading="2021" status="completed">
               <ProgressList.Substeps>
                 <ProgressList.Substep status="completed">
@@ -377,7 +377,7 @@ export const Default: StoryObj = {
        * A ProgressList shows a timeline. status="completed" marks a finished step, status="current" the one
        * in progress, and a step with no status is still to come. hasSubsteps nests a ProgressList.Substeps.
        */}
-      <ProgressList collapsible={true} headingLevel={3}>
+      <ProgressList collapsible headingLevel={3}>
         <ProgressList.Step hasSubsteps heading="2021" status="completed">
           <ProgressList.Substeps>
             <ProgressList.Substep status="completed">


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## What

Two small, syntax-only cleanups to how boolean-ish JSX attributes are written:

- Replace `prop={true}` with the JSX boolean shorthand (`prop`) across tests and stories.
- Normalise `aria-hidden={true}` to the string form `aria-hidden="true"` in the component source (8 occurrences, in Avatar, Breadcrumb, Calendar, CalendarBody, CalendarDay, DatePickerDay and TabNavigation).

## Why

The boolean shorthand is the idiomatic JSX form for genuine boolean props and reads more cleanly.

ARIA attributes, however, aren’t real booleans — they’re string-valued enumerated attributes (`"true"` / `"false"`), so the shorthand doesn’t apply to them. Writing `aria-hidden="true"` matches the ARIA semantics and the rendered HTML, and it aligns these outliers with the string form already used everywhere else in the codebase (e.g. `aria-required="true"`, `aria-hidden="true"` in `PageHeader`, `TabsButton`, the icon components, …).

## How

Mechanical find-and-replace, verified through the ESLint + Prettier pre-commit hooks. There is no behaviour or DOM-output change: `aria-hidden={true}` and `aria-hidden="true"` both render to `aria-hidden="true"`. The two concerns are kept in separate commits.

## Checklist

- [x] Add or update unit tests _(not necessary — no behaviour change)_
- [x] Add or update documentation _(not necessary)_
- [x] Add or update stories _(not necessary)_
- [x] Add or update exports in index.\* files _(not necessary)_
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Purely syntactic; no visual change is expected, so Chromatic should be a no-op.
- No related issue.
