### PR TITLE
chore(Storybook): Add a Release notes page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ For details, rely on the official documentation and per-package instructions:
 - Accessibility and quality: [documentation/definition-of-done.md](documentation/definition-of-done.md) (full quality checklist including WCAG 2.2 Level AA).
 - Component docs and Storybook: [documentation/component-docs.md](documentation/component-docs.md) and [documentation/storybook.md](documentation/storybook.md).
 - Git and contribution workflow: [documentation/git.md](documentation/git.md), [documentation/code-reviews.md](documentation/code-reviews.md), and [documentation/publishing.md](documentation/publishing.md).
+- Release notes: [documentation/release-notes.md](documentation/release-notes.md) — how to summarise a release for the people who use the design system, and why the changelogs alone are not enough.
 
 Key agent expectations:
 

--- a/documentation/release-notes.md
+++ b/documentation/release-notes.md
@@ -295,4 +295,4 @@ Concretely:
   On 12 July 2026 six icons and a set of field tokens were three days past theirs, and no changelog mentioned it.
   These belong in the notes for the release that removes them, but they are worth raising with the team when you notice.
 - Confirm the release notes sort right after the Introduction: add the entry to `storySort.order` in [storybook/config/preview.tsx](../storybook/config/preview.tsx).
-- Run `npx prettier --check` and `npx eslint` on the file, and build Storybook once to confirm the MDX compiles.
+- Run `pnpm exec prettier --check` and `pnpm exec eslint` on the file, and build Storybook once to confirm the MDX compiles.

