### PR TITLE
fix(Menu): Keep the horizontal padding inside the maximum inline size

### DIFF
--- a/packages/css/src/components/menu/menu.scss
+++ b/packages/css/src/components/menu/menu.scss
@@ -10,6 +10,9 @@
 
 .ams-menu {
   background-color: var(--ams-menu-background-color);
+
+  // Keeps the horizontal padding within the maximum inline size in wide windows.
+  box-sizing: border-box;
   font-family: var(--ams-menu-font-family);
   font-size: var(--ams-menu-font-size);
   font-weight: var(--ams-menu-font-weight);


### PR DESCRIPTION
## What

This adds `box-sizing: border-box` to `.ams-menu`.

In wide windows the menu column is now exactly the 128 pixels that `ams.menu.vi-wide.max-inline-size` specifies.
It used to be wider.

## Why

`.ams-menu` set no `box-sizing`, and we have no global reset for it.
`max-inline-size` therefore capped the content box, and the wide `padding-inline` — the `s` space token — sat outside that cap.

The rendered column came out wider than its own token: 144 pixels in Compact Mode, and 150 to 152 pixels in Spacious Mode.
Because `.ams-page--with-menu` places the menu in an `auto` grid column beside the body, that surplus was taken straight out of the Grid.

The documentation says the menu has a maximum width of `8rem`, which simply wasn’t true of the element as rendered.

## How

One declaration.
`box-sizing` only affects a box that has a size constraint, and the menu sets `max-inline-size` in wide windows only, so narrow and medium windows are untouched.
It sets no block size, so `padding-block` is unaffected as well.

Measured in a headless browser on `.ams-page--with-menu`:

| Window | Mode     | Menu before | Menu after | Grid width before | Grid width after |
| -----: | :------- | ----------: | ---------: | ----------------: | ---------------: |
|   1160 | Spacious |         150 |        128 |               851 |              873 |
|   1160 | Compact  |         144 |        128 |               950 |              966 |
|   1920 | Spacious |         152 |        128 |              1588 |             1612 |
|   1920 | Compact  |         144 |        128 |              1704 |             1720 |

The menu shrinks by twice its horizontal padding, and the Grid gains exactly that width.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- This is a visual change in wide windows wherever a Page has a menu, in both modes. The menu’s own content box narrows by 16 to 24 pixels, so its links may wrap differently. Chromatic feedback is most useful there.
- No documentation needed updating. `Menu.docs.mdx` already states a maximum width of `8rem`, and this change makes that accurate.
- The Grid documentation quotes a 108 pixel menu bar, which is wrong for an unrelated reason. That is corrected separately, along with the rest of the Grid dimension tables.
