### PR TITLE
chore(docs): Add a package version overview to the Introduction home page

### DIFF
--- a/storybook/src/_components/PackageVersions/PackageVersions.test.stories.tsx
+++ b/storybook/src/_components/PackageVersions/PackageVersions.test.stories.tsx
@@ -1,0 +1,21 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { PackageVersions } from './PackageVersions'
+
+const meta = {
+  title: 'Components/Docs/Package Versions',
+} satisfies Meta<typeof PackageVersions>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Test: Story = {
+  render: () => <PackageVersions />,
+  tags: ['!dev', '!autodocs'],
+}

--- a/storybook/src/_components/PackageVersions/PackageVersions.tsx
+++ b/storybook/src/_components/PackageVersions/PackageVersions.tsx
@@ -1,0 +1,31 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import assets from '../../../../packages-proprietary/assets/package.json'
+import reactIcons from '../../../../packages-proprietary/react-icons/package.json'
+import tokens from '../../../../packages-proprietary/tokens/package.json'
+import css from '../../../../packages/css/package.json'
+import react from '../../../../packages/react/package.json'
+import { InlineList } from '../InlineList/InlineList'
+
+// Versions come from each package manifest, so this list tracks every release without manual updates.
+const packages = [
+  { label: 'Assets', version: assets.version },
+  { label: 'CSS', version: css.version },
+  { label: 'React', version: react.version },
+  { label: 'React Icons', version: reactIcons.version },
+  { label: 'Tokens', version: tokens.version },
+]
+
+/** Lists the current published version of each package as an inline band. */
+export const PackageVersions = () => (
+  <InlineList>
+    {packages.map(({ label, version }) => (
+      <InlineList.Item key={label}>
+        {label} <strong>{version}</strong>
+      </InlineList.Item>
+    ))}
+  </InlineList>
+)

--- a/storybook/src/docs/introduction.docs.mdx
+++ b/storybook/src/docs/introduction.docs.mdx
@@ -31,7 +31,7 @@ Faster and cheaper to build and iterate with.
     <strong>2</strong> modes
   </InlineList.Item>
   <InlineList.Item>
-    <strong>1300+</strong> tests
+    <strong>1500+</strong> tests
   </InlineList.Item>
 </InlineList>
 

--- a/storybook/src/docs/introduction.docs.mdx
+++ b/storybook/src/docs/introduction.docs.mdx
@@ -79,7 +79,7 @@ We coordinate with their core team and cooperate with many designers and develop
 
 ## Latest package versions
 
-The documentation applies to these latest release of the Amsterdam Design System packages:
+The documentation applies to these latest releases of the Amsterdam Design System packages:
 
 ---
 

--- a/storybook/src/docs/introduction.docs.mdx
+++ b/storybook/src/docs/introduction.docs.mdx
@@ -3,6 +3,7 @@
 import { Meta } from "@storybook/addon-docs/blocks";
 
 import { InlineList } from "#storybook/_components/InlineList/InlineList";
+import { PackageVersions } from "#storybook/_components/PackageVersions/PackageVersions";
 
 <Meta title="Docs/Introduction" />
 
@@ -65,6 +66,12 @@ Plan with confidence and upgrade on your own timeline.
 Major changes happen at most once a quarter.
 Older versions keep working for at least six months.
 Every release is backed by extensive unit and visual tests.
+
+## Current versions
+
+The latest published version of each package on npm.
+
+<PackageVersions />
 
 ## Public and internal services
 

--- a/storybook/src/docs/introduction.docs.mdx
+++ b/storybook/src/docs/introduction.docs.mdx
@@ -67,12 +67,6 @@ Major changes happen at most once a quarter.
 Older versions keep working for at least six months.
 Every release is backed by extensive unit and visual tests.
 
-## Current versions
-
-The latest published version of each package on npm.
-
-<PackageVersions />
-
 ## Public and internal services
 
 The same components and design language serve public-facing websites and internal backoffice applications alike.
@@ -83,11 +77,19 @@ Residents and City staff alike get interfaces tailored to the task, whether read
 Amsterdam Design System adopts the architecture, principles and goals of the [NL Design System](https://nldesignsystem.nl/).
 We coordinate with their core team and cooperate with many designers and developers in its community.
 
+## Latest package versions
+
+The documentation applies to these latest release of the Amsterdam Design System packages:
+
+---
+
+<PackageVersions />
+
+---
+
 ## Get involved
 
-We are happy to work with you.
-
+- **Download**: get new releases [from npm](https://www.npmjs.com/search?q=keywords:amsterdam-design-system) with semantic versions and clear changelogs.
+- **Ask us anything**: [email us](mailto:designsystem@amsterdam.nl) with suggestions, for our roadmap, to help each other out.
+- **Join the conversation**: [in Teams](https://teams.microsoft.com/l/team/19%3afYKS_RD2n1q4UhguA9jwEJk0A_VjYPO4TiLQjYlG_bo1%40thread.tacv2/conversations?groupId=381b5f11-b342-4a3a-8a78-8b371a90457d&tenantId=72fca1b1-2c2e-4376-a445-294d80196804) to be kept in the loop and share your experiences.
 - **Contribute**: all code is [on GitHub](https://github.com/Amsterdam/design-system); your ideas, issues and pull requests are welcome.
-- **Download**: get new releases [through npm](https://www.npmjs.com/search?q=keywords:amsterdam-design-system) with clear version numbers and changelogs.
-- **Ask us anything**: [email us](mailto:designsystem@amsterdam.nl) with suggestions, our roadmap, or we can help each other.
-- **Join the conversation**: [in Teams](https://teams.microsoft.com/l/team/19%3afYKS_RD2n1q4UhguA9jwEJk0A_VjYPO4TiLQjYlG_bo1%40thread.tacv2/conversations?groupId=381b5f11-b342-4a3a-8a78-8b371a90457d&tenantId=72fca1b1-2c2e-4376-a445-294d80196804) to stay informed and share your experiences.

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -7,6 +7,7 @@
       "#storybook/*": ["./src/*"],
       "#tokens/*": ["../packages-proprietary/tokens/src/*"]
     },
+    "resolveJsonModule": true,
     "skipLibCheck": true
   },
   "extends": "../tsconfig.json",


### PR DESCRIPTION
## Links

- Story: **Docs → Introduction** (the Storybook home page).
- Feature-branch deploy link to follow once the first preview is ready.

## What

Adds a compact overview of the latest published version of each package to the Storybook home page.
It renders as an inline band between horizontal rules, just above “Get involved”, mirroring the statistics band at the top of the page — listing Assets, CSS, React, React Icons and Tokens with their current versions.

## Why

Designers and developers often want to know which version is current before they install or upgrade.
Showing it on the landing page — right next to the “Download” link under “Get involved” — saves a trip to npm, and reinforces the “clear version numbers and changelogs” promise the page already makes.

## How

- A new `PackageVersions` helper (`storybook/src/_components/PackageVersions/`) reads each version straight from the package’s own `package.json` and renders them through the existing `InlineList` component. Because the numbers come from the manifests, the overview tracks every release automatically — there is nothing to bump by hand.
- Enables `resolveJsonModule` in the Storybook `tsconfig.json` so the JSON imports type-check.
- Packages are listed alphabetically.

While here, the “Get involved” list is reordered and lightly reworded.

## Checklist

- [x] Add or update unit tests (not needed — presentational helper, covered by a visual test story)
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files (not needed — internal Storybook helper, imported by path)
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- Versions are read at build time, so the band refreshes on the next deploy after any release.
- Visual review focus: the new band above “Get involved”. It inherits `InlineList` styling, so it should match the statistics band at the top.