--- a/documentation/release-notes.md
+++ b/documentation/release-notes.md
@@ -1,0 +1,166 @@
+<!-- @license CC0-1.0 -->
+
+# Writing release notes
+
+Release notes live in Storybook at [storybook/src/docs/release-notes.docs.mdx](../storybook/src/docs/release-notes.docs.mdx), directly below the Introduction.
+This guide describes how to write them, for any release, past or future.
+
+## Why the page exists
+
+The changelogs record every change.
+That is a different job from telling someone what a release means for them.
+A changelog answers ‘what did you commit’; release notes answer ‘what is new, what should I do, and can I upgrade today’.
+
+The page is also the only home some changes have.
+Our documentation, examples and page templates live in Storybook rather than in a package, so nothing about them reaches a `CHANGELOG.md`.
+If the release notes do not mention a new template or guideline, no one finds out about it.
+
+## Who reads it
+
+Business owners, designers and developers, in one page.
+Write so all three can read the same sentence and each take something from it.
+That rules out both extremes: no raw commit subjects, and no vague reassurance without specifics.
+
+A useful test per entry: could a designer tell what changed on screen, and could a developer tell what to type?
+
+## What it is not
+
+It is not a complete picture.
+Leave out refactors, dependency bumps, CI, tests, tooling, linting, and documentation aimed at people contributing _to_ the design system rather than building _with_ it.
+These are assumed.
+Including them buries the few things that actually matter.
+
+Everything you leave out is a choice you should be able to defend in one sentence.
+Everything you include should change what a reader does next.
+
+## Establishing the release window
+
+Every release is bounded by two `chore: release main` commits on `main`.
+Find them, then read everything between:
+
+```sh
+git log --oneline --all --grep="chore: release main"
+git log --format="%h %ad %s" --date=short <previous-release>..<this-release>
+```
+
+That range is the truth.
+Work from it, and use the sources below to interpret it — never the other way around.
+
+## Sources, and how each one lies
+
+**Each package’s `CHANGELOG.md`** gives the versions and the dates.
+Take the version numbers from the section headings that carry the release date.
+But do not treat the changelogs as a complete inventory, for two reasons:
+
+- Release-please occasionally drops a commit.
+  In the 12 July 2026 release, `feat(Accordion): Add an onToggle callback to Section` (#2758) shipped in React 4.3.0 — the property is in the published package — yet it appears in no changelog.
+  Every sibling `feat` from the same week made it in.
+- `chore:` commits never reach a changelog by design, and some of them are user-facing.
+  In the same release, #2728 activated the `locale` and `dir` properties on Calendar and Date Picker, and #2785 added property documentation that ships in the Controls table and in IDE tooltips.
+
+So: reconcile the commit range against the changelogs, and report the difference.
+A user-facing change that shipped but reached no changelog is not an edge case to tidy away — it is the single most valuable thing the release notes can carry, because it exists nowhere else.
+
+**The release preview pull request** (`chore: Preview the next release`) is a good starting inventory.
+It is a draft written before the release, so it can be wrong in both directions: it may promise something that slipped, and its links may point at pages that were later renamed or deleted.
+The 12 July preview linked a ‘Language guide’ that a commit in the same release had already renamed to Localisation.
+Verify every claim and every link against the tree.
+
+**Summaries written for other audiences** — a Slack post, a note to a partner team — are useful for tone and for spotting what someone thought was worth saying.
+They are not a scope.
+They are often cumulative, covering several releases at once, so lifting one wholesale silently pulls in changes from earlier releases.
+
+**The code** settles every disagreement.
+Read the diff before describing a change.
+
+## Structure
+
+One `##` section per release, newest first, dated `## 12 July 2026`.
+Split the page into one page per release if it ever grows unwieldy.
+
+### Versions
+
+Open with a single paragraph: package names in alphabetical order, version numbers bold.
+
+> Assets **2.5.0**, CSS **4.3.0**, React **4.3.0**, React Icons **2.2.0**, Tokens **4.2.0**.
+
+Hard-code them.
+The `PackageVersions` component on the Introduction reads the live manifests, so it always shows the latest — which is wrong for a release note about a specific past release.
+
+### Framing
+
+Two or three sentences naming the essence of the release, before any list.
+Most releases have a theme; find it.
+State plainly whether anything breaks.
+
+### Changed, New, Improved, Fixed
+
+Use these four headings rather than ‘Breaking’, ‘Features’ and ‘Bugfixes’.
+They describe the reader’s experience instead of our commit conventions, and they let a release with no breaking changes still be honest about what moved.
+
+- **Changed** — existing markup renders or behaves differently, with no action required.
+  Visual shifts, new defaults, deprecations.
+  For a major release, this is where breaking changes go, with migration steps.
+- **New** — did not exist before.
+- **Improved** — an existing component gained something optional.
+- **Fixed** — a bug that is gone.
+
+An item belongs in exactly one bucket.
+When a change is both an improvement and a shift in behaviour, put it in **Changed** — that is what the reader needs to notice.
+Scroll containment and a scroll lock read as improvements from our side; from the reader’s side they change how a page they already shipped behaves.
+
+Where several components gained the same kind of capability, write a short paragraph instead of scattering identical bullets.
+The 12 July notes do this for the collapsibles that became controllable: one paragraph on why you would want it, then one line per component.
+
+### Documentation
+
+A separate section, always.
+This covers new examples, new page templates and new or changed guidelines.
+It exists because these changes are in no changelog, and this is the only place anyone will learn of them.
+
+Apply the same filter as everywhere else: guidance for people _using_ the design system, not for people maintaining it.
+
+### Upgrading
+
+Three questions, in this order, each as a `####` heading:
+
+1. **Do you need to change anything?**
+   For anything short of a major release the answer is **No**, and it should be stated in one word before any qualification.
+   Say why it holds: nothing removed, every new property optional.
+   Then note anything to migrate at leisure, with its deadline.
+   For a major release, this is where the migration steps go.
+2. **What you could start using.**
+   The new capabilities, framed as an offer rather than an obligation.
+3. **Bugs you may have run into.**
+   The fixes, restated as symptoms a reader might recognise from their own work.
+   ‘A Menu that grew past its maximum width’ lands where ‘Keep the horizontal padding inside the maximum inline size’ does not.
+
+## Voice
+
+The undercurrent: a design system that never changed would be one that had stopped listening.
+Change is the product, not an apology for it.
+What makes change safe is documentation and a choice about when to follow — so the notes should read as confident, not defensive, and never bury a shift to make a release look calmer than it is.
+
+Concretely:
+
+- Write Markdown with one sentence per line, as everywhere in this repository.
+- Sentence case for headings; title case for component names, so readers recognise them.
+- Link a component on its **first** occurrence, to its documentation page or to the specific story that shows the change.
+  Plain title case after that.
+- Prefer the plain word.
+  ‘Property’ over ‘prop’ in prose, since designers read this too.
+- Give numbers where a number is what someone needs: ‘4 and 8 pixels tighter’, not ‘slightly tighter’.
+- No commit hashes, no pull request numbers.
+  Anyone who wants that has the changelog.
+
+## Before you publish
+
+- Derive every link from the `title:` of the story or the `<Meta title>` of the page, kebab-cased: `Components/Feedback/Skeleton` becomes `/docs/components-feedback-skeleton--docs`.
+  Check each target exists rather than pattern-matching from memory; pages get renamed.
+- Reconcile the commit range against the changelogs in both directions, and account for every gap.
+- Verify the ‘nothing breaks’ claim against the changelogs _and_ the range: look for `!` in commit subjects, `BREAKING CHANGE:` footers, removals, and required properties.
+- Check whether any existing deprecation has passed its removal date.
+  On 12 July 2026 six icons and a set of field tokens were three days past theirs, and no changelog mentioned it.
+  These belong in the notes for the release that removes them, but they are worth raising with the team when you notice.
+- Confirm the release notes sort right after the Introduction: add the entry to `storySort.order` in [storybook/config/preview.tsx](../storybook/config/preview.tsx).
+- Run `npx prettier --check` and `npx eslint` on the file, and build Storybook once to confirm the MDX compiles.

--- a/documentation/release-notes.md
+++ b/documentation/release-notes.md
@@ -182,6 +182,14 @@ List only the ones that did, and say so in a second line: ‘Assets and React Ic
 Then check the published peer dependencies of the packages that did move, because they pin exact versions and that is what a reader actually has to install.
 On 24 April only CSS, React and Tokens moved, but CSS 4.1.0 still asks for Assets 2.3.0, which had arrived four days earlier.
 
+Append the changelog link to the end of the version-numbers line, in parentheses before the full stop:
+‘…, Tokens **4.2.0** ([changelogs](…)).’
+Link the release-please ‘chore: release main’ pull request for that release: its description is the structured per-package changelog, and every release has one.
+Find it with `gh pr list --repo Amsterdam/design-system --base main --search "chore: release main"`, or from the ‘chore: release main’ commit that bounds the window.
+Do not link the ‘develop → main’ pull request: its body is empty boilerplate, and the releases before June 2026 have none.
+Keep the pull request number in the URL only, never in the link text.
+See the note under Voice.
+
 ### Framing
 
 Two or three sentences naming the essence of the release, before any list.
@@ -280,8 +288,9 @@ Concretely:
 - Use a numbered list when the count is the point.
   ‘Two things to know’ and ‘three components’ earn one.
   A set of unordered options does not.
-- No commit hashes, no pull request numbers.
+- No commit hashes, and no pull request numbers in the prose.
   Anyone who wants that has the changelog.
+  The one allowed pull request link is the release changelog on the version-numbers line, and even there the number stays in the URL, never in the link text.
 
 ## Before you publish
 

--- a/documentation/release-notes.md
+++ b/documentation/release-notes.md
@@ -44,7 +44,8 @@ git log --format="%h %ad %s" --date=short <previous-release>..<this-release>
 ```
 
 That range is the truth.
-Work from it, and use the sources below to interpret it — never the other way around.
+Work from it.
+Use the sources below to interpret it, never the other way around.
 
 ## Sources, and how each one lies
 
@@ -53,24 +54,28 @@ Take the version numbers from the section headings that carry the release date.
 But do not treat the changelogs as a complete inventory, for two reasons:
 
 - Release-please occasionally drops a commit.
-  In the 12 July 2026 release, `feat(Accordion): Add an onToggle callback to Section` (#2758) shipped in React 4.3.0 — the property is in the published package — yet it appears in no changelog.
+  In the 12 July 2026 release, `feat(Accordion): Add an onToggle callback to Section` (#2758) shipped in React 4.3.0.
+  The property is in the published package.
+  It appears in no changelog.
   Every sibling `feat` from the same week made it in.
 - `chore:` commits never reach a changelog by design, and some of them are user-facing.
   In the same release, #2728 documented how to localise Calendar and Date Picker, and #2785 added property documentation that ships in the Controls table and in IDE tooltips.
 
 So: reconcile the commit range against the changelogs, and report the difference.
-A user-facing change that shipped but reached no changelog is not an edge case to tidy away — it is the single most valuable thing the release notes can carry, because it exists nowhere else.
+A user-facing change that shipped but reached no changelog is not an edge case to tidy away.
+It is the single most valuable thing the release notes can carry, because it exists nowhere else.
 
 **The release preview pull request** (`chore: Preview the next release`) is a good starting inventory.
 It is a draft written before the release, so it can be wrong in both directions: it may promise something that slipped, and its links may point at pages that were later renamed or deleted.
 The 12 July preview linked a ‘Language guide’ that a commit in the same release had already renamed to Localisation.
 Verify every claim and every link against the tree.
 
-**Summaries written for other audiences** — a Slack post, a note to a partner team — are useful for tone and for spotting what someone thought was worth saying.
+**Summaries written for other audiences**, such as a Slack post or a note to a partner team, are useful for tone.
+They also show what someone thought was worth saying.
 They are not a scope.
 They are often cumulative, covering several releases at once, so lifting one wholesale silently pulls in changes from earlier releases.
 
-**A pull request description** — ours or an agent’s — states an intention.
+**A pull request description**, ours or an agent’s, states an intention.
 The merged code states the outcome.
 They diverge more often than you would expect, and a title is the least reliable part of both: #2728 is titled ‘Activate and document the `locale` and `dir` props’, but there is no `dir` property on either component.
 It is a Storybook control derived from the locale.
@@ -86,24 +91,30 @@ They share a shape: a claim that is nearly true, in a sentence that reads well.
 1. **A capability that only half landed.**
    The 12 July draft said four components became controllable.
    Three did.
-   Accordion Section only gained an `onToggle` callback — it runs `useCollapsible` in uncontrolled mode, and its `expanded` is a deprecated alias for `defaultExpanded` until October, so the name is not free yet.
+   Accordion Section only gained an `onToggle` callback.
+   It runs `useCollapsible` in uncontrolled mode.
+   Its `expanded` is a deprecated alias for `defaultExpanded` until October, so the name is not free yet.
    A reader who acted on the draft would have passed `expanded` to Accordion, earned a deprecation warning, and watched the value be treated as an initial default.
    Check the implementation, not the property name: `defaultValue` is uncontrolled, `value` is controlled.
 2. **A group with one member that does not belong.**
    The draft said Dialog, Table, Tabs and Tab Navigation all clip vertical overflow.
-   Dialog does the opposite — its body keeps `overflow-y: auto`, because it is the scroll container.
+   Dialog does the opposite.
+   Its body keeps `overflow-y: auto`, because it is the scroll container.
    When a commit names four components, check all four.
 3. **A token mistaken for the thing it names.**
    The draft said Amsterdam Sans gained three weights and an italic.
    Only the black weight is a new font file; light, extra bold and italic were already shipping and merely gained tokens.
    ‘Added a token for X’ and ‘added X’ are different sentences.
 4. **A guarantee with unstated preconditions.**
-   The modal Dialog scroll lock needs the `ams-body` class on the consumer’s `<body>`, sits behind an `@supports` query, and does not hold on iOS Safari touch — the source comment says so.
+   The modal Dialog scroll lock needs the `ams-body` class on the consumer’s `<body>`.
+   It sits behind an `@supports` query.
+   It does not hold on iOS Safari touch, and the source comment says so.
    The draft told readers to delete their own scroll lock.
    Before writing ‘you can remove your workaround’, read the implementation for the cases where it still fails.
 5. **A pattern assumed to be uniform.**
    All five packages look like they pin each other.
-   React Icons does not — it depends only on React.
+   React Icons does not.
+   It depends only on React.
    Check each one; do not generalise from two.
 6. **A count that is not counting what you think.**
    ‘23 component pages’ was the number of files a commit touched; only 21 gained the section being described.
@@ -111,8 +122,13 @@ They share a shape: a claim that is nearly true, in a sentence that reads well.
 
 ## Structure
 
-One `##` section per release, newest first, dated `## 12 July 2026`.
-Split the page into one page per release if it ever grows unwieldy.
+One page, with one `##` section per release, newest first, dated `## 12 July 2026`.
+
+Keep it one page.
+Storybook cannot make a node both a page and a folder.
+Giving each release its own page under `Docs/Release notes/…` turns ‘Release notes’ into a folder, and the index page then appears beside the releases as a stray entry labelled ‘Docs’.
+That is not fixable from the file: unattached MDX entries are always named ‘Docs’, and `MetaProps` is only `{ of?, title? }`, so there is no `name` to override.
+If the page ever does grow unwieldy, the way out is a folder of releases plus a separate child page for the index, not a page that is also a folder.
 
 ### Versions
 
@@ -121,7 +137,8 @@ Open with a single paragraph: package names in alphabetical order, version numbe
 > Assets **2.5.0**, CSS **4.3.0**, React **4.3.0**, React Icons **2.2.0**, Tokens **4.2.0**.
 
 Hard-code them.
-The `PackageVersions` component on the Introduction reads the live manifests, so it always shows the latest — which is wrong for a release note about a specific past release.
+The `PackageVersions` component on the Introduction reads the live manifests, so it always shows the latest.
+That is wrong for a release note about a specific past release.
 
 ### Framing
 
@@ -129,30 +146,35 @@ Two or three sentences naming the essence of the release, before any list.
 Most releases have a theme; find it.
 State plainly whether anything breaks.
 
-### Changed, New, Improved, Fixed
+### New, Changed, Improved, Fixed
 
-Use these four headings rather than ‘Breaking’, ‘Features’ and ‘Bugfixes’.
-They describe the reader’s experience instead of our commit conventions, and they let a release with no breaking changes still be honest about what moved.
+Use these four headings, in this order, rather than ‘Breaking’, ‘Features’ and ‘Bugfixes’.
+They describe the reader’s experience instead of our commit conventions.
+They also let a release with no breaking changes still be honest about what moved.
+**New** leads, because that is what people came for.
 
-- **Changed** — existing markup renders or behaves differently, with no action required.
-  Visual shifts, new defaults, deprecations.
-  For a major release, this is where breaking changes go, with migration steps.
-- **New** — did not exist before.
-- **Improved** — an existing component gained something optional.
-- **Fixed** — a bug that is gone.
+1. **New**: did not exist before.
+2. **Changed**: existing markup renders or behaves differently, with no action required.
+   Visual shifts, new defaults, deprecations.
+   For a major release, this is where breaking changes go, with migration steps.
+3. **Improved**: an existing component gained something optional.
+4. **Fixed**: a bug that is gone.
 
 An item belongs in exactly one bucket.
-When a change is both an improvement and a shift in behaviour, put it in **Changed** — that is what the reader needs to notice.
-Scroll containment and a scroll lock read as improvements from our side; from the reader’s side they change how a page they already shipped behaves.
+When a change is both an improvement and a shift in behaviour, put it in **Changed**.
+That is what the reader needs to notice.
+Scroll containment and a scroll lock read as improvements from our side.
+From the reader’s side they change how a page they already shipped behaves.
 
 Where several components gained the same kind of capability, write a short paragraph instead of scattering identical bullets.
 The 12 July notes do this for the collapsibles that became controllable: one paragraph on why you would want it, then one line per component.
 
-### Documentation
+### Docs
 
 A separate section, always.
 This covers new examples, new page templates and new or changed guidelines.
-It exists because these changes are in no changelog, and this is the only place anyone will learn of them.
+It exists because these changes are in no changelog.
+This is the only place anyone will learn of them.
 
 Apply the same filter as everywhere else: guidance for people _using_ the design system, not for people maintaining it.
 
@@ -175,22 +197,35 @@ Three questions, in this order, each as a `####` heading:
 
 The undercurrent: a design system that never changed would be one that had stopped listening.
 Change is the product, not an apology for it.
-What makes change safe is documentation and a choice about when to follow — so the notes should read as confident, not defensive, and never bury a shift to make a release look calmer than it is.
+What makes change safe is documentation and a choice about when to follow.
+So the notes should read as confident, not defensive.
+Never bury a shift to make a release look calmer than it is.
 
 Keep that as an undercurrent.
-It is carried by the structure — a deprecation with a date on it, ‘every new property is optional’, a **Changed** section that admits what moved — and it dies the moment you say it out loud.
+The structure carries it: a deprecation with a date on it, ‘every new property is optional’, a **Changed** section that admits what moved.
+It dies the moment you say it out loud.
 An opening aphorism about change being good is the one thing guaranteed not to convince anybody.
 Cut it and let the page prove the point.
 
 Concretely:
 
 - Write Markdown with one sentence per line, as everywhere in this repository.
-- Sentence case for headings; title case for component names, so readers recognise them.
-- Link a component on its **first** occurrence, to its documentation page or to the specific story that shows the change.
-  Plain title case after that.
+- Keep sentences short and simple.
+  Avoid compound sentences: two independent clauses joined by ‘and’, ‘but’ or ‘so’ are two sentences.
+  Split them.
+- Never use an em dash.
+  A full stop, a colon, or a pair of commas will do the same work.
+- Sentence case for headings.
+  Title case for component names, so readers recognise them.
+- Link a component on its first occurrence **in each section**, to its documentation page or to the specific story that shows the change.
+  Plain title case for the rest of that section.
+  Readers scan one section at a time, so each should stand on its own.
 - Prefer the plain word.
   ‘Property’ over ‘prop’ in prose, since designers read this too.
 - Give numbers where a number is what someone needs: ‘4 and 8 pixels tighter’, not ‘slightly tighter’.
+- Use a numbered list when the count is the point.
+  ‘Two things to know’ and ‘three components’ earn one.
+  A set of unordered options does not.
 - No commit hashes, no pull request numbers.
   Anyone who wants that has the changelog.
 

--- a/documentation/release-notes.md
+++ b/documentation/release-notes.md
@@ -143,6 +143,15 @@ Expect to make several of them per release, and budget a verification pass to fi
     Progress List’s `collapsed` was the current API in June and deprecated in July.
     Describing June from HEAD would have announced a deprecation that had not happened yet.
     Read the tree at the release commit: `git show <release-commit>:<path>`.
+11. **A cause you find satisfying is still a claim.**
+    The April draft said Compact Mode got the grid padding ‘the major had meant to give it’.
+    The bug predated the major by a year, and the padding had never been narrower than the default at any width.
+    A tidy story about why a bug existed is the easiest thing to get wrong, because it is the part you infer rather than read.
+    Trace the token’s history with `git log -S` before you assign blame, or just describe the fix and skip the cause.
+12. **Which release did a dependency version come from.**
+    The April draft said Tokens 4.0.1 arrived with the major four days earlier.
+    It was the patch in the release being written about.
+    When you say a version ‘arrived with’ something, read its changelog date rather than assuming it rode along with a neighbour.
 
 ## Structure
 
@@ -164,6 +173,11 @@ Hard-code them.
 The `PackageVersions` component on the Introduction reads the live manifests, so it always shows the latest.
 That is wrong for a release note about a specific past release.
 
+Not every release moves all five packages.
+List only the ones that did, and say so in a second line: ‘Assets and React Icons did not move this time.’
+Then check the published peer dependencies of the packages that did move, because they pin exact versions and that is what a reader actually has to install.
+On 24 April only CSS, React and Tokens moved, but CSS 4.1.0 still asks for Assets 2.3.0, which had arrived four days earlier.
+
 ### Framing
 
 Two or three sentences naming the essence of the release, before any list.
@@ -183,6 +197,10 @@ They also let a release with no breaking changes still be honest about what move
    For a major release, this is where breaking changes go, with migration steps.
 3. **Improved**: an existing component gained something optional.
 4. **Fixed**: a bug that is gone.
+
+Omit a heading that has nothing under it rather than padding it.
+The 24 April release has no **New** section, because nothing new arrived.
+Never reorder the ones that remain.
 
 An item belongs in exactly one bucket.
 When a change is both an improvement and a shift in behaviour, put it in **Changed**.

--- a/documentation/release-notes.md
+++ b/documentation/release-notes.md
@@ -152,6 +152,10 @@ Expect to make several of them per release, and budget a verification pass to fi
     The April draft said Tokens 4.0.1 arrived with the major four days earlier.
     It was the patch in the release being written about.
     When you say a version ‘arrived with’ something, read its changelog date rather than assuming it rode along with a neighbour.
+13. **Two pages with the same name.**
+    The 20 April draft linked the ‘Navigation Page’ example to `Pages/Public/Navigation Page`, which already existed.
+    The new template was `Pages/Internal/Navigation Page`.
+    A kebab-cased title is not unique: check the full title, and that the page is new, before you link it.
 
 ## Structure
 

--- a/documentation/release-notes.md
+++ b/documentation/release-notes.md
@@ -56,7 +56,7 @@ But do not treat the changelogs as a complete inventory, for two reasons:
   In the 12 July 2026 release, `feat(Accordion): Add an onToggle callback to Section` (#2758) shipped in React 4.3.0 — the property is in the published package — yet it appears in no changelog.
   Every sibling `feat` from the same week made it in.
 - `chore:` commits never reach a changelog by design, and some of them are user-facing.
-  In the same release, #2728 activated the `locale` and `dir` properties on Calendar and Date Picker, and #2785 added property documentation that ships in the Controls table and in IDE tooltips.
+  In the same release, #2728 documented how to localise Calendar and Date Picker, and #2785 added property documentation that ships in the Controls table and in IDE tooltips.
 
 So: reconcile the commit range against the changelogs, and report the difference.
 A user-facing change that shipped but reached no changelog is not an edge case to tidy away — it is the single most valuable thing the release notes can carry, because it exists nowhere else.
@@ -70,8 +70,44 @@ Verify every claim and every link against the tree.
 They are not a scope.
 They are often cumulative, covering several releases at once, so lifting one wholesale silently pulls in changes from earlier releases.
 
+**A pull request description** — ours or an agent’s — states an intention.
+The merged code states the outcome.
+They diverge more often than you would expect, and a title is the least reliable part of both: #2728 is titled ‘Activate and document the `locale` and `dir` props’, but there is no `dir` property on either component.
+It is a Storybook control derived from the locale.
+
 **The code** settles every disagreement.
 Read the diff before describing a change.
+
+## Six ways to be wrong
+
+Every one of these was caught in review of the 12 July notes, after the draft looked finished.
+They share a shape: a claim that is nearly true, in a sentence that reads well.
+
+1. **A capability that only half landed.**
+   The 12 July draft said four components became controllable.
+   Three did.
+   Accordion Section only gained an `onToggle` callback — it runs `useCollapsible` in uncontrolled mode, and its `expanded` is a deprecated alias for `defaultExpanded` until October, so the name is not free yet.
+   A reader who acted on the draft would have passed `expanded` to Accordion, earned a deprecation warning, and watched the value be treated as an initial default.
+   Check the implementation, not the property name: `defaultValue` is uncontrolled, `value` is controlled.
+2. **A group with one member that does not belong.**
+   The draft said Dialog, Table, Tabs and Tab Navigation all clip vertical overflow.
+   Dialog does the opposite — its body keeps `overflow-y: auto`, because it is the scroll container.
+   When a commit names four components, check all four.
+3. **A token mistaken for the thing it names.**
+   The draft said Amsterdam Sans gained three weights and an italic.
+   Only the black weight is a new font file; light, extra bold and italic were already shipping and merely gained tokens.
+   ‘Added a token for X’ and ‘added X’ are different sentences.
+4. **A guarantee with unstated preconditions.**
+   The modal Dialog scroll lock needs the `ams-body` class on the consumer’s `<body>`, sits behind an `@supports` query, and does not hold on iOS Safari touch — the source comment says so.
+   The draft told readers to delete their own scroll lock.
+   Before writing ‘you can remove your workaround’, read the implementation for the cases where it still fails.
+5. **A pattern assumed to be uniform.**
+   All five packages look like they pin each other.
+   React Icons does not — it depends only on React.
+   Check each one; do not generalise from two.
+6. **A count that is not counting what you think.**
+   ‘23 component pages’ was the number of files a commit touched; only 21 gained the section being described.
+   Prefer ‘every compound component’ to a number you have not counted yourself.
 
 ## Structure
 
@@ -141,6 +177,11 @@ The undercurrent: a design system that never changed would be one that had stopp
 Change is the product, not an apology for it.
 What makes change safe is documentation and a choice about when to follow — so the notes should read as confident, not defensive, and never bury a shift to make a release look calmer than it is.
 
+Keep that as an undercurrent.
+It is carried by the structure — a deprecation with a date on it, ‘every new property is optional’, a **Changed** section that admits what moved — and it dies the moment you say it out loud.
+An opening aphorism about change being good is the one thing guaranteed not to convince anybody.
+Cut it and let the page prove the point.
+
 Concretely:
 
 - Write Markdown with one sentence per line, as everywhere in this repository.
@@ -157,6 +198,8 @@ Concretely:
 
 - Derive every link from the `title:` of the story or the `<Meta title>` of the page, kebab-cased: `Components/Feedback/Skeleton` becomes `/docs/components-feedback-skeleton--docs`.
   Check each target exists rather than pattern-matching from memory; pages get renamed.
+- Check whether a new component brought an example with it.
+  Skeleton shipped with the Loading Page template in the same pull request, and the Documentation section is the only place it gets announced.
 - Reconcile the commit range against the changelogs in both directions, and account for every gap.
 - Verify the ‘nothing breaks’ claim against the changelogs _and_ the range: look for `!` in commit subjects, `BREAKING CHANGE:` footers, removals, and required properties.
 - Check whether any existing deprecation has passed its removal date.

--- a/documentation/release-notes.md
+++ b/documentation/release-notes.md
@@ -184,29 +184,37 @@ Two or three sentences naming the essence of the release, before any list.
 Most releases have a theme; find it.
 State plainly whether anything breaks.
 
-### New, Changed, Improved, Fixed
+### Changed, Added, Adjusted, Improved, Fixed
 
-Use these four headings, in this order, rather than ‘Breaking’, ‘Features’ and ‘Bugfixes’.
+Use these five headings, in this order, rather than ‘Breaking’, ‘Features’ and ‘Bugfixes’.
 They describe the reader’s experience instead of our commit conventions.
-They also let a release with no breaking changes still be honest about what moved.
-**New** leads, because that is what people came for.
+They read as a plain account of how the software grew, not a compliance record, and the friendly tone is the point.
 
-1. **New**: did not exist before.
-2. **Changed**: existing markup renders or behaves differently, with no action required.
+1. **Changed**: something that was there is now different in a way you have to deal with.
+   This is the breaking bucket: name what broke and why, and leave the step-by-step to the Upgrading section.
+   It is optional and appears only when a release breaks something, which by policy means a major.
+   Keep it friendly.
+   The changelog already carries the formal ‘Breaking changes’ heading with its alert icon, and the major version number is a signal in itself, so the page does not need a scare.
+2. **Added**: did not exist before.
+3. **Adjusted**: existing markup renders or behaves differently, with no action required.
    Visual shifts, new defaults, deprecations.
-   For a major release, this is where breaking changes go, with migration steps.
-3. **Improved**: an existing component gained something optional.
-4. **Fixed**: a bug that is gone.
+   Some are cosmetic and some can move a consumer’s layout, so the section’s opening lines say ‘look after upgrading’ plainly.
+4. **Improved**: an existing component gained something optional.
+5. **Fixed**: a bug that is gone.
+
+**Added** leads on a release that breaks nothing, because that is what people came for.
+On a major, **Changed** comes first, because the first question is what you have to do.
 
 Omit a heading that has nothing under it rather than padding it.
-The 24 April release has no **New** section, because nothing new arrived.
+Most releases have no **Changed** section, and the 24 April release has no **Added** section either.
 Never reorder the ones that remain.
 
-An item belongs in exactly one bucket.
-When a change is both an improvement and a shift in behaviour, put it in **Changed**.
-That is what the reader needs to notice.
+The line between **Adjusted** and **Improved** is whether the reader has to do anything.
+Adjusted happens to the markup they already shipped, so they look after upgrading.
+Improved is a capability they can reach for or ignore.
+When a change is both, put it in **Adjusted**, because that is what they need to notice.
 Scroll containment and a scroll lock read as improvements from our side.
-From the reader’s side they change how a page they already shipped behaves.
+From the reader’s side they change how a page they already shipped behaves, so they are Adjusted.
 
 Where several components gained the same kind of capability, write a short paragraph instead of scattering identical bullets.
 The 12 July notes do this for the collapsibles that became controllable: one paragraph on why you would want it, then one line per component.
@@ -244,7 +252,7 @@ So the notes should read as confident, not defensive.
 Never bury a shift to make a release look calmer than it is.
 
 Keep that as an undercurrent.
-The structure carries it: a deprecation with a date on it, ‘every new property is optional’, a **Changed** section that admits what moved.
+The structure carries it: a deprecation with a date on it, ‘every new property is optional’, an **Adjusted** section that admits what moved.
 It dies the moment you say it out loud.
 An opening aphorism about change being good is the one thing guaranteed not to convince anybody.
 Cut it and let the page prove the point.

--- a/documentation/release-notes.md
+++ b/documentation/release-notes.md
@@ -83,10 +83,11 @@ It is a Storybook control derived from the locale.
 **The code** settles every disagreement.
 Read the diff before describing a change.
 
-## Six ways to be wrong
+## Ways to be wrong
 
-Every one of these was caught in review of the 12 July notes, after the draft looked finished.
+Every one of these was caught while reviewing a draft that already looked finished.
 They share a shape: a claim that is nearly true, in a sentence that reads well.
+Expect to make several of them per release, and budget a verification pass to find them.
 
 1. **A capability that only half landed.**
    The 12 July draft said four components became controllable.
@@ -118,7 +119,30 @@ They share a shape: a claim that is nearly true, in a sentence that reads well.
    Check each one; do not generalise from two.
 6. **A count that is not counting what you think.**
    ‘23 component pages’ was the number of files a commit touched; only 21 gained the section being described.
-   Prefer ‘every compound component’ to a number you have not counted yourself.
+   ‘All 62 component pages’ was the number of pages one commit touched; there were 63.
+   A diff count and a total are different numbers.
+   Prefer ‘every component page’ to a number you have not counted yourself.
+7. **A property on the compound instead of the part.**
+   The June draft said Table of Contents items take a `collapsible` property.
+   `collapsible` is on the root; the Link takes `defaultExpanded`.
+   It also said Menu and Breadcrumb take `linkComponent`; the property is on `Menu.Link` and `Breadcrumb.Link`, and Page Header’s logo uses a different name again.
+   A reader who copies the sentence writes code that silently does nothing.
+   Grep the actual props interface for each component you name.
+8. **A fix that fixes nothing anyone could have hit.**
+   The June draft asked readers whether they had worked around a Switch whose track vanished in forced colours.
+   Nobody had. The border width was a local custom property, never themeable, and never zero.
+   #2656 made it themeable and floored it at 1px so that a token set to zero could not hide it.
+   That is hardening against a hazard the same commit introduced, filed under `fix:`.
+   Before restating a fix as a symptom, check that the symptom was reachable.
+9. **Two components that look alike from the outside.**
+   The June draft called Date Picker ‘the same calendar inside a form field’.
+   It is neither. Date Picker does not import Calendar, renders no field, and sits inline.
+   Calendar is a nav landmark of links; Date Picker is a grid of buttons that selects.
+   Read both implementations before you draw a family resemblance.
+10. **The repo at HEAD is not the repo at the release.**
+    Progress List’s `collapsed` was the current API in June and deprecated in July.
+    Describing June from HEAD would have announced a deprecation that had not happened yet.
+    Read the tree at the release commit: `git show <release-commit>:<path>`.
 
 ## Structure
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -8,6 +8,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
+* **Accordion:** Add an onToggle callback to Section ([#2758](https://github.com/Amsterdam/design-system/issues/2758)) ([20ebc93](https://github.com/Amsterdam/design-system/commit/20ebc9392d4a36f80f80acc97e6ff40d94e33d39))
 * **Calendar, Date Picker:** Add props to configure the navigation icons ([#2765](https://github.com/Amsterdam/design-system/issues/2765)) ([004bfe5](https://github.com/Amsterdam/design-system/commit/004bfe53e8e721c467ef3f1b4f27a240cc48719e))
 * **icons:** Mark directional icons for RTL mirroring ([#2727](https://github.com/Amsterdam/design-system/issues/2727)) ([a0b1b84](https://github.com/Amsterdam/design-system/commit/a0b1b84399ea86bffe7497e3e23e8aa65750953e))
 * **Page Header:** Add controlled open prop to the mega menu ([#2754](https://github.com/Amsterdam/design-system/issues/2754)) ([74ddca0](https://github.com/Amsterdam/design-system/commit/74ddca001d6be5e16f25b8d4da05fee1aea07938))

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -186,7 +186,7 @@ export const parameters = {
     storySort: {
       order: [
         'Docs',
-        ['Introduction', ['Getting Started'], 'Release notes'],
+        ['Introduction', 'Release notes'],
         'Brand',
         'Components',
         ['Buttons', 'Containers', 'Feedback', 'Forms', 'Layout', 'Media', 'Navigation', 'Text'],

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -186,7 +186,7 @@ export const parameters = {
     storySort: {
       order: [
         'Docs',
-        ['Introduction', ['Getting Started']],
+        ['Introduction', ['Getting Started'], 'Release notes'],
         'Brand',
         'Components',
         ['Buttons', 'Containers', 'Feedback', 'Forms', 'Layout', 'Media', 'Navigation', 'Text'],

--- a/storybook/src/docs/release-notes.docs.mdx
+++ b/storybook/src/docs/release-notes.docs.mdx
@@ -13,7 +13,7 @@ A bug stops bothering you.
 Everything that moves is written down here before you have to act on it.
 You decide when to follow.
 
-These notes cover one release at a time.
+One release at a time, newest first.
 Each opens with the package versions.
 It sets out what changed.
 It closes with what upgrading actually asks of you.
@@ -183,3 +183,156 @@ A `<div as="section">` where you asked for a `<section>`?
 Day numerals that ignored the locale?
 Those are all gone.
 You can take the workarounds out.
+
+## 23 June 2026
+
+Assets **2.4.0**, CSS **4.2.0**, React **4.2.0**, React Icons **2.1.0**, Tokens **4.1.0**.
+
+This release is bigger than most.
+Calendar and Date Picker arrive together.
+Container queries begin to replace window-width breakpoints.
+Bold text gets lighter on every page.
+Almost no code has to change, but Amsterdam Sans now ships as WOFF2 only and those files moved.
+Read the upgrade notes before you bump.
+
+### New
+
+- **[Calendar](/docs/components-navigation-calendar--docs)** shows a month at a time, for navigating to dates that have something behind them.
+  It is a set of links.
+- **[Date Picker](/docs/components-forms-date-picker--docs)** shows a month too, but for choosing a date or a range.
+  It sits inline on the page rather than in a form field.
+  When someone already knows the date and can type it, reach for [Date Input](/docs/components-forms-date-input--docs) instead.
+- **[Query Container](/docs/utilities-css-query-container--docs)** begins our move to container queries.
+  A component can now respond to the width of the box it sits in rather than the width of the window.
+  [Page](/docs/components-containers-page--docs), [Dialog](/docs/components-containers-dialog--docs) and [Grid](/docs/components-layout-grid--docs) Cell establish a container on their own.
+  The utility class covers everything that sits outside them.
+- **26 new [icons](/docs/brand-assets-icons--docs)**, among them a bridge, a litter bin, a bird house, zoom and rotate controls, and double chevrons for paging.
+
+### Changed
+
+- **Bold text is lighter.**
+  The heading and bold body-text [typography tokens](/docs/brand-design-tokens-typography--docs) moved from weight 800 to 700.
+  Every [Heading](/docs/components-text-heading--docs), label and Description List term now renders in Amsterdam Sans Bold instead of Extra Bold.
+  So does the bold text our components draw for you, in [Badge](/docs/components-feedback-badge--docs), [Blockquote](/docs/components-text-blockquote--docs), Pagination, Table and Tabs.
+  Plain `b` and `strong` are untouched, because we never styled them.
+  If you followed our old advice and applied the bold token to them yourself, they get lighter too.
+  That advice is gone now.
+  Nothing to change in your code, but expect a visible difference on nearly every page.
+  Extra bold still ships, so it is there if you ask for it directly.
+- **The font files moved.**
+  Amsterdam Sans ships as WOFF2 only now.
+  The EOT and WOFF files are gone, and the WOFF2 files moved from `font/woff2/` up into `font/`.
+  Our stylesheet keeps working.
+  A path you wrote yourself does not.
+- **[Description List](/docs/components-text-description-list--docs) switches on its container.**
+  It used to go side by side above a window of 37.5rem.
+  It now does so above a container of 32rem.
+  Outside a query container it stays stacked at any width.
+  If yours went side by side and no longer does, wrap it in one.
+- **Page, Dialog and Grid Cell became query containers.**
+  That is what makes the above work, and it applies whether or not you write a container query.
+  Each of them is now the containing block for `position: fixed` and `position: absolute` children, and a new stacking context.
+  If a fixed banner, a sticky bar or a `z-index` inside one of them moved after upgrading, this is why.
+- **React properties are read-only.**
+  TypeScript now flags code that mutates a properties object.
+  That is a compile error you may meet on upgrade, not a change at runtime.
+
+### Improved
+
+**Every link component takes your router.**
+[Link](/docs/components-navigation-link--docs), [Standalone Link](/docs/components-navigation-standalone-link--docs), [Call to Action Link](/docs/components-navigation-call-to-action-link--docs), [Breadcrumb](/docs/components-navigation-breadcrumb--docs), [Calendar](/docs/components-navigation-calendar--docs), [Card](/docs/components-navigation-card--docs), [Link List](/docs/components-navigation-link-list--docs), [Menu](/docs/components-navigation-menu--docs), [Page Footer](/docs/components-containers-page-footer--docs), [Page Header](/docs/components-containers-page-header--docs), [Skip Link](/docs/components-navigation-skip-link--docs) and [Table of Contents](/docs/components-navigation-table-of-contents--docs) all accept a `linkComponent` property.
+Pass your router’s link and the component renders that instead of a plain anchor.
+On a compound component the property sits on the link part, so `Menu.Link` and `Breadcrumb.Link` rather than `Menu` and `Breadcrumb`.
+Page Header’s logo takes `logoLinkComponent`.
+The `<NextLink legacyBehavior passHref>` wrapper is no longer needed.
+The [Routing Libraries](/docs/docs-developer-guide-routing-libraries--docs) guide was rewritten around the new pattern.
+
+- **Table of Contents can collapse.**
+  Set `collapsible` on the root and every item with a nested list gets a toggle button.
+  Pre-open one with `defaultExpanded` on the Link.
+- **[Progress List](/docs/components-containers-progress-list--docs) Step takes a `collapsed` property.**
+  Pass it and your application drives the step.
+  Leave it out and the step keeps managing itself.
+- **[Pagination](/docs/components-navigation-pagination--docs) is themeable.**
+  Thirty-two new tokens cover the hover, active and current states.
+  New elements cover the ellipsis and the previous and next links.
+  Links gained a visible active state.
+- **[Dialog](/docs/components-containers-dialog--docs) draws better inner and outer borders in forced colours mode.**
+- **[Switch](/docs/components-forms-switch--docs) has a themeable track border.**
+  Forced colours mode keeps that border visible even if you set the new token to zero.
+- **All five packages publish with provenance.**
+  You can verify on npm that a release was built from our repository by our own pipeline.
+
+### Fixed
+
+- **Deprecated tokens resolved to nothing.**
+  Twenty-five of them carried the value `initial`, so reading one directly fell back to the property’s own default.
+  For the spacing tokens that meant zero.
+  This had been broken since 20 April.
+  Our own components were never affected, because they read through a fallback.
+  Yours were, if you used a deprecated token to line something up with the [Grid](/docs/components-layout-grid--docs).
+- **[Progress List](/docs/components-containers-progress-list--docs)** shows a dashed connector for a collapsed current step with substeps.
+- **[Pagination](/docs/components-navigation-pagination--docs)** generates a unique fallback id for its accessible name.
+- **[Logo](/docs/components-media-logo--docs)** stays clear of the clipping edge.
+- **[Page Header](/docs/components-containers-page-header--docs) and Pagination use a stable default link.**
+  They used to define it inline, so React saw a new component on every render, remounted the links and dropped focus.
+
+### Docs
+
+- **Component documentation follows one model.**
+  Every component page opens with the description, the main example and the controls, then a fixed set of headings.
+  Every page has inline navigation.
+  Guidance moved out of the packages’ README files and onto the pages themselves.
+- **[Spacing](/docs/docs-developer-guide-spacing--docs)** is a new guide.
+  It works down from page layout to individual elements, and says which tool to reach for at each level.
+- **[Dialog](/docs/components-containers-dialog--docs) explains where to put the initial focus.**
+  Focus lands on the close button by default, so people can read the Dialog before acting.
+  Move it with `autoFocus` when one element is clearly the first thing to do.
+- **[Accordion](/docs/components-containers-accordion--docs) and [Field Set](/docs/components-forms-field-set--docs) guidance is sharper.**
+  Accordion now asks you to consider separate pages first.
+  Field Set is clearer about marking a group optional.
+
+### Upgrading
+
+#### Do you need to change anything?
+
+**Almost nothing.**
+All five packages take a minor bump.
+Every new property is optional, and nothing was removed from the React or CSS API.
+The one removal is in the assets package: the EOT and WOFF font files are gone.
+
+Five things to check, most silent first:
+
+1. **Anything positioned inside a Page, Dialog or Grid Cell.**
+   These are query containers now, whether or not you write a container query.
+   That makes each of them the containing block for `position: fixed` and `position: absolute` children, and a new stacking context.
+   A fixed banner, a sticky bar or a `z-index` inside one of them may land somewhere new.
+   Nothing warns you about this, so look before you ship.
+2. **Font paths.**
+   If you preload a font file, wrote your own `@font-face`, or copy `font/woff2/` in a build step, update the path.
+   The WOFF2 files now sit directly in `font/`.
+   If you pointed at the `.woff` or `.eot` files, drop those `src` entries, because we no longer publish those formats.
+   If you import our stylesheet, you are fine.
+3. **Visual snapshots.**
+   Headings and bold text drop from weight 800 to 700, so nearly every snapshot will differ.
+   Re-baseline after upgrading.
+4. **A Description List that used to go side by side.**
+   If it does not sit inside a Page, Dialog or Grid Cell, wrap it in the Query Container utility.
+5. **TypeScript.**
+   Read-only properties may flag code that mutates a properties object.
+
+#### What you could start using
+
+- Show a month of dates, either for navigation or in a form, with Calendar and Date Picker.
+- Let a component respond to the width of its own box instead of the window, with the Query Container utility.
+- Hand your router to any link component through `linkComponent`.
+- Collapse a long Table of Contents, or drive a Progress List Step from your application.
+- Theme Pagination to match your product.
+
+#### Bugs you may have run into
+
+Have you been working around a deprecated token that resolved to nothing?
+A Pagination link that lost focus as you clicked it?
+A Logo with a clipped edge?
+A Progress List connector that went solid where it should have been dashed?
+Those are all gone.

--- a/storybook/src/docs/release-notes.docs.mdx
+++ b/storybook/src/docs/release-notes.docs.mdx
@@ -6,11 +6,17 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 # Release notes
 
-Our design system moves every few weeks: a component arrives, a default gets sharper, a bug stops bothering you.
-Everything that moves is written down here before you have to act on it, and you decide when to follow.
+Our design system moves every few weeks.
+A component arrives.
+A default gets sharper.
+A bug stops bothering you.
+Everything that moves is written down here before you have to act on it.
+You decide when to follow.
 
 These notes cover one release at a time.
-Each opens with the package versions, sets out what changed, and closes with what upgrading actually asks of you.
+Each opens with the package versions.
+It sets out what changed.
+It closes with what upgrading actually asks of you.
 For the cadence and the guarantees behind it, read the [Release Policy](/docs/docs-developer-guide-release-policy--docs).
 
 ## 12 July 2026
@@ -22,80 +28,116 @@ Three components that used to manage their own open and closed state now let you
 Around that: a new component for loading states, a black weight for Amsterdam Sans, and directional icons that follow the reading direction.
 Nothing breaks.
 
-### Changed
-
-Nothing here needs a code change.
-Some things do render or behave differently on markup you already have, so give these a look after upgrading.
-
-- **Compact Mode is a little tighter.**
-  The `xl` and `2xl` [space tokens](/docs/brand-design-tokens-space--docs) drop by 4 and 8 pixels at every viewport width.
-  Anything spaced with them in [Compact Mode](/docs/docs-developer-guide-modes--docs) closes up, [Grid](/docs/components-layout-grid--docs) gaps and vertical padding included.
-- **The page behind a modal [Dialog](/docs/components-containers-dialog--docs) no longer scrolls.**
-  This needs the `ams-body` class on your `<body>`, and iOS Safari still needs JavaScript to guarantee it on touch.
-  So keep a scroll lock you wrote for that, and drop one you wrote for anything else.
-- **[Table](/docs/components-containers-table--docs), [Tabs](/docs/components-containers-tabs--docs) and [Tab Navigation](/docs/components-navigation-tab-navigation--docs) now clip vertical overflow.**
-  Check anything you render inside them that used to spill out — a vertical Tab Navigation is unaffected.
-  Scrolling a wide Table or Tabs sideways no longer carries on into the page behind it either, and the Tabs list comes to rest on a whole tab instead of halfway through one.
-- **[Progress List](/docs/components-containers-progress-list--docs) Step prefers `expanded` over `collapsed`**, and `defaultExpanded` over `defaultCollapsed`.
-  The old properties keep working until at least 10 January 2027, so migrate whenever it suits.
-  Mind the flip: `collapsed={false}` becomes `expanded`, not `expanded={false}`.
-
 ### New
 
 - **[Skeleton](/docs/components-feedback-skeleton--docs)** stands in for content that has not arrived yet.
-  It has shapes for headings, paragraphs, lists, images and tables, so a loading page keeps the silhouette of the real one instead of flashing empty.
+  It has shapes for headings, paragraphs, lists, images and tables.
+  A loading page keeps the silhouette of the real one instead of flashing empty.
 - **Amsterdam Sans gains a black weight.**
-  Light, extra bold and italic were already in the font files but had no [typography tokens](/docs/brand-design-tokens-typography--docs) of their own.
-  Now they do, so you can reach for them without hard-coding a value.
+  Light, extra bold and italic were already in the font files.
+  They had no [typography tokens](/docs/brand-design-tokens-typography--docs) of their own.
+  Now they do.
+  You can reach for them without hard-coding a value.
+
+### Changed
+
+Nothing here needs a code change.
+Some things do render or behave differently on markup you already have.
+Give these a look after upgrading.
+
+- **Compact Mode is a little tighter.**
+  The `xl` and `2xl` [space tokens](/docs/brand-design-tokens-space--docs) drop by 4 and 8 pixels at every viewport width.
+  Anything spaced with them in [Compact Mode](/docs/docs-developer-guide-modes--docs) closes up.
+  That includes [Grid](/docs/components-layout-grid--docs) gaps and vertical padding.
+- **The page behind a modal [Dialog](/docs/components-containers-dialog--docs) no longer scrolls.**
+  This needs the `ams-body` class on your `<body>`.
+  iOS Safari still needs JavaScript to guarantee it on touch.
+  Keep a scroll lock you wrote for that.
+  Drop one you wrote for anything else.
+- **[Table](/docs/components-containers-table--docs), [Tabs](/docs/components-containers-tabs--docs) and [Tab Navigation](/docs/components-navigation-tab-navigation--docs) now clip vertical overflow.**
+  Check anything you render inside them that used to spill out.
+  A vertical Tab Navigation is unaffected.
+  Scrolling a wide Table or Tabs sideways no longer carries on into the page behind it.
+  The Tabs list now comes to rest on a whole tab instead of halfway through one.
+- **[Progress List](/docs/components-containers-progress-list--docs) Step prefers `expanded` over `collapsed`.**
+  It prefers `defaultExpanded` over `defaultCollapsed`.
+  Both old properties keep working until at least 10 January 2027.
+  Migrate whenever it suits.
+  Mind the flip: `collapsed={false}` becomes `expanded`, not `expanded={false}`.
 
 ### Improved
 
 **Three components now take their expanded state from your application.**
-[Page Header](/docs/components-containers-page-header--docs), Progress List and [Table of Contents](/docs/components-navigation-table-of-contents--docs) each managed that state internally.
+[Page Header](/docs/components-containers-page-header--docs), [Progress List](/docs/components-containers-progress-list--docs) and [Table of Contents](/docs/components-navigation-table-of-contents--docs) each managed that state internally.
 That is fine until you need to open a section from a link elsewhere on the page, close the mega menu when the route changes, or remember what someone had expanded when they return.
-Now you can pass it in, and be told when it changes.
-Every one of these properties is optional: left alone, each component still manages itself exactly as before.
+Now you can pass that state in.
+You are told when it changes.
+Every one of these properties is optional.
+Left alone, each component still manages itself exactly as before.
 
-- Page Header drives the mega menu with `open`, `defaultOpen` and `onOpenChange`.
-- Progress List Step takes `expanded` and `defaultExpanded`.
-- Table of Contents Link takes `expanded`, and its List can start branches open with `defaultExpanded`.
-- [Accordion](/docs/components-containers-accordion--docs) Section is not there yet: the name `expanded` is still serving as the deprecated alias for `defaultExpanded` until October.
-  Its new `onToggle` reports every open and close in the meantime.
+1. Page Header drives the mega menu with `open`, `defaultOpen` and `onOpenChange`.
+2. Progress List Step takes `expanded` and `defaultExpanded`.
+3. Table of Contents Link takes `expanded`.
+   Its List can start branches open with `defaultExpanded`.
+
+[Accordion](/docs/components-containers-accordion--docs) Section is not there yet.
+The name `expanded` is still serving as the deprecated alias for `defaultExpanded` until October.
+Its new `onToggle` reports every open and close in the meantime.
 
 Elsewhere:
 
 - **[Calendar](/docs/components-navigation-calendar--docs) and [Date Picker](/docs/components-forms-date-picker--docs) let you swap the navigation icons** on the previous and next month and year buttons.
-  Websites for the City of Amsterdam keep the defaults; the properties are there for everyone else.
+  Websites for the City of Amsterdam keep the defaults.
+  The properties are there for everyone else.
 - **Directional [icons](/docs/brand-assets-icons--docs) mirror in right-to-left layouts.**
-  Arrows, chevrons and their kin are marked as directional, so an [Icon](/docs/components-media-icon--docs) points the right way in Arabic and other right-to-left contexts.
+  Arrows, chevrons and their kin are marked as directional.
+  An [Icon](/docs/components-media-icon--docs) points the right way in Arabic and other right-to-left contexts.
 
 ### Fixed
 
-- **[Menu](/docs/components-navigation-menu--docs)** keeps its horizontal padding inside its maximum width instead of growing past it.
-- **Page Header** crops the logo a touch wider, so sub-pixel rounding stops shaving its edge.
+- **[Menu](/docs/components-navigation-menu--docs)** keeps its horizontal padding inside its maximum width.
+  It no longer grows past it.
+- **[Page Header](/docs/components-containers-page-header--docs)** crops the logo a touch wider.
+  Sub-pixel rounding no longer shaves its edge.
 - **[Breakout](/docs/components-layout-breakout--docs)** applies the `as` property instead of leaking it into the DOM.
-  If you passed `as`, you now get the element you asked for — worth a look at your selectors and snapshots.
-- **Calendar and Date Picker** localise day numerals and the separator between the boundaries of a range.
+  If you passed `as`, you now get the element you asked for.
+  Worth a look at your selectors and snapshots.
+- **[Calendar](/docs/components-navigation-calendar--docs) and [Date Picker](/docs/components-forms-date-picker--docs)** localise day numerals.
+  They localise the separator between the boundaries of a range too.
 
-### Documentation
+### Docs
 
 New examples and guidelines only appear here.
-Our documentation ships with Storybook rather than as a package, so this page is its changelog.
+Our documentation ships with Storybook rather than as a package.
+This page is its changelog.
 
-- **[Loading Page](/docs/pages-public-loading-page--docs)** shows Skeleton in place: a search that waits, placeholders in the shape of what is coming, then results — including how to announce the wait to a screen reader.
-- **[Handbook Page](/docs/pages-public-handbook-page--docs)** is a new template for long reference documents split across many short pages: a personnel handbook, a policy, a regulation.
-  A collapsible Table of Contents sits beside the content and swaps pages in place.
-- **[AI assistance](/docs/docs-developer-guide-ai-assistance--docs)** is a new guide, and behind it a Model Context Protocol server.
-  Point your coding assistant at it and it builds with our real components and properties instead of guessing at them.
+- **[Loading Page](/docs/pages-public-loading-page--docs)** shows [Skeleton](/docs/components-feedback-skeleton--docs) in place.
+  A search waits.
+  Placeholders take the shape of what is coming.
+  Then the results arrive.
+  It also shows how to announce the wait to a screen reader.
+- **[Handbook Page](/docs/pages-public-handbook-page--docs)** is a new template for long reference documents split across many short pages.
+  Think of a personnel handbook, a policy, or a regulation.
+  A collapsible [Table of Contents](/docs/components-navigation-table-of-contents--docs) sits beside the content and swaps pages in place.
+- **[AI assistance](/docs/docs-developer-guide-ai-assistance--docs)** is a new guide.
+  Behind it sits a Model Context Protocol server.
+  Point your coding assistant at it.
+  It then builds with our real components and properties instead of guessing at them.
   It covers React for now, and republishes with every release.
 - **[Responsive design](/docs/docs-developer-guide-responsive-design--docs)** replaces the Breakpoints guide.
-  It now covers container queries alongside media queries, including how to make an element a query container.
-- **[Localisation](/docs/docs-developer-guide-localisation--docs)** replaces the Language guide, and Calendar and Date Picker document how to localise them properly — with examples checked by native speakers in German, French, Turkish and Arabic.
+  It now covers container queries alongside media queries.
+  That includes how to make an element a query container.
+- **[Localisation](/docs/docs-developer-guide-localisation--docs)** replaces the Language guide.
+  [Calendar](/docs/components-navigation-calendar--docs) and [Date Picker](/docs/components-forms-date-picker--docs) now document how to localise them properly.
+  Native speakers checked the examples in German, French, Turkish and Arabic.
 - **Every compound component now names its parts.**
-  The parts you can configure each come with an example and controls to try them, so their properties are finally discoverable.
+  The parts you can configure each come with an example and controls to try them.
+  Their properties are finally discoverable.
 - **Icon overrides state the rule.**
   Where a component lets you swap an icon, the property now says plainly that websites for the City of Amsterdam use the default.
-- **Grid’s Compact Mode dimensions were wrong** and are now correct — worth a look if you sized anything from that table.
+- **[Grid](/docs/components-layout-grid--docs)’s Compact Mode dimensions were wrong.**
+  They are now correct.
+  Worth a look if you sized anything from that table.
 
 If you kept links to the Breakpoints or Language guides, point them at their new homes.
 
@@ -104,27 +146,40 @@ If you kept links to the Breakpoints or Language guides, point them at their new
 #### Do you need to change anything?
 
 **No.**
-All five packages move up by a minor version: nothing was removed, every new property is optional, and existing markup keeps rendering.
+All five packages move up by a minor version.
+Nothing was removed.
+Every new property is optional.
+Existing markup keeps rendering.
 
 Two things to know:
 
-- **Move the packages together.**
-  React needs this exact version of CSS, and CSS needs these exact versions of Tokens and Assets, so your package manager will flag a partial upgrade.
-  React Icons stands on its own.
-  If Dependabot offers you a separate pull request per package, group them — the [Release Policy](/docs/docs-developer-guide-release-policy--docs) explains how.
-- **Migrate `collapsed` and `defaultCollapsed` on Progress List Step when it suits you.**
-  You have until at least 10 January 2027, and each old property warns once in the console in the meantime.
+1. **Move the packages together.**
+   React needs this exact version of CSS.
+   CSS needs these exact versions of Tokens and Assets.
+   Your package manager will flag a partial upgrade.
+   React Icons stands on its own.
+   If Dependabot offers you a separate pull request per package, group them.
+   The [Release Policy](/docs/docs-developer-guide-release-policy--docs) explains how.
+2. **Migrate `collapsed` and `defaultCollapsed` on [Progress List](/docs/components-containers-progress-list--docs) Step when it suits you.**
+   You have until at least 10 January 2027.
+   Each old property warns once in the console in the meantime.
 
 #### What you could start using
 
-- Show the shape of a page while it loads, instead of an empty screen — Skeleton, with the Loading Page template as a worked example.
-- Open or close a mega menu, a step or a branch from anywhere in your application — the controlled Page Header, Progress List and Table of Contents.
+- Show the shape of a page while it loads, instead of an empty screen.
+  Reach for [Skeleton](/docs/components-feedback-skeleton--docs), with the [Loading Page](/docs/pages-public-loading-page--docs) template as a worked example.
+- Open or close a mega menu, a step or a branch from anywhere in your application.
+  The controlled [Page Header](/docs/components-containers-page-header--docs), Progress List and [Table of Contents](/docs/components-navigation-table-of-contents--docs) do that now.
 - Set text in the light, extra bold or new black weight of Amsterdam Sans.
-- Offer Calendar and Date Picker in another language, including right-to-left ones like Arabic.
-- Publish a long reference document, with the Handbook Page template.
-- Let your coding assistant read the design system directly, through the AI assistance guide.
+- Offer [Calendar](/docs/components-navigation-calendar--docs) and [Date Picker](/docs/components-forms-date-picker--docs) in another language, including right-to-left ones like Arabic.
+- Publish a long reference document, with the [Handbook Page](/docs/pages-public-handbook-page--docs) template.
+- Let your coding assistant read the design system directly, through the [AI assistance](/docs/docs-developer-guide-ai-assistance--docs) guide.
 
 #### Bugs you may have run into
 
-If you have been working around a Menu that grew past its maximum width, a shaved edge on the Page Header logo, a `<div as="section">` where you asked for a `<section>`, or day numerals that ignored the locale — those are all gone.
+Have you been working around a [Menu](/docs/components-navigation-menu--docs) that grew past its maximum width?
+A shaved edge on the Page Header logo?
+A `<div as="section">` where you asked for a `<section>`?
+Day numerals that ignored the locale?
+Those are all gone.
 You can take the workarounds out.

--- a/storybook/src/docs/release-notes.docs.mdx
+++ b/storybook/src/docs/release-notes.docs.mdx
@@ -21,7 +21,7 @@ For the cadence and the guarantees behind it, read the [Release Policy](/docs/do
 
 ## 12 July 2026
 
-Assets **2.5.0**, CSS **4.3.0**, React **4.3.0**, React Icons **2.2.0**, Tokens **4.2.0**.
+Assets **2.5.0**, CSS **4.3.0**, React **4.3.0**, React Icons **2.2.0**, Tokens **4.2.0** ([changelogs](https://github.com/Amsterdam/design-system/pull/2787)).
 
 This release hands over control.
 Three components that used to manage their own open and closed state now let your application drive it.
@@ -186,7 +186,7 @@ You can take the workarounds out.
 
 ## 23 June 2026
 
-Assets **2.4.0**, CSS **4.2.0**, React **4.2.0**, React Icons **2.1.0**, Tokens **4.1.0**.
+Assets **2.4.0**, CSS **4.2.0**, React **4.2.0**, React Icons **2.1.0**, Tokens **4.1.0** ([changelogs](https://github.com/Amsterdam/design-system/pull/2712)).
 
 This release is bigger than most.
 Calendar and Date Picker arrive together.
@@ -342,7 +342,7 @@ Those are all gone.
 
 ## 24 April 2026
 
-CSS **4.1.0**, React **4.1.0**, Tokens **4.0.1**.
+CSS **4.1.0**, React **4.1.0**, Tokens **4.0.1** ([changelogs](https://github.com/Amsterdam/design-system/pull/2590)).
 Assets and React Icons did not move this time.
 
 A small release, four days after the 4.0.0 major.
@@ -411,7 +411,7 @@ Those are gone.
 
 ## 20 April 2026
 
-Assets **2.3.0**, CSS **4.0.0**, React **4.0.0**, Tokens **4.0.0**.
+Assets **2.3.0**, CSS **4.0.0**, React **4.0.0**, Tokens **4.0.0** ([changelogs](https://github.com/Amsterdam/design-system/pull/2567)).
 React Icons did not move this time.
 
 This is a major release, our once-a-quarter chance to remove what we had deprecated and to change a few things that needed it.

--- a/storybook/src/docs/release-notes.docs.mdx
+++ b/storybook/src/docs/release-notes.docs.mdx
@@ -28,7 +28,7 @@ Three components that used to manage their own open and closed state now let you
 Around that: a new component for loading states, a black weight for Amsterdam Sans, and directional icons that follow the reading direction.
 Nothing breaks.
 
-### New
+### Added
 
 - **[Skeleton](/docs/components-feedback-skeleton--docs)** stands in for content that has not arrived yet.
   It has shapes for headings, paragraphs, lists, images and tables.
@@ -39,7 +39,7 @@ Nothing breaks.
   Now they do.
   You can reach for them without hard-coding a value.
 
-### Changed
+### Adjusted
 
 Nothing here needs a code change.
 Some things do render or behave differently on markup you already have.
@@ -195,7 +195,7 @@ Bold text gets lighter on every page.
 Almost no code has to change, but Amsterdam Sans now ships as WOFF2 only and those files moved.
 Read the upgrade notes before you bump.
 
-### New
+### Added
 
 - **[Calendar](/docs/components-navigation-calendar--docs)** shows a month at a time, for navigating to dates that have something behind them.
   It is a set of links.
@@ -208,7 +208,10 @@ Read the upgrade notes before you bump.
   The utility class covers everything that sits outside them.
 - **26 new [icons](/docs/brand-assets-icons--docs)**, among them a bridge, a litter bin, a bird house, zoom and rotate controls, and double chevrons for paging.
 
-### Changed
+### Adjusted
+
+None of this needs a code change.
+Some of it is cosmetic, and some can move your layout or your build, so give the list a look after upgrading.
 
 - **Bold text is lighter.**
   The heading and bold body-text [typography tokens](/docs/brand-design-tokens-typography--docs) moved from weight 800 to 700.
@@ -347,7 +350,7 @@ Table learned to align the content of its cells.
 Compact Mode finally gives the Grid narrower side padding than the spacious default.
 Nothing breaks.
 
-### Changed
+### Adjusted
 
 - **[Table](/docs/components-containers-table--docs) header cells sit at the bottom.**
   A cell used to align its content to the top.

--- a/storybook/src/docs/release-notes.docs.mdx
+++ b/storybook/src/docs/release-notes.docs.mdx
@@ -6,9 +6,8 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 # Release notes
 
-A design system that stopped changing would be one that stopped listening.
-Ours moves every few weeks: a component arrives, a default gets sharper, a bug stops bothering you.
-Change is the point — and it stays comfortable as long as you can see exactly what moved and decide for yourself when to follow.
+Our design system moves every few weeks: a component arrives, a default gets sharper, a bug stops bothering you.
+Everything that moves is written down here before you have to act on it, and you decide when to follow.
 
 These notes cover one release at a time.
 Each opens with the package versions, sets out what changed, and closes with what upgrading actually asks of you.
@@ -19,8 +18,8 @@ For the cadence and the guarantees behind it, read the [Release Policy](/docs/do
 Assets **2.5.0**, CSS **4.3.0**, React **4.3.0**, React Icons **2.2.0**, Tokens **4.2.0**.
 
 This release hands over control.
-Four components that used to keep their expanded state to themselves now let your application drive it.
-Around that: a new component for loading states, three more weights of Amsterdam Sans, and directional icons that follow the reading direction.
+Three components that used to manage their own open and closed state now let your application drive it.
+Around that: a new component for loading states, a black weight for Amsterdam Sans, and directional icons that follow the reading direction.
 Nothing breaks.
 
 ### Changed
@@ -29,47 +28,46 @@ Nothing here needs a code change.
 Some things do render or behave differently on markup you already have, so give these a look after upgrading.
 
 - **Compact Mode is a little tighter.**
-  The `xl` and `2xl` [space tokens](/docs/brand-design-tokens-space--docs) drop by 4 and 8 pixels at every window width.
+  The `xl` and `2xl` [space tokens](/docs/brand-design-tokens-space--docs) drop by 4 and 8 pixels at every viewport width.
   Anything spaced with them in [Compact Mode](/docs/docs-developer-guide-modes--docs) closes up, [Grid](/docs/components-layout-grid--docs) gaps and vertical padding included.
-- **A modal [Dialog](/docs/components-containers-dialog--docs) holds the page still.**
-  The page behind it no longer scrolls while it is open.
-  If you built your own scroll lock for this, you can take it out.
-- **Dialog, [Table](/docs/components-containers-table--docs), [Tabs](/docs/components-containers-tabs--docs) and [Tab Navigation](/docs/components-navigation-tab-navigation--docs) keep their scrolling to themselves.**
-  They now clip vertical overflow rather than let it escape, and the Tabs list comes to rest on a whole tab instead of halfway through one.
-  Worth checking anything you render inside them that used to spill out.
-- **[Progress List](/docs/components-containers-progress-list--docs) Step prefers `expanded` over `collapsed`.**
-  The old prop keeps working until at least 10 January 2027, so migrate whenever it suits.
+- **The page behind a modal [Dialog](/docs/components-containers-dialog--docs) no longer scrolls.**
+  This needs the `ams-body` class on your `<body>`, and iOS Safari still needs JavaScript to guarantee it on touch.
+  So keep a scroll lock you wrote for that, and drop one you wrote for anything else.
+- **[Table](/docs/components-containers-table--docs), [Tabs](/docs/components-containers-tabs--docs) and [Tab Navigation](/docs/components-navigation-tab-navigation--docs) contain their own scrolling.**
+  Scrolling a wide Table or Tabs sideways no longer carries on into the page behind it, and the Tabs list comes to rest on a whole tab instead of halfway through one.
+  All three now clip vertical overflow, so check anything you render inside them that used to spill out — a vertical Tab Navigation is unaffected.
+- **[Progress List](/docs/components-containers-progress-list--docs) Step prefers `expanded` over `collapsed`**, and `defaultExpanded` over `defaultCollapsed`.
+  The old properties keep working until at least 10 January 2027, so migrate whenever it suits.
   Mind the flip: `collapsed={false}` becomes `expanded`, not `expanded={false}`.
 
 ### New
 
 - **[Skeleton](/docs/components-feedback-skeleton--docs)** stands in for content that has not arrived yet.
   It has shapes for headings, paragraphs, lists, images and tables, so a loading page keeps the silhouette of the real one instead of flashing empty.
-- **Amsterdam Sans gains three weights and an italic.**
-  The [typography tokens](/docs/brand-design-tokens-typography--docs) now cover `light`, `extra bold` and a new `black`, plus an italic font style.
-  [Image](/docs/components-media-image--docs) already puts that italic to work on alternative text, so it reads as a stand-in rather than as body copy.
+- **Amsterdam Sans gains a black weight.**
+  Light, extra bold and italic were already in the font files but had no [typography tokens](/docs/brand-design-tokens-typography--docs) of their own.
+  Now they do, so you can reach for them without hard-coding a value.
 
 ### Improved
 
-**Collapsible components now take direction from your application.**
-[Accordion](/docs/components-containers-accordion--docs), [Page Header](/docs/components-containers-page-header--docs), Progress List and [Table of Contents](/docs/components-navigation-table-of-contents--docs) each used to keep their own counsel about what was open.
+**Three components now take their expanded state from your application.**
+[Page Header](/docs/components-containers-page-header--docs), Progress List and [Table of Contents](/docs/components-navigation-table-of-contents--docs) each managed that state internally.
 That is fine until you need to open a section from a link elsewhere on the page, close the mega menu when the route changes, or remember what someone had expanded when they return.
-All four now accept that state from you and report back when it changes.
+Now you can pass it in, and be told when it changes.
 Every one of these properties is optional: left alone, each component still manages itself exactly as before.
 
-- Accordion Section reports opening and closing through `onToggle`.
 - Page Header drives the mega menu with `open`, `defaultOpen` and `onOpenChange`.
 - Progress List Step takes `expanded` and `defaultExpanded`.
 - Table of Contents Link takes `expanded`, and its List can start branches open with `defaultExpanded`.
+- [Accordion](/docs/components-containers-accordion--docs) Section is not there yet: the name `expanded` is still serving as the deprecated alias for `defaultExpanded` until October.
+  Its new `onToggle` reports every open and close in the meantime.
 
 Elsewhere:
 
 - **[Calendar](/docs/components-navigation-calendar--docs) and [Date Picker](/docs/components-forms-date-picker--docs) let you swap the navigation icons** on the previous and next month and year buttons.
   Websites for the City of Amsterdam keep the defaults; the properties are there for everyone else.
 - **Directional [icons](/docs/brand-assets-icons--docs) mirror in right-to-left layouts.**
-  Arrows, chevrons and their kin are marked as directional, so they point the right way in Arabic and other right-to-left contexts.
-- **Calendar and Date Picker speak more languages.**
-  Their `locale` and `dir` properties are now active and documented — see [Localisation](/docs/docs-developer-guide-localisation--docs).
+  Arrows, chevrons and their kin are marked as directional, so an [Icon](/docs/components-media-icon--docs) points the right way in Arabic and other right-to-left contexts.
 
 ### Fixed
 
@@ -81,9 +79,10 @@ Elsewhere:
 
 ### Documentation
 
-Our documentation lives here in Storybook rather than in a package, so it has no changelog of its own.
-This is the place to find out what is new.
+New examples and guidelines only appear here.
+Our documentation ships with Storybook rather than as a package, so this page is its changelog.
 
+- **[Loading Page](/docs/pages-public-loading-page--docs)** shows Skeleton in place: a search that waits, placeholders in the shape of what is coming, then results — including how to announce the wait to a screen reader.
 - **[Handbook Page](/docs/pages-public-handbook-page--docs)** is a new template for long reference documents split across many short pages: a personnel handbook, a policy, a regulation.
   A collapsible Table of Contents sits beside the content and swaps pages in place.
 - **[AI assistance](/docs/docs-developer-guide-ai-assistance--docs)** is a new guide, and behind it a Model Context Protocol server.
@@ -91,40 +90,41 @@ This is the place to find out what is new.
   It covers React for now, and republishes with every release.
 - **[Responsive design](/docs/docs-developer-guide-responsive-design--docs)** replaces the Breakpoints guide.
   It now covers container queries alongside media queries, including how to make an element a query container.
-  Update any links you kept to the old page.
-- **Subcomponents are documented across 23 component pages.**
-  Every compound component names its full set of parts, and the ones with choices of their own each gained an example and their own controls.
+- **[Localisation](/docs/docs-developer-guide-localisation--docs)** replaces the Language guide, and Calendar and Date Picker document how to localise them properly — with examples checked by native speakers in German, French, Turkish and Arabic.
+- **Every compound component now names its parts.**
+  The parts you can configure each come with an example and controls to try them, so their properties are finally discoverable.
 - **Icon overrides state the rule.**
   Where a component lets you swap an icon, the property now says plainly that websites for the City of Amsterdam use the default.
-- **Grid’s Compact Mode figures are corrected**, and the space token descriptions are complete — including the viewport range over which they scale.
+- **Grid’s Compact Mode dimensions were wrong** and are now correct — worth a look if you sized anything from that table.
+
+If you kept links to the Breakpoints or Language guides, point them at their new homes.
 
 ### Upgrading
 
 #### Do you need to change anything?
 
 **No.**
-All five packages take a minor bump.
-Nothing was removed, every new property is optional, and existing markup keeps rendering.
+All five packages move up by a minor version: nothing was removed, every new property is optional, and existing markup keeps rendering.
 
 Two things to know:
 
-- **Move all five packages together.**
-  They pin each other to exact versions, so your package manager will insist on it anyway.
+- **Move the packages together.**
+  React needs this exact version of CSS, and CSS needs these exact versions of Tokens and Assets, so your package manager will flag a partial upgrade.
+  React Icons stands on its own.
   If Dependabot offers you a separate pull request per package, group them — the [Release Policy](/docs/docs-developer-guide-release-policy--docs) explains how.
-- **Migrate `collapsed` to `expanded` on Progress List Step when it suits you.**
-  You have until at least 10 January 2027, and the old property warns once in the console in the meantime.
+- **Migrate `collapsed` and `defaultCollapsed` on Progress List Step when it suits you.**
+  You have until at least 10 January 2027, and each old property warns once in the console in the meantime.
 
 #### What you could start using
 
-- [Skeleton](/docs/components-feedback-skeleton--docs), if anything in your interface waits on data.
-- Controlled Accordion, Page Header, Progress List and Table of Contents, if you have ever wanted to open or close one of them from elsewhere.
-- The `light`, `extra bold` and `black` weights of Amsterdam Sans.
-- Right-to-left layouts, now that directional icons mirror — with Calendar and Date Picker localised to match.
-- The [Handbook Page](/docs/pages-public-handbook-page--docs) template, if you publish long reference documents.
+- Show the shape of a page while it loads, instead of an empty screen — Skeleton, with the Loading Page template as a worked example.
+- Open or close a mega menu, a step or a branch from anywhere in your application — the controlled Page Header, Progress List and Table of Contents.
+- Set text in the light, extra bold or new black weight of Amsterdam Sans.
+- Offer Calendar and Date Picker in another language, including right-to-left ones like Arabic.
+- Publish a long reference document, with the Handbook Page template.
+- Let your coding assistant read the design system directly, through the AI assistance guide.
 
 #### Bugs you may have run into
 
-- A Menu that grew past its maximum width.
-- A logo with a shaved edge in the Page Header.
-- A `<div as="section">` where you expected a `<section>`.
-- Day numerals in a Calendar or Date Picker that ignored the locale.
+If you have been working around a Menu that grew past its maximum width, a shaved edge on the Page Header logo, a `<div as="section">` where you asked for a `<section>`, or day numerals that ignored the locale — those are all gone.
+You can take the workarounds out.

--- a/storybook/src/docs/release-notes.docs.mdx
+++ b/storybook/src/docs/release-notes.docs.mdx
@@ -355,7 +355,7 @@ Nothing breaks.
 - **[Table](/docs/components-containers-table--docs) header cells sit at the bottom.**
   A cell used to align its content to the top.
   Inside the table header it now aligns to the bottom.
-  A header that wraps onto two lines lines up with the single-line headers beside it.
+  A header that wraps onto two lines aligns with the single-line headers beside it.
   Nothing to change in your code.
 
 ### Improved

--- a/storybook/src/docs/release-notes.docs.mdx
+++ b/storybook/src/docs/release-notes.docs.mdx
@@ -1,0 +1,130 @@
+{/* @license CC0-1.0 */}
+
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Docs/Release notes" />
+
+# Release notes
+
+A design system that stopped changing would be one that stopped listening.
+Ours moves every few weeks: a component arrives, a default gets sharper, a bug stops bothering you.
+Change is the point — and it stays comfortable as long as you can see exactly what moved and decide for yourself when to follow.
+
+These notes cover one release at a time.
+Each opens with the package versions, sets out what changed, and closes with what upgrading actually asks of you.
+For the cadence and the guarantees behind it, read the [Release Policy](/docs/docs-developer-guide-release-policy--docs).
+
+## 12 July 2026
+
+Assets **2.5.0**, CSS **4.3.0**, React **4.3.0**, React Icons **2.2.0**, Tokens **4.2.0**.
+
+This release hands over control.
+Four components that used to keep their expanded state to themselves now let your application drive it.
+Around that: a new component for loading states, three more weights of Amsterdam Sans, and directional icons that follow the reading direction.
+Nothing breaks.
+
+### Changed
+
+Nothing here needs a code change.
+Some things do render or behave differently on markup you already have, so give these a look after upgrading.
+
+- **Compact Mode is a little tighter.**
+  The `xl` and `2xl` [space tokens](/docs/brand-design-tokens-space--docs) drop by 4 and 8 pixels at every window width.
+  Anything spaced with them in [Compact Mode](/docs/docs-developer-guide-modes--docs) closes up, [Grid](/docs/components-layout-grid--docs) gaps and vertical padding included.
+- **A modal [Dialog](/docs/components-containers-dialog--docs) holds the page still.**
+  The page behind it no longer scrolls while it is open.
+  If you built your own scroll lock for this, you can take it out.
+- **Dialog, [Table](/docs/components-containers-table--docs), [Tabs](/docs/components-containers-tabs--docs) and [Tab Navigation](/docs/components-navigation-tab-navigation--docs) keep their scrolling to themselves.**
+  They now clip vertical overflow rather than let it escape, and the Tabs list comes to rest on a whole tab instead of halfway through one.
+  Worth checking anything you render inside them that used to spill out.
+- **[Progress List](/docs/components-containers-progress-list--docs) Step prefers `expanded` over `collapsed`.**
+  The old prop keeps working until at least 10 January 2027, so migrate whenever it suits.
+  Mind the flip: `collapsed={false}` becomes `expanded`, not `expanded={false}`.
+
+### New
+
+- **[Skeleton](/docs/components-feedback-skeleton--docs)** stands in for content that has not arrived yet.
+  It has shapes for headings, paragraphs, lists, images and tables, so a loading page keeps the silhouette of the real one instead of flashing empty.
+- **Amsterdam Sans gains three weights and an italic.**
+  The [typography tokens](/docs/brand-design-tokens-typography--docs) now cover `light`, `extra bold` and a new `black`, plus an italic font style.
+  [Image](/docs/components-media-image--docs) already puts that italic to work on alternative text, so it reads as a stand-in rather than as body copy.
+
+### Improved
+
+**Collapsible components now take direction from your application.**
+[Accordion](/docs/components-containers-accordion--docs), [Page Header](/docs/components-containers-page-header--docs), Progress List and [Table of Contents](/docs/components-navigation-table-of-contents--docs) each used to keep their own counsel about what was open.
+That is fine until you need to open a section from a link elsewhere on the page, close the mega menu when the route changes, or remember what someone had expanded when they return.
+All four now accept that state from you and report back when it changes.
+Every one of these properties is optional: left alone, each component still manages itself exactly as before.
+
+- Accordion Section reports opening and closing through `onToggle`.
+- Page Header drives the mega menu with `open`, `defaultOpen` and `onOpenChange`.
+- Progress List Step takes `expanded` and `defaultExpanded`.
+- Table of Contents Link takes `expanded`, and its List can start branches open with `defaultExpanded`.
+
+Elsewhere:
+
+- **[Calendar](/docs/components-navigation-calendar--docs) and [Date Picker](/docs/components-forms-date-picker--docs) let you swap the navigation icons** on the previous and next month and year buttons.
+  Websites for the City of Amsterdam keep the defaults; the properties are there for everyone else.
+- **Directional [icons](/docs/brand-assets-icons--docs) mirror in right-to-left layouts.**
+  Arrows, chevrons and their kin are marked as directional, so they point the right way in Arabic and other right-to-left contexts.
+- **Calendar and Date Picker speak more languages.**
+  Their `locale` and `dir` properties are now active and documented — see [Localisation](/docs/docs-developer-guide-localisation--docs).
+
+### Fixed
+
+- **[Menu](/docs/components-navigation-menu--docs)** keeps its horizontal padding inside its maximum width instead of growing past it.
+- **Page Header** crops the logo a touch wider, so sub-pixel rounding stops shaving its edge.
+- **[Breakout](/docs/components-layout-breakout--docs)** applies the `as` property instead of leaking it into the DOM.
+  If you passed `as`, you now get the element you asked for — worth a look at your selectors and snapshots.
+- **Calendar and Date Picker** localise day numerals and the separator between the boundaries of a range.
+
+### Documentation
+
+Our documentation lives here in Storybook rather than in a package, so it has no changelog of its own.
+This is the place to find out what is new.
+
+- **[Handbook Page](/docs/pages-public-handbook-page--docs)** is a new template for long reference documents split across many short pages: a personnel handbook, a policy, a regulation.
+  A collapsible Table of Contents sits beside the content and swaps pages in place.
+- **[AI assistance](/docs/docs-developer-guide-ai-assistance--docs)** is a new guide, and behind it a Model Context Protocol server.
+  Point your coding assistant at it and it builds with our real components and properties instead of guessing at them.
+  It covers React for now, and republishes with every release.
+- **[Responsive design](/docs/docs-developer-guide-responsive-design--docs)** replaces the Breakpoints guide.
+  It now covers container queries alongside media queries, including how to make an element a query container.
+  Update any links you kept to the old page.
+- **Subcomponents are documented across 23 component pages.**
+  Every compound component names its full set of parts, and the ones with choices of their own each gained an example and their own controls.
+- **Icon overrides state the rule.**
+  Where a component lets you swap an icon, the property now says plainly that websites for the City of Amsterdam use the default.
+- **Grid’s Compact Mode figures are corrected**, and the space token descriptions are complete — including the viewport range over which they scale.
+
+### Upgrading
+
+#### Do you need to change anything?
+
+**No.**
+All five packages take a minor bump.
+Nothing was removed, every new property is optional, and existing markup keeps rendering.
+
+Two things to know:
+
+- **Move all five packages together.**
+  They pin each other to exact versions, so your package manager will insist on it anyway.
+  If Dependabot offers you a separate pull request per package, group them — the [Release Policy](/docs/docs-developer-guide-release-policy--docs) explains how.
+- **Migrate `collapsed` to `expanded` on Progress List Step when it suits you.**
+  You have until at least 10 January 2027, and the old property warns once in the console in the meantime.
+
+#### What you could start using
+
+- [Skeleton](/docs/components-feedback-skeleton--docs), if anything in your interface waits on data.
+- Controlled Accordion, Page Header, Progress List and Table of Contents, if you have ever wanted to open or close one of them from elsewhere.
+- The `light`, `extra bold` and `black` weights of Amsterdam Sans.
+- Right-to-left layouts, now that directional icons mirror — with Calendar and Date Picker localised to match.
+- The [Handbook Page](/docs/pages-public-handbook-page--docs) template, if you publish long reference documents.
+
+#### Bugs you may have run into
+
+- A Menu that grew past its maximum width.
+- A logo with a shaved edge in the Page Header.
+- A `<div as="section">` where you expected a `<section>`.
+- Day numerals in a Calendar or Date Picker that ignored the locale.

--- a/storybook/src/docs/release-notes.docs.mdx
+++ b/storybook/src/docs/release-notes.docs.mdx
@@ -33,9 +33,9 @@ Some things do render or behave differently on markup you already have, so give 
 - **The page behind a modal [Dialog](/docs/components-containers-dialog--docs) no longer scrolls.**
   This needs the `ams-body` class on your `<body>`, and iOS Safari still needs JavaScript to guarantee it on touch.
   So keep a scroll lock you wrote for that, and drop one you wrote for anything else.
-- **[Table](/docs/components-containers-table--docs), [Tabs](/docs/components-containers-tabs--docs) and [Tab Navigation](/docs/components-navigation-tab-navigation--docs) contain their own scrolling.**
-  Scrolling a wide Table or Tabs sideways no longer carries on into the page behind it, and the Tabs list comes to rest on a whole tab instead of halfway through one.
-  All three now clip vertical overflow, so check anything you render inside them that used to spill out — a vertical Tab Navigation is unaffected.
+- **[Table](/docs/components-containers-table--docs), [Tabs](/docs/components-containers-tabs--docs) and [Tab Navigation](/docs/components-navigation-tab-navigation--docs) now clip vertical overflow.**
+  Check anything you render inside them that used to spill out — a vertical Tab Navigation is unaffected.
+  Scrolling a wide Table or Tabs sideways no longer carries on into the page behind it either, and the Tabs list comes to rest on a whole tab instead of halfway through one.
 - **[Progress List](/docs/components-containers-progress-list--docs) Step prefers `expanded` over `collapsed`**, and `defaultExpanded` over `defaultCollapsed`.
   The old properties keep working until at least 10 January 2027, so migrate whenever it suits.
   Mind the flip: `collapsed={false}` becomes `expanded`, not `expanded={false}`.

--- a/storybook/src/docs/release-notes.docs.mdx
+++ b/storybook/src/docs/release-notes.docs.mdx
@@ -408,3 +408,99 @@ Two things to know:
 Have you been working around a Grid in Compact Mode whose side padding was as wide as the spacious default?
 A Field Set stretched wide by an input with a `size` attribute?
 Those are gone.
+
+## 20 April 2026
+
+Assets **2.3.0**, CSS **4.0.0**, React **4.0.0**, Tokens **4.0.0**.
+React Icons did not move this time.
+
+This is a major release, our once-a-quarter chance to remove what we had deprecated and to change a few things that needed it.
+Most of the breaking work is cleanup you were warned about.
+A new component and a new utility arrive alongside it, and the Grid learns some new tricks.
+Plan a little time for this one.
+
+### Changed
+
+A major release is where breaking changes land.
+The changelogs carry the full, exact list under their ‘Breaking changes’ heading.
+Here is what it means for you.
+
+- **Everything we had deprecated is now gone.**
+  If you kept up with the deprecation warnings, you are already done.
+  If not, the renames are straightforward.
+  Page Heading becomes a [Heading](/docs/components-text-heading--docs).
+  `Heading` size `level-6` becomes `level-5`.
+  [Icon](/docs/components-media-icon--docs) sizes `heading-0` and `heading-6` become `heading-1` and `heading-5`.
+  [Accordion](/docs/components-containers-accordion--docs) `headingLevel={1}` becomes `2`, `3` or `4`.
+  [Pagination](/docs/components-navigation-pagination--docs)’s `visuallyHiddenLabel` family becomes the `accessibleName` family.
+  The `color` property of [Menu](/docs/components-navigation-menu--docs) Link is gone with no replacement.
+  The CSS classes and design tokens behind all of these went too.
+  The changelogs list every name.
+- **[Compact Mode](/docs/docs-developer-guide-modes--docs) looks different.**
+  The page is now grey and [Grid](/docs/components-layout-grid--docs) Cells are white with their own padding, so cells stand out instead of blending in.
+  Spacious Mode is unchanged, so if you do not use Compact Mode you see nothing.
+  A cell that should blend back into the grey takes a new `transparent` appearance.
+- **[Progress List](/docs/components-containers-progress-list--docs) steps no longer collapse on their own.**
+  Collapsing is opt-in now: add the `collapsible` property to the list to bring it back.
+  Without it, every step shows in full, with no toggle.
+- **Icon’s `svg` property needs a real SVG.**
+  It used to accept almost anything.
+  It now expects an SVG element, an icon component, or a function that returns one.
+  TypeScript points out whatever no longer fits.
+
+### Added
+
+- **[Tab Navigation](/docs/components-navigation-tab-navigation--docs)** moves between the sections of a site, as a horizontal or vertical set of tabs.
+- **[Prose](/docs/utilities-css-prose--docs)** is a new utility class that puts vertical space between flowing text elements, for content you do not lay out one element at a time.
+
+### Adjusted
+
+None of this needs a code change.
+
+- **[Grid](/docs/components-layout-grid--docs) cells align to the top of their row.**
+  A short cell no longer stretches to match a tall neighbour.
+- **[Table](/docs/components-containers-table--docs) captions have space beneath them.**
+- **[Accordion](/docs/components-containers-accordion--docs) Section renames `expanded` to `defaultExpanded`.**
+  The old name keeps working as a deprecated alias until at least 20 October 2026.
+- **Viewport tokens gain a `vi-` prefix.**
+  The component tokens named `*.medium.*` and `*.wide.*` are now `*.vi-medium.*` and `*.vi-wide.*`.
+  The old names remain, deprecated, until at least 20 October 2026, so rename them when it suits.
+  Our components read the `vi-` names now, so if you overrode an old name, point that override at the `vi-` one.
+
+### Improved
+
+- **[Grid](/docs/components-layout-grid--docs) cells can span rows.**
+  A `rowSpan` property lets one cell run alongside up to four rows of others.
+- **Grid cells take a `flush` appearance** that removes their own padding while keeping the background.
+
+### Docs
+
+- **[Navigation Page](/docs/pages-internal-navigation-page--docs)** is a new template for a large site split into sections, built with two levels of the new [Tab Navigation](/docs/components-navigation-tab-navigation--docs).
+- **[Table Page](/docs/pages-internal-table-page--docs)** shows a full page of sortable, filterable, paginated data.
+  Its lesson: keep the table’s state in the URL, so a view can be bookmarked and shared.
+  That is why the controls are links and forms rather than buttons.
+
+### Upgrading
+
+#### Do you need to change anything?
+
+**Yes, this is a major.**
+Work through it in this order:
+
+1. **Clear the deprecation warnings first.**
+   Upgrade to the last 3.x release, fix everything it warns about, then move to 4.0.0.
+   If your console and build were already clean, the removals here touch nothing.
+2. **Look at your Compact Mode layouts.**
+   Cells are white on a grey page now.
+   Give the `transparent` appearance to any that should blend back in.
+3. **Add `collapsible` to a [Progress List](/docs/components-containers-progress-list--docs)** if you relied on its steps collapsing.
+4. **Check any custom `svg` you passed to [Icon](/docs/components-media-icon--docs).**
+   TypeScript flags whatever no longer fits.
+
+Two deprecations can wait, both until at least 20 October 2026: [Accordion](/docs/components-containers-accordion--docs)’s `expanded` becomes `defaultExpanded`, and the `*.medium.*` and `*.wide.*` tokens take their `vi-` names.
+
+#### What you could start using
+
+- [Tab Navigation](/docs/components-navigation-tab-navigation--docs), for a site organised into sections.
+- The [Prose](/docs/utilities-css-prose--docs) utility, for spacing a block of flowing text.
+- [Grid](/docs/components-layout-grid--docs) cells that span rows, or drop their padding with the flush appearance.

--- a/storybook/src/docs/release-notes.docs.mdx
+++ b/storybook/src/docs/release-notes.docs.mdx
@@ -336,3 +336,72 @@ A Pagination link that lost focus as you clicked it?
 A Logo with a clipped edge?
 A Progress List connector that went solid where it should have been dashed?
 Those are all gone.
+
+## 24 April 2026
+
+CSS **4.1.0**, React **4.1.0**, Tokens **4.0.1**.
+Assets and React Icons did not move this time.
+
+A small release, four days after the 4.0.0 major.
+Table learned to align the content of its cells.
+Compact Mode finally gives the Grid narrower side padding than the spacious default.
+Nothing breaks.
+
+### Changed
+
+- **[Table](/docs/components-containers-table--docs) header cells sit at the bottom.**
+  A cell used to align its content to the top.
+  Inside the table header it now aligns to the bottom.
+  A header that wraps onto two lines lines up with the single-line headers beside it.
+  Nothing to change in your code.
+
+### Improved
+
+- **[Table](/docs/components-containers-table--docs) cells can centre or right-align their content.**
+  Cell and Header Cell take an `align` property, set to `center` or `end`.
+  In CSS the modifiers are `ams-table__cell--align-center` and `ams-table__cell--align-end`, with a matching pair for a header cell.
+  A column of numbers can finally line up on the right.
+
+### Fixed
+
+- **[Grid](/docs/components-layout-grid--docs) padding in [Compact Mode](/docs/docs-developer-guide-modes--docs).**
+  Compact Mode was supposed to give the Grid narrower horizontal padding than the spacious default.
+  It never did, at any width: it set only the base value, which matched the default, and left the wider windows to the default steps.
+  Compact Mode now has its own steps, `m` then `l` then `xl`, one below the spacious `l`, `xl`, `2xl` at every width.
+- **[Field Set](/docs/components-forms-field-set--docs) stays inside its container.**
+  An input with a `size` attribute, or a textarea with `cols`, used to stretch the Field Set past its container.
+  It no longer does.
+
+### Docs
+
+- **[Table Page](/docs/pages-internal-table-page--docs) shows a full page of data.**
+  Two new examples: one pages through the rows with [Pagination](/docs/components-navigation-pagination--docs), the other sorts them with a [Select](/docs/components-forms-select--docs).
+- **[Text Input](/docs/components-forms-text-input--docs) and [Password Input](/docs/components-forms-password-input--docs) explain their size.**
+  The `size` attribute sets a preferred width, and the input will not grow past its container.
+
+### Upgrading
+
+#### Do you need to change anything?
+
+**No.**
+CSS and React take a minor bump, Tokens a patch.
+
+Two things to know:
+
+1. **Leave Assets and React Icons where they are.**
+   Neither changed.
+   CSS 4.1.0 asks for Tokens 4.0.1, which is in this release, and for Assets 2.3.0, which arrived with the 4.0.0 major four days earlier.
+2. **Look at any Table with a header.**
+   Header text moves from the top of its cell to the bottom.
+   If every header fits on one line, you will not see a difference.
+
+#### What you could start using
+
+- Right-align a column of numbers, or centre a column of icons, with `align` on a Table Cell.
+- The Table Page examples, if you are building a page of data that pages or sorts.
+
+#### Bugs you may have run into
+
+Have you been working around a Grid in Compact Mode whose side padding was as wide as the spacious default?
+A Field Set stretched wide by an input with a `size` attribute?
+Those are gone.


### PR DESCRIPTION
## Links

- The new page in the main deploy: [Docs/Release notes](https://designsystem.amsterdam/?path=/docs/docs-release-notes--docs)
- Storybook on main: https://designsystem.amsterdam/
- House guide for writing these: `documentation/release-notes.md` (linked from `AGENTS.md`).
- Related: [Release Policy](https://designsystem.amsterdam/?path=/docs/docs-guidelines-release-policy--docs), which already promises “Find migration guidance in release notes”.

## What

Adds a **Release notes** page to Storybook, directly below the Introduction, that summarises our releases for the people who *use* the design system rather than the people who build it.

It covers the four releases back to and including the 4.0.0 major, newest first:

- 12 July 2026
- 23 June 2026
- 24 April 2026
- 20 April 2026 (major)

Each release opens with the package versions as a single bold-numbered line, groups what changed under **Changed / Added / Adjusted / Improved / Fixed**, carries a **Docs** section for the Storybook-only examples and guidelines that appear in no changelog, and closes with upgrade guidance from three angles: what you have to change, what you could start using, and which bugs you may have run into are now fixed.

Alongside the page:

- A house guide, `documentation/release-notes.md`, on how to write these for any future or past release, linked from `AGENTS.md`.
- A retroactive correction to the React 4.3.0 changelog: the `onToggle` callback on Accordion Section (#2758) shipped in the package but release-please had dropped it from the changelog.

## Why

Our changelogs record every commit, which is a different job from telling a business owner, designer or developer what a release means for them. The Release Policy already points people to release notes for migration guidance, but we had none. This fills that gap, and gives the Storybook-only documentation changes their only place to be announced.

## How

- The page is a single `.docs.mdx` under `storybook/src/docs/`, ordered right after the Introduction via `storySort` in `storybook/config/preview.tsx`. Storybook cannot make one node both a page and a folder, so each release is a dated `##` section on one page rather than a page of its own.
- Version numbers are hard-coded per release, because the `PackageVersions` component reads the live manifests and so always shows the latest.
- The section taxonomy is **Changed / Added / Adjusted / Improved / Fixed**: a friendly participle series meant to read as a plain account of how the software grows over time. The optional **Changed** section holds breaking changes and appears only on a major (here, 20 April); the changelog’s own “Breaking changes” heading and the major version number carry the formal warning, so the page itself stays gentle.
- Every component and page is linked on its first mention in each section, to its documentation page or a specific story. Every link was checked against the built Storybook index.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- The Release notes page is an unattached MDX docs page rather than a story, so Chromatic does not snapshot it.
- The `packages/react/CHANGELOG.md` edit sits under the already-released 4.3.0 heading. Release-please only manages the unreleased section, so it will not be rewritten. The `chore` PR title keeps this from generating a spurious new changelog entry.
- I stopped at the 4.0.0 major; earlier releases pre-date it and can be added later if we want them.
