### PR TITLE
chore: Use sentence case consistently in the Storybook sidebar and docs

### DIFF
--- a/packages/css/src/components/prose/README.md
+++ b/packages/css/src/components/prose/README.md
@@ -10,6 +10,6 @@ Applies the recommended vertical spacing between the direct children of a contai
 
 ## Guidelines
 
-- Wrap this utility class around editorial content to space its content according to the [Vertical space](/docs/docs-designer-guide-vertical-space--docs) recommendations.
+- Wrap this utility class around editorial content to space its content according to the [vertical space](/docs/docs-designer-guide-vertical-space--docs) recommendations.
 - To add a single ad-hoc gap between two elements, prefer the [Margin Bottom](/docs/utilities-css-margin--docs) utility class on the first one.
 - To add even spacing between a set of siblings, prefer the [Gap](/docs/utilities-css-gap--docs) utility class on their parent.

--- a/storybook/config/manager.js
+++ b/storybook/config/manager.js
@@ -6,7 +6,24 @@ import Logo from '../../packages-proprietary/assets/logo/amsterdam.svg'
 import '@amsterdam/design-system-assets/font/index.css'
 import '../src/_styles/manager.css'
 
+// Storybook labels stories in Title Case, derived from their export names. Show them in
+// sentence case to match our heading convention, while keeping component names (the parent
+// nodes) in Title Case so they stand out. All-caps acronyms and the Logo stories (Amsterdam
+// organisation names) keep their casing.
+const toSentenceCase = (label) =>
+  label
+    .split(' ')
+    .map((word, index) => {
+      if (word.length > 1 && word === word.toUpperCase()) return word
+      return index === 0 ? word : word.toLowerCase()
+    })
+    .join(' ')
+
 addons.setConfig({
+  sidebar: {
+    renderLabel: ({ id, name, type }) =>
+      type === 'story' && !id.startsWith('components-media-logo--') ? toSentenceCase(name) : name,
+  },
   theme: create({
     appBg: '#ffffff',
     appBorderColor: '#e6e6e6',

--- a/storybook/config/manager.js
+++ b/storybook/config/manager.js
@@ -8,8 +8,7 @@ import '../src/_styles/manager.css'
 
 // Storybook labels stories in Title Case, derived from their export names. Show them in
 // sentence case to match our heading convention, while keeping component names (the parent
-// nodes) in Title Case so they stand out. All-caps acronyms and the Logo stories (Amsterdam
-// organisation names) keep their casing.
+// nodes) in Title Case so they stand out. All-caps acronyms keep their casing.
 const toSentenceCase = (label) =>
   label
     .split(' ')
@@ -21,8 +20,7 @@ const toSentenceCase = (label) =>
 
 addons.setConfig({
   sidebar: {
-    renderLabel: ({ id, name, type }) =>
-      type === 'story' && !id.startsWith('components-media-logo--') ? toSentenceCase(name) : name,
+    renderLabel: ({ name, type }) => (type === 'story' ? toSentenceCase(name) : name),
   },
   theme: create({
     appBg: '#ffffff',

--- a/storybook/src/brand/design-tokens/aspect-ratio.docs.mdx
+++ b/storybook/src/brand/design-tokens/aspect-ratio.docs.mdx
@@ -5,9 +5,9 @@ import { Meta } from "@storybook/addon-docs/blocks";
 import { DesignTokensTable } from "#storybook/_components/DesignTokensTable/DesignTokensTable";
 import tokens from "#tokens/brand/ams/aspect-ratio.tokens.json";
 
-<Meta title="Brand/Design Tokens/Aspect Ratio" />
+<Meta title="Brand/Design tokens/Aspect ratio" />
 
-# Aspect Ratio
+# Aspect ratio
 
 Constrains media content to a supported aspect ratio.
 

--- a/storybook/src/brand/design-tokens/border.docs.mdx
+++ b/storybook/src/brand/design-tokens/border.docs.mdx
@@ -6,7 +6,7 @@ import { DesignTokensTable } from "#storybook/_components/DesignTokensTable/Desi
 import tokensCompact from "#tokens/brand/ams/border.compact.tokens.json";
 import tokensSpacious from "#tokens/brand/ams/border.tokens.json";
 
-<Meta title="Brand/Design Tokens/Border" />
+<Meta title="Brand/Design tokens/Border" />
 
 # Border
 

--- a/storybook/src/brand/design-tokens/colour.docs.mdx
+++ b/storybook/src/brand/design-tokens/colour.docs.mdx
@@ -6,7 +6,7 @@ import { ColorPalette } from "#storybook/_components/ColorPalette/ColorPalette";
 import { ColorSample } from "#storybook/_components/ColorSample/ColorSample";
 import { InlineColorSample } from "#storybook/_components/InlineColorSample/InlineColorSample";
 
-<Meta title="Brand/Design Tokens/Colour" />
+<Meta title="Brand/Design tokens/Colour" />
 
 # Colour
 

--- a/storybook/src/brand/design-tokens/cursor.docs.mdx
+++ b/storybook/src/brand/design-tokens/cursor.docs.mdx
@@ -5,7 +5,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 import { DesignTokensTable } from "#storybook/_components/DesignTokensTable/DesignTokensTable";
 import tokens from "#tokens/brand/ams/cursor.tokens.json";
 
-<Meta title="Brand/Design Tokens/Cursor" />
+<Meta title="Brand/Design tokens/Cursor" />
 
 # Cursor
 

--- a/storybook/src/brand/design-tokens/focus.docs.mdx
+++ b/storybook/src/brand/design-tokens/focus.docs.mdx
@@ -2,7 +2,7 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Brand/Design Tokens/Focus" />
+<Meta title="Brand/Design tokens/Focus" />
 
 # Focus
 

--- a/storybook/src/brand/design-tokens/inputs.docs.mdx
+++ b/storybook/src/brand/design-tokens/inputs.docs.mdx
@@ -5,7 +5,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 import { DesignTokensTable } from "#storybook/_components/DesignTokensTable/DesignTokensTable";
 import tokens from "#tokens/common/ams/inputs.tokens.json";
 
-<Meta title="Brand/Design Tokens/Inputs" />
+<Meta title="Brand/Design tokens/Inputs" />
 
 # Inputs
 

--- a/storybook/src/brand/design-tokens/links.docs.mdx
+++ b/storybook/src/brand/design-tokens/links.docs.mdx
@@ -5,7 +5,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 import { DesignTokensTable } from "#storybook/_components/DesignTokensTable/DesignTokensTable";
 import tokens from "#tokens/common/ams/links.tokens.json";
 
-<Meta title="Brand/Design Tokens/Links" />
+<Meta title="Brand/Design tokens/Links" />
 
 # Links
 

--- a/storybook/src/brand/design-tokens/space.docs.mdx
+++ b/storybook/src/brand/design-tokens/space.docs.mdx
@@ -4,7 +4,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 import { SpaceSample } from "#storybook/_components/SpaceSample/SpaceSample";
 
-<Meta title="Brand/Design Tokens/Space" />
+<Meta title="Brand/Design tokens/Space" />
 
 # Space
 

--- a/storybook/src/brand/design-tokens/typography.docs.mdx
+++ b/storybook/src/brand/design-tokens/typography.docs.mdx
@@ -4,7 +4,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 import { TypographySample } from "#storybook/_components/TypographySample/TypographySample";
 
-<Meta title="Brand/Design Tokens/Typography" />
+<Meta title="Brand/Design tokens/Typography" />
 
 # Typography
 

--- a/storybook/src/components/Calendar/Calendar.docs.mdx
+++ b/storybook/src/components/Calendar/Calendar.docs.mdx
@@ -42,7 +42,7 @@ The Calendar renders this name as a visually hidden heading and generates a uniq
 The Calendar renders weekday names, the month caption, and the accessible date labels in the language of `locale`, which defaults to `nl-NL`.
 It does not translate the rest: set `accessibleName`, `nextMonthButtonLabel`, `nextYearButtonLabel`, `previousMonthButtonLabel`, and `previousYearButtonLabel` in the same language, or they stay Dutch and screen readers announce a mix.
 For right-to-left scripts such as Arabic, also add `dir="rtl"`; this mirrors the layout and the navigation chevrons.
-Try the `locale` control above to preview each language; see the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs) for the tested locales.
+Try the `locale` control above to preview each language; see the [localisation developer guide](/docs/docs-developer-guide-localisation--docs) for the tested locales.
 
 If your app uses Calendar in multiple places with the same language, a small wrapper component avoids repeating these props:
 
@@ -96,7 +96,7 @@ const linkTemplate = (date: Date): string => `?date=${formatDate(date)}`
 
 Different navigation icons can be used through the `*ButtonIcon` props, which each take the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
 Websites for the City of Amsterdam must use the default icons.
-For right-to-left scripts, give a custom icon a `data-directional="true"` attribute so it mirrors like the default chevrons; see the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs).
+For right-to-left scripts, give a custom icon a `data-directional="true"` attribute so it mirrors like the default chevrons; see the [localisation developer guide](/docs/docs-developer-guide-localisation--docs).
 
 ## Accessibility
 

--- a/storybook/src/components/Column/Column.docs.mdx
+++ b/storybook/src/components/Column/Column.docs.mdx
@@ -71,7 +71,7 @@ In this example, the Column uses a `<section>` element to group the heading and 
 
 ## Features
 
-Five sizes of [Space](/docs/brand-design-tokens-space--docs) are available for the width or height of the gap.
+Five sizes of [space](/docs/brand-design-tokens-space--docs) are available for the width or height of the gap.
 The medium gap is the default.
 
 Align the elements horizontally or vertically through the alignment props.

--- a/storybook/src/components/DatePicker/DatePicker.docs.mdx
+++ b/storybook/src/components/DatePicker/DatePicker.docs.mdx
@@ -49,7 +49,7 @@ The Date Picker renders weekday names, the month caption, and the accessible dat
 It does not translate the rest: set `nextMonthButtonLabel`, `nextYearButtonLabel`, `previousMonthButtonLabel`, and `previousYearButtonLabel` in the same language, or they stay Dutch and screen readers announce a mix.
 In range mode, also localise `rangeStartAccessibleName` and `rangeEndAccessibleName`; they are appended to the start and end dates when those are announced.
 For right-to-left scripts such as Arabic, also add `dir="rtl"`; this mirrors the layout and the navigation chevrons.
-Try the `locale` control above to preview each language; see the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs) for the tested locales.
+Try the `locale` control above to preview each language; see the [localisation developer guide](/docs/docs-developer-guide-localisation--docs) for the tested locales.
 
 If your app uses Date Picker in multiple places with the same language, a small wrapper component avoids repeating these props:
 
@@ -130,7 +130,7 @@ Moving past the end of a month shows the adjacent month and keeps focus on the d
 
 Different navigation icons can be used through the `*ButtonIcon` props, which each take the same value as the [Icon](/docs/components-media-icon--docs) component’s `svg` prop.
 Websites for the City of Amsterdam must use the default icons.
-For right-to-left scripts, give a custom icon a `data-directional="true"` attribute so it mirrors like the default chevrons; see the [Localisation developer guide](/docs/docs-developer-guide-localisation--docs).
+For right-to-left scripts, give a custom icon a `data-directional="true"` attribute so it mirrors like the default chevrons; see the [localisation developer guide](/docs/docs-developer-guide-localisation--docs).
 
 ## Accessibility
 

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -68,7 +68,7 @@ In Compact Mode, the page background is light grey.
 
 The Grid has no vertical padding of its own.
 Add white space above and below it through the `padding…` props.
-They accept `large`, `x-large`, and `2x-large`, matching the `l`, `xl`, and `2xl` design tokens for [Space](/docs/brand-design-tokens-space--docs).
+They accept `large`, `x-large`, and `2x-large`, matching the `l`, `xl`, and `2xl` design tokens for [space](/docs/brand-design-tokens-space--docs).
 This is useful in a container with a coloured background, like [Page Footer](/docs/components-containers-page-footer--docs) or [Spotlight](/docs/components-containers-spotlight--docs), or between two consecutive Grids.
 Specify `x-large` to match the gaps between the columns and the rows.
 Like the other features of the Grid, this padding is responsive.

--- a/storybook/src/components/Logo/Logo.docs.mdx
+++ b/storybook/src/components/Logo/Logo.docs.mdx
@@ -51,14 +51,7 @@ This also applies to sub-brand logos.
 Websites operated by one of the sub-brands use their specific logo.
 They have a separate status because of their unique service provision not directly associated with the City.
 
-The sub-brands are:
-
-- GGD Amsterdam
-- GGD Amsterdam Inspectie
-- Museum Weesp
-- Stadsarchief
-- Stadsbank van Lening
-- VGA Verzekeringen
+[Stijlweb](https://www.amsterdam.nl/stijlweb/uitgangspunten/logo-gemeente-amsterdam/#hbab93411-6797-410f-8c1d-40fb988dd077) lists the sub-brands and their logos.
 
 ## See also
 

--- a/storybook/src/components/Logo/Logo.docs.mdx
+++ b/storybook/src/components/Logo/Logo.docs.mdx
@@ -32,37 +32,7 @@ Other logo variations exist, but they cannot be used on our websites.
 
 ## Examples
 
-### Sub-brands
-
-#### GGD Amsterdam
-
-<Canvas of={LogoStories.GgdAmsterdam} />
-
-#### GGD Amsterdam Inspectie
-
-<Canvas of={LogoStories.GgdAmsterdamInspectie} />
-
-#### Museum Weesp
-
-<Canvas of={LogoStories.MuseumWeesp} />
-
-#### Stadsarchief
-
-<Canvas of={LogoStories.Stadsarchief} />
-
-#### Stadsbank van Lening
-
-<Canvas of={LogoStories.StadsbankVanLening} />
-
-#### VGA Verzekeringen
-
-<Canvas of={LogoStories.VgaVerzekeringen} />
-
-### Amsterdam English
-
-<Canvas of={LogoStories.AmsterdamEnglish} />
-
-### Custom
+### Custom logo
 
 Websites for the City of Amsterdam must use one of our own logos.
 
@@ -71,7 +41,7 @@ The label should be ‘name of the organisation + logo’.
 The image must be an svg.
 Set the appropriate values for the sizing tokens.
 
-<Canvas of={LogoStories.Custom} />
+<Canvas of={LogoStories.CustomLogo} />
 
 ## Design
 

--- a/storybook/src/components/Logo/Logo.stories.tsx
+++ b/storybook/src/components/Logo/Logo.stories.tsx
@@ -31,49 +31,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
-export const GgdAmsterdam: Story = {
-  args: {
-    brand: 'ggd-amsterdam',
-  },
-}
-
-export const GgdAmsterdamInspectie: Story = {
-  args: {
-    brand: 'ggd-amsterdam-inspectie',
-  },
-}
-
-export const MuseumWeesp: Story = {
-  args: {
-    brand: 'museum-weesp',
-  },
-}
-
-export const Stadsarchief: Story = {
-  args: {
-    brand: 'stadsarchief',
-  },
-}
-
-export const StadsbankVanLening: Story = {
-  args: {
-    brand: 'stadsbank-van-lening',
-  },
-}
-
-export const VgaVerzekeringen: Story = {
-  args: {
-    brand: 'vga-verzekeringen',
-  },
-}
-
-export const AmsterdamEnglish: Story = {
-  args: {
-    brand: 'amsterdam-english',
-  },
-}
-
-export const Custom: Story = {
+export const CustomLogo: Story = {
   args: {
     brand: {
       label: 'Gemeente logo',

--- a/storybook/src/components/PageFooter/PageFooter.docs.mdx
+++ b/storybook/src/components/PageFooter/PageFooter.docs.mdx
@@ -72,12 +72,12 @@ Customize it when the menu serves a different purpose, or the interface language
 
 ## Examples
 
-### Onderzoek en Statistiek
+### Custom content
 
 The Page Footer for a specific website can be a bit different.
 Here’s an example for the ‘Onderzoek en Statistiek’ department.
 
-<Canvas of={PageFooterStories.OnderzoekEnStatistiek} />
+<Canvas of={PageFooterStories.CustomContent} />
 
 ### Custom menu heading
 

--- a/storybook/src/components/PageFooter/PageFooter.stories.tsx
+++ b/storybook/src/components/PageFooter/PageFooter.stories.tsx
@@ -116,7 +116,7 @@ export const Default: Story = {
   },
 }
 
-export const OnderzoekEnStatistiek: Story = {
+export const CustomContent: Story = {
   render: (args, context) => {
     const cellAppearance = isCompactTheme(context) ? 'transparent' : undefined
 

--- a/storybook/src/components/Row/Row.docs.mdx
+++ b/storybook/src/components/Row/Row.docs.mdx
@@ -88,7 +88,7 @@ Items that may not fit together on a single line should be allowed to wrap onto 
 
 ## Features
 
-Five sizes of [Space](/docs/brand-design-tokens-space--docs) are available for the width or height of the gap.
+Five sizes of [space](/docs/brand-design-tokens-space--docs) are available for the width or height of the gap.
 The medium gap is the default.
 
 Align the elements horizontally or vertically through the alignment props.

--- a/storybook/src/docs/designer-guide/vertical-space.docs.mdx
+++ b/storybook/src/docs/designer-guide/vertical-space.docs.mdx
@@ -4,7 +4,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 import { VerticalSpaceFinder } from "#storybook/_components/VerticalSpaceFinder/VerticalSpaceFinder";
 
-<Meta title="Docs/Designer Guide/Vertical space" />
+<Meta title="Docs/Designer guide/Vertical space" />
 
 # Vertical space
 

--- a/storybook/src/docs/developer-guide/ai-assistance.docs.mdx
+++ b/storybook/src/docs/developer-guide/ai-assistance.docs.mdx
@@ -2,7 +2,7 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Docs/Developer Guide/AI assistance" />
+<Meta title="Docs/Developer guide/AI assistance" />
 
 # AI assistance
 

--- a/storybook/src/docs/developer-guide/browser-support.docs.mdx
+++ b/storybook/src/docs/developer-guide/browser-support.docs.mdx
@@ -2,9 +2,9 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Docs/Developer Guide/Browser Support" />
+<Meta title="Docs/Developer guide/Browser support" />
 
-# Browser Support
+# Browser support
 
 The Amsterdam Design System uses the [Baseline standard](https://web.dev/baseline/) 'Widely available' for browser support. This means we only use features that have been supported in the 4 major browsers (Chrome, Edge, Firefox, and Safari) for at least 30 months.
 This is considered a good trade-off between using modern web platform features and ensuring broad compatibility.

--- a/storybook/src/docs/developer-guide/getting-started.docs.mdx
+++ b/storybook/src/docs/developer-guide/getting-started.docs.mdx
@@ -2,9 +2,9 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Docs/Developer Guide/Getting Started" />
+<Meta title="Docs/Developer guide/Getting started" />
 
-# Getting Started
+# Getting started
 
 ## Installing
 

--- a/storybook/src/docs/developer-guide/interactivity.docs.mdx
+++ b/storybook/src/docs/developer-guide/interactivity.docs.mdx
@@ -2,7 +2,7 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Docs/Developer Guide/Interactivity" />
+<Meta title="Docs/Developer guide/Interactivity" />
 
 # Interactivity
 

--- a/storybook/src/docs/developer-guide/localisation.docs.mdx
+++ b/storybook/src/docs/developer-guide/localisation.docs.mdx
@@ -2,7 +2,7 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Docs/Developer Guide/Localisation" />
+<Meta title="Docs/Developer guide/Localisation" />
 
 # Localisation
 

--- a/storybook/src/docs/developer-guide/modes.docs.mdx
+++ b/storybook/src/docs/developer-guide/modes.docs.mdx
@@ -4,7 +4,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 import { InlineColorSample } from "#storybook/_components/InlineColorSample/InlineColorSample";
 
-<Meta title="Docs/Developer Guide/Modes" />
+<Meta title="Docs/Developer guide/Modes" />
 
 # Modes
 

--- a/storybook/src/docs/developer-guide/release-policy.docs.mdx
+++ b/storybook/src/docs/developer-guide/release-policy.docs.mdx
@@ -2,9 +2,9 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Docs/Developer Guide/Release Policy" />
+<Meta title="Docs/Developer guide/Release policy" />
 
-# Release Policy
+# Release policy
 
 We aim to publish new releases on a monthly basis.
 Breaking changes will occur at most once every 3 months.

--- a/storybook/src/docs/developer-guide/responsive-design.docs.mdx
+++ b/storybook/src/docs/developer-guide/responsive-design.docs.mdx
@@ -2,7 +2,7 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Docs/Developer Guide/Responsive design" />
+<Meta title="Docs/Developer guide/Responsive design" />
 
 # Responsive design
 

--- a/storybook/src/docs/developer-guide/routing-libraries.docs.mdx
+++ b/storybook/src/docs/developer-guide/routing-libraries.docs.mdx
@@ -2,7 +2,7 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Docs/Developer Guide/Routing Libraries" />
+<Meta title="Docs/Developer guide/Routing libraries" />
 
 # Routing libraries
 

--- a/storybook/src/docs/developer-guide/spacing.docs.mdx
+++ b/storybook/src/docs/developer-guide/spacing.docs.mdx
@@ -2,7 +2,7 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Docs/Developer Guide/Spacing" />
+<Meta title="Docs/Developer guide/Spacing" />
 
 # Spacing
 

--- a/storybook/src/docs/developer-guide/usability.docs.mdx
+++ b/storybook/src/docs/developer-guide/usability.docs.mdx
@@ -2,7 +2,7 @@
 
 import { Meta } from "@storybook/addon-docs/blocks";
 
-<Meta title="Docs/Developer Guide/Usability" />
+<Meta title="Docs/Developer guide/Usability" />
 
 # Usability
 

--- a/storybook/src/docs/developer-guide/web-app.docs.mdx
+++ b/storybook/src/docs/developer-guide/web-app.docs.mdx
@@ -4,7 +4,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 import { WebAppIcons } from "#storybook/_components/AppIcon/WebAppIcons";
 
-<Meta title="Docs/Developer Guide/Web App" />
+<Meta title="Docs/Developer guide/Web app" />
 
 # Web app
 

--- a/storybook/src/docs/release-notes.docs.mdx
+++ b/storybook/src/docs/release-notes.docs.mdx
@@ -17,7 +17,7 @@ One release at a time, newest first.
 Each opens with the package versions.
 It sets out what changed.
 It closes with what upgrading actually asks of you.
-For the cadence and the guarantees behind it, read the [Release Policy](/docs/docs-developer-guide-release-policy--docs).
+For the cadence and the guarantees behind it, read the [release policy](/docs/docs-developer-guide-release-policy--docs).
 
 ## 12 July 2026
 
@@ -159,7 +159,7 @@ Two things to know:
    Your package manager will flag a partial upgrade.
    React Icons stands on its own.
    If Dependabot offers you a separate pull request per package, group them.
-   The [Release Policy](/docs/docs-developer-guide-release-policy--docs) explains how.
+   The [release policy](/docs/docs-developer-guide-release-policy--docs) explains how.
 2. **Migrate `collapsed` and `defaultCollapsed` on [Progress List](/docs/components-containers-progress-list--docs) Step when it suits you.**
    You have until at least 10 January 2027.
    Each old property warns once in the console in the meantime.
@@ -248,7 +248,7 @@ Pass your router’s link and the component renders that instead of a plain anch
 On a compound component the property sits on the link part, so `Menu.Link` and `Breadcrumb.Link` rather than `Menu` and `Breadcrumb`.
 Page Header’s logo takes `logoLinkComponent`.
 The `<NextLink legacyBehavior passHref>` wrapper is no longer needed.
-The [Routing Libraries](/docs/docs-developer-guide-routing-libraries--docs) guide was rewritten around the new pattern.
+The [routing libraries](/docs/docs-developer-guide-routing-libraries--docs) guide was rewritten around the new pattern.
 
 - **Table of Contents can collapse.**
   Set `collapsible` on the root and every item with a nested list gets a toggle button.

--- a/storybook/src/docs/terms-of-use/copyright.docs.mdx
+++ b/storybook/src/docs/terms-of-use/copyright.docs.mdx
@@ -4,6 +4,6 @@ import { Markdown, Meta } from "@storybook/addon-docs/blocks";
 
 import NOTICE from "../../../../NOTICE.md?raw";
 
-<Meta title="Docs/Terms of Use/Copyright" />
+<Meta title="Docs/Terms of use/Copyright" />
 
 <Markdown>{NOTICE}</Markdown>

--- a/storybook/src/docs/terms-of-use/license.docs.mdx
+++ b/storybook/src/docs/terms-of-use/license.docs.mdx
@@ -4,6 +4,6 @@ import { Markdown, Meta } from "@storybook/addon-docs/blocks";
 
 import LICENSE from "../../../../LICENSE.md?raw";
 
-<Meta title="Docs/Terms of Use/License" />
+<Meta title="Docs/Terms of use/License" />
 
 <Markdown>{LICENSE}</Markdown>

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.docs.mdx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.docs.mdx
@@ -25,4 +25,4 @@ This page type is for news or similar kinds of articles.
 
 - The Grids use the [recommended Cell sizes](/docs/pages-public-introduction--docs#how-to-size-the-grid-cells).
 - The [Prose](/docs/utilities-css-prose--docs) utility class automatically creates vertical whitespace in the article body.
-- For the spacing between components in the header area, refer to [Vertical space](/docs/docs-designer-guide-vertical-space--docs).
+- For the spacing between components in the header area, refer to [vertical space](/docs/docs-designer-guide-vertical-space--docs).


### PR DESCRIPTION
## Links

- [Storybook guidelines](https://github.com/Amsterdam/design-system/blob/develop/documentation/storybook.md) – the convention this PR applies: sentence case for headings, Title Case for component names.
- Storybook preview: I’ll add the deploy links once the feature-branch build is ready.

## What

The Storybook sidebar and docs now use sentence case consistently, so navigation no longer alternates between ‘Responsive design’ and ‘Routing Libraries’.

- Section groups and page titles in the sidebar – and their page headings – use sentence case: ‘Developer guide’, ‘Design tokens’, ‘Terms of use’, ‘Getting started’, ‘Routing libraries’, ‘Aspect ratio’, and so on.
- Story labels render in sentence case through a `renderLabel` transform, while component names (the parent nodes) stay Title Case so they keep standing out.
- The Page Footer ‘Onderzoek en Statistiek’ story is renamed to ‘Custom content’.
- Logo drops its per-sub-brand stories – each only set the `brand` prop, which the control already exposes – and its ‘Custom’ story becomes ‘Custom logo’. The hardcoded sub-brand list in the docs is replaced with a link to Stijlweb, which is the better source of truth.
- Internal links to non-component pages (guides, design tokens, brand assets) use sentence case in their link text: lowercase mid-sentence, capitalised only when the link starts a sentence.

## Why

Our [Storybook guidelines](https://github.com/Amsterdam/design-system/blob/develop/documentation/storybook.md) state that headings use sentence case and only component names use Title Case, so people recognise them as names. The sidebar had drifted from this: guide pages, section groups, and many links mixed the two styles. This change brings everything back in line with the documented convention.

## How

- Updated the `title` args and `<Meta title>` values – and the matching page `#` headings – for the guide, design-token, and brand pages.
- Added a small `sidebar.renderLabel` in `storybook/config/manager.js` that sentence-cases story leaves and leaves component, group, and docs nodes untouched. All-caps acronyms keep their casing.
- A blind transform would have mangled the two stories whose labels were organisation names, so those were fixed at the source rather than with an exception: Page Footer’s example became a generic ‘Custom content’, and Logo’s sub-brand stories were removed. That let the transform stay exception-free.
- Swept every internal `/docs/…` link to a non-component page and lowercased the ones that were Title Case mid-sentence.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- **What counts as ‘non-component’:** component, utility, and page names stay Title Case, because we treat those as proper names. Only guide, design-token, and brand pages – and links to them – use sentence case.
- **‘Compact Mode’ and ‘Spacious Mode’** are left in Title Case everywhere, including in links. The design system writes them as proper feature names throughout, so lowercasing only the links would clash with the surrounding prose.
- **Changed story URLs:** `…page-footer--onderzoek-en-statistiek` → `…--custom-content`, and `…media-logo--custom` → `…--custom-logo`; the Logo sub-brand story URLs are gone. Every sub-brand is still covered by Logo’s Chromatic ‘Test’ story and listed on Stijlweb.
