### PR TITLE
chore(Skeleton): Add subcomponent controls and show prop descriptions

### DIFF
--- a/documentation/component-docs.md
+++ b/documentation/component-docs.md
@@ -59,6 +59,9 @@ Sections are optional: omit any section that has no meaningful content for the c
 1. **Title and description** – `<Title />` and `<Description of={…} />`, rendered from the component’s TSDoc via react-docgen.
 2. **Primary story and Controls** – `<Primary />` and `<Controls />`.
    If the component has no props of its own, replace `<Controls />` with the sentence ‘This component has no props to configure.’ – an empty table would suggest missing documentation, and omitting the block silently would leave readers guessing.
+   A container whose Primary story composes its parts, such as Skeleton, is the exception: give that story an arg for each choice the example makes, so the table configures the parts rather than standing empty.
+   Keep `<Controls />` in that case and follow it with the sentence, which still tells readers that the container itself takes no props.
+   Describe those args in `argTypes`: they belong to the story rather than to a component, so no JSDoc describes them.
 3. **Subcomponents** – if the component has named subcomponents, an H2 that names all of them, with an H3 for each subcomponent that offers choices of its own.
    Omit if there are none.
 4. **Usage guidelines** – an H2 with up to four H3 subsections: ‘When to use’, ‘When not to use’, ‘How to use’, and ‘How to write’.

--- a/storybook/src/components/Skeleton/Skeleton.docs.mdx
+++ b/storybook/src/components/Skeleton/Skeleton.docs.mdx
@@ -6,6 +6,11 @@ import { DesignTokensTable } from "#storybook/_components/DesignTokensTable/Desi
 import tokens from "#tokens/components/ams/skeleton.tokens.json";
 
 import * as SkeletonStories from "./Skeleton.stories.tsx";
+import * as SkeletonHeadingStories from "./SkeletonHeading.stories.tsx";
+import * as SkeletonImageStories from "./SkeletonImage.stories.tsx";
+import * as SkeletonListStories from "./SkeletonList.stories.tsx";
+import * as SkeletonParagraphStories from "./SkeletonParagraph.stories.tsx";
+import * as SkeletonTableStories from "./SkeletonTable.stories.tsx";
 
 <Meta of={SkeletonStories} />
 
@@ -33,43 +38,43 @@ Set the `lines`, `rows`, and `columns` props to approximate the amount of conten
 Lines the size of a Heading.
 Set `lines` above one for a heading that wraps onto several lines.
 
-<Canvas of={SkeletonStories.Heading} />
+<Canvas of={SkeletonHeadingStories.Heading} />
 
-<Controls of={SkeletonStories.Heading} />
+<Controls of={SkeletonHeadingStories.Heading} />
 
 ### Paragraph
 
 Lines the size of body text.
 Their lengths alternate between two widths, and the last line of a multi-line paragraph is shorter, approximating its ragged end.
 
-<Canvas of={SkeletonStories.Paragraph} />
+<Canvas of={SkeletonParagraphStories.Paragraph} />
 
-<Controls of={SkeletonStories.Paragraph} />
+<Controls of={SkeletonParagraphStories.Paragraph} />
 
 ### List
 
 Body-text lines, each with a marker, indented like an Unordered List.
 
-<Canvas of={SkeletonStories.List} />
+<Canvas of={SkeletonListStories.List} />
 
-<Controls of={SkeletonStories.List} />
+<Controls of={SkeletonListStories.List} />
 
 ### Table
 
 A grid of cells.
 
-<Canvas of={SkeletonStories.Table} />
+<Canvas of={SkeletonTableStories.Table} />
 
-<Controls of={SkeletonStories.Table} />
+<Controls of={SkeletonTableStories.Table} />
 
 ### Image
 
 A block that stands in for an image.
 Set the `aspectRatio` prop to match the image that will replace it; it defaults to 16:9.
 
-<Canvas of={SkeletonStories.Image} />
+<Canvas of={SkeletonImageStories.Image} />
 
-<Controls of={SkeletonStories.Image} />
+<Controls of={SkeletonImageStories.Image} />
 
 ## Usage guidelines
 

