### PR TITLE
chore(tokens): Document where to apply a mode that overrides token values

### DIFF
--- a/packages-proprietary/tokens/README.md
+++ b/packages-proprietary/tokens/README.md
@@ -93,14 +93,16 @@ import "@amsterdam/design-system-tokens/dist/compact.theme.css"
 A stylesheet that overrides token values must be declared on the same element as the tokens it overrides.
 That element is `html` when you use `index.css`, and the element carrying the `ams-theme` class when you use `index.theme.css`.
 
-Applying `ams-theme--compact` anywhere else does not work, not even on a child of the element with the `ams-theme` class.
-Most components silently keep their spacious values.
+Applying `ams-theme--compact` anywhere else – even on a child of the element with the `ams-theme` class – takes effect only in part.
+The tokens that the mode stylesheet declares itself, such as `--ams-space-xl`, do take their new value there.
+Any other token that refers to them keeps the value it resolved on the element where it was declared.
+Our components mostly read such tokens, so they silently keep their spacious values.
 
 The cause is that CSS resolves a `var()` reference inside a custom property on the element where that property is declared.
 For example, `--ams-paragraph-font-size` refers to `--ams-typography-body-text-font-size` and is declared on the root element, where it resolves to the spacious font size.
 A paragraph deeper in the document inherits that resolved value, so overriding the typography token further down arrives too late.
 
-Applying a mode to a part of a page is therefore not supported.
+Applying a mode to a part of a page is therefore not supported: our components would not follow it.
 
 ### Three layers
 

--- a/packages-proprietary/tokens/README.md
+++ b/packages-proprietary/tokens/README.md
@@ -73,6 +73,35 @@ import "@amsterdam/design-system-tokens/dist/index.css"
 import "@amsterdam/design-system-tokens/dist/compact.css"
 ```
 
+Pair `compact.theme.css` with `index.theme.css` if you apply the tokens through a class rather than through `:root`.
+Import it after the main stylesheet here as well, and add the `ams-theme--compact` class to the very element that carries the `ams-theme` class.
+
+<!-- prettier-ignore -->
+```ts
+import "@amsterdam/design-system-tokens/dist/index.theme.css"
+import "@amsterdam/design-system-tokens/dist/compact.theme.css"
+```
+
+```html
+<body class="ams-theme ams-theme--compact">
+  …
+</body>
+```
+
+#### Where to apply a mode
+
+A stylesheet that overrides token values must be declared on the same element as the tokens it overrides.
+That element is `html` when you use `index.css`, and the element carrying the `ams-theme` class when you use `index.theme.css`.
+
+Applying `ams-theme--compact` anywhere else does not work, not even on a child of the element with the `ams-theme` class.
+Most components silently keep their spacious values.
+
+The cause is that CSS resolves a `var()` reference inside a custom property on the element where that property is declared.
+For example, `--ams-paragraph-font-size` refers to `--ams-typography-body-text-font-size` and is declared on the root element, where it resolves to the spacious font size.
+A paragraph deeper in the document inherits that resolved value, so overriding the typography token further down arrives too late.
+
+Applying a mode to a part of a page is therefore not supported.
+
 ### Three layers
 
 The tokens are organised in three layers: brand, common and component.


### PR DESCRIPTION
## What

This documents where a stylesheet that overrides token values must be applied.

It adds a `#### Where to apply a mode` subsection to the tokens README, and an example of pairing `compact.theme.css` with `index.theme.css`.
The README did not mention that pairing at all — it only showed `index.css` together with `compact.css`.

## Why

`ams-theme--compact` only takes effect when it is declared on the **same element** as the tokens it overrides.
That is `html` for `index.css`, and the element carrying the `ams-theme` class for `index.theme.css`.
Putting it anywhere else fails silently, and the README currently points people towards exactly that mistake: it says to use `index.theme.css` “if that doesn’t work for your project”, and a wrapper `<div>` is the obvious way to reach for it.

The cause is that CSS resolves a `var()` reference inside a custom property on the element where that property is **declared**, not where it is used.
`--ams-paragraph-font-size` refers to `--ams-typography-body-text-font-size` and is declared at `:root`, so it resolves to the spacious font size there, and that already-resolved value is what inherits down.
Redefining the typography token further down the tree arrives too late.

Measured in a headless browser at a 1160 pixel viewport, with the class on a nested `div` instead of the root element:

- A `Paragraph` renders at 19.5px, the spacious size, rather than 16px. A direct token read on that same `div` returns 16px, so the element genuinely holds the compact token — the pre-resolved component token is what wins.
- A `Grid` gets a column gap of 54 and a padding of 79.5, rather than the correct 29 and 29.

`compact.theme.css` re-emits 44 tokens, but 420 of the 1185 tokens declared at `:root` transitively depend on something Compact Mode overrides.
So 408 tokens silently keep their spacious values. This reaches Dialog, Page, Progress List, Menu, icons and form fields, not only Grid.

Import order matters for the same reason.
`:root` and `.ams-theme--compact` both have a specificity of (0,1,0), so the tie is broken by source order — loading the compact stylesheet first yields spacious values even when the classes are correctly co-located.

## How

Documentation only, no code changes.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- This records the constraint as it stands today. Whether we want to lift it — so that a mode can be applied to part of a page — is a separate question. The options are to emit every mode-sensitive token into the theme stylesheet, or to stop pre-resolving component tokens at the root.
- The same reasoning will apply to a future dark mode, and with more force: colour tokens are referenced by far more component tokens than the space scale is.
