### PR TITLE
chore(ci): Restore the strict publish-step guards

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -5,7 +5,6 @@ on:
     workflows: ["Check build and tests"]
     types: [completed]
     branches: [main]
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -16,7 +15,7 @@ jobs:
   create-release-and-publish:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Create release
@@ -28,7 +27,7 @@ jobs:
 
       # The logic below handles the npm publication:
       - name: Check out branch
-        if: ${{ steps.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # This is necessary because on.workflow_run always runs on the
@@ -36,11 +35,11 @@ jobs:
           ref: "main"
 
       - name: Install pnpm
-        if: ${{ steps.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Set up Node.js version
-        if: ${{ steps.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           cache: pnpm
@@ -48,19 +47,19 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        if: ${{ steps.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build packages
-        if: ${{ steps.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: pnpm --filter=!storybook -r run build
 
       # Reset any tree modifications from earlier steps so pnpm's git checks
       # pass without us having to disable them with --no-git-checks.
       - name: Reset working tree before publish
-        if: ${{ steps.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: git reset --hard HEAD && git clean -fd
 
       - name: Publish
-        if: ${{ steps.release.outputs.releases_created == 'true' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: pnpm -r publish


### PR DESCRIPTION
## What

Restore the strict `if:` guards on the publish workflow and remove the temporary `workflow_dispatch` trigger that #2788 added.

## Why

#2788 temporarily relaxed the guards so we could manually publish the packages that had failed to release. Renaming the workflow file (`publish.yml` → `publish-packages.yml`) had broken npm’s trusted publishing, so the automatic run couldn’t authenticate. The manual publish has since succeeded — all five packages are live at their intended versions with provenance attestations — so the temporary bypass is no longer needed and shouldn’t linger on `develop`.

## How

Reverted the squash commit from #2788, restoring the workflow to its pre-#2788 state (verified byte-identical). Every publish step is once again gated on `releases_created == 'true'`, and the manual `workflow_dispatch` trigger is gone.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Follows up #2788; no runtime or visual changes, CI configuration only.
- Now that npm’s trusted-publisher config points at `publish-packages.yml`, the next automatic release will publish on its own.
