### PR TITLE
chore(Storybook): Load the pseudo-states addon in Chromatic only

### DIFF
--- a/storybook/AGENTS.md
+++ b/storybook/AGENTS.md
@@ -46,7 +46,7 @@ See [documentation/component-docs.md](../documentation/component-docs.md) for th
 
 - One story per visual variant / state in `<Name>.test.stories.tsx`.
 - Tag test stories with `['!dev', '!autodocs']` to exclude them from docs and development views.
-- The CSS pseudo-state simulation addon (`:hover`, `:focus`, etc.) loads in Chromatic CI (via `IS_CHROMATIC`) and in local development (`NODE_ENV === 'development'`). See `config/main.ts`. Do not set `IS_CHROMATIC` manually.
+- The CSS pseudo-state simulation addon (`:hover`, `:focus`, etc.) loads only in Chromatic CI, via `IS_CHROMATIC` (set by `build:chromatic`). It is deliberately not loaded in local development, where its CSS rewrite breaks focus-hidden selectors like the Skip Link's. See `config/main.ts`. Do not set `IS_CHROMATIC` manually.
 - Visual changes must be reviewed and approved in the Chromatic dashboard before merging.
 - **Never approve Chromatic changes as an agent** — visual approval is a human responsibility.
 

--- a/storybook/config/main.ts
+++ b/storybook/config/main.ts
@@ -30,9 +30,11 @@ const config: StorybookConfig = {
     },
     '@linus_janns/storybook-addon-html',
     '@storybook/addon-mcp',
-    ...(process.env['IS_CHROMATIC'] || process.env['NODE_ENV'] === 'development'
-      ? ['storybook-addon-pseudo-states']
-      : []),
+    // Load the pseudo-states addon only for Chromatic, which sets `IS_CHROMATIC` through the
+    // `build:chromatic` command. It rewrites CSS at runtime to simulate `:hover`/`:focus`/`:active`
+    // for the visual regression snapshots. That rewrite breaks selectors that hide on focus, such as
+    // `.ams-visually-hidden:not(:focus)` on the Skip Link, so keep it out of the local dev server.
+    ...(process.env['IS_CHROMATIC'] ? ['storybook-addon-pseudo-states'] : []),
   ],
 
   core: {

--- a/storybook/config/main.ts
+++ b/storybook/config/main.ts
@@ -34,7 +34,7 @@ const config: StorybookConfig = {
     // `build:chromatic` command. It rewrites CSS at runtime to simulate `:hover`/`:focus`/`:active`
     // for the visual regression snapshots. That rewrite breaks selectors that hide on focus, such as
     // `.ams-visually-hidden:not(:active, :focus)` on the Skip Link, so keep it out of the local dev server.
-    ...(process.env['IS_CHROMATIC'] ? ['storybook-addon-pseudo-states'] : []),
+    ...(process.env['IS_CHROMATIC'] === 'true' ? ['storybook-addon-pseudo-states'] : []),
   ],
 
   core: {

--- a/storybook/config/main.ts
+++ b/storybook/config/main.ts
@@ -33,7 +33,7 @@ const config: StorybookConfig = {
     // Load the pseudo-states addon only for Chromatic, which sets `IS_CHROMATIC` through the
     // `build:chromatic` command. It rewrites CSS at runtime to simulate `:hover`/`:focus`/`:active`
     // for the visual regression snapshots. That rewrite breaks selectors that hide on focus, such as
-    // `.ams-visually-hidden:not(:focus)` on the Skip Link, so keep it out of the local dev server.
+    // `.ams-visually-hidden:not(:active, :focus)` on the Skip Link, so keep it out of the local dev server.
     ...(process.env['IS_CHROMATIC'] ? ['storybook-addon-pseudo-states'] : []),
   ],
 


### PR DESCRIPTION
## What

Load the `storybook-addon-pseudo-states` addon only when building for Chromatic, instead of also loading it in the local development server.

## Why

The addon rewrites CSS at runtime to simulate `:hover`, `:focus` and `:active`, so those states show up in Chromatic’s visual regression snapshots. It only needs to run in that build.

In the local dev server the same rewrite breaks selectors that hide an element until it’s focused. It expands `.ams-visually-hidden:not(:active, :focus)` into a comma-separated list that also negates class-based `.pseudo-*` variants, and one of those alternatives keeps matching a genuinely focused element. The result is that the Skip Link stays hidden when it should appear on focus.

Chromatic builds through `build:chromatic`, which sets `IS_CHROMATIC`, so restricting the addon to that flag leaves the visual regression tests unchanged. #2312 had gated the addon to dev and Chromatic together; this drops the dev half now that we know it does more harm than good there.

## How

Remove the `NODE_ENV === 'development'` branch from the addon’s conditional in `storybook/config/main.ts` so it loads on `IS_CHROMATIC` alone, and add a comment explaining the constraint.

Trade-off: the addon’s toolbar control for manually toggling pseudo-states is no longer available in the dev server. Running `IS_CHROMATIC=true pnpm --filter @amsterdam/storybook start` brings it back for a session when needed.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Follow-up to #2312, which introduced the dev-and-Chromatic gate.
