### PR TITLE
fix(storybook): Make Grid Cells transparent inside Compact Mode Spotlights

### DIFF
--- a/storybook/src/_common/isCompactTheme.ts
+++ b/storybook/src/_common/isCompactTheme.ts
@@ -1,0 +1,17 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { StoryContext } from '@storybook/react-vite'
+
+/**
+ * Whether the story renders in one of the Compact themes, based on the theme selected in the toolbar.
+ * Use this to adapt markup that only makes sense in Compact Mode, such as making a Grid Cell
+ * transparent so it does not cover a coloured Spotlight background with its own white background.
+ */
+export const isCompactTheme = (context: Pick<StoryContext, 'globals'>): boolean => {
+  const theme = context.globals['theme']
+
+  return typeof theme === 'string' && theme.toLowerCase().includes('compact')
+}

--- a/storybook/src/components/PageFooter/PageFooter.stories.tsx
+++ b/storybook/src/components/PageFooter/PageFooter.stories.tsx
@@ -19,6 +19,7 @@ import {
 import { PageFooter } from '@amsterdam/design-system-react/src'
 
 import { wrapInPage } from '#storybook/_common/decorators'
+import { isCompactTheme } from '#storybook/_common/isCompactTheme'
 
 const meta = {
   title: 'Components/Containers/Page Footer',
@@ -45,141 +46,149 @@ const followLinks: FollowLink[] = [
 ]
 
 export const Default: Story = {
-  args: {
-    children: [
-      <PageFooter.Spotlight key={1}>
-        <Grid paddingVertical="x-large">
-          <Grid.Cell span={4}>
-            <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
-              Contact
-            </Heading>
-            <LinkList className="ams-mb-xl">
-              <LinkList.Link color="inverse" href="#" icon={<MailIcon />}>
-                Contactformulier
-              </LinkList.Link>
-              <LinkList.Link color="inverse" href="#" icon={<PhoneIcon />}>
-                14 020
-              </LinkList.Link>
-              <LinkList.Link color="inverse" href="#" icon={<ClockIcon />}>
-                Adressen en openingstijden
-              </LinkList.Link>
-            </LinkList>
-            <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
-              Vacatures
-            </Heading>
-            <StandaloneLink color="inverse" href="#">
-              Werken bij Amsterdam
-            </StandaloneLink>
-          </Grid.Cell>
-          <Grid.Cell span={4}>
-            <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
-              Volg ons
-            </Heading>
-            <LinkList>
-              {followLinks.map(({ icon, text }) => (
-                <LinkList.Link color="inverse" href="#" icon={icon} key={text}>
-                  {text}
+  render: (args, context) => {
+    const cellAppearance = isCompactTheme(context) ? 'transparent' : undefined
+
+    return (
+      <PageFooter {...args}>
+        <PageFooter.Spotlight>
+          <Grid paddingVertical="x-large">
+            <Grid.Cell appearance={cellAppearance} span={4}>
+              <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
+                Contact
+              </Heading>
+              <LinkList className="ams-mb-xl">
+                <LinkList.Link color="inverse" href="#" icon={<MailIcon />}>
+                  Contactformulier
                 </LinkList.Link>
-              ))}
-            </LinkList>
-          </Grid.Cell>
-          <Grid.Cell span={4}>
-            <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
-              Doen in de stad
-            </Heading>
-            <LinkList>
-              <LinkList.Link color="inverse" href="#">
-                Bijeenkomsten en activiteiten
-              </LinkList.Link>
-              <LinkList.Link color="inverse" href="#">
-                Uit in Amsterdam
-              </LinkList.Link>
-              <LinkList.Link color="inverse" href="#">
-                Amsterdam 750 jaar
-              </LinkList.Link>
-            </LinkList>
-          </Grid.Cell>
-        </Grid>
-      </PageFooter.Spotlight>,
-      <PageFooter.Menu key={2}>
-        <PageFooter.MenuLink href="#">Over deze site</PageFooter.MenuLink>
-        <PageFooter.MenuLink href="#">Privacy</PageFooter.MenuLink>
-        <PageFooter.MenuLink href="#">Cookies op deze site</PageFooter.MenuLink>
-        <PageFooter.MenuLink href="#">Webarchief</PageFooter.MenuLink>
-      </PageFooter.Menu>,
-    ],
+                <LinkList.Link color="inverse" href="#" icon={<PhoneIcon />}>
+                  14 020
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="#" icon={<ClockIcon />}>
+                  Adressen en openingstijden
+                </LinkList.Link>
+              </LinkList>
+              <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
+                Vacatures
+              </Heading>
+              <StandaloneLink color="inverse" href="#">
+                Werken bij Amsterdam
+              </StandaloneLink>
+            </Grid.Cell>
+            <Grid.Cell appearance={cellAppearance} span={4}>
+              <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
+                Volg ons
+              </Heading>
+              <LinkList>
+                {followLinks.map(({ icon, text }) => (
+                  <LinkList.Link color="inverse" href="#" icon={icon} key={text}>
+                    {text}
+                  </LinkList.Link>
+                ))}
+              </LinkList>
+            </Grid.Cell>
+            <Grid.Cell appearance={cellAppearance} span={4}>
+              <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
+                Doen in de stad
+              </Heading>
+              <LinkList>
+                <LinkList.Link color="inverse" href="#">
+                  Bijeenkomsten en activiteiten
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="#">
+                  Uit in Amsterdam
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="#">
+                  Amsterdam 750 jaar
+                </LinkList.Link>
+              </LinkList>
+            </Grid.Cell>
+          </Grid>
+        </PageFooter.Spotlight>
+        <PageFooter.Menu>
+          <PageFooter.MenuLink href="#">Over deze site</PageFooter.MenuLink>
+          <PageFooter.MenuLink href="#">Privacy</PageFooter.MenuLink>
+          <PageFooter.MenuLink href="#">Cookies op deze site</PageFooter.MenuLink>
+          <PageFooter.MenuLink href="#">Webarchief</PageFooter.MenuLink>
+        </PageFooter.Menu>
+      </PageFooter>
+    )
   },
 }
 
 export const OnderzoekEnStatistiek: Story = {
-  args: {
-    children: [
-      <PageFooter.Spotlight key={1}>
-        <Grid paddingVertical="x-large">
-          <Grid.Cell span={4}>
-            <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
-              Contact
-            </Heading>
-            <Paragraph className="ams-mb-m" color="inverse">
-              Heeft u een vraag en kunt u het antwoord niet vinden op deze site? Neem dan contact met ons op.
-            </Paragraph>
-            <LinkList>
-              <LinkList.Link color="inverse" href="mailto:redactie.os@amsterdam.nl" icon={<MailIcon />}>
-                E-mail
-              </LinkList.Link>
-              <LinkList.Link color="inverse" href="tel:+31202510333" icon={<PhoneIcon />}>
-                020 251 0333
-              </LinkList.Link>
-            </LinkList>
-          </Grid.Cell>
-          <Grid.Cell span={4}>
-            <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
-              Panels en enquêtes
-            </Heading>
-            <Paragraph className="ams-mb-m" color="inverse">
-              Bent u uitgenodigd om mee te doen aan onderzoek of heeft u vragen over het panel of stadspaspanel?
-            </Paragraph>
-            <LinkList>
-              <LinkList.Link color="inverse" href="#" rel="external">
-                Meedoen aan onderzoek
-              </LinkList.Link>
-              <LinkList.Link color="inverse" href="#" rel="external">
-                Panel Amsterdam
-              </LinkList.Link>
-              <LinkList.Link color="inverse" href="#" rel="external">
-                Stadspaspanel Amsterdam
-              </LinkList.Link>
-            </LinkList>
-          </Grid.Cell>
-          <Grid.Cell span={4}>
-            <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
-              Onderzoek en Statistiek
-            </Heading>
-            <LinkList>
-              <LinkList.Link color="inverse" href="#">
-                Over Onderzoek en Statistiek
-              </LinkList.Link>
-              <LinkList.Link color="inverse" href="#">
-                Veelgestelde vragen
-              </LinkList.Link>
-              <LinkList.Link color="inverse" href="#">
-                Termen en categorieën
-              </LinkList.Link>
-              <LinkList.Link color="inverse" href="#" rel="external">
-                Nieuwsbrief
-              </LinkList.Link>
-              <LinkList.Link color="inverse" href="#">
-                Vacatures
-              </LinkList.Link>
-            </LinkList>
-          </Grid.Cell>
-        </Grid>
-      </PageFooter.Spotlight>,
-      <PageFooter.Menu key={2}>
-        <PageFooter.MenuLink href="#">Privacy</PageFooter.MenuLink>
-        <PageFooter.MenuLink href="#">Toegankelijkheid</PageFooter.MenuLink>
-      </PageFooter.Menu>,
-    ],
+  render: (args, context) => {
+    const cellAppearance = isCompactTheme(context) ? 'transparent' : undefined
+
+    return (
+      <PageFooter {...args}>
+        <PageFooter.Spotlight>
+          <Grid paddingVertical="x-large">
+            <Grid.Cell appearance={cellAppearance} span={4}>
+              <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
+                Contact
+              </Heading>
+              <Paragraph className="ams-mb-m" color="inverse">
+                Heeft u een vraag en kunt u het antwoord niet vinden op deze site? Neem dan contact met ons op.
+              </Paragraph>
+              <LinkList>
+                <LinkList.Link color="inverse" href="mailto:redactie.os@amsterdam.nl" icon={<MailIcon />}>
+                  E-mail
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="tel:+31202510333" icon={<PhoneIcon />}>
+                  020 251 0333
+                </LinkList.Link>
+              </LinkList>
+            </Grid.Cell>
+            <Grid.Cell appearance={cellAppearance} span={4}>
+              <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
+                Panels en enquêtes
+              </Heading>
+              <Paragraph className="ams-mb-m" color="inverse">
+                Bent u uitgenodigd om mee te doen aan onderzoek of heeft u vragen over het panel of stadspaspanel?
+              </Paragraph>
+              <LinkList>
+                <LinkList.Link color="inverse" href="#" rel="external">
+                  Meedoen aan onderzoek
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="#" rel="external">
+                  Panel Amsterdam
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="#" rel="external">
+                  Stadspaspanel Amsterdam
+                </LinkList.Link>
+              </LinkList>
+            </Grid.Cell>
+            <Grid.Cell appearance={cellAppearance} span={4}>
+              <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
+                Onderzoek en Statistiek
+              </Heading>
+              <LinkList>
+                <LinkList.Link color="inverse" href="#">
+                  Over Onderzoek en Statistiek
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="#">
+                  Veelgestelde vragen
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="#">
+                  Termen en categorieën
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="#" rel="external">
+                  Nieuwsbrief
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="#">
+                  Vacatures
+                </LinkList.Link>
+              </LinkList>
+            </Grid.Cell>
+          </Grid>
+        </PageFooter.Spotlight>
+        <PageFooter.Menu>
+          <PageFooter.MenuLink href="#">Privacy</PageFooter.MenuLink>
+          <PageFooter.MenuLink href="#">Toegankelijkheid</PageFooter.MenuLink>
+        </PageFooter.Menu>
+      </PageFooter>
+    )
   },
 }
 

--- a/storybook/src/components/Spotlight/Spotlight.stories.tsx
+++ b/storybook/src/components/Spotlight/Spotlight.stories.tsx
@@ -12,6 +12,7 @@ import { spotlightColors, spotlightTags } from '@amsterdam/design-system-react/s
 import { asArgType, colorArgType } from '#storybook/_common/argTypes'
 import { wrapInPage } from '#storybook/_common/decorators'
 import { exampleQuote } from '#storybook/_common/exampleContent'
+import { isCompactTheme } from '#storybook/_common/isCompactTheme'
 
 const quote = exampleQuote()
 
@@ -30,10 +31,10 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
-  render: ({ as, color }) => (
+  render: ({ as, color }, context) => (
     <Spotlight as={as} color={color}>
       <Grid paddingVertical="x-large">
-        <Grid.Cell span="all">
+        <Grid.Cell appearance={isCompactTheme(context) ? 'transparent' : undefined} span="all">
           <Blockquote color={!color || ['azure', 'green', 'magenta'].includes(color) ? 'inverse' : undefined}>
             {quote}
           </Blockquote>
@@ -47,7 +48,7 @@ export const HighlightContent: Story = {
   args: {
     color: 'green',
   },
-  render: ({ color }) => {
+  render: ({ color }, context) => {
     const lightBackgroundColors = ['lime', 'orange', 'yellow']
     const textColor = lightBackgroundColors.includes(color!) ? undefined : 'inverse'
     const linkColor = lightBackgroundColors.includes(color!) ? 'contrast' : 'inverse'
@@ -55,7 +56,10 @@ export const HighlightContent: Story = {
     return (
       <Spotlight color={color}>
         <Grid paddingVertical="x-large">
-          <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+          <Grid.Cell
+            appearance={isCompactTheme(context) ? 'transparent' : undefined}
+            span={{ narrow: 4, medium: 5, wide: 7 }}
+          >
             <Heading className="ams-mb-s" color={textColor} level={2} size="level-3">
               Steun geven aan een partij
             </Heading>


### PR DESCRIPTION
## Links

- Affected stories (switch the theme toolbar to **Compact** to see the effect): _Components › Containers › Spotlight_ (Default, Highlight content) and _Components › Containers › Page Footer_ (Default, Onderzoek en Statistiek).
- No related issue.

## What

In Compact Mode, a Grid Cell placed inside a coloured Spotlight (or Page Footer Spotlight) rendered as a white block that hid the cell’s `color="inverse"` text.
The affected example stories now make those cells transparent in Compact Mode, so the Spotlight’s background shows through and the text stays legible.

## Why

In Compact Mode, Grid Cells get a white background and padding to set them apart (`--ams-grid-cell-background-color` → `{ams.color.background.default}`); in Spacious they’re transparent.
On a coloured Spotlight background that white cell covers the Spotlight and leaves white-on-white text, which is exactly what these examples were showing.

## How

- Added a small Storybook helper, `isCompactTheme`, that reads the current theme from the story context.
- Spotlight and Page Footer stories now pass `appearance="transparent"` to their Grid Cells **only when the theme is Compact** — it’s a no-op in Spacious, so that view is unchanged and its code panel stays clean.
- The two Page Footer stories moved from `args.children` to a `render` function so they can read the theme; the markup is inlined so the code panel still shows the real JSX.

This is a Compact Mode fix and is independent of the wireframe work.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Only the example stories change — no component, CSS, or token changes. These stories aren’t part of the Chromatic “Test” snapshots.
- Heads-up for whoever integrates the wireframe branch (#2792): it moves the theme out of Storybook globals, so `isCompactTheme` (which reads `context.globals.theme`) will need updating at that point, or the Compact branch silently stops applying.
