### PR TITLE
chore(Storybook): Add space below the sidebar tree

### DIFF
--- a/storybook/config/manager.js
+++ b/storybook/config/manager.js
@@ -4,6 +4,7 @@ import { create } from 'storybook/theming/create'
 import Logo from '../../packages-proprietary/assets/logo/amsterdam.svg'
 
 import '@amsterdam/design-system-assets/font/index.css'
+import '../src/_styles/manager.css'
 
 addons.setConfig({
   theme: create({

--- a/storybook/src/_styles/manager.css
+++ b/storybook/src/_styles/manager.css
@@ -1,0 +1,12 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+/* stylelint-disable selector-max-id -- Targeting Storybook’s own manager DOM, which we don’t control. */
+
+/* Add space below the sidebar tree so the last items aren’t jammed against the bottom of the screen. */
+/* stylelint-disable-next-line plugin/use-baseline -- Suboptimal scrolling in non-supporting browsers is acceptable. */
+#storybook-explorer-menu {
+  padding-block-end: 6rem;
+}

--- a/storybook/src/_styles/manager.css
+++ b/storybook/src/_styles/manager.css
@@ -6,7 +6,6 @@
 /* stylelint-disable selector-max-id -- Targeting Storybook’s own manager DOM, which we don’t control. */
 
 /* Add space below the sidebar tree so the last items aren’t jammed against the bottom of the screen. */
-/* stylelint-disable-next-line plugin/use-baseline -- Suboptimal scrolling in non-supporting browsers is acceptable. */
 #storybook-explorer-menu {
   padding-block-end: 6rem;
 }

--- a/storybook/src/_styles/manager.css
+++ b/storybook/src/_styles/manager.css
@@ -3,9 +3,8 @@
  * Copyright Gemeente Amsterdam
  */
 
-/* stylelint-disable selector-max-id -- Targeting Storybook’s own manager DOM, which we don’t control. */
-
 /* Add space below the sidebar tree so the last items aren’t jammed against the bottom of the screen. */
+/* stylelint-disable-next-line selector-max-id -- Targeting Storybook’s own manager DOM, which we don’t control. */
 #storybook-explorer-menu {
   padding-block-end: 6rem;
 }


### PR DESCRIPTION
## What

Adds bottom spacing below the Storybook sidebar tree so the last items no longer sit flush against the bottom of the viewport.

## Why

The lowest items in the sidebar were too close to the bottom edge, making them awkward to reach. An earlier attempt added the padding in `overrides.css` targeting an Emotion-generated hash class (`.css-…`), but that stylesheet is only imported into the preview iframe — it never reaches the manager UI where the sidebar actually lives — so it had no effect. Emotion hashes are also unstable across builds, so they’re a poor thing to target.

## How

- Added a dedicated `storybook/src/_styles/manager.css`, imported from the manager entry (`storybook/config/manager.js`), so the rule loads into the manager document rather than the preview iframe.
- Targeted `#storybook-explorer-menu`, Storybook’s long-stable hook for the sidebar tree, with `padding-block-end`. Because it’s an ID selector it outspecifies Storybook’s Emotion styles, so no `!important` is needed.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- This only affects Storybook’s own manager chrome, not any published component, token, or story — so no component snapshots should change.
