### PR TITLE
feat(space): Decrease the xl and 2xl space tokens in Compact Mode

### DIFF
--- a/packages-proprietary/tokens/src/brand/ams/space.compact.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/space.compact.tokens.json
@@ -30,14 +30,14 @@
         }
       },
       "xl": {
-        "$value": "clamp(1.5rem, 1.2857rem + 1.0714vw, 2.25rem)",
+        "$value": "clamp(1.25rem, 1.0357rem + 1.0714vw, 2rem)",
         "$extensions": {
           "nl.amsterdam.type": "dimension",
           "nl.amsterdam.subtype": "space"
         }
       },
       "2xl": {
-        "$value": "clamp(2rem, 1.7143rem + 1.4286vw, 3rem)",
+        "$value": "clamp(1.5rem, 1.2143rem + 1.4286vw, 2.5rem)",
         "$extensions": {
           "nl.amsterdam.type": "dimension",
           "nl.amsterdam.subtype": "space"

--- a/storybook/src/brand/design-tokens/space.docs.mdx
+++ b/storybook/src/brand/design-tokens/space.docs.mdx
@@ -37,8 +37,8 @@ This helps make better use of small screens.
 | `var(--ams-space-s)`   |     8      | <SpaceSample value="0.5rem" />  |      8      | <SpaceSample value="0.5rem" />  |
 | `var(--ams-space-m)`   |     12     | <SpaceSample value="0.75rem" /> |     16      | <SpaceSample value="1rem" />    |
 | `var(--ams-space-l)`   |     16     | <SpaceSample value="1rem" />    |     24      | <SpaceSample value="1.5rem" />  |
-| `var(--ams-space-xl)`  |     24     | <SpaceSample value="1.5rem" />  |     36      | <SpaceSample value="2.25rem" /> |
-| `var(--ams-space-2xl)` |     32     | <SpaceSample value="2rem" />    |     48      | <SpaceSample value="3rem" />    |
+| `var(--ams-space-xl)`  |     20     | <SpaceSample value="1.25rem" /> |     32      | <SpaceSample value="2rem" />    |
+| `var(--ams-space-2xl)` |     24     | <SpaceSample value="1.5rem" />  |     40      | <SpaceSample value="2.5rem" />  |
 
 ## How to use
 


### PR DESCRIPTION
## What

This decreases the two largest space tokens in Compact Mode.

- `--ams-space-xl` now scales from 20px to 32px, where it used to scale from 24px to 36px.
- `--ams-space-2xl` now scales from 24px to 40px, where it used to scale from 32px to 48px.

The Compact table on the Space docs page is updated to match.
The spacious scale is untouched.
This PR does not touch the Grid documentation; all of that, including the sentence that quotes the compact `xl` value, is corrected on the stacked `fix/grid-docs` branch.

## Why

We want slightly less whitespace between grid cells in Compact Mode.
It doesn’t need to change much, because we still need to set cells apart, but this is Compact Mode after all.

In the spacious scale it is right for these two sizes to swirl out to much larger values.
That suits the spacious grid, where the big whitespace next to the grid reads as editorial.
Compact Mode doesn’t need that style, and it can get closer to the physical edges of the device.
That is also why we are comfortable with `m` padding-inline sitting alongside `xl` column and row gaps on mobile.

We analysed the scale as a whole and concluded that what we have is fine.
Only the largest space lengths needed a slight decrease.

The new values also tidy the compact scale up:

- At 320px and below it is a straight 4px ladder: 4, 8, 12, 16, 20, 24.
- At 1440px and above it steps by 8px from `m` upwards: 16, 24, 32, 40.
- At that upper end `xl` (32px) is now exactly twice `m` (16px).

## How

`space.compact.tokens.json` holds the change.
Both `clamp()` values keep their existing `vw` coefficient; only the `rem` intercept and the two bounds move.
Each token therefore shrinks by a constant amount at every viewport width: 4px for `xl` and 8px for `2xl`.
The offset survives the point where the scale stops growing, so there is no discontinuity at 1440px.

The values were derived with the same interpolation the rest of the scale uses, from a 320px viewport to a 1440px viewport, and checked against the built `compact.css`.

The knock-on effect on Grid in Compact Mode:

- `column-gap` and the default `row-gap` map to `xl`, so they go from 24→36px to 20→32px.
- `row-gap="2x-large"` and `padding-block="2x-large"` map to `2xl`, so they go from 32→48px to 24→40px.
- `padding-inline` on wide viewports maps to `xl`, so it goes from 24→36px to 20→32px. On narrow and medium viewports it maps to `m` and `l`, and does not change.

Anything else that consumes `--ams-space-xl` or `--ams-space-2xl` in Compact Mode shifts by the same constant amounts.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- All Grid documentation changes — the prose and the full Dimensions tables — live on a separate branch, `fix/grid-docs`, because those figures also fold in fixes unrelated to this change. That branch describes the compact gaps at their new values, so it belongs on top of this PR.
- The visual impact reaches beyond Grid: every component that uses the two largest space tokens in Compact Mode moves in by the same 4px or 8px. Chromatic only snapshots Compact Mode once the compact-mode snapshot config lands, so a `/chromatic test` here is worth running with that in mind.
