### PR TITLE
chore(ci): Build Storybook in the check-build-and-tests gate

### DIFF
--- a/.github/workflows/check-build-and-tests.yml
+++ b/.github/workflows/check-build-and-tests.yml
@@ -68,3 +68,9 @@ jobs:
       - name: Test packages
         run: |
           pnpm run --if-present test
+
+      # Storybook is excluded from "Build packages" above and is otherwise only built by Chromatic,
+      # which is gated on pull-request state. Building it here turns a broken story, MDX doc, or
+      # config change into a deterministic failure on every push. Reuses the packages built above.
+      - name: Build Storybook
+        run: pnpm --filter=storybook run build


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Build Storybook in the check-build-and-tests gate

## What

Add a "Build Storybook" step to the build-lint-test job, reusing the packages it already builds, so the docs site compiling becomes a deterministic gate on every push.

## Why

"Check build and tests" builds every package except Storybook, so a broken story, MDX doc, or config change is only caught by Chromatic — which is gated on pull-request state and can be skipped.

## How

n/a

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- n/a