### PR TITLE
feat(Storybook): Add Handbook Page template

### DIFF
--- a/storybook/src/pages/public/HandbookPage/HandbookPage.docs.mdx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.docs.mdx
@@ -15,7 +15,9 @@ Use this template for long-form reference content that is split across many shor
 - Two [Skip Links](/docs/components-navigation-skip-link--docs) at the top of the page let keyboard users jump straight to the table of contents or to the content.
 - The page uses a two-column [Grid](/docs/components-layout-grid--docs) layout.
 - The left column holds a collapsible [Table of Contents](/docs/components-navigation-table-of-contents--docs) showing the full document tree.
-  - Set `aria-current="page"` on the active link and `defaultExpanded` on its ancestors so the current position is pre-expanded on load.
+  - Set `aria-current="page"` on the active link.
+  - Drive each branch with the controlled `expanded` prop and an `onToggle` handler, so the current position stays open as the reader moves through the document.
+    Keeping the Table of Contents mounted means the link a keyboard user just activated never loses focus.
 - The right column contains a `main` element using the [Prose](/docs/utilities-css-prose--docs) utility class.
   - Each page opens with a level 1 [Heading](/docs/components-text-heading--docs), followed by a large lead [Paragraph](/docs/components-text-paragraph--docs) and body text.
 