--- a/storybook/src/components/Skeleton/Skeleton.docs.mdx
+++ b/storybook/src/components/Skeleton/Skeleton.docs.mdx
@@ -15,10 +15,12 @@ import * as SkeletonStories from "./Skeleton.stories.tsx";
 
 <Primary />
 
+<Controls />
+
 The Skeleton container takes only the parts you compose inside it and hides them from assistive technologies.
 Each part has its own options, documented under Subcomponents.
 
-The container itself has no props to configure.
+The container itself has no props to configure; the controls above set the props of the parts in this example.
 
 ## Subcomponents
 

--- a/storybook/src/components/Skeleton/Skeleton.stories.tsx
+++ b/storybook/src/components/Skeleton/Skeleton.stories.tsx
@@ -32,11 +32,22 @@ export const Default: DefaultStory = {
     headingLines: 1,
     paragraphLines: 3,
   },
-  // These argTypes describe flattened args specific to this composed story; the meta cannot provide them.
+  // These args are specific to this composed story, so they have no JSDoc to describe them: the meta
+  // provides the props of the container, not those of the parts. Hence the descriptions below.
   argTypes: {
-    aspectRatio: { control: 'select', options: aspectRatioOptions },
-    headingLines: { control: { min: 1, step: 1, type: 'number' } },
-    paragraphLines: { control: { min: 1, step: 1, type: 'number' } },
+    aspectRatio: {
+      control: 'select',
+      description: 'The aspect ratio of the Image in this example.',
+      options: aspectRatioOptions,
+    },
+    headingLines: {
+      control: { min: 1, step: 1, type: 'number' },
+      description: 'The number of lines the Heading in this example spans.',
+    },
+    paragraphLines: {
+      control: { min: 1, step: 1, type: 'number' },
+      description: 'The number of lines the Paragraph in this example spans.',
+    },
   },
   decorators: [maximiseInlineSize('24rem')],
   render: ({ aspectRatio, headingLines, paragraphLines, ...args }) => (
@@ -44,60 +55,6 @@ export const Default: DefaultStory = {
       <Skeleton.Image aspectRatio={aspectRatio} />
       <Skeleton.Heading lines={headingLines} />
       <Skeleton.Paragraph lines={paragraphLines} />
-    </Skeleton>
-  ),
-}
-
-export const Heading: StoryObj<{ lines: number }> = {
-  args: { lines: 2 },
-  argTypes: { lines: { control: { min: 1, step: 1, type: 'number' } } },
-  render: ({ lines }) => (
-    <Skeleton>
-      <Skeleton.Heading lines={lines} />
-    </Skeleton>
-  ),
-}
-
-export const Paragraph: StoryObj<{ lines: number }> = {
-  args: { lines: 3 },
-  argTypes: { lines: { control: { min: 1, step: 1, type: 'number' } } },
-  render: ({ lines }) => (
-    <Skeleton>
-      <Skeleton.Paragraph lines={lines} />
-    </Skeleton>
-  ),
-}
-
-export const List: StoryObj<{ lines: number }> = {
-  args: { lines: 3 },
-  argTypes: { lines: { control: { min: 1, step: 1, type: 'number' } } },
-  render: ({ lines }) => (
-    <Skeleton>
-      <Skeleton.List lines={lines} />
-    </Skeleton>
-  ),
-}
-
-export const Table: StoryObj<{ columns: number; rows: number }> = {
-  args: { columns: 3, rows: 3 },
-  argTypes: {
-    columns: { control: { min: 1, step: 1, type: 'number' } },
-    rows: { control: { min: 1, step: 1, type: 'number' } },
-  },
-  render: ({ columns, rows }) => (
-    <Skeleton>
-      <Skeleton.Table columns={columns} rows={rows} />
-    </Skeleton>
-  ),
-}
-
-export const Image: StoryObj<{ aspectRatio: (typeof aspectRatioOptions)[number] }> = {
-  args: { aspectRatio: '16:9' },
-  argTypes: { aspectRatio: { control: 'select', options: aspectRatioOptions } },
-  decorators: [maximiseInlineSize('24rem')],
-  render: ({ aspectRatio }) => (
-    <Skeleton>
-      <Skeleton.Image aspectRatio={aspectRatio} />
     </Skeleton>
   ),
 }

