### PR TITLE
chore(tokens): Correct the fluid scaling viewport range in token descriptions

### DIFF
--- a/packages-proprietary/tokens/src/brand/ams/space.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/space.tokens.json
@@ -1,7 +1,7 @@
 {
   "ams": {
     "space": {
-      "$description": "A responsive spacing scale. All values scale fluidly between 320px and 1600px viewports.",
+      "$description": "A responsive spacing scale. All values scale fluidly between 320px and 1440px viewports.",
       "xs": {
         "$value": "clamp(0.25rem, 0.2143rem + 0.1786vw, 0.375rem)",
         "$description": "Scales from 4px to 6px.",

--- a/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
@@ -22,7 +22,7 @@
         }
       },
       "body-text": {
-        "$description": "Text styles for running body copy. Font sizes scale fluidly between 320px and 1600px viewports.",
+        "$description": "Text styles for running body copy. Font sizes scale fluidly between 320px and 1440px viewports.",
         "font-size": {
           "$value": "clamp(1.125rem, 1.0893rem + 0.1786vw, 1.25rem)",
           "$description": "Scales from 18px to 20px.",


### PR DESCRIPTION
## What

Two token group descriptions claimed that their values scale fluidly between 320px and 1600px viewports:

- `ams.space` in `space.tokens.json`
- `ams.typography.body-text` in `typography.tokens.json`

Both now say 1440px. No token value changes.

## Why

The descriptions were wrong. Every `clamp()` in `space.tokens.json`, `space.compact.tokens.json` and `typography.tokens.json` interpolates from a 320px viewport to a **1440px** viewport, and pins at its maximum above that. Nothing in the repository has ever scaled to 1600px.

Three things confirm 1440px is the intended range, so this is a wording error rather than fourteen wrong values:

- `calculate-fluid-style()` in `packages/css/src/common/calculate-fluid-style.scss` — the Sass function that produces exactly this shape of clamp — defaults to `$maxScreenWidthPx: 1440`.
- The token tables in `space.docs.mdx` and `typography.docs.mdx` already publish the range as “≤ 320” to “≥ 1440”.
- The Page container caps at `90rem` = 1440px, as the new Responsive design guide states. Scaling spacing beyond that point would keep growing the scale across a band where the content column has already stopped widening.

## How

Each clamp has the form `clamp(min, A + B·vw, max)`, so its preferred value is `A + (B / 100) · V` for viewport `V`. Solving the committed coefficients for the viewport at which the preferred value reaches `max`:

`R = (max − A) · 100 / B`

gives 1440px for all fourteen clamps in the three files, and each one evaluates to exactly its minimum at `V = 320`. Reproducing the coefficients from `R = 1600` matches none of them: `ams.space.m`, for instance, would need `0.875rem + 0.625vw` rather than the committed `0.8571rem + 0.7143vw`.

Only the two group descriptions changed. The per-token descriptions, such as “Scales from 24px to 36px”, were already correct and are untouched.

## Checklist

- [x] Add or update unit tests — not necessary, no behaviour changes
- [x] Add or update documentation — the changed strings are the documentation
- [x] Add or update stories — not necessary
- [x] Add or update exports in index.\* files — not necessary
- [x] Comment `/chromatic test` and verify visual regression tests pass — not necessary, see below
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- Not a visual change. Every `clamp()` is byte for byte unchanged, so no rendered spacing or font size moves at any viewport. Correcting the values instead, to genuinely reach their maximum at 1600px, *would* be a visual change at every viewport between 320px and 1600px, and would need Chromatic review — but the evidence above says that is not what the scale is meant to do.
- The prefix is `chore` rather than `fix` on purpose: a `fix(tokens)` release note would suggest to consumers that token values changed, which is the opposite of what happened.
- One related inaccuracy left alone: `ams.space.$description` also says “All values scale fluidly”, which holds for the six default tokens but not for `space.compact.tokens.json`, where `xs` and `s` are static. The compact file carries no description of its own, so whether that sentence reaches the compact tokens depends on how `build.js` merges them. Happy to look into it separately if it is worth fixing.