### PR TITLE
feat(Table of Contents): Add option to expand branches initially

### DIFF
--- a/packages/react/src/TableOfContents/TableOfContents.test.tsx
+++ b/packages/react/src/TableOfContents/TableOfContents.test.tsx
@@ -148,6 +148,145 @@ describe('TableOfContents', () => {
       expect(item).toHaveClass('ams-table-of-contents__item--collapsed')
     })
 
+    it('honours list defaultExpanded by expanding nested items by default', () => {
+      render(
+        <TableOfContents collapsible>
+          <TableOfContents.List defaultExpanded>
+            <TableOfContents.Link href="#a" label="A">
+              <TableOfContents.List>
+                <TableOfContents.Link href="#b" label="B">
+                  <TableOfContents.List>
+                    <TableOfContents.Link href="#b-1" label="B.1" />
+                  </TableOfContents.List>
+                </TableOfContents.Link>
+              </TableOfContents.List>
+            </TableOfContents.Link>
+          </TableOfContents.List>
+        </TableOfContents>,
+      )
+
+      const buttons = screen.getAllByRole('button')
+
+      expect(buttons).toHaveLength(2)
+      expect(buttons[0]).toHaveAttribute('aria-expanded', 'true')
+      expect(buttons[1]).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('lets nested lists override defaultExpanded', () => {
+      render(
+        <TableOfContents collapsible>
+          <TableOfContents.List defaultExpanded>
+            <TableOfContents.Link href="#a" label="A">
+              <TableOfContents.List>
+                <TableOfContents.Link href="#b" label="B">
+                  <TableOfContents.List defaultExpanded={false}>
+                    <TableOfContents.Link href="#b-1" label="B.1" />
+                  </TableOfContents.List>
+                </TableOfContents.Link>
+              </TableOfContents.List>
+            </TableOfContents.Link>
+          </TableOfContents.List>
+        </TableOfContents>,
+      )
+
+      const buttons = screen.getAllByRole('button')
+
+      expect(buttons).toHaveLength(2)
+      expect(buttons[0]).toHaveAttribute('aria-expanded', 'true')
+      expect(buttons[1]).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('reads the nested defaultExpanded default only on mount, ignoring later changes', () => {
+      const { rerender } = render(
+        <TableOfContents collapsible>
+          <TableOfContents.List defaultExpanded>
+            <TableOfContents.Link href="#a" label="A">
+              <TableOfContents.List>
+                <TableOfContents.Link href="#b" label="B">
+                  <TableOfContents.List>
+                    <TableOfContents.Link aria-current="page" href="#b-1" label="B.1" />
+                  </TableOfContents.List>
+                </TableOfContents.Link>
+              </TableOfContents.List>
+            </TableOfContents.Link>
+          </TableOfContents.List>
+        </TableOfContents>,
+      )
+
+      let buttons = screen.getAllByRole('button')
+
+      expect(buttons).toHaveLength(2)
+      expect(buttons[0]).toHaveAttribute('aria-expanded', 'true')
+      expect(buttons[1]).toHaveAttribute('aria-expanded', 'true')
+
+      // The resolved default seeds the state once, on mount. Flipping defaultExpanded afterwards is
+      // ignored: use the controlled `expanded` prop to drive the state after mount.
+      rerender(
+        <TableOfContents collapsible>
+          <TableOfContents.List defaultExpanded>
+            <TableOfContents.Link href="#a" label="A">
+              <TableOfContents.List>
+                <TableOfContents.Link href="#b" label="B">
+                  <TableOfContents.List defaultExpanded={false}>
+                    <TableOfContents.Link aria-current="page" href="#b-1" label="B.1" />
+                  </TableOfContents.List>
+                </TableOfContents.Link>
+              </TableOfContents.List>
+            </TableOfContents.Link>
+          </TableOfContents.List>
+        </TableOfContents>,
+      )
+
+      buttons = screen.getAllByRole('button')
+
+      expect(buttons).toHaveLength(2)
+      expect(buttons[0]).toHaveAttribute('aria-expanded', 'true')
+      expect(buttons[1]).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it("honours defaultExpanded on a link's direct nested list", () => {
+      render(
+        <TableOfContents collapsible>
+          <TableOfContents.List defaultExpanded>
+            <TableOfContents.Link href="#s2" label="S2">
+              <TableOfContents.List>
+                <TableOfContents.Link href="#s2-2" label="S2.2">
+                  <TableOfContents.List defaultExpanded={false}>
+                    <TableOfContents.Link aria-current="page" href="#s2-2-1" label="S2.2.1" />
+                  </TableOfContents.List>
+                </TableOfContents.Link>
+              </TableOfContents.List>
+            </TableOfContents.Link>
+          </TableOfContents.List>
+        </TableOfContents>,
+      )
+
+      const buttons = screen.getAllByRole('button')
+
+      expect(buttons).toHaveLength(2)
+      expect(buttons[0]).toHaveAttribute('aria-expanded', 'true')
+      expect(buttons[1]).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('lets a Link defaultExpanded override the list default', () => {
+      render(
+        <TableOfContents collapsible>
+          <TableOfContents.List defaultExpanded>
+            <TableOfContents.Link defaultExpanded={false} href="#a" label="A">
+              <TableOfContents.List>
+                <TableOfContents.Link href="#a-1" label="A.1" />
+              </TableOfContents.List>
+            </TableOfContents.Link>
+          </TableOfContents.List>
+        </TableOfContents>,
+      )
+
+      const button = screen.getByRole('button')
+
+      expect(button).toHaveAttribute('aria-expanded', 'false')
+      expect(button).toHaveAccessibleName('Toon submenu van A')
+    })
+
     it('honours defaultExpanded', () => {
       render(
         <TableOfContents collapsible>

--- a/packages/react/src/TableOfContents/TableOfContentsList.tsx
+++ b/packages/react/src/TableOfContents/TableOfContentsList.tsx
@@ -12,7 +12,8 @@ import { TableOfContentsListContext } from './TableOfContentsListContext'
 
 export type TableOfContentsListProps = {
   /**
-   * Whether descendant items with nested lists start expanded.
+   * Whether items with nested lists in this list start expanded.
+   * When this list is nested inside a Link, this also controls whether that Link starts expanded.
    * Inherits from the parent list when omitted.
    * @default false
    */

--- a/packages/react/src/TableOfContents/TableOfContentsList.tsx
+++ b/packages/react/src/TableOfContents/TableOfContentsList.tsx
@@ -6,9 +6,18 @@
 import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 import { clsx } from 'clsx'
-import { forwardRef } from 'react'
+import { forwardRef, useContext } from 'react'
 
-export type TableOfContentsListProps = PropsWithChildren<HTMLAttributes<HTMLUListElement>>
+import { TableOfContentsListContext } from './TableOfContentsListContext'
+
+export type TableOfContentsListProps = {
+  /**
+   * Whether descendant items with nested lists start expanded.
+   * Inherits from the parent list when omitted.
+   * @default false
+   */
+  readonly defaultExpanded?: boolean
+} & PropsWithChildren<HTMLAttributes<HTMLUListElement>>
 
 /**
  * The list of section links within a Table of Contents.
@@ -16,11 +25,19 @@ export type TableOfContentsListProps = PropsWithChildren<HTMLAttributes<HTMLULis
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-navigation-table-of-contents--docs Table of Contents docs at Amsterdam Design System}
  */
 export const TableOfContentsList = forwardRef(
-  ({ children, className, ...restProps }: TableOfContentsListProps, ref: ForwardedRef<HTMLUListElement>) => {
+  (
+    { children, className, defaultExpanded, ...restProps }: TableOfContentsListProps,
+    ref: ForwardedRef<HTMLUListElement>,
+  ) => {
+    const parentExpanded = useContext(TableOfContentsListContext)
+    const expandedByDefault = defaultExpanded ?? parentExpanded
+
     return (
-      <ul {...restProps} className={clsx('ams-table-of-contents__list', className)} ref={ref}>
-        {children}
-      </ul>
+      <TableOfContentsListContext.Provider value={expandedByDefault}>
+        <ul {...restProps} className={clsx('ams-table-of-contents__list', className)} ref={ref}>
+          {children}
+        </ul>
+      </TableOfContentsListContext.Provider>
     )
   },
 )

--- a/packages/react/src/TableOfContents/TableOfContentsListContext.tsx
+++ b/packages/react/src/TableOfContents/TableOfContentsListContext.tsx
@@ -1,0 +1,9 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { createContext } from 'react'
+
+// `false` keeps the current default behavior for collapsible TOCs: nested lists start collapsed (not expanded).
+export const TableOfContentsListContext = createContext(false)

--- a/packages/react/src/TableOfContents/useCollapsibleItem.tsx
+++ b/packages/react/src/TableOfContents/useCollapsibleItem.tsx
@@ -10,6 +10,7 @@ import { Children, cloneElement, isValidElement, useContext, useId, useRef } fro
 import { useCollapsible } from '../common/useCollapsible'
 import { TableOfContentsContext } from './TableOfContentsContext'
 import { TableOfContentsList } from './TableOfContentsList'
+import { TableOfContentsListContext } from './TableOfContentsListContext'
 
 // A Link is expandable when it has a `TableOfContents.List` as a direct child.
 const findListChild = (children: ReactNode): ReactElement | undefined => {
@@ -34,21 +35,31 @@ type UseCollapsibleItemProps = {
  * button to the nested list through a stable `aria-controls` id, and restores focus to the toggle when
  * collapsing a subtree that holds focus.
  *
+ * When uncontrolled, the initial expanded state follows the nested list's `defaultExpanded` prop,
+ * falling back to the default inherited from the surrounding list; an explicit `defaultExpanded` on the
+ * Link overrides both. This resolved default seeds the shared `useCollapsible` state once, on mount.
+ *
  * Returns the refs, state, and rendered children the link needs; it deliberately leaves the markup and
  * the accessible label text to the component.
  */
 export const useCollapsibleItem = ({ children, defaultExpanded, expanded, onToggle }: UseCollapsibleItemProps) => {
   const { collapsible } = useContext(TableOfContentsContext)
+  const inheritedDefaultExpanded = useContext(TableOfContentsListContext)
 
   const panelId = useId()
   const buttonRef = useRef<HTMLButtonElement>(null)
   const itemRef = useRef<HTMLLIElement>(null)
 
   const listChild = findListChild(children)
+  const childListProps = listChild?.props as { defaultExpanded?: boolean; id?: string } | undefined
   const isExpandable = collapsible && !!listChild
 
+  // A Link follows its direct nested list's `defaultExpanded` prop, falling back to the default
+  // inherited from the surrounding list; an explicit `defaultExpanded` on the Link overrides both.
+  const expandedByDefault = defaultExpanded ?? childListProps?.defaultExpanded ?? inheritedDefaultExpanded
+
   const [isExpanded, toggle] = useCollapsible({
-    defaultValue: defaultExpanded,
+    defaultValue: expandedByDefault,
     gate: isExpandable,
     onToggle,
     value: expanded,
@@ -56,7 +67,7 @@ export const useCollapsibleItem = ({ children, defaultExpanded, expanded, onTogg
 
   // Reuse a provided nested list id to keep aria-controls references stable, but ignore a blank
   // id so aria-controls never points at an empty string.
-  const providedListId = (listChild?.props as { id?: string } | undefined)?.id
+  const providedListId = childListProps?.id
   const nestedListId = providedListId?.trim() ? providedListId : panelId
 
   // When collapsing, if focus is inside the subtree that's about to be hidden, move it to the toggle button.

--- a/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
+++ b/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
@@ -43,7 +43,7 @@ For the last case, use `collapsible` mode so branches can be expanded and collap
 ### When not to use
 
 Use a [Tab Navigation](/docs/components-navigation-tab-navigation--docs) when the user switches between views rather than navigating to distinct sections or pages.
-Use a [Link List](/docs/components-navigation-link-list--docs) for a flat group of related links that doesn’t map to the sections of the current content — for example, a list of related articles at the foot of a page.
+Use a [Link List](/docs/components-navigation-link-list--docs) for a flat group of related links that doesn’t map to the sections of the current page or a set of related pages.
 
 ### How to use
 
@@ -83,9 +83,11 @@ This example keeps a single branch open at a time by expanding the clicked branc
 
 ## Accessibility
 
-The component renders as a `nav` landmark.
-Set `aria-current="page"` on the link that represents the active section or page to help screen reader users identify their position.
-In collapsible mode, arrow keys navigate between the visible toggle buttons.
+- The component renders as a `nav` landmark, and a `heading` becomes its accessible name.
+- In collapsible mode, each toggle button reports its state through `aria-expanded`, references the list it reveals through `aria-controls`, and gets an accessible name that says which section it expands or collapses.
+- Arrow keys move focus between the visible toggle buttons; toggles inside a collapsed section are skipped so focus never lands on hidden content, while that section’s own toggle stays reachable to reopen it.
+- Collapsing a section while focus is inside it returns focus to that section’s toggle button, so focus is never stranded on content that was just hidden.
+- When printing, collapsed sections expand so the full outline is available.
 
 ## See also
 

--- a/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
+++ b/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
@@ -21,7 +21,7 @@ import * as TableOfContentsLinkStories from "./TableOfContentsLink.stories.tsx";
 ## Subcomponents
 
 Lists nest Links to form the hierarchy of the Table of Contents.
-The List has no props of its own; the ‘Multiple levels’ example shows how to nest one.
+Set `defaultExpanded` on a List to open its collapsible branches by default; the ‘Multiple levels’ example shows how to nest one.
 
 ### Link
 
@@ -59,9 +59,15 @@ Set `aria-current="page"` on the link for the active section or page to highligh
 
 Set `collapsible` on the root to add a separate toggle button to each item that has nested links.
 The toggle expands and collapses the nested list without following the link.
-Use `defaultExpanded` on a Link to pre-open its nested list when the component mounts, for example to show the ancestors of the current page.
+Set `defaultExpanded` on `TableOfContents.List` to open nested items by default.
+This setting is inherited by nested lists unless they set their own `defaultExpanded` value.
+Use `defaultExpanded` on a Link to override the list default for that specific item, for example to show the ancestors of the current page.
 
 <Canvas of={TableOfContentsStories.Collapsible} />
+
+### Collapsible with nested items opened by default
+
+<Canvas of={TableOfContentsStories.CollapsibleExpandedByDefault} />
 
 ### Controlled
 

--- a/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
+++ b/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
@@ -43,6 +43,7 @@ For the last case, use `collapsible` mode so branches can be expanded and collap
 ### When not to use
 
 Use a [Tab Navigation](/docs/components-navigation-tab-navigation--docs) when the user switches between views rather than navigating to distinct sections or pages.
+Use a [Link List](/docs/components-navigation-link-list--docs) for a flat group of related links that doesn’t map to the sections of the current content — for example, a list of related articles at the foot of a page.
 
 ### How to use
 
@@ -88,6 +89,7 @@ In collapsible mode, arrow keys navigate between the visible toggle buttons.
 
 ## See also
 
+- [Link List](/docs/components-navigation-link-list--docs) – groups related links that don’t form an outline of content.
 - [Tab Navigation](/docs/components-navigation-tab-navigation--docs) – switches between views on the same page.
 
 ## Design tokens

--- a/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
+++ b/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
@@ -65,9 +65,12 @@ Use `defaultExpanded` on a Link to override the list default for that specific i
 
 <Canvas of={TableOfContentsStories.Collapsible} />
 
-### Collapsible with nested items opened by default
+### Initially expanded
 
-<Canvas of={TableOfContentsStories.CollapsibleExpandedByDefault} />
+`defaultExpanded` on the root List expands every collapsible branch on load, while a nested List overrides it with `defaultExpanded={false}` to stay closed.
+Starting expanded suits a deep handbook or documentation tree, where showing the full structure helps readers place the current page.
+
+<Canvas of={TableOfContentsStories.InitiallyExpanded} />
 
 ### Controlled
 

--- a/storybook/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/storybook/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -114,7 +114,7 @@ export const Collapsible: Story = {
   },
 }
 
-export const CollapsibleExpandedByDefault: Story = {
+export const InitiallyExpanded: Story = {
   args: {
     children: (
       <TableOfContents.List defaultExpanded>

--- a/storybook/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/storybook/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -114,6 +114,43 @@ export const Collapsible: Story = {
   },
 }
 
+export const CollapsibleExpandedByDefault: Story = {
+  args: {
+    children: (
+      <TableOfContents.List defaultExpanded>
+        <TableOfContents.Link href="#s1" label="Inleiding" />
+        <TableOfContents.Link href="#s2" label="Vaststellen en waarderen van functies">
+          <TableOfContents.List>
+            <TableOfContents.Link href="#s2-1" label="Algemeen" />
+            <TableOfContents.Link href="#s2-2" label="Waardering van functies">
+              <TableOfContents.List>
+                <TableOfContents.Link aria-current="page" href="#s2-2-1" label="Methode" />
+                <TableOfContents.Link href="#s2-2-2" label="Procedure" />
+                <TableOfContents.Link href="#s2-2-3" label="Bezwaar" />
+              </TableOfContents.List>
+            </TableOfContents.Link>
+            <TableOfContents.Link href="#s2-3" label="Herwaardering">
+              <TableOfContents.List defaultExpanded={false}>
+                <TableOfContents.Link href="#s2-3-1" label="Aanleiding" />
+                <TableOfContents.Link href="#s2-3-2" label="Procedure" />
+              </TableOfContents.List>
+            </TableOfContents.Link>
+          </TableOfContents.List>
+        </TableOfContents.Link>
+        <TableOfContents.Link href="#s3" label="Salaristoelagen">
+          <TableOfContents.List>
+            <TableOfContents.Link href="#s3-1" label="Functioneringstoelage" />
+            <TableOfContents.Link href="#s3-2" label="Arbeidsmarkttoelage" />
+          </TableOfContents.List>
+        </TableOfContents.Link>
+        <TableOfContents.Link href="#s4" label="Vergoedingen" />
+      </TableOfContents.List>
+    ),
+    collapsible: true,
+    heading: 'Inhoudsopgave',
+  },
+}
+
 export const Controlled: Story = {
   args: {
     collapsible: true,


### PR DESCRIPTION
## What

Adds a `defaultExpanded` prop to `TableOfContents.List` that sets whether descendant items with nested lists start expanded.
The value flows down through a new `TableOfContentsListContext`, so a nested list inherits its parent’s setting unless it sets its own; a Link’s existing `defaultExpanded` still overrides the inherited default for that one item.

## Why

For dynamic, single-page rendering, consumers need to decide whether Table of Contents branches start open or closed — for example to reveal the ancestors of the current page.
`defaultExpanded` gives that control at the list level, inheritable across the tree.
Resolves DES-1887.

## How

- `TableOfContents.List` reads `defaultExpanded`, falls back to the value from `TableOfContentsListContext`, and provides the resolved value to its descendants — so the setting is inherited and overridable per nested list.
- Each collapsible Link derives its initial expanded state from that resolved default (its own `defaultExpanded` taking precedence) and seeds the shared `useCollapsible` hook from #2753. The default is read once on mount, matching the hook’s uncontrolled contract; drive the state after mount with the Link’s `expanded` prop.
- The prop is `defaultExpanded` (not `defaultCollapsed`) to keep the collapse API consistent: a component is `collapsible` (the capability) and its state is steered by `expanded`/`defaultExpanded` throughout — matching `TableOfContents.Link` and the direction `ProgressList.Step` is already taking (its `collapsed`/`defaultCollapsed` are deprecated in favour of `defaultExpanded`).

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files _(not needed — no new public exports)_
- [x] Comment `/chromatic test` and verify visual regression tests pass _(runs automatically on PR creation)_
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- Resolves DES-1887.
- Builds on the shared `useCollapsible` hook from #2753.
- Split out from #2769 to keep this API change focused. A separate change will add a Handbook Page example that demonstrates the prop, along with the docs cross-links back to it.
- Story to review: Table of Contents → “Collapsible with nested items opened by default”.
