### PR TITLE
chore(Storybook): Constrain form stories to a realistic inline size

### DIFF
--- a/storybook/src/components/CharacterCount/CharacterCount.stories.tsx
+++ b/storybook/src/components/CharacterCount/CharacterCount.stories.tsx
@@ -7,6 +7,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { CharacterCount } from '@amsterdam/design-system-react/src'
 
+import { maximiseInlineSize } from '#storybook/_common/decorators'
+
 const meta = {
   title: 'Components/Forms/Character Count',
   component: CharacterCount,
@@ -22,6 +24,7 @@ const meta = {
       control: { min: 0, type: 'number' },
     },
   },
+  decorators: [maximiseInlineSize('7-of-12-columns')],
 } satisfies Meta<typeof CharacterCount>
 
 export default meta

--- a/storybook/src/components/Checkbox/Checkbox.stories.tsx
+++ b/storybook/src/components/Checkbox/Checkbox.stories.tsx
@@ -11,6 +11,7 @@ import { Checkbox } from '@amsterdam/design-system-react/src'
 import { useArgs } from 'storybook/preview-api'
 
 import { checkedArgType, childrenArgType, disabledArgType, idArgType } from '#storybook/_common/argTypes'
+import { maximiseInlineSize } from '#storybook/_common/decorators'
 
 import CustomIcon from './CustomIcon'
 
@@ -34,6 +35,7 @@ const meta = {
       table: { disable: false },
     },
   },
+  decorators: [maximiseInlineSize('7-of-12-columns')],
   render: (args) => {
     const [, setArgs] = useArgs()
 

--- a/storybook/src/components/Field/Field.stories.tsx
+++ b/storybook/src/components/Field/Field.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { ErrorMessage, FieldSet, Label, Paragraph, TextInput } from '@amsterdam/design-system-react'
 import { Field } from '@amsterdam/design-system-react/src'
 
+import { maximiseInlineSize } from '#storybook/_common/decorators'
 import { exampleFamilyName, exampleGivenName } from '#storybook/_common/exampleContent'
 
 const givenName = exampleGivenName()
@@ -19,6 +20,7 @@ const meta = {
   args: {
     invalid: false,
   },
+  decorators: [maximiseInlineSize('7-of-12-columns')],
 } satisfies Meta<typeof Field>
 
 export default meta

--- a/storybook/src/components/FieldSet/FieldSet.stories.tsx
+++ b/storybook/src/components/FieldSet/FieldSet.stories.tsx
@@ -17,6 +17,7 @@ import {
 } from '@amsterdam/design-system-react'
 import { FieldSet } from '@amsterdam/design-system-react/src'
 
+import { maximiseInlineSize } from '#storybook/_common/decorators'
 import { exampleFamilyName, exampleGivenName } from '#storybook/_common/exampleContent'
 
 const familyName = exampleFamilyName()
@@ -30,6 +31,7 @@ const meta = {
     legend: 'Wat is uw naam?',
   },
   decorators: [
+    maximiseInlineSize('7-of-12-columns'),
     (Story) => (
       <form>
         <Story />

--- a/storybook/src/components/FileInput/FileInput.stories.tsx
+++ b/storybook/src/components/FileInput/FileInput.stories.tsx
@@ -9,6 +9,7 @@ import { Field, Label, Paragraph } from '@amsterdam/design-system-react'
 import { FileInput } from '@amsterdam/design-system-react/src'
 
 import { disabledArgType } from '#storybook/_common/argTypes'
+import { maximiseInlineSize } from '#storybook/_common/decorators'
 
 const meta = {
   title: 'Components/Forms/File Input',
@@ -33,6 +34,7 @@ const meta = {
       table: { disable: false },
     },
   },
+  decorators: [maximiseInlineSize('7-of-12-columns')],
 } satisfies Meta<typeof FileInput>
 
 export default meta

--- a/storybook/src/components/InvalidFormAlert/InvalidFormAlert.stories.tsx
+++ b/storybook/src/components/InvalidFormAlert/InvalidFormAlert.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { InvalidFormAlert } from '@amsterdam/design-system-react/src'
 
 import { headingLevelArgType } from '#storybook/_common/argTypes'
+import { maximiseInlineSize } from '#storybook/_common/decorators'
 
 const meta = {
   title: 'Components/Forms/Invalid Form Alert',
@@ -23,6 +24,7 @@ const meta = {
   argTypes: {
     headingLevel: headingLevelArgType(),
   },
+  decorators: [maximiseInlineSize('7-of-12-columns')],
 } satisfies Meta<typeof InvalidFormAlert>
 
 export default meta

--- a/storybook/src/components/PasswordInput/PasswordInput.stories.tsx
+++ b/storybook/src/components/PasswordInput/PasswordInput.stories.tsx
@@ -9,6 +9,7 @@ import { ErrorMessage, Field, Label, Paragraph } from '@amsterdam/design-system-
 import { PasswordInput } from '@amsterdam/design-system-react/src'
 
 import { disabledArgType } from '#storybook/_common/argTypes'
+import { maximiseInlineSize } from '#storybook/_common/decorators'
 
 const meta = {
   title: 'Components/Forms/Password Input',
@@ -30,6 +31,7 @@ const meta = {
       description: 'The width, expressed in the average number of characters.',
     },
   },
+  decorators: [maximiseInlineSize('7-of-12-columns')],
 } satisfies Meta<typeof PasswordInput>
 
 export default meta

--- a/storybook/src/components/Radio/Radio.stories.tsx
+++ b/storybook/src/components/Radio/Radio.stories.tsx
@@ -11,6 +11,7 @@ import { Radio } from '@amsterdam/design-system-react/src'
 import { useArgs } from 'storybook/preview-api'
 
 import { checkedArgType, childrenArgType, disabledArgType, idArgType } from '#storybook/_common/argTypes'
+import { maximiseInlineSize } from '#storybook/_common/decorators'
 
 import CustomIcon from './CustomIcon'
 
@@ -34,6 +35,7 @@ const meta = {
       table: { disable: false },
     },
   },
+  decorators: [maximiseInlineSize('7-of-12-columns')],
   render: (args) => {
     const [, setArgs] = useArgs()
 

--- a/storybook/src/components/SearchField/SearchField.stories.tsx
+++ b/storybook/src/components/SearchField/SearchField.stories.tsx
@@ -10,6 +10,8 @@ import type { ChangeEvent } from 'react'
 import { SearchField } from '@amsterdam/design-system-react/src'
 import { useArgs } from 'storybook/preview-api'
 
+import { maximiseInlineSize } from '#storybook/_common/decorators'
+
 type InputProps = {
   invalid?: boolean
   label?: string
@@ -39,6 +41,7 @@ const meta = {
       description: 'Displayed while the field is empty.',
     },
   },
+  decorators: [maximiseInlineSize('7-of-12-columns')],
   render: ({ invalid, label, placeholder, ...args }) => (
     <SearchField {...args}>
       <SearchField.Input invalid={invalid} label={label} placeholder={placeholder} />

--- a/storybook/src/components/TextArea/TextArea.stories.tsx
+++ b/storybook/src/components/TextArea/TextArea.stories.tsx
@@ -9,6 +9,7 @@ import { ErrorMessage, Field, Label, Paragraph } from '@amsterdam/design-system-
 import { TextArea } from '@amsterdam/design-system-react/src'
 
 import { disabledArgType } from '#storybook/_common/argTypes'
+import { maximiseInlineSize } from '#storybook/_common/decorators'
 import { exampleParagraph } from '#storybook/_common/exampleContent'
 
 const paragraph = exampleParagraph()
@@ -45,6 +46,7 @@ const meta = {
       description: 'The number of lines to show.',
     },
   },
+  decorators: [maximiseInlineSize('7-of-12-columns')],
 } satisfies Meta<typeof TextArea>
 
 export default meta

--- a/storybook/src/components/TextInput/TextInput.stories.tsx
+++ b/storybook/src/components/TextInput/TextInput.stories.tsx
@@ -10,6 +10,7 @@ import { textInputTypes } from '@amsterdam/design-system-react/dist/TextInput/Te
 import { TextInput } from '@amsterdam/design-system-react/src'
 
 import { disabledArgType } from '#storybook/_common/argTypes'
+import { maximiseInlineSize } from '#storybook/_common/decorators'
 
 const meta = {
   title: 'Components/Forms/Text Input',
@@ -39,6 +40,7 @@ const meta = {
       options: [undefined, ...textInputTypes.filter((type) => type !== 'text')],
     },
   },
+  decorators: [maximiseInlineSize('7-of-12-columns')],
 } satisfies Meta<typeof TextInput>
 
 export default meta


