### PR TITLE
feat(space): Decrease the xl and 2xl space tokens in Compact Mode

### DIFF
--- a/packages-proprietary/tokens/src/brand/ams/space.compact.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/space.compact.tokens.json
@@ -30,14 +30,14 @@
         }
       },
       "xl": {
-        "$value": "clamp(1.5rem, 1.2857rem + 1.0714vw, 2.25rem)",
+        "$value": "clamp(1.25rem, 1.0357rem + 1.0714vw, 2rem)",
         "$extensions": {
           "nl.amsterdam.type": "dimension",
           "nl.amsterdam.subtype": "space"
         }
       },
       "2xl": {
-        "$value": "clamp(2rem, 1.7143rem + 1.4286vw, 3rem)",
+        "$value": "clamp(1.5rem, 1.2143rem + 1.4286vw, 2.5rem)",
         "$extensions": {
           "nl.amsterdam.type": "dimension",
           "nl.amsterdam.subtype": "space"

--- a/storybook/src/brand/design-tokens/space.docs.mdx
+++ b/storybook/src/brand/design-tokens/space.docs.mdx
@@ -37,8 +37,8 @@ This helps make better use of small screens.
 | `var(--ams-space-s)`   |     8      | <SpaceSample value="0.5rem" />  |      8      | <SpaceSample value="0.5rem" />  |
 | `var(--ams-space-m)`   |     12     | <SpaceSample value="0.75rem" /> |     16      | <SpaceSample value="1rem" />    |
 | `var(--ams-space-l)`   |     16     | <SpaceSample value="1rem" />    |     24      | <SpaceSample value="1.5rem" />  |
-| `var(--ams-space-xl)`  |     24     | <SpaceSample value="1.5rem" />  |     36      | <SpaceSample value="2.25rem" /> |
-| `var(--ams-space-2xl)` |     32     | <SpaceSample value="2rem" />    |     48      | <SpaceSample value="3rem" />    |
+| `var(--ams-space-xl)`  |     20     | <SpaceSample value="1.25rem" /> |     32      | <SpaceSample value="2rem" />    |
+| `var(--ams-space-2xl)` |     24     | <SpaceSample value="1.5rem" />  |     40      | <SpaceSample value="2.5rem" />  |
 
 ## How to use
 

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -172,7 +172,7 @@ Column widths, gaps, and margins scale continuously between breakpoints; only th
 
 In Spacious Mode, gaps between columns use the `xl` space token.
 It grows from 36 to 60 pixels between windows 320 and 1440 pixels wide.
-In Compact Mode, the same token scales from 16 to 24 pixels to accommodate denser layouts.
+In Compact Mode, the same token scales from 20 to 32 pixels to accommodate denser layouts.
 
 Margins use the `l` token on the narrow grid in Spacious Mode (`xl` in Compact), `xl` on medium, and `2xl` on wide.
 

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -66,10 +66,11 @@ In Compact Mode, the page background is light grey.
 
 ### Vertical padding
 
-Add white space above and below the Grid through the `padding…` props.
-Their options match the design tokens for [Space](/docs/brand-design-tokens-space--docs).
+The Grid has no vertical padding of its own.
+Add white space above and below it through the `padding…` props.
+They accept `large`, `x-large`, and `2x-large`, matching the `l`, `xl`, and `2xl` design tokens for [Space](/docs/brand-design-tokens-space--docs).
 This is useful in a container with a coloured background, like [Page Footer](/docs/components-containers-page-footer--docs) or [Spotlight](/docs/components-containers-spotlight--docs), or between two consecutive Grids.
-Specify `x-large` to match the vertical gap between columns.
+Specify `x-large` to match the gaps between the columns and the rows.
 Like the other features of the Grid, this padding is responsive.
 
 <Canvas of={GridStories.VerticalPadding} />
@@ -78,7 +79,7 @@ Like the other features of the Grid, this padding is responsive.
 
 A Grid automatically creates a new row if the next cell doesn’t fit the current one.
 White space between rows defaults to `x-large`, matching the gap between columns.
-Use `verticalGap` to adjust or remove it.
+Use `gapVertical` to lower it to `large` or raise it to `2x-large`, or to remove it with `none`.
 
 <Canvas of={GridStories.VerticalGap} />
 
@@ -143,7 +144,7 @@ Use the `as` prop on either to make the markup more semantic.
 ## Features
 
 The Grid is responsive: 4 columns on narrow windows, 8 on medium, 12 on wide.
-Column counts, gaps, and padding all change at the same breakpoints, so the layout scales as a whole.
+The column count and the horizontal padding change at the breakpoints; the gaps scale continuously across all of them.
 
 Cells flow automatically.
 A cell that doesn’t fit in the current row moves to the next, which keeps simple layouts simple.
@@ -166,17 +167,26 @@ The narrow grid has 4 columns for windows up to 600 pixels wide.
 The medium grid has 8 columns for windows up to 1160 pixels.
 The wide grid has 12 columns at 1160 pixels and beyond.
 
-Column widths, gaps, and margins scale continuously between breakpoints; only the column count changes at each step.
+Column widths and gaps scale continuously with the width of the window.
+At each breakpoint the column count changes, and the margin moves up to the next space token.
 
 ### Spacious and Compact Mode
 
-In Spacious Mode, gaps between columns use the `xl` space token.
-It grows from 36 to 60 pixels between windows 320 and 1440 pixels wide.
-In Compact Mode, the same token scales from 20 to 32 pixels to accommodate denser layouts.
+Gaps between columns use the `xl` space token, at every breakpoint.
+In Spacious Mode it grows from 36 to 60 pixels between windows 320 and 1440 pixels wide.
+In Compact Mode it scales from 20 to 32 pixels to accommodate denser layouts.
+Rows use the same token by default, so cells sit equally far apart in both directions.
 
-Margins use the `l` token on the narrow grid in Spacious Mode (`xl` in Compact), `xl` on medium, and `2xl` on wide.
+Margins step up at each breakpoint.
+In Spacious Mode they use the `l` token on the narrow grid, `xl` on medium, and `2xl` on wide.
+In Compact Mode they use `m`, `l`, and `xl` respectively.
+This makes the margin smaller than the gap between cells on narrow windows: content sits closer to the edges of the device than the cells do to each other.
+That is deliberate, as Compact Mode has no need for the editorial white space beside the spacious grid.
 
-In Compact Mode the wide grid includes a vertical menu bar beside the grid, up to 128 pixels wide.
+The Grid has no vertical padding of its own; the `padding…` props add `l`, `xl`, or `2xl` where a design calls for it.
+In Compact Mode every cell adds `m` of padding on all sides, inside the margins of the Grid.
+
+In Compact Mode the wide grid includes a vertical menu bar beside the grid, 128 pixels wide.
 On medium and narrow grids, the menu bar moves below the header.
 
 ### Maximum width
@@ -188,6 +198,7 @@ There is no minimum: the grid scales as narrow as the available space.
 ## Dimensions
 
 These tables show the pixel values at each breakpoint; between breakpoints, all values scale continuously.
+‘Margin’ is the horizontal padding of the Grid itself; ‘Gap’ sits between the columns and, by default, between the rows as well.
 Dimensions are multiples of 16, not the precise measurements of any specific device.
 We name the breakpoints ‘narrow’, ‘medium’, and ‘wide’ rather than ‘mobile’, ‘tablet’, and ‘desktop’ for this reason.
 
@@ -203,9 +214,9 @@ We name the breakpoints ‘narrow’, ‘medium’, and ‘wide’ rather than �
 
 | Breakpoint | From | Columns | Menu bar | Column width | Gap | Margin | Grid width |
 | :--------- | ---: | ------: | -------: | -----------: | --: | -----: | ---------: |
-| narrow     |  320 |       4 |        0 |         54.0 |  24 |     16 |        288 |
-| medium     |  600 |       8 |        0 |         44.6 |  27 |     27 |        548 |
-| wide       | 1160 |      12 |      108 |         50.1 |  33 |     44 |        964 |
+| narrow     |  320 |       4 |        0 |         59.0 |  20 |     12 |        296 |
+| medium     |  600 |       8 |        0 |         50.4 |  23 |     18 |        564 |
+| wide       | 1160 |      12 |      128 |         54.6 |  29 |     29 |        974 |
 
 ### Reference widths for designers
 
@@ -224,9 +235,9 @@ These correspond to the narrow, medium, and wide breakpoints respectively.
 
 | Device class | Reference width | Columns | Menu bar | Column width | Gap | Margin | Grid width |
 | :----------- | --------------: | ------: | -------: | -----------: | --: | -----: | ---------: |
-| phone        |             320 |       4 |        0 |           54 |  24 |     16 |        288 |
-| tablet       |             880 |       8 |        0 |         76.3 |  30 |     30 |        820 |
-| desktop      |            1920 |      12 |      108 |          110 |  36 |     48 |       1716 |
+| phone        |             320 |       4 |        0 |           59 |  20 |     12 |        296 |
+| tablet       |             880 |       8 |        0 |         82.3 |  26 |     20 |        840 |
+| desktop      |            1920 |      12 |      128 |        114.7 |  32 |     32 |       1728 |
 
 The Figma grid styles are in the shared library under 'Grid styles'.
 


### PR DESCRIPTION
## What

This decreases the two largest space tokens in Compact Mode.

- `--ams-space-xl` now scales from 20px to 32px, where it used to scale from 24px to 36px.
- `--ams-space-2xl` now scales from 24px to 40px, where it used to scale from 32px to 48px.

The Compact table on the Space docs page is updated to match.
The spacious scale is untouched.

## Why

We want slightly less whitespace between grid cells in Compact Mode.
It doesn’t need to change much, because we still need to set cells apart, but this is Compact Mode after all.

In the spacious scale it is right for these two sizes to swirl out to much larger values.
That suits the spacious grid, where the big whitespace next to the grid reads as editorial.
Compact Mode doesn’t need that style, and it can get closer to the physical edges of the device.
That is also why we are comfortable with `m` padding-inline sitting alongside `xl` column and row gaps on mobile.

We analysed the scale as a whole and concluded that what we have is fine.
Only the largest space lengths needed a slight decrease.

The new values also tidy the compact scale up:

- At 320px and below it is a straight 4px ladder: 4, 8, 12, 16, 20, 24.
- At 1440px and above it steps by 8px from `m` upwards: 16, 24, 32, 40.
- At that upper end `xl` (32px) is now exactly twice `m` (16px).

## How

Only `space.compact.tokens.json` changed.
Both `clamp()` values keep their existing `vw` coefficient; only the `rem` intercept and the two bounds move.
Each token therefore shrinks by a constant amount at every viewport width: 4px for `xl` and 8px for `2xl`.
The offset survives the point where the scale stops growing, so there is no discontinuity at 1440px.

The values were derived with the same interpolation the rest of the scale uses, from a 320px viewport to a 1440px viewport, and checked against the built `compact.css`.

The knock-on effect on Grid in Compact Mode:

- `column-gap` and the default `row-gap` map to `xl`, so they go from 24→36px to 20→32px.
- `row-gap="2x-large"` and `padding-block="2x-large"` map to `2xl`, so they go from 32→48px to 24→40px.
- `padding-inline` on wide viewports maps to `xl`, so it goes from 24→36px to 20→32px. On narrow and medium viewports it maps to `m` and `l`, and does not change.

Anything else that consumes `--ams-space-xl` or `--ams-space-2xl` in Compact Mode shifts by the same constant amounts.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- The updated table is on the Space docs page, under Brand → Design Tokens → Space.
- The visual impact reaches beyond Grid: every component that uses the two largest space tokens in Compact Mode moves in by the same 4px or 8px. That is the area where review and Chromatic feedback are most useful.