--- a/storybook/src/pages/public/HandbookPage/HandbookPage.docs.mdx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.docs.mdx
@@ -1,0 +1,25 @@
+{/* @license CC0-1.0 */}
+
+import { Meta } from "@storybook/addon-docs/blocks";
+
+import * as HandbookPageStories from "./HandbookPage.stories";
+
+<Meta of={HandbookPageStories} />
+
+# Handbook page
+
+Use this template for long-form reference content that is split across many short pages, such as a personnel handbook or a policy document.
+
+## Structure
+
+- Two [Skip Link](/docs/components-navigation-skip-link--docs)s at the top of the page let keyboard users jump straight to the table of contents or to the content.
+- The page uses a two-column [Grid](/docs/components-layout-grid--docs) layout.
+- The left column holds a collapsible [Table of Contents](/docs/components-navigation-table-of-contents--docs) showing the full document tree.
+  - Set `aria-current="page"` on the active link and `defaultExpanded` on its ancestors so the current position is pre-expanded on load.
+- The right column contains a `main` element using the [Prose](/docs/utilities-css-prose--docs) utility class.
+  - Each page opens with a level 1 [Heading](/docs/components-text-heading--docs), followed by a large lead [Paragraph](/docs/components-text-paragraph--docs) and body text.
+
+## Layout and spacing
+
+- The Grid uses the [recommended Cell sizes](/docs/pages-public-introduction--docs#how-to-size-the-grid-cells).
+- The Prose utility class handles vertical spacing within the content area automatically.

--- a/storybook/src/pages/public/HandbookPage/HandbookPage.docs.mdx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.docs.mdx
@@ -12,7 +12,7 @@ Use this template for long-form reference content that is split across many shor
 
 ## Structure
 
-- Two [Skip Link](/docs/components-navigation-skip-link--docs)s at the top of the page let keyboard users jump straight to the table of contents or to the content.
+- Two [Skip Links](/docs/components-navigation-skip-link--docs) at the top of the page let keyboard users jump straight to the table of contents or to the content.
 - The page uses a two-column [Grid](/docs/components-layout-grid--docs) layout.
 - The left column holds a collapsible [Table of Contents](/docs/components-navigation-table-of-contents--docs) showing the full document tree.
   - Set `aria-current="page"` on the active link and `defaultExpanded` on its ancestors so the current position is pre-expanded on load.

--- a/storybook/src/pages/public/HandbookPage/HandbookPage.docs.mdx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.docs.mdx
@@ -2,9 +2,9 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
-import * as HandbookPageStories from "./HandbookPage.stories";
+import * as HandbookStories from "./HandbookPage.stories.tsx";
 
-<Meta of={HandbookPageStories} />
+<Meta of={HandbookStories} />
 
 # Handbook page
 

--- a/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
@@ -1,0 +1,85 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { MouseEvent } from 'react'
+
+import { Grid, Heading, Paragraph, TableOfContents } from '@amsterdam/design-system-react'
+import { useState } from 'react'
+
+import type { HandbookPage } from './pages'
+
+import { commonMeta } from '../common/config'
+import { findAncestors, findPage, pages } from './pages'
+
+const meta = {
+  ...commonMeta,
+  title: 'Pages/Public/Handbook Page',
+  parameters: {
+    ...commonMeta.parameters,
+    skipLinks: [
+      { label: 'Direct naar de inhoudsopgave', targetId: 'inhoudsopgave' },
+      { label: 'Direct naar de inhoud', targetId: 'inhoud' },
+    ],
+  },
+} satisfies Meta
+
+export default meta
+
+type RenderTocOptions = {
+  currentSlug: string
+  expandedSlugs: Set<string>
+  onSelect: (event: MouseEvent<HTMLAnchorElement>, slug: string) => void
+}
+
+const renderTocList = (list: Array<HandbookPage>, options: RenderTocOptions) => (
+  <TableOfContents.List>
+    {list.map((page) => (
+      <TableOfContents.Link
+        aria-current={page.slug === options.currentSlug ? 'page' : undefined}
+        defaultExpanded={page.slug === options.currentSlug || options.expandedSlugs.has(page.slug)}
+        href={`#${page.slug}`}
+        key={page.slug}
+        label={page.heading}
+        onClick={(event) => options.onSelect(event, page.slug)}
+      >
+        {page.children && renderTocList(page.children, options)}
+      </TableOfContents.Link>
+    ))}
+  </TableOfContents.List>
+)
+
+export const Default: StoryObj = {
+  render: () => {
+    const [currentSlug, setCurrentSlug] = useState('s2-2-1')
+
+    const handleSelect = (event: MouseEvent<HTMLAnchorElement>, slug: string) => {
+      event.preventDefault()
+      setCurrentSlug(slug)
+    }
+
+    const currentPage = findPage(currentSlug) ?? pages[0]
+    const expandedSlugs = new Set(findAncestors(currentSlug) ?? [])
+
+    return (
+      <>
+        <Grid paddingVertical="x-large">
+          <Grid.Cell span={{ narrow: 4, medium: 3, wide: 4 }}>
+            <TableOfContents collapsible heading="Inhoudsopgave" id="inhoudsopgave" key={currentSlug}>
+              {renderTocList(pages, { currentSlug, expandedSlugs, onSelect: handleSelect })}
+            </TableOfContents>
+          </Grid.Cell>
+          <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+            <main className="ams-prose" id="inhoud">
+              <Heading level={1}>{currentPage.heading}</Heading>
+              <Paragraph size="large">{currentPage.lead}</Paragraph>
+              <Paragraph>{currentPage.body}</Paragraph>
+            </main>
+          </Grid.Cell>
+        </Grid>
+      </>
+    )
+  },
+}

--- a/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
@@ -64,22 +64,20 @@ export const Default: StoryObj = {
     const expandedSlugs = new Set(findAncestors(currentSlug) ?? [])
 
     return (
-      <>
-        <Grid paddingVertical="x-large">
-          <Grid.Cell span={{ narrow: 4, medium: 3, wide: 4 }}>
-            <TableOfContents collapsible heading="Inhoudsopgave" id="inhoudsopgave" key={currentSlug}>
-              {renderTocList(pages, { currentSlug, expandedSlugs, onSelect: handleSelect })}
-            </TableOfContents>
-          </Grid.Cell>
-          <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
-            <main className="ams-prose" id="inhoud">
-              <Heading level={1}>{currentPage.heading}</Heading>
-              <Paragraph size="large">{currentPage.lead}</Paragraph>
-              <Paragraph>{currentPage.body}</Paragraph>
-            </main>
-          </Grid.Cell>
-        </Grid>
-      </>
+      <Grid paddingVertical="x-large">
+        <Grid.Cell span={{ narrow: 4, medium: 3, wide: 4 }}>
+          <TableOfContents collapsible heading="Inhoudsopgave" id="inhoudsopgave" key={currentSlug}>
+            {renderTocList(pages, { currentSlug, expandedSlugs, onSelect: handleSelect })}
+          </TableOfContents>
+        </Grid.Cell>
+        <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+          <main className="ams-prose" id="inhoud">
+            <Heading level={1}>{currentPage.heading}</Heading>
+            <Paragraph size="large">{currentPage.lead}</Paragraph>
+            <Paragraph>{currentPage.body}</Paragraph>
+          </main>
+        </Grid.Cell>
+      </Grid>
     )
   },
 }

--- a/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
@@ -28,10 +28,24 @@ const meta = {
 
 export default meta
 
+const initialSlug = 's2-2-1'
+
+/** The slugs whose branches are open when a page is the current one: its ancestors, plus the page itself if it has children. */
+const branchFor = (slug: string) => {
+  const slugs = new Set(findAncestors(slug) ?? [])
+
+  if (findPage(slug)?.children) {
+    slugs.add(slug)
+  }
+
+  return slugs
+}
+
 type RenderTocOptions = {
   currentSlug: string
   expandedSlugs: Set<string>
   onSelect: (event: MouseEvent<HTMLAnchorElement>, slug: string) => void
+  onToggle: (slug: string, expanded: boolean) => void
 }
 
 const renderTocList = (list: Array<HandbookPage>, options: RenderTocOptions) => (
@@ -39,11 +53,12 @@ const renderTocList = (list: Array<HandbookPage>, options: RenderTocOptions) => 
     {list.map((page) => (
       <TableOfContents.Link
         aria-current={page.slug === options.currentSlug ? 'page' : undefined}
-        defaultExpanded={page.slug === options.currentSlug || options.expandedSlugs.has(page.slug)}
+        expanded={options.expandedSlugs.has(page.slug)}
         href={`#${page.slug}`}
         key={page.slug}
         label={page.heading}
         onClick={(event) => options.onSelect(event, page.slug)}
+        onToggle={(expanded) => options.onToggle(page.slug, expanded)}
       >
         {page.children && renderTocList(page.children, options)}
       </TableOfContents.Link>
@@ -53,21 +68,36 @@ const renderTocList = (list: Array<HandbookPage>, options: RenderTocOptions) => 
 
 export const Default: StoryObj = {
   render: () => {
-    const [currentSlug, setCurrentSlug] = useState('s2-2-1')
+    const [currentSlug, setCurrentSlug] = useState(initialSlug)
+    const [expandedSlugs, setExpandedSlugs] = useState(() => branchFor(initialSlug))
 
     const handleSelect = (event: MouseEvent<HTMLAnchorElement>, slug: string) => {
       event.preventDefault()
       setCurrentSlug(slug)
+      setExpandedSlugs((slugs) => new Set([...slugs, ...branchFor(slug)]))
+    }
+
+    const handleToggle = (slug: string, expanded: boolean) => {
+      setExpandedSlugs((slugs) => {
+        const nextSlugs = new Set(slugs)
+
+        if (expanded) {
+          nextSlugs.add(slug)
+        } else {
+          nextSlugs.delete(slug)
+        }
+
+        return nextSlugs
+      })
     }
 
     const currentPage = findPage(currentSlug) ?? pages[0]
-    const expandedSlugs = new Set(findAncestors(currentSlug) ?? [])
 
     return (
       <Grid paddingVertical="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 3, wide: 4 }}>
-          <TableOfContents collapsible heading="Inhoudsopgave" id="inhoudsopgave" key={currentSlug}>
-            {renderTocList(pages, { currentSlug, expandedSlugs, onSelect: handleSelect })}
+          <TableOfContents collapsible heading="Inhoudsopgave" id="inhoudsopgave">
+            {renderTocList(pages, { currentSlug, expandedSlugs, onSelect: handleSelect, onToggle: handleToggle })}
           </TableOfContents>
         </Grid.Cell>
         <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>

--- a/storybook/src/pages/public/HandbookPage/pages.ts
+++ b/storybook/src/pages/public/HandbookPage/pages.ts
@@ -1,0 +1,137 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+export type HandbookPage = {
+  body: string
+  children?: Array<HandbookPage>
+  heading: string
+  lead: string
+  slug: string
+}
+
+export const pages: Array<HandbookPage> = [
+  {
+    body: 'Deze regeling vervangt eerdere afspraken en geldt voor alle medewerkers in loondienst van de gemeente Amsterdam. Afwijkingen zijn alleen mogelijk als dit expliciet is vastgelegd in een individuele arbeidsovereenkomst of cao-bijlage.',
+    heading: 'Inleiding',
+    lead: 'Deze regeling beschrijft hoe de gemeente Amsterdam salarissen, salaristoelagen en vergoedingen vaststelt.',
+    slug: 's1',
+  },
+  {
+    body: 'De waardering bepaalt in welke salarisschaal een functie wordt ingedeeld. De procedure volgt de methode die is overeengekomen in de cao Gemeenten.',
+    children: [
+      {
+        body: 'Alle functies binnen de gemeente Amsterdam worden gewaardeerd volgens dezelfde methode. Zo ontstaat een samenhangend loongebouw waarin vergelijkbare functies op hetzelfde niveau zijn ingedeeld.',
+        heading: 'Algemeen',
+        lead: 'De gemeente waardeert alle functies met één consistente methode, zodat vergelijkbare werkzaamheden ook vergelijkbaar worden beloond.',
+        slug: 's2-1',
+      },
+      {
+        body: 'Waardering gebeurt op basis van een functiebeschrijving en een weging van kenmerken als verantwoordelijkheid, complexiteit en vereiste kennis. De uitkomst bepaalt de salarisschaal.',
+        children: [
+          {
+            body: 'De methode kent punten toe aan gezichtspunten zoals kennis, zelfstandigheid, contacten en afbreukrisico. De som van de punten bepaalt de indeling in een salarisschaal. Deze werkwijze is landelijk afgestemd.',
+            heading: 'Methode',
+            lead: 'We gebruiken de HR21-systematiek om functies objectief en vergelijkbaar te waarderen.',
+            slug: 's2-2-1',
+          },
+          {
+            body: 'Een leidinggevende dient een onderbouwd voorstel in bij de afdeling HR. Een onafhankelijke adviseur toetst het voorstel en brengt advies uit aan het bevoegd gezag. Het besluit wordt schriftelijk vastgelegd.',
+            heading: 'Procedure',
+            lead: 'Een waardering doorloopt een vaste route van voorstel, advies en besluit.',
+            slug: 's2-2-2',
+          },
+          {
+            body: 'Bezwaar moet binnen zes weken na het besluit worden ingediend. Een bezwaarcommissie hoort de medewerker en brengt advies uit. Het bevoegd gezag neemt vervolgens een nieuw besluit.',
+            heading: 'Bezwaar',
+            lead: 'Bent u het oneens met een waardering? Dan kunt u bezwaar maken volgens de daarvoor geldende procedure.',
+            slug: 's2-2-3',
+          },
+        ],
+        heading: 'Waardering van functies',
+        lead: 'Elke functie krijgt een waardering die past bij de zwaarte van het werk.',
+        slug: 's2-2',
+      },
+      {
+        body: 'Een herwaardering kan leiden tot een hogere of lagere indeling. De procedure is gelijk aan die van een eerste waardering.',
+        children: [
+          {
+            body: 'Herwaardering kan worden aangevraagd door de leidinggevende of door de medewerker zelf. Daarvoor is een actuele functiebeschrijving nodig.',
+            heading: 'Aanleiding',
+            lead: 'Als de inhoud van een functie structureel verandert, kan een herwaardering worden aangevraagd.',
+            slug: 's2-3-1',
+          },
+          {
+            body: 'De procedure volgt dezelfde stappen als de eerste waardering: voorstel, advies en besluit. Gedurende de procedure blijft de huidige indeling van kracht.',
+            heading: 'Procedure',
+            lead: 'Een herwaardering doorloopt dezelfde stappen als een eerste waardering.',
+            slug: 's2-3-2',
+          },
+        ],
+        heading: 'Herwaardering',
+        lead: 'Als het werk structureel verandert, kan een functie opnieuw worden gewaardeerd.',
+        slug: 's2-3',
+      },
+    ],
+    heading: 'Vaststellen en waarderen van functies',
+    lead: 'Iedere functie binnen de organisatie krijgt een functiebeschrijving en een waardering.',
+    slug: 's2',
+  },
+  {
+    body: 'Een toelage is altijd tijdelijk en wordt schriftelijk toegekend door het bevoegd gezag. Toelagen tellen niet mee voor de pensioengrondslag, tenzij anders bepaald.',
+    children: [
+      {
+        body: 'De hoogte hangt af van het beoordelingsresultaat en is maximaal tien procent van het jaarsalaris. De toelage wordt jaarlijks opnieuw beoordeeld.',
+        heading: 'Functioneringstoelage',
+        lead: 'Medewerkers die structureel uitzonderlijk presteren, kunnen in aanmerking komen voor een functioneringstoelage.',
+        slug: 's3-1',
+      },
+      {
+        body: 'De toelage wordt toegekend voor een periode van maximaal drie jaar. Daarna vervalt de toelage, tenzij de krapte op de markt voortduurt.',
+        heading: 'Arbeidsmarkttoelage',
+        lead: 'Voor functies die lastig te vervullen zijn, kan tijdelijk een arbeidsmarkttoelage worden toegekend.',
+        slug: 's3-2',
+      },
+    ],
+    heading: 'Salaristoelagen',
+    lead: 'Bovenop het reguliere salaris kunnen verschillende toelagen worden toegekend.',
+    slug: 's3',
+  },
+  {
+    body: 'Denk aan reiskosten, thuiswerkvergoeding en een vergoeding voor representatiekosten. Declaraties moeten binnen drie maanden worden ingediend via het personeelssysteem.',
+    heading: 'Vergoedingen',
+    lead: 'Naast het salaris kent de gemeente vergoedingen toe voor kosten die met het werk samenhangen.',
+    slug: 's4',
+  },
+]
+
+export const findAncestors = (slug: string, list: Array<HandbookPage> = pages): Array<string> | undefined => {
+  for (const page of list) {
+    if (page.slug === slug) {
+      return []
+    }
+    if (page.children) {
+      const trail = findAncestors(slug, page.children)
+      if (trail !== undefined) {
+        return [page.slug, ...trail]
+      }
+    }
+  }
+  return undefined
+}
+
+export const findPage = (slug: string, list: Array<HandbookPage> = pages): HandbookPage | undefined => {
+  for (const page of list) {
+    if (page.slug === slug) {
+      return page
+    }
+    if (page.children) {
+      const found = findPage(slug, page.children)
+      if (found) {
+        return found
+      }
+    }
+  }
+  return undefined
+}

--- a/storybook/src/pages/public/common/Layout.tsx
+++ b/storybook/src/pages/public/common/Layout.tsx
@@ -3,18 +3,32 @@
  * Copyright Gemeente Amsterdam
  */
 
-import type { HTMLAttributes, PropsWithChildren } from 'react'
+import type { PropsWithChildren } from 'react'
 
 import { PageFooter, SkipLink } from '@amsterdam/design-system-react'
 
 import { Default as PageFooterStory } from '../../../components/PageFooter/PageFooter.stories'
 import { AppHeader } from './AppHeader'
 
-type LayoutProps = PropsWithChildren<HTMLAttributes<HTMLElement>>
+type SkipLinkItem = {
+  readonly label: string
+  readonly targetId: string
+}
 
-export const Layout = ({ children }: LayoutProps) => (
+type LayoutProps = PropsWithChildren<{
+  readonly skipLinks?: ReadonlyArray<SkipLinkItem>
+}>
+
+export const Layout = ({
+  children,
+  skipLinks = [{ label: 'Direct naar inhoud', targetId: 'inhoud' }],
+}: LayoutProps) => (
   <>
-    <SkipLink href="#inhoud">Direct naar inhoud</SkipLink>
+    {skipLinks.map(({ label, targetId }) => (
+      <SkipLink href={`#${targetId}`} key={targetId}>
+        {label}
+      </SkipLink>
+    ))}
     <AppHeader />
     {children}
     <PageFooter>{PageFooterStory.args?.children}</PageFooter>

--- a/storybook/src/pages/public/common/config.tsx
+++ b/storybook/src/pages/public/common/config.tsx
@@ -11,9 +11,9 @@ import { Layout } from './Layout'
 
 export const commonMeta = {
   decorators: [
-    (Story) => (
+    (Story, { parameters }) => (
       <Page>
-        <Layout>
+        <Layout skipLinks={parameters['skipLinks']}>
           <Story />
         </Layout>
       </Page>


### PR DESCRIPTION
## What

Adds a **Handbook page** template to the public page templates, for long-form reference content that is split across many short pages — a personnel handbook, a policy document, a regulation.

The page puts a collapsible Table of Contents showing the full document tree in the left column, and the selected page’s content in the right column. Selecting an entry swaps the content in place, opens that entry’s branch, and marks the active link with `aria-current="page"`.

To support it, the shared `Layout` used by all public page templates now renders a list of Skip Links instead of a single hard-coded one.

## Why

Our page templates cover articles, products, projects, forms and navigation, but none of them showed how to present a deep, hierarchical document. This is a recurring shape on amsterdam.nl, and it is the case the collapsible Table of Contents was built for.

A handbook needs two Skip Links rather than one: with a table of contents this large, keyboard users benefit from jumping straight to it, not only to the content. The old `Layout` hard-coded exactly one link to `#inhoud`, so it could not express that.

## How

- **`Layout`** now takes an optional `skipLinks` array of `{ label, targetId }` and maps it to Skip Links. It defaults to the single “Direct naar inhoud” link it rendered before, so the six existing page templates are unchanged. The unused `HTMLAttributes<HTMLElement>` on its props type is dropped in the process.
- **`commonMeta`** reads `skipLinks` off the story’s `parameters` and forwards it, which keeps the opt-in per story rather than per template directory.
- **`pages.ts`** holds the document tree plus two small helpers: `findPage` resolves a slug to its page, and `findAncestors` returns the slugs on the path to it.
- **The Table of Contents is controlled.** Each branch takes `expanded` from an `expandedSlugs` state and writes back through `onToggle`. Selecting a page opens its ancestors and, if it has children, its own branch. Because nothing remounts, the link a keyboard user has just activated keeps focus.
- Content is realistic Dutch policy text so the template shows how the layout behaves at true line lengths rather than with lorem ipsum.

Verified with a clean `tsc --noEmit` over the Storybook package and ESLint over the changed directories.

## Checklist

- [x] Add or update unit tests — not needed; this adds a page template, not component logic
- [x] Add or update documentation — `HandbookPage.docs.mdx`, with cross-links to the components used
- [x] Add or update stories — the template is the story
- [x] Add or update exports in index.\* files — n/a; the Storybook package publishes nothing
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- Context: DES-1887, resolved by #2770.
- Story to review: Pages → Public → Handbook Page.
- The template exercises the **controlled** expansion API (`expanded` + `onToggle`) from #2753 rather than `defaultExpanded` from #2770. An earlier revision used `defaultExpanded` together with a `key={currentSlug}` remount to re-apply it on every selection; that remount destroyed the anchor the reader had just activated and dropped focus to the top of the document. `defaultExpanded` already has its own dedicated story on the Table of Contents component, so it does not need this page as its demo.
- **Feedback wanted on the Dutch copy of the Skip Links.** The `Layout` default reads “Direct naar inhoud”, while this page passes “Direct naar de inhoud” and “Direct naar de inhoudsopgave”. I kept the existing default untouched, but the two phrasings should probably converge — happy to change either side.