### PR DESCRIPTION
## Links

- Affected stories live under **Components / Forms** in the feature-branch deploy.
- Decorator: [`maximiseInlineSize`](storybook/src/_common/decorators.tsx).

## What

Adds the `maximiseInlineSize('7-of-12-columns')` decorator, at the `meta` level, to the form component stories whose controls stretch to fill their container:

- Text Input, Password Input, Text Area, File Input, Search Field — full-width inputs.
- Field, Field Set — field containers.
- Checkbox, Radio — their long-label and field-set stories now wrap at a realistic width.
- Invalid Form Alert — the error summary now sits at a form width.
- Character Count — included for consistency.

## Why

In Storybook these controls stretch to the full width of the preview canvas, which is far wider than a real form and makes the stories hard to read.
Constraining them to seven of twelve columns (≈ 44 rem) shows each control at the width it actually has in an application form.

## How

Each component’s `meta` gets `decorators: [maximiseInlineSize('7-of-12-columns')]`.
For Field Set the decorator is merged into the existing `<form>` decorator as the outer wrapper.

The change is limited to components whose controls genuinely stretch full-width (verified via `inline-size: 100%` in the CSS package).
Select, Date Input and Time Input are deliberately left out: they are content-sized, so the constraint would have no visible effect.
Character Count is a short status text, so its effect is cosmetic, but it is included to keep the form stories consistent.

## Checklist

- [x] Add or update unit tests <!-- not necessary; stories only -->
- [x] Add or update documentation <!-- not necessary -->
- [x] Add or update stories
- [x] Add or update exports in index.\* files <!-- not necessary -->
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- No component behaviour changes — this only affects how the stories are framed in Storybook.
- Deliberately excluded: Select, Date Input, Time Input (content-sized controls, no visible effect).