--- a/storybook/src/components/Skeleton/Skeleton.stories.tsx
+++ b/storybook/src/components/Skeleton/Skeleton.stories.tsx
@@ -4,6 +4,7 @@
  */
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { ComponentProps } from 'react'
 
 import { Skeleton } from '@amsterdam/design-system-react/src'
 import { aspectRatioOptions } from '@amsterdam/design-system-react/src/common/types'
@@ -17,13 +18,34 @@ const meta = {
 
 export default meta
 
-type Story = StoryObj<typeof meta>
+type DefaultProps = {
+  aspectRatio: (typeof aspectRatioOptions)[number]
+  headingLines: number
+  paragraphLines: number
+} & Readonly<ComponentProps<typeof Skeleton>>
 
-export const Default: Story = {
+type DefaultStory = StoryObj<DefaultProps>
+
+export const Default: DefaultStory = {
   args: {
-    children: [<Skeleton.Image key={1} />, <Skeleton.Heading key={2} />, <Skeleton.Paragraph key={3} lines={3} />],
+    aspectRatio: '16:9',
+    headingLines: 1,
+    paragraphLines: 3,
+  },
+  // These argTypes describe flattened args specific to this composed story; the meta cannot provide them.
+  argTypes: {
+    aspectRatio: { control: 'select', options: aspectRatioOptions },
+    headingLines: { control: { min: 1, step: 1, type: 'number' } },
+    paragraphLines: { control: { min: 1, step: 1, type: 'number' } },
   },
   decorators: [maximiseInlineSize('24rem')],
+  render: ({ aspectRatio, headingLines, paragraphLines, ...args }) => (
+    <Skeleton {...args}>
+      <Skeleton.Image aspectRatio={aspectRatio} />
+      <Skeleton.Heading lines={headingLines} />
+      <Skeleton.Paragraph lines={paragraphLines} />
+    </Skeleton>
+  ),
 }
 
 export const Heading: StoryObj<{ lines: number }> = {

--- a/storybook/src/components/Skeleton/SkeletonHeading.stories.tsx
+++ b/storybook/src/components/Skeleton/SkeletonHeading.stories.tsx
@@ -1,0 +1,29 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Skeleton } from '@amsterdam/design-system-react/src'
+
+const meta = {
+  title: 'Components/Feedback/Skeleton',
+  component: Skeleton.Heading,
+  argTypes: {
+    lines: { control: { min: 1, step: 1, type: 'number' } },
+  },
+  render: (args) => (
+    <Skeleton>
+      <Skeleton.Heading {...args} />
+    </Skeleton>
+  ),
+} satisfies Meta<typeof Skeleton.Heading>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Heading: Story = {
+  args: { lines: 2 },
+}

--- a/storybook/src/components/Skeleton/SkeletonImage.stories.tsx
+++ b/storybook/src/components/Skeleton/SkeletonImage.stories.tsx
@@ -1,0 +1,33 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Skeleton } from '@amsterdam/design-system-react/src'
+import { aspectRatioOptions } from '@amsterdam/design-system-react/src/common/types'
+
+import { maximiseInlineSize } from '#storybook/_common/decorators'
+
+const meta = {
+  title: 'Components/Feedback/Skeleton',
+  component: Skeleton.Image,
+  argTypes: {
+    aspectRatio: { control: 'select', options: aspectRatioOptions },
+  },
+  decorators: [maximiseInlineSize('24rem')],
+  render: (args) => (
+    <Skeleton>
+      <Skeleton.Image {...args} />
+    </Skeleton>
+  ),
+} satisfies Meta<typeof Skeleton.Image>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Image: Story = {
+  args: { aspectRatio: '16:9' },
+}

--- a/storybook/src/components/Skeleton/SkeletonList.stories.tsx
+++ b/storybook/src/components/Skeleton/SkeletonList.stories.tsx
@@ -1,0 +1,29 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Skeleton } from '@amsterdam/design-system-react/src'
+
+const meta = {
+  title: 'Components/Feedback/Skeleton',
+  component: Skeleton.List,
+  argTypes: {
+    lines: { control: { min: 1, step: 1, type: 'number' } },
+  },
+  render: (args) => (
+    <Skeleton>
+      <Skeleton.List {...args} />
+    </Skeleton>
+  ),
+} satisfies Meta<typeof Skeleton.List>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const List: Story = {
+  args: { lines: 3 },
+}

