### PR TITLE
chore(Grid): Correct the compact dimensions in docs and complete the space token description

### DIFF
--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -66,10 +66,11 @@ In Compact Mode, the page background is light grey.
 
 ### Vertical padding
 
-Add white space above and below the Grid through the `padding…` props.
-Their options match the design tokens for [Space](/docs/brand-design-tokens-space--docs).
+The Grid has no vertical padding of its own.
+Add white space above and below it through the `padding…` props.
+They accept `large`, `x-large`, and `2x-large`, matching the `l`, `xl`, and `2xl` design tokens for [Space](/docs/brand-design-tokens-space--docs).
 This is useful in a container with a coloured background, like [Page Footer](/docs/components-containers-page-footer--docs) or [Spotlight](/docs/components-containers-spotlight--docs), or between two consecutive Grids.
-Specify `x-large` to match the vertical gap between columns.
+Specify `x-large` to match the gaps between the columns and the rows.
 Like the other features of the Grid, this padding is responsive.
 
 <Canvas of={GridStories.VerticalPadding} />
@@ -78,7 +79,7 @@ Like the other features of the Grid, this padding is responsive.
 
 A Grid automatically creates a new row if the next cell doesn’t fit the current one.
 White space between rows defaults to `x-large`, matching the gap between columns.
-Use `verticalGap` to adjust or remove it.
+Use `gapVertical` to lower it to `large` or raise it to `2x-large`, or to remove it with `none`.
 
 <Canvas of={GridStories.VerticalGap} />
 
@@ -143,7 +144,7 @@ Use the `as` prop on either to make the markup more semantic.
 ## Features
 
 The Grid is responsive: 4 columns on narrow windows, 8 on medium, 12 on wide.
-Column counts, gaps, and padding all change at the same breakpoints, so the layout scales as a whole.
+The column count and the horizontal padding change at the breakpoints; the gaps scale continuously across all of them.
 
 Cells flow automatically.
 A cell that doesn’t fit in the current row moves to the next, which keeps simple layouts simple.
@@ -166,17 +167,26 @@ The narrow grid has 4 columns for windows up to 600 pixels wide.
 The medium grid has 8 columns for windows up to 1160 pixels.
 The wide grid has 12 columns at 1160 pixels and beyond.
 
-Column widths, gaps, and margins scale continuously between breakpoints; only the column count changes at each step.
+Column widths and gaps scale continuously with the width of the window.
+At each breakpoint the column count changes, and the margin moves up to the next space token.
 
 ### Spacious and Compact Mode
 
-In Spacious Mode, gaps between columns use the `xl` space token.
-It grows from 36 to 60 pixels between windows 320 and 1440 pixels wide.
-In Compact Mode, the same token scales from 16 to 24 pixels to accommodate denser layouts.
+Gaps between columns use the `xl` space token, at every breakpoint.
+In Spacious Mode it grows from 36 to 60 pixels between windows 320 and 1440 pixels wide.
+In Compact Mode it scales from 20 to 32 pixels to accommodate denser layouts.
+Rows use the same token by default, so cells sit equally far apart in both directions.
 
-Margins use the `l` token on the narrow grid in Spacious Mode (`xl` in Compact), `xl` on medium, and `2xl` on wide.
+Margins step up at each breakpoint.
+In Spacious Mode they use the `l` token on the narrow grid, `xl` on medium, and `2xl` on wide.
+In Compact Mode they use `m`, `l`, and `xl` respectively.
+This makes the margin smaller than the gap between cells on narrow windows: content sits closer to the edges of the device than the cells do to each other.
+That is deliberate, as Compact Mode has no need for the editorial white space beside the spacious grid.
 
-In Compact Mode the wide grid includes a vertical menu bar beside the grid, up to 128 pixels wide.
+The Grid has no vertical padding of its own; the `padding…` props add `l`, `xl`, or `2xl` where a design calls for it.
+In Compact Mode every cell adds `m` of padding on all sides, inside the margins of the Grid.
+
+In Compact Mode the wide grid includes a vertical menu bar beside the grid, 128 pixels wide.
 On medium and narrow grids, the menu bar moves below the header.
 
 ### Maximum width
@@ -188,6 +198,7 @@ There is no minimum: the grid scales as narrow as the available space.
 ## Dimensions
 
 These tables show the pixel values at each breakpoint; between breakpoints, all values scale continuously.
