### PR TITLE
chore(docs): Document the default-icon requirement on City of Amsterdam websites

### DIFF
--- a/packages/react/src/Calendar/Calendar.tsx
+++ b/packages/react/src/Calendar/Calendar.tsx
@@ -32,7 +32,7 @@ export type CalendarProps = {
   readonly locale?: string
   /**
    * The icon for the button that navigates to the next month.
-   * Not for use within Amsterdam.
+   * Websites for the City of Amsterdam must use the default icon.
    * @default ChevronForwardIcon
    */
   readonly nextMonthButtonIcon?: IconProps['svg']
@@ -43,7 +43,7 @@ export type CalendarProps = {
   readonly nextMonthButtonLabel?: string
   /**
    * The icon for the button that navigates to the next year.
-   * Not for use within Amsterdam.
+   * Websites for the City of Amsterdam must use the default icon.
    * @default ChevronDoubleForwardIcon
    */
   readonly nextYearButtonIcon?: IconProps['svg']
@@ -54,7 +54,7 @@ export type CalendarProps = {
   readonly nextYearButtonLabel?: string
   /**
    * The icon for the button that navigates to the previous month.
-   * Not for use within Amsterdam.
+   * Websites for the City of Amsterdam must use the default icon.
    * @default ChevronBackwardIcon
    */
   readonly previousMonthButtonIcon?: IconProps['svg']
@@ -65,7 +65,7 @@ export type CalendarProps = {
   readonly previousMonthButtonLabel?: string
   /**
    * The icon for the button that navigates to the previous year.
-   * Not for use within Amsterdam.
+   * Websites for the City of Amsterdam must use the default icon.
    * @default ChevronDoubleBackwardIcon
    */
   readonly previousYearButtonIcon?: IconProps['svg']

--- a/packages/react/src/Checkbox/Checkbox.tsx
+++ b/packages/react/src/Checkbox/Checkbox.tsx
@@ -15,6 +15,7 @@ import CheckboxIcon from './CheckboxIcon'
 export type CheckboxProps = {
   /**
    * An icon to display instead of the default icon.
+   * Websites for the City of Amsterdam must use the default icon.
    * @default CheckboxIcon
    */
   readonly icon?: IconProps['svg']

--- a/packages/react/src/DatePicker/DatePicker.tsx
+++ b/packages/react/src/DatePicker/DatePicker.tsx
@@ -37,7 +37,7 @@ type DatePickerBaseProps = {
   readonly minDate?: Date
   /**
    * The icon for the button that navigates to the next month.
-   * Not for use within Amsterdam.
+   * Websites for the City of Amsterdam must use the default icon.
    * @default ChevronForwardIcon
    */
   readonly nextMonthButtonIcon?: IconProps['svg']
@@ -48,7 +48,7 @@ type DatePickerBaseProps = {
   readonly nextMonthButtonLabel?: string
   /**
    * The icon for the button that navigates to the next year.
-   * Not for use within Amsterdam.
+   * Websites for the City of Amsterdam must use the default icon.
    * @default ChevronDoubleForwardIcon
    */
   readonly nextYearButtonIcon?: IconProps['svg']
@@ -59,7 +59,7 @@ type DatePickerBaseProps = {
   readonly nextYearButtonLabel?: string
   /**
    * The icon for the button that navigates to the previous month.
-   * Not for use within Amsterdam.
+   * Websites for the City of Amsterdam must use the default icon.
    * @default ChevronBackwardIcon
    */
   readonly previousMonthButtonIcon?: IconProps['svg']
@@ -70,7 +70,7 @@ type DatePickerBaseProps = {
   readonly previousMonthButtonLabel?: string
   /**
    * The icon for the button that navigates to the previous year.
-   * Not for use within Amsterdam.
+   * Websites for the City of Amsterdam must use the default icon.
    * @default ChevronDoubleBackwardIcon
    */
   readonly previousYearButtonIcon?: IconProps['svg']

--- a/packages/react/src/ErrorMessage/ErrorMessage.tsx
+++ b/packages/react/src/ErrorMessage/ErrorMessage.tsx
@@ -16,6 +16,7 @@ import { Icon } from '../Icon'
 export type ErrorMessageProps = {
   /**
    * An icon to display instead of the default icon.
+   * Websites for the City of Amsterdam must use the default icon.
    * @default WarningIcon
    */
   readonly icon?: IconProps['svg']

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -48,6 +48,7 @@ export type PageHeaderProps = {
   /**
    * An icon to display instead of the default icon.
    * Websites for the City of Amsterdam must use the default icon.
+   * @default PageHeaderMenuIcon
    */
   readonly menuButtonIcon?: IconProps['svg']
   /** The visible text for the menu button. */

--- a/packages/react/src/PageHeader/PageHeader.tsx
+++ b/packages/react/src/PageHeader/PageHeader.tsx
@@ -45,7 +45,10 @@ export type PageHeaderProps = {
   readonly logoLinkComponent?: ElementType
   /** The accessible text for the link on the logo. */
   readonly logoLinkTitle?: string
-  /** An icon to display instead of the default icon. */
+  /**
+   * An icon to display instead of the default icon.
+   * Websites for the City of Amsterdam must use the default icon.
+   */
   readonly menuButtonIcon?: IconProps['svg']
   /** The visible text for the menu button. */
   readonly menuButtonText?: string

--- a/packages/react/src/Radio/Radio.tsx
+++ b/packages/react/src/Radio/Radio.tsx
@@ -15,6 +15,7 @@ import RadioIcon from './RadioIcon'
 export type RadioProps = {
   /**
    * An icon to display instead of the default icon.
+   * Websites for the City of Amsterdam must use the default icon.
    * @default RadioIcon
    */
   readonly icon?: IconProps['svg']

--- a/storybook/src/components/Calendar/Calendar.docs.mdx
+++ b/storybook/src/components/Calendar/Calendar.docs.mdx
@@ -95,7 +95,7 @@ const linkTemplate = (date: Date): string => `?date=${formatDate(date)}`
 ### Custom navigation icons
 
 Different navigation icons can be used through the `*ButtonIcon` props, which each take the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
-Websites for Amsterdam must use the default icons.
+Websites for the City of Amsterdam must use the default icons.
 For right-to-left scripts, give a custom icon a `data-directional="true"` attribute so it mirrors like the default chevrons; see the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs).
 
 ## Accessibility

--- a/storybook/src/components/Calendar/Calendar.stories.tsx
+++ b/storybook/src/components/Calendar/Calendar.stories.tsx
@@ -42,10 +42,10 @@ const meta = {
     defaultMonth: { control: false }, // Enabling the control breaks the story with an error.
     linkComponent: { control: false }, // Enabling the control breaks the story with an error.
     linkTemplate: { control: false }, // A function returning string or undefined has no usable controls panel widget.
-    nextMonthButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
-    nextYearButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
-    previousMonthButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
-    previousYearButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
+    nextMonthButtonIcon: { control: false }, // Websites for the City of Amsterdam must use the default icon; hidden from the controls.
+    nextYearButtonIcon: { control: false }, // Websites for the City of Amsterdam must use the default icon; hidden from the controls.
+    previousMonthButtonIcon: { control: false }, // Websites for the City of Amsterdam must use the default icon; hidden from the controls.
+    previousYearButtonIcon: { control: false }, // Websites for the City of Amsterdam must use the default icon; hidden from the controls.
   },
   decorators: [SyncLocaleArgs],
   parameters: { localeVariant: 'calendar' },

--- a/storybook/src/components/DatePicker/DatePicker.docs.mdx
+++ b/storybook/src/components/DatePicker/DatePicker.docs.mdx
@@ -129,7 +129,7 @@ Moving past the end of a month shows the adjacent month and keeps focus on the d
 ### Custom navigation icons
 
 Different navigation icons can be used through the `*ButtonIcon` props, which each take the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
-Websites for Amsterdam must use the default icons.
+Websites for the City of Amsterdam must use the default icons.
 For right-to-left scripts, give a custom icon a `data-directional="true"` attribute so it mirrors like the default chevrons; see the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs).
 
 ## Accessibility

--- a/storybook/src/components/DatePicker/DatePicker.stories.tsx
+++ b/storybook/src/components/DatePicker/DatePicker.stories.tsx
@@ -46,11 +46,11 @@ const meta = {
     maxDate: { control: false }, // No usable Storybook control for Date objects; configured directly in each story.
     minDate: { control: false }, // No usable Storybook control for Date objects; configured directly in each story.
     mode: { table: { disable: true } }, // Owned by the story's state wrapper; not a user-configurable control.
-    nextMonthButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
-    nextYearButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
+    nextMonthButtonIcon: { control: false }, // Websites for the City of Amsterdam must use the default icon; hidden from the controls.
+    nextYearButtonIcon: { control: false }, // Websites for the City of Amsterdam must use the default icon; hidden from the controls.
     onChange: { table: { disable: true } }, // Owned by the story's state wrapper; not a user-configurable control.
-    previousMonthButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
-    previousYearButtonIcon: { control: false }, // Not for use within Amsterdam; hidden from the controls.
+    previousMonthButtonIcon: { control: false }, // Websites for the City of Amsterdam must use the default icon; hidden from the controls.
+    previousYearButtonIcon: { control: false }, // Websites for the City of Amsterdam must use the default icon; hidden from the controls.
     value: { table: { disable: true } }, // Owned by the story's state wrapper; not a user-configurable control.
   },
   decorators: [SyncLocaleArgs],

--- a/storybook/src/components/Logo/Logo.docs.mdx
+++ b/storybook/src/components/Logo/Logo.docs.mdx
@@ -64,7 +64,7 @@ Other logo variations exist, but they cannot be used on our websites.
 
 ### Custom
 
-Websites for the City of Amsterdam **must** use one of our own logos.
+Websites for the City of Amsterdam must use one of our own logos.
 
 Other organisations using this component can display their own brand by providing a label and a custom image.
 The label should be ‘name of the organisation + logo’.

--- a/storybook/src/components/PageHeader/PageHeader.docs.mdx
+++ b/storybook/src/components/PageHeader/PageHeader.docs.mdx
@@ -184,7 +184,7 @@ return <PageHeader logoLinkComponent={LinkComponent} />
 
 ### With different branding
 
-Websites for the City of Amsterdam **must** use one of our own logos and the default menu icon.
+Websites for the City of Amsterdam must use one of our own logos and the default menu icon.
 
 Other organisations using this component can provide elements to display their own brand.
 The image for the logo must be an svg, and its label should be ‘name of the organisation + logo’.

--- a/storybook/src/components/PageHeader/PageHeader.docs.mdx
+++ b/storybook/src/components/PageHeader/PageHeader.docs.mdx
@@ -184,7 +184,7 @@ return <PageHeader logoLinkComponent={LinkComponent} />
 
 ### With different branding
 
-Websites for the City of Amsterdam **must** use one of our own logos and our menu icon.
+Websites for the City of Amsterdam **must** use one of our own logos and the default menu icon.
 
 Other organisations using this component can provide elements to display their own brand.
 The image for the logo must be an svg, and its label should be ‘name of the organisation + logo’.


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## What

Documents that websites for the City of Amsterdam must use the default icons, wherever a component exposes an icon override prop.
This affects Calendar, Checkbox, Date Picker, Error Message, Page Header, and Radio.

It also standardises how that requirement is phrased across the JSDoc, the Storybook docs pages, and the story control comments, and adds a missing `@default` to Page Header’s `menuButtonIcon`.

## Why

These icon props exist mainly for other organisations that use the open-source components; websites for the City of Amsterdam must keep the default icons for a consistent brand.
The guidance was inconsistent: some props read “Not for use within Amsterdam”, others said nothing, and the docs prose varied between “Websites for Amsterdam” and “Websites for the City of Amsterdam”.
A single, explicit sentence everywhere makes the requirement clear and helps prevent teams from unintentionally overriding the defaults.

## How

- Added or updated the JSDoc on each icon prop to state the requirement in one standard sentence.
- Replaced the older “Not for use within Amsterdam” note on the Calendar and Date Picker navigation-icon props.
- Aligned the Storybook control comments and the Calendar and Date Picker docs prose to the same wording.
- Added `@default PageHeaderMenuIcon` to Page Header’s `menuButtonIcon`, for parity with the other icon props.
- Removed the bold weight from “must” in Logo and Page Header so every requirement sentence reads in plain type, and changed Page Header’s “our menu icon” to “the default menu icon”.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Documentation only: no component behaviour changes, and the icon override props remain fully supported for use outside the City of Amsterdam.
- No visual output changes, so there is nothing for Chromatic to snapshot.
- Addresses the Copilot review comments on wording consistency and the missing `@default`.