--- a/storybook/src/components/Skeleton/SkeletonParagraph.stories.tsx
+++ b/storybook/src/components/Skeleton/SkeletonParagraph.stories.tsx
@@ -1,0 +1,29 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Skeleton } from '@amsterdam/design-system-react/src'
+
+const meta = {
+  title: 'Components/Feedback/Skeleton',
+  component: Skeleton.Paragraph,
+  argTypes: {
+    lines: { control: { min: 1, step: 1, type: 'number' } },
+  },
+  render: (args) => (
+    <Skeleton>
+      <Skeleton.Paragraph {...args} />
+    </Skeleton>
+  ),
+} satisfies Meta<typeof Skeleton.Paragraph>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Paragraph: Story = {
+  args: { lines: 3 },
+}

--- a/storybook/src/components/Skeleton/SkeletonTable.stories.tsx
+++ b/storybook/src/components/Skeleton/SkeletonTable.stories.tsx
@@ -1,0 +1,30 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Skeleton } from '@amsterdam/design-system-react/src'
+
+const meta = {
+  title: 'Components/Feedback/Skeleton',
+  component: Skeleton.Table,
+  argTypes: {
+    columns: { control: { min: 1, step: 1, type: 'number' } },
+    rows: { control: { min: 1, step: 1, type: 'number' } },
+  },
+  render: (args) => (
+    <Skeleton>
+      <Skeleton.Table {...args} />
+    </Skeleton>
+  ),
+} satisfies Meta<typeof Skeleton.Table>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Table: Story = {
+  args: { columns: 3, rows: 3 },
+}


### PR DESCRIPTION
## Links

- [Documentation guidelines](https://github.com/Amsterdam/design-system/blob/main/documentation/component-docs.md?plain=1#L60) – the rule this PR extends.
- [Storybook guidelines: prop descriptions](https://github.com/Amsterdam/design-system/blob/develop/documentation/storybook.md?plain=1#L26) – the policy this PR follows.
- (Links to the stories in the feature branch deploy follow once it is ready.)

## What

The Default story of Skeleton gains controls for the parts it composes: the aspect ratio of the Image, and the number of lines of the Heading and the Paragraph.
The documentation page gains the `<Controls />` block that goes with it.

Every Controls block of Skeleton now shows a description per prop, on the documentation page as well as on the story pages.
To get there, each subcomponent moved into its own story file, and the guidelines gained a note about a container that has no props of its own.

## Why

The Default story showed the composition of Skeleton but offered nothing to configure, so the parts could only be explored one story at a time.
Its Controls block was missing for the same reason: the container has no props of its own, and an empty table reads as missing documentation.

The subcomponent props were described with JSDoc, but none of those descriptions reached Storybook.
A story only picks up docgen from the component of its meta, which was the Skeleton container for all of them.
Their props therefore arrived as plain args, and the Controls blocks showed a bare type where a description belongs.

## How

The subcomponent stories moved into a story file each, with the subcomponent as the component of their meta – the structure the Card and Figure stories already use.
Docgen now fills in the description of every subcomponent prop, and the `@default` tags fill in the Default column as a bonus.
The stories keep their names and titles, so their ids, their deep links and the Skeleton entry in the sidebar are unchanged.
Their meta renders each part inside a Skeleton, which keeps the container visible in the code panel.

The args of the Default story describe themselves in `argTypes`.
They belong to the composed story rather than to a component, so no JSDoc describes them – the case the guidelines reserve `argTypes.description` for.

The rule in `component-docs.md` that replaces `<Controls />` with a sentence assumes an empty table.
It gained the exception this PR runs into: a container whose Primary story composes its parts fills that table with the choices the example makes, so it keeps the block and adds the sentence below it.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- No visual change is intended.
- The Image of the Default story now carries an explicit `ams-aspect-ratio-16-9` class, where it relied on `--ams-skeleton-image-aspect-ratio` before.
  Both resolve to `16 / 9`, so the story renders as it did.
- The Test story is untouched and defines its own render, so it holds no coupling to the argTypes that moved.
- Worth a second opinion: the Default story describes its args in `argTypes`, and the note in `component-docs.md` sanctions that.
  Both are exceptions to a policy that is otherwise strict about descriptions living in JSDoc, so please read them as such.