+‘Margin’ is the horizontal padding of the Grid itself; ‘Gap’ sits between the columns and, by default, between the rows as well.
 Dimensions are multiples of 16, not the precise measurements of any specific device.
 We name the breakpoints ‘narrow’, ‘medium’, and ‘wide’ rather than ‘mobile’, ‘tablet’, and ‘desktop’ for this reason.
 
@@ -203,9 +214,9 @@ We name the breakpoints ‘narrow’, ‘medium’, and ‘wide’ rather than �
 
 | Breakpoint | From | Columns | Menu bar | Column width | Gap | Margin | Grid width |
 | :--------- | ---: | ------: | -------: | -----------: | --: | -----: | ---------: |
-| narrow     |  320 |       4 |        0 |         54.0 |  24 |     16 |        288 |
-| medium     |  600 |       8 |        0 |         44.6 |  27 |     27 |        548 |
-| wide       | 1160 |      12 |      108 |         50.1 |  33 |     44 |        964 |
+| narrow     |  320 |       4 |        0 |         59.0 |  20 |     12 |        296 |
+| medium     |  600 |       8 |        0 |         50.4 |  23 |     18 |        564 |
+| wide       | 1160 |      12 |      128 |         54.6 |  29 |     29 |        974 |
 
 ### Reference widths for designers
 
@@ -224,9 +235,9 @@ These correspond to the narrow, medium, and wide breakpoints respectively.
 
 | Device class | Reference width | Columns | Menu bar | Column width | Gap | Margin | Grid width |
 | :----------- | --------------: | ------: | -------: | -----------: | --: | -----: | ---------: |
-| phone        |             320 |       4 |        0 |           54 |  24 |     16 |        288 |
-| tablet       |             880 |       8 |        0 |         76.3 |  30 |     30 |        820 |
-| desktop      |            1920 |      12 |      108 |          110 |  36 |     48 |       1716 |
+| phone        |             320 |       4 |        0 |           59 |  20 |     12 |        296 |
+| tablet       |             880 |       8 |        0 |         82.3 |  26 |     20 |        840 |
+| desktop      |            1920 |      12 |      128 |        114.7 |  32 |     32 |       1728 |
 
 The Figma grid styles are in the shared library under 'Grid styles'.
 


### PR DESCRIPTION
## What

This corrects the Compact Mode figures in the Grid documentation and completes the description of how the space tokens map onto the grid. It only touches `Grid.docs.mdx`; no component behaviour changes.

- Every compact column width, margin, and grid width is recomputed to its measured value. The compact margins use the `m`, `l`, and `xl` tokens (as they have since #2582), not the `l`, `xl`, and `2xl` of Spacious Mode that the tables previously quoted.
- The compact gap and 2×-large figures now reflect the reduced `xl` and `2xl` compact space tokens from #2782 (`xl` 20→32, `2xl` 24→40).
- The wide-grid menu bar is 128 pixels, not 108, so it fits the “multiples of 16” convention the tables describe and the grid-width maths that depend on it.
- The Design section now also covers the row gap, the vertical-padding props, and the cell padding in Compact Mode.
- The vertical-gap prop is named `gapVertical` (the old text said `verticalGap`, which does not exist), and the contradiction over which values step at a breakpoint versus scale continuously is resolved: the column count and the horizontal padding step at each breakpoint, while the gaps scale continuously across all of them.

## Why

The Grid docs had drifted from the code and tokens. They quoted the Spacious margin tokens for Compact Mode, listed pre-reduction compact gap values, and named a prop that does not exist. Several figures in the Dimensions tables followed from those wrong inputs, so designers and developers reading the page could not reproduce the layout the Grid actually renders.

## How

Each figure in the four Dimensions tables was recomputed from first principles: the space-token `clamp()` values evaluated at the relevant viewport width, then the grid geometry (grid width = viewport − 2 × margin − menu bar; column width = (grid width − (columns − 1) × gap) ÷ columns). The prose token mappings were checked against `grid.tokens.json` and `grid.compact.tokens.json`, and the prop names and accepted values against `Grid.tsx` and `GridCell.tsx`.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- This is a docs-only change to a single `.mdx` file; it adds no stories and alters no component, so there is nothing new for Chromatic to snapshot.
- It is stacked on #2782 (“Decrease the `xl` and `2xl` space tokens in Compact Mode”), which is now merged into `develop`. This branch is rebased on top of that, so it describes the compact gaps at their new values.
