### PR TITLE
chore: Add defensive CSS linting with token-aware rules and a full audit

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["stylelint-config-standard-scss"],
+  "extends": ["stylelint-config-standard-scss", "stylelint-plugin-defensive-css/configs/strict"],
   "plugins": [
     "./stylelint/index.mjs",
     "stylelint-order",
@@ -52,6 +52,24 @@
         "text-align": ["left", "right"]
       }
     ],
+    "defensive-css/no-accidental-hover": [true, { "severity": "warning" }],
+    "defensive-css/no-fixed-sizes": [true, { "severity": "warning" }],
+    "defensive-css/no-list-style-none": [true, { "severity": "warning" }],
+    "defensive-css/no-unsafe-clamp-font-size": null,
+    "defensive-css/no-user-select-none": [true, { "severity": "warning" }],
+    "defensive-css/require-at-layer": null,
+    "defensive-css/require-background-repeat": [true, { "severity": "warning" }],
+    "defensive-css/require-custom-property-fallback": null,
+    "defensive-css/require-dynamic-viewport-height": [true, { "severity": "warning" }],
+    "defensive-css/require-flex-wrap": [true, { "severity": "warning" }],
+    "defensive-css/require-focus-visible": [true, { "severity": "warning" }],
+    "defensive-css/require-grid-minmax": [true, { "severity": "warning" }],
+    "defensive-css/require-named-grid-lines": [true, { "severity": "warning" }],
+    "defensive-css/require-overscroll-behavior": [true, { "severity": "warning" }],
+    "defensive-css/require-prefers-reduced-motion": [true, { "severity": "warning" }],
+    "defensive-css/require-pure-selectors": null,
+    "defensive-css/require-scrollbar-gutter": [true, { "severity": "warning" }],
+    "defensive-css/require-system-font-fallback": null,
     "font-family-name-quotes": "always-unless-keyword",
     "font-family-no-duplicate-names": true,
     "font-family-no-missing-generic-family-keyword": true,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["stylelint-config-standard-scss"],
   "plugins": [
+    "./stylelint/index.mjs",
     "stylelint-order",
     "stylelint-plugin-use-baseline",
     "stylelint-use-logical",
@@ -8,6 +9,18 @@
   ],
   "rules": {
     "alpha-value-notation": ["percentage"],
+    "ams/no-unsafe-clamp-font-size": [
+      true,
+      {
+        "importFrom": ["packages-proprietary/tokens/dist/index.css"]
+      }
+    ],
+    "ams/require-system-font-fallback": [
+      true,
+      {
+        "importFrom": ["packages-proprietary/tokens/dist/index.css"]
+      }
+    ],
     "at-rule-empty-line-before": null,
     "at-rule-no-unknown": null,
     "block-no-empty": true,

--- a/documentation/defensive-css.md
+++ b/documentation/defensive-css.md
@@ -1,0 +1,327 @@
+<!-- @license CC0-1.0 -->
+
+# Defensive CSS audit
+
+This report assesses every rule of [stylelint-plugin-defensive-css](https://github.com/yuschick/stylelint-plugin-defensive-css) against this repository: what each rule enforces, how effective it is here, where we violate it, and what fixing or ignoring it would mean.
+It supports the decisions in our Stylelint configuration and proposes a remediation path.
+
+The plugin is a devDependency.
+Linting changes nothing that we ship — only the remediation described here would alter the compiled CSS, and the closing sections quantify that.
+
+## Method
+
+Violation counts were collected on 18 July 2026 at commit `28d9a24cf4`, with the plugin at version 2.9.4 in its `strict` configuration (all 21 rules, strictest options), on top of our own `.stylelintrc.json`.
+The counts distinguish `packages/css` — the stylesheet consumers install — from `storybook`, which contains hand-written CSS for our documentation site and is not part of any published package.
+
+To reproduce, extend the repository configuration with the strict preset and run Stylelint with the JSON formatter (note that it writes JSON to stderr):
+
+```sh
+pnpm exec stylelint --config <config-extending-repo-and-strict> --formatter json '**/*.{css,scss}'
+```
+
+Two rules interact with options in a way that affects counts.
+Overriding the severity of `no-fixed-sizes` or `require-pure-selectors` without restating their options silently resets those options to defaults: `no-fixed-sizes` then checks ~40 properties instead of strict’s ~90 (8 violations instead of 15), and `require-pure-selectors` loses `strict: true` (15 instead of 78).
+All counts below use the strict options.
+
+## Summary
+
+We violate 16 of the 21 rules somewhere; 5 are clean.
+Of the 1,991 violations, 86% come from two rules we have deliberately turned off (`require-custom-property-fallback` and `require-at-layer`).
+Outside the five disabled rules, 191 violations remain, 167 of them in shipped CSS — and roughly a quarter of those are false positives or deliberate patterns to annotate rather than fix.
+
+| Rule                             | packages/css | storybook | Effectiveness caveat                      | Status  | Recommendation                                 |
+| -------------------------------- | -----------: | --------: | ----------------------------------------- | ------- | ---------------------------------------------- |
+| require-custom-property-fallback |         1103 |        45 | flags same-file private properties        | off     | keep off                                       |
+| require-at-layer                 |          492 |        82 | —                                         | off     | keep off, revisit as architecture decision     |
+| require-pure-selectors           |           49 |        29 | many false positives                      | off     | keep off                                       |
+| no-accidental-hover              |           72 |         1 | —                                         | warning | fix, then error                                |
+| require-flex-wrap                |           36 |         4 | —                                         | warning | fix (mostly `nowrap`), then error              |
+| require-named-grid-lines         |           14 |         3 | mismatch with span-based APIs             | warning | turn off                                       |
+| no-fixed-sizes                   |            7 |         8 | cannot resolve tokens                     | warning | annotate, then error                           |
+| require-grid-minmax              |           11 |         1 | cannot resolve tokens                     | warning | fix, then error                                |
+| require-background-repeat        |            9 |         1 | flags same-element state swaps            | warning | fix 3, annotate rest, then error               |
+| require-scrollbar-gutter         |            6 |         2 | flags hidden and horizontal scrollbars    | warning | fix 1, annotate rest, then error               |
+| no-user-select-none              |            8 |         0 | cannot resolve tokens                     | warning | annotate (all deliberate), then error          |
+| require-overscroll-behavior      |            0 |         2 | —                                         | warning | fix Storybook, then error                      |
+| require-focus-visible            |            2 |         0 | —                                         | warning | fix 1, annotate 1, then error                  |
+| require-dynamic-viewport-height  |            1 |         1 | flags the fallback of the correct pattern | warning | annotate, fix Storybook, then error            |
+| no-list-style-none               |            0 |         1 | cannot see into mixins                    | warning | fix mixins + Storybook, then error             |
+| require-prefers-reduced-motion   |            1 |         0 | only recognises the positive pattern      | warning | refactor, then error                           |
+| no-mixed-vendor-prefixes         |            0 |         0 | —                                         | error   | keep                                           |
+| no-unsafe-will-change            |            0 |         0 | —                                         | error   | keep                                           |
+| require-forced-colors-focus      |            0 |         0 | —                                         | error   | keep                                           |
+| no-unsafe-clamp-font-size        |            0 |         0 | cannot resolve tokens                     | off     | replaced by `ams/no-unsafe-clamp-font-size`    |
+| require-system-font-fallback     |            0 |         0 | cannot resolve tokens                     | off     | replaced by `ams/require-system-font-fallback` |
+
+A recurring theme: seven rules judge declaration _values_, and none of them resolve `var()`.
+In a repository where nearly every value is a token reference, those rules only ever see literal values.
+That mostly means false _negatives_ (they silently pass tokenised declarations), which is why two of them are replaced by our own token-resolving rules.
+The blind spot is smaller than it sounds, though: because our tokens are `rem`- and `clamp()`-based by design, only two tokens hold a `px` value at all — both 1px hairlines for the Progress List connector.
+
+## Rules with a backlog
+
+### no-accidental-hover — 73 (72 shipped)
+
+Requires every `:hover` selector to sit inside `@media (hover: hover)` ([defensivecss.dev/tip/hover-media](https://defensivecss.dev/tip/hover-media/)).
+On touch screens, a tap can leave hover styles “stuck” on an element until the next tap elsewhere, which reads as a glitch.
+
+This is our largest genuine backlog, spread over 32 components.
+Three patterns:
+
+- Simple feedback on links and buttons: `&:hover { color: … }` in Accordion, Breadcrumb, Calendar, Link, and friends.
+- Guarded control hovers: `&:hover:not(:disabled, [aria-disabled="true"])` on Button and the input components, changing box shadows or border colors.
+- Compound sibling hovers in Checkbox and Radio, such as `&:hover:not(:disabled) + *` and `&:checked + *:hover .ams-checkbox__rectangle`, where hovering either the control or its label restyles SVG parts.
+
+No selector mixes `:hover` and `:focus` in one list, so wrapping hover rules cannot accidentally remove focus styles.
+The repository already reasons about pointer capabilities elsewhere — Image Slider hides its controls under `@media (pointer: coarse)` — so the media query fits house style.
+
+**Approach:** wrap each hover rule in `@media (hover: hover)`.
+Mechanical but broad; Chromatic verifies that nothing changes for mouse users.
+Then raise the rule to error.
+
+**Impact:** the largest single chunk of the byte cost (72 × ~22 B ≈ 1.6 KB raw, mostly compressed away).
+Visitors on touch devices stop seeing stuck hover states; nobody else notices anything.
+
+### require-flex-wrap — 40 (36 shipped)
+
+Requires an explicit `flex-wrap` (or `flex-flow` with a wrap value) on every `display: flex` container.
+The default `nowrap` makes content overflow rather than wrap when space runs out, which is the right choice for some containers and a silent bug for others — the rule forces the choice to be visible.
+
+Most of our 36 shipped cases are small icon-plus-label controls where wrapping is undesirable or impossible: Button, Badge, Icon Button, Standalone Link, Pagination links, Checkbox and Radio labels, Error Message.
+For these, `flex-wrap: nowrap` documents intent and changes nothing.
+Row is the clearest example of nowrap-by-design: wrapping is an explicit opt-in via its `.ams-row--wrap` modifier, so the base must stay `nowrap`.
+A handful are genuine judgment calls — toolbar-like rows such as the Calendar and Date Picker headers, the Dialog header, and Image Slider controls — where wrapping on narrow viewports may be the better behaviour.
+
+**Approach:** one pass over all 36 containers, writing `nowrap` for the single-line controls and deciding the toolbar cases individually.
+Then raise to error.
+
+**Impact:** ~0.6 KB raw.
+Where `nowrap` is written, visitors see nothing; where `wrap` is chosen, narrow-viewport overflow turns into wrapping — a small, visible improvement.
+
+### require-named-grid-lines — 17 (14 shipped)
+
+Wants named lines in every `grid-template-columns`/`rows`, so that placement reads as `grid-column: content` instead of `grid-column: 2`.
+
+The premise does not fit this codebase.
+Our grids place children by _span_, not by line number: Grid cells use `grid-column-end: span n` and `grid-column: 1 / -1`, the Calendar and Date Picker use auto-placement into `repeat(7, 1fr)`, and Page uses named _areas_ — a stronger version of what this rule wants.
+Line names would add bytes and noise without a single consumer being able to benefit, since the classes are the API, not the grid lines.
+The rule also fires on `grid-template-columns: var(--…)` declarations it cannot inspect, and double-reports the same lines as `require-grid-minmax`.
+
+**Approach:** turn the rule off, with this reasoning recorded in the configuration documentation.
+
+### no-fixed-sizes — 15 (7 shipped)
+
+Discourages `px` in size-related properties in favour of relative units, so that sizes scale when users raise their default font size.
+This is a value-checking rule: it cannot resolve tokens, so in shipped CSS it only sees the rare literal.
+
+All 7 shipped hits are defensible `px`:
+
+- Dialog’s 1px `border-block-*-width` hairlines exist only in `@media (forced-colors: active)`, as functional separators.
+- Visually Hidden’s 1px `block-size`/`inline-size` box is the canonical inclusively-hidden pattern; scaling it serves nobody.
+- Page Header’s `translate: -4px 4px` nudges are the geometry of the animated menu icon.
+- Skeleton’s margin comes from its text-line-mimicking calculation.
+
+The 8 Storybook hits (mostly the Code sample component) deliberately replicate Storybook’s own pixel-based docs styling.
+
+**Approach:** annotate the 7 shipped sites with `stylelint-disable-next-line` plus a reason — the pattern we already use for `plugin/use-baseline` — and raise to error so future _accidental_ pixels are blocked.
+Note that error severity must restate strict’s full property list, or the rule silently narrows to ~40 properties.
+
+**Impact:** none; nothing changes.
+
+### require-grid-minmax — 12 (11 shipped)
+
+Wants `minmax(0, 1fr)` instead of bare `1fr` tracks.
+A `1fr` track cannot shrink below its content’s min-content size, so one long unbreakable word — a URL, a reference number — can blow the whole grid out of its container.
+
+The 11 shipped cases include the core Grid mixins (`repeat(var(--ams-grid-column-count), 1fr)` at three breakpoints), the Calendar and Date Picker week grids, Description List, Table of Contents, Page, and Image Slider thumbnails.
+The Grid ones matter most: every page layout built on Grid inherits the blowout risk.
+
+**Approach:** mechanical replacement of `1fr` with `minmax(0, 1fr)` at all 11 sites, verified with Chromatic; then error.
+
+**Impact:** ~0.1 KB raw.
+Visitors only notice in the failure case this defends against: content that previously pushed a layout sideways now stays inside its column and truncates or scrolls per component design.
+
+### require-background-repeat — 10 (9 shipped)
+
+Requires an explicit `background-repeat` wherever `background-image` is set, because the `repeat` default tiles the image if the box ever outgrows it.
+
+Two patterns, only one of which is real:
+
+- Genuinely missing: the calendar-picker icons of Date Input and Time Input and the cancel icon of Search Field set `background-image` on a pseudo-element without ever declaring `background-repeat`.
+- False positives: Select declares `background-repeat: no-repeat` in its base rule, but the rule also flags the `:disabled` and `:hover` rules that merely _swap_ `background-image` on the same element.
+  The rule checks per rule block, not per element, so these four can never be fixed without redundant declarations.
+
+**Approach:** add `background-repeat: no-repeat` at the three genuinely missing base declarations; annotate the same-element swap blocks; then error.
+
+**Impact:** ~0.1 KB raw; visitors see nothing unless a future icon change would otherwise have tiled.
+
+### require-scrollbar-gutter — 8 (6 shipped)
+
+Wants `scrollbar-gutter` on scrollable containers, so that the appearance of a classic scrollbar (Windows, or macOS with “always show scrollbars”) does not shift content.
+
+Of the 6 shipped hits, one is genuinely valuable: the Dialog body scrolls vertically when content grows, and `scrollbar-gutter: stable` prevents its content from shifting when that happens.
+The rest are marginal or moot: the Image Slider scroller hides its scrollbar entirely (`scrollbar-width: none`), and the Tabs list, Tab Navigation list, and Table are horizontal scrollers, where the property addresses a scrollbar that rarely appears.
+
+**Approach:** add `scrollbar-gutter: stable` to the Dialog body; annotate the others; then error.
+
+**Impact:** ~24 B. Windows visitors stop seeing a subtle content shift when dialog content becomes scrollable.
+
+### no-user-select-none — 8 (8 shipped)
+
+Flags `user-select: none` because disabling text selection usually harms users.
+
+All 8 declarations (4 sites, each with a `-webkit-` twin) are the same deliberate pattern: preventing interaction with _ghost_ elements that are rendered but not meant to be perceived.
+Tabs and Tab Navigation render a hidden bold copy of each label to reserve width and avoid layout shift on selection; Page Header renders an invisible duplicate logo link; Visually Hidden prevents copying of screen-reader-only text into the clipboard.
+Selecting any of these would put invisible duplicate text on the user’s clipboard.
+
+**Approach:** annotate all four sites with the reasoning; then error, so `user-select: none` on actual content is blocked in future.
+
+**Impact:** none.
+
+### require-overscroll-behavior — 2 (0 shipped)
+
+Wants `overscroll-behavior` on scrollable containers so that reaching the end of an inner scroller does not start scrolling the page behind it.
+
+The shipped CSS is already exemplary: all six scroll containers (Tabs list and panel, Tab Navigation, Dialog body, Image Slider, Table) declare `overscroll-behavior-*: contain` as an annotated progressive enhancement.
+Only two Storybook dev-tool containers lack it.
+
+**Approach:** fix the two Storybook cases; then error.
+
+**Impact:** none for design system consumers.
+
+### require-focus-visible — 2 (2 shipped)
+
+Prefers `:focus-visible` over `:focus`, so that focus styling follows the browser’s heuristic for when a focus indication helps (keyboard yes, mouse click usually no).
+
+Both hits need a different treatment:
+
+- `search-field.scss` raises `z-index` on `:focus` so the focus outline is not clipped by the adjacent button.
+  Since the raise only matters when the outline shows, `:focus-visible` is the more precise selector; browsers match it on text inputs even for mouse focus, so nothing regresses.
+- `input-label-focus.scss` is a deliberate progressive enhancement: it styles on `:focus`, then _undoes_ it via `:focus:not(:focus-visible)`, giving older Safari a focus ring and modern browsers the heuristic.
+  The rule cannot recognise this construction.
+
+**Approach:** switch Search Field to `:focus-visible`; annotate the progressive-enhancement helper; then error.
+
+**Impact:** ~8 B; no visible change.
+
+### require-dynamic-viewport-height — 2 (1 shipped)
+
+Flags viewport-height units (`100vh`, `100vb`), which on mobile browsers describe the _largest_ viewport — content sized with them gets cut off while the address bar is visible.
+The fix is the dynamic variant (`dvh`), with `vh` only as a fallback for older browsers.
+
+The one shipped hit is that fallback: `page.scss` already declares `min-block-size: 100vh` followed by `min-block-size: 100dvh` — exactly the recommended pattern — and the rule flags the fallback line because it judges declarations in isolation.
+The Storybook grid overlay has a genuine static `100vb`.
+
+**Approach:** annotate the fallback line; fix the Storybook overlay; then error.
+
+**Impact:** none; the shipped behaviour is already correct.
+
+### no-list-style-none — 1 (0 shipped, but 13 shipped sites affected)
+
+In Safari, `list-style: none` removes list semantics from the accessibility tree, so VoiceOver no longer announces the list or item count.
+Writing `list-style-type: ""` hides the markers while keeping the semantics.
+
+The rule’s single hit is a Storybook component, but that undercounts our exposure: it cannot see into Sass mixins, and both real occurrences live in the `reset-ol`/`reset-ul` mixins in `resets.scss`, which 13 components include — among them genuine content lists such as File List, Link List, Progress List, and the no-marker variants of Ordered and Unordered List.
+
+**Approach:** change both mixins (and the Storybook case) to `list-style-type: ""`; then error.
+The rule will keep guarding only literal future uses — the mixin fix is on us, not the linter.
+
+**Impact:** ~65 B compiled.
+VoiceOver users in Safari regain list announcements (“list, 5 items”) on marker-less lists.
+
+### require-prefers-reduced-motion — 1 (1 shipped)
+
+Requires transitions and animations of motion properties to sit inside `@media (prefers-reduced-motion: no-preference)`, honouring users who configure their system to reduce motion because animations can trigger vestibular disorders, migraines, or nausea.
+
+The rule is more discerning than expected: it ignores color-only transitions (Switch’s background fade is rightly not flagged) and fires only on motion properties.
+Our shipped CSS already honours reduced motion everywhere — Accordion, Table of Contents, and Progress List use the positive pattern the rule recognises.
+The single hit, Page Header’s menu icon, uses the equivalent _inverse_ construction: an unconditional transition plus `@media (prefers-reduced-motion) { transition: none }`.
+Users experience the same thing; only the rule cannot tell.
+
+**Approach:** refactor Page Header to the positive pattern for consistency with its three siblings; then error.
+
+**Impact:** none; behaviour is identical.
+
+## Rules turned off
+
+### require-custom-property-fallback — 1,148
+
+Wants a fallback value in every `var()`, so that a component still renders reasonably if the token stylesheet fails to load.
+
+We keep this off for three reasons.
+First, cost: resolving each of the 1,093 affected `var()` uses in shipped CSS against its actual token value measures 36 KB of added fallbacks — a 26.6% increase of the compiled stylesheet (gzip would soften the transfer, not the duplication).
+Second, maintenance: every fallback restates a design decision that the token already owns, leaving two places to change.
+Third, accuracy: the rule also flags 17 uses of `--_ams-*` private properties that are defined lines above in the same file.
+Our position is that the token stylesheet is a hard dependency of the component stylesheet, documented as such — not something to degrade gracefully without.
+
+### require-at-layer — 574
+
+Wants all styles wrapped in a top-level `@layer`, which gives consumers a clean way to override library styles regardless of specificity.
+
+This is an architecture decision disguised as a lint rule.
+Adopting cascade layers changes how every existing consumer’s overrides interact with our styles — unlayered author styles would suddenly beat all of ours, which is the point, but also the breaking change.
+It deserves an RFC with migration guidance (and coordination with NL Design System), not a mechanical fix.
+Until then the rule stays off; the violation count (574, i.e. every top-level rule) illustrates why a partial fix is meaningless.
+
+### require-pure-selectors — 78
+
+Wants selectors to target only classes and IDs, keeping styles decoupled from markup structure.
+
+The rule is not usable on this codebase in either mode.
+In strict mode (as the preset ships), most of its 78 reports are false positives: it flags `> *`, `+ *`, `[aria-expanded="true"] &`, and `.ams-date-input:not(:disabled):invalid` as “element tags”, none of which are.
+In non-strict mode 15 remain, still including `> *` and `:nth-of-type(…)` false positives; its genuine finds — `svg`, `img`, `+ label` — are deliberate API surface for a CSS library that consumers apply to their own HTML structure (an `.ams-avatar` must style whichever `img` or `svg` it contains; the input–label pairing _is_ the contract).
+Keep off; the false positives are worth reporting upstream.
+
+## Rules we do not violate
+
+Three rules are clean and enforced as errors; whether by accident or on purpose:
+
+- **require-forced-colors-focus** — deliberate.
+  The repository has an explicit convention (“never remove focus outlines”) and ships forced-colors work throughout: `LinkText` fills in the Page Header logo, `SelectedItem` backgrounds in Tabs, hairline separators in Dialog.
+  The failure this rule guards against — a box-shadow-only focus style that Windows High Contrast erases — has been designed out.
+- **no-mixed-vendor-prefixes** — deliberate by architecture.
+  We prefix at the _declaration_ level (`-webkit-user-select` beside `user-select`, each annotated), and never group differently-prefixed _selectors_ into one rule, which is the pattern that makes browsers drop the whole block.
+- **no-unsafe-will-change** — aligned rather than deliberate.
+  There is no `will-change` anywhere; nobody decided against it so much as never needed it.
+  The “make the simplest change” convention would resist introducing it, so the rule formalises an existing instinct.
+
+Two more rules report zero but prove nothing, because they cannot resolve `var()` and every relevant declaration here is tokenised:
+
+- **no-unsafe-clamp-font-size** — clean _in fact_, but verified only by our replacement rule `ams/no-unsafe-clamp-font-size`, which resolves token chains and confirms all four fluid font-size tokens scale by 1.11–1.50×, well under the 2.5× limit that would endanger 200% text resize (WCAG 1.4.4).
+- **require-system-font-fallback** — likewise: `ams/require-system-font-fallback` resolves every `font-family` through its alias chain to `'Amsterdam Sans', Arial, sans-serif` and requires the generic family to come last.
+
+Both upstream rules stay off to avoid double-reporting on literal values; the `ams/` rules are the enforcement.
+
+## What this does to the bundle
+
+Baseline: the compiled `packages/css` stylesheet is 135,452 B raw, 15,907 B gzipped; the token stylesheet adds 89,163 B raw, 10,218 B gzipped.
+Storybook CSS ships to nobody.
+
+The complete remediation set above — 72 hover media queries, 36 flex-wrap declarations, 11 minmax substitutions, 3 background-repeats, 1 scrollbar-gutter, 13 compiled list-style changes, and the focus-visible swap — measures **+2,682 B raw (+2.0%)** and, because the additions are highly repetitive, approximately **+86 B gzipped (+0.5%)** when appended to the real stylesheet.
+Interleaving the additions where they actually belong will compress slightly worse than this synthetic measurement, but the order of magnitude stands: roughly a tenth of a kilobyte on the wire.
+
+For contrast, the one rule that would be expensive is off: `require-custom-property-fallback` would add 36 KB raw (+26.6%).
+
+## What visitors would notice
+
+Almost nothing on day one — and that is the point: most of these rules guard against futures rather than fixing presents.
+By audience:
+
+- **Touch and hybrid device users** stop seeing hover styles stick to tapped controls (73 fixes; the one visible behaviour change).
+- **VoiceOver users in Safari** regain list semantics on marker-less lists such as File List and Progress List.
+- **Windows users with classic scrollbars** lose a subtle content shift when Dialog content grows scrollable.
+- **Users who enlarge text or zoom** are already served (fluid type ratios verified at 1.11–1.50×) and stay served by the error-level guards.
+- **Users with reduced-motion preferences** are already honoured everywhere; one component’s construction changes without changing behaviour.
+- **Keyboard users** see no change; focus indication was already sound, including in forced-colors mode.
+- **Everyone**, in rare failure scenarios that no longer occur: a long reference number can no longer blow a Grid-based layout out of its container, and a resized icon can no longer tile.
+
+## Suggested sequencing
+
+1. **Safety adds, no visible change** — background-repeat (3), scrollbar-gutter (1), grid-minmax (11), Storybook overscroll and viewport fixes, list-style mixins.
+   One mechanical PR, Chromatic-verified.
+2. **Flex-wrap intent pass** — 36 explicit declarations, mostly `nowrap`; the handful of toolbar judgment calls reviewed individually.
+3. **Hover media queries** — the 72-site wrap, as its own PR for reviewability.
+4. **Annotations** — `stylelint-disable-next-line` with reasons on the ~30 deliberate patterns and false positives documented above, each in the same PR as the fix that makes its rule clean.
+5. **Ratchet** — as each rule’s backlog reaches zero, raise it from warning to error in `.stylelintrc.json` (restating strict’s options where severity overrides would narrow them).
+   End state: 16 rules at error, 5 off with documented reasons, no standing warnings.
+6. **Separately** — decide on `require-named-grid-lines` (this report recommends off), and treat cascade layers as the architecture discussion it is.

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "stylelint": "17.14.0",
     "stylelint-config-standard-scss": "17.0.0",
     "stylelint-order": "8.1.1",
+    "stylelint-plugin-defensive-css": "2.9.4",
     "stylelint-plugin-use-baseline": "1.4.4",
     "stylelint-use-logical": "2.1.3",
     "stylelint-value-no-unknown-custom-properties": "6.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       stylelint-order:
         specifier: 8.1.1
         version: 8.1.1(stylelint@17.14.0(typescript@6.0.3))
+      stylelint-plugin-defensive-css:
+        specifier: 2.9.4
+        version: 2.9.4(stylelint@17.14.0(typescript@6.0.3))
       stylelint-plugin-use-baseline:
         specifier: 1.4.4
         version: 1.4.4(stylelint@17.14.0(typescript@6.0.3))
@@ -5790,6 +5793,11 @@ packages:
     engines: {node: '>=20.19.0'}
     peerDependencies:
       stylelint: ^16.18.0 || ^17.0.0
+
+  stylelint-plugin-defensive-css@2.9.4:
+    resolution: {integrity: sha512-LIqhTJHGyliBiO9MwMOFlL37Rm+3lTeGzfrKsIeR2hMMKpw7I+essHymSXokOOLD+ndyjCLTMrXgtq88rtHCVQ==}
+    peerDependencies:
+      stylelint: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
   stylelint-plugin-use-baseline@1.4.4:
     resolution: {integrity: sha512-AHLlNRmnP+8FQZ7OqwWyzVapnAUAPTLhWVdR9+0lfVf9ahuxbsoGn2Oi+BURpcbNvAXRIu9V/8aC4F9j56PnFA==}
@@ -12515,6 +12523,10 @@ snapshots:
     dependencies:
       postcss: 8.5.14
       postcss-sorting: 10.0.0(postcss@8.5.14)
+      stylelint: 17.14.0(typescript@6.0.3)
+
+  stylelint-plugin-defensive-css@2.9.4(stylelint@17.14.0(typescript@6.0.3)):
+    dependencies:
       stylelint: 17.14.0(typescript@6.0.3)
 
   stylelint-plugin-use-baseline@1.4.4(stylelint@17.14.0(typescript@6.0.3)):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,6 +359,19 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@types/node@25.7.0)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.4(@types/node@25.7.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))
 
+  stylelint:
+    dependencies:
+      postcss:
+        specifier: 8.5.16
+        version: 8.5.16
+    devDependencies:
+      stylelint:
+        specifier: 17.14.0
+        version: 17.14.0(typescript@6.0.3)
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@25.7.0)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@8.1.4(@types/node@25.7.0)(esbuild@0.28.1)(sass@1.101.0)(terser@5.47.1)(yaml@2.9.0))
+
 packages:
 
   '@adobe/css-tools@4.4.4':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - "packages/*"
   - "packages-proprietary/*"
   - "storybook"
+  - "stylelint"
 overrides:
   "@tootallnate/once@<3.0.1": "^3.0.1"
   "esbuild@<0.28.1": "^0.28.1"

--- a/stylelint/README.md
+++ b/stylelint/README.md
@@ -64,6 +64,32 @@ The rules skip anything they cannot resolve with certainty, rather than guess:
 Resolution is flat: a custom property is looked up by name, without regard for the selector it was declared under.
 A component that redeclares a token under one selector is therefore treated as ambiguous and skipped.
 
+## Relationship to `stylelint-plugin-defensive-css`
+
+That plugin is installed and extended from its `strict` config, which enables all 21 of its rules.
+Four of its rules are turned off in [.stylelintrc.json](../.stylelintrc.json), which cannot hold comments, so the reasoning lives here.
+
+`defensive-css/no-unsafe-clamp-font-size` and `defensive-css/require-system-font-fallback` are off because the two rules above replace them.
+Neither upstream rule resolves `var()`, so both pass on every tokenised declaration in this repository.
+The rules here check the same thing and also catch literal values, so running both would only duplicate warnings on the literals.
+
+`defensive-css/require-custom-property-fallback` is off.
+It asks for `var(--token, fallback)` at every use, which would restate a value that the token already defines and leave two places to change it.
+
+`defensive-css/require-at-layer` is off.
+It asks for every style to sit in a top-level `@layer`, which changes how consumers override our CSS.
+That is an architecture decision, not a lint fix.
+
+`defensive-css/require-pure-selectors` is off.
+It reports `> *`, `+ *`, `[aria-expanded="true"] &` and `.ams-date-input:not(:disabled):invalid` as element tags, none of which are.
+
+Every remaining rule runs at `warning` severity where the repository still has violations, so they are visible without failing `lint:css`, and at `error` where it has none.
+
+Two of the upstream rules are narrower than they look:
+
+- `no-fixed-sizes` only checks its default properties once its severity is overridden, which drops coverage of borders, outlines and `translate`. Restoring the full list means restating all ninety properties in the config. It reports 8 violations as configured, against 15 with the full list.
+- `no-list-style-none` misses both uses of `list-style: none` in [resets.scss](../packages/css/src/common/resets.scss), because they sit in `@mixin` blocks where it cannot see a list element in the selector.
+
 ## Requirements
 
 The token file has to be built before the rules can resolve anything:

--- a/stylelint/README.md
+++ b/stylelint/README.md
@@ -1,0 +1,81 @@
+<!-- @license CC0-1.0 -->
+
+# Stylelint plugin
+
+Stylelint rules that resolve design tokens before judging a declaration.
+
+## Why this exists
+
+Almost every value in this repository is written as a token reference:
+
+```scss
+.ams-heading--level-1 {
+  font-size: var(--ams-heading-1-font-size);
+}
+```
+
+Rules that inspect the literal value of a declaration cannot see through that reference.
+They read `var(--ams-heading-1-font-size)`, find nothing to check, and pass.
+That is the correct thing for a general purpose rule to do, because resolving the reference needs knowledge of where the token is defined.
+It does mean such a rule reports no problems here, whatever the token turns out to contain.
+
+The rules in this plugin read the built token file, follow the reference — through as many aliases as it takes — and check the value it ends at.
+A problem is reported at the declaration that uses the token, so the warning points at a line you can act on.
+
+## Rules
+
+### `ams/no-unsafe-clamp-font-size`
+
+Reports a `font-size` that resolves to a `clamp()` whose maximum is more than 2.5 times its minimum, when the preferred value scales with the viewport.
+
+A viewport unit does not grow when someone zooms in, so a font size that leans on one heavily leaves too little room to enlarge text.
+Text has to stay resizable to 200% under WCAG 2.2 Level AA, success criterion 1.4.4.
+
+A `clamp()` without a viewport unit in its preferred value is not reported: zoom still resizes it.
+
+Options:
+
+- `importFrom` — paths to the CSS files to read tokens from, relative to the working directory.
+- `maxRatio` — the largest allowed ratio between the minimum and the maximum. Defaults to `2.5`.
+
+### `ams/require-system-font-fallback`
+
+Reports a `font-family` that resolves to a stack which does not end in a generic family such as `sans-serif`.
+
+Without one, text has nothing to render in when the web font fails to load.
+A generic family that is not last is reported too, because the families after it are never reached.
+
+The `font-family` descriptor inside `@font-face` and `@font-palette-values` is skipped, since there it names the font being defined rather than a stack to fall through.
+So are the global keywords `inherit`, `initial`, `revert`, `revert-layer` and `unset`.
+
+Options:
+
+- `importFrom` — paths to the CSS files to read tokens from, relative to the working directory.
+
+## What it does not check
+
+The rules skip anything they cannot resolve with certainty, rather than guess:
+
+- A token that is declared more than once with different values, because which declaration wins depends on the cascade.
+- A reference cycle, or a chain longer than twenty steps.
+- A custom property that is defined nowhere the rule can see, and has no fallback.
+- A value that contains Sass interpolation, which only resolves once the stylesheet is compiled.
+
+Resolution is flat: a custom property is looked up by name, without regard for the selector it was declared under.
+A component that redeclares a token under one selector is therefore treated as ambiguous and skipped.
+
+## Requirements
+
+The token file has to be built before the rules can resolve anything:
+
+```sh
+pnpm --filter @amsterdam/design-system-tokens run build
+```
+
+When a file listed in `importFrom` cannot be read, the rule reports that as an invalid option instead of passing silently.
+
+## Tests
+
+```sh
+pnpm --filter @amsterdam/stylelint-plugin run test
+```

--- a/stylelint/README.md
+++ b/stylelint/README.md
@@ -67,7 +67,8 @@ A component that redeclares a token under one selector is therefore treated as a
 ## Relationship to `stylelint-plugin-defensive-css`
 
 That plugin is installed and extended from its `strict` config, which enables all 21 of its rules.
-Four of its rules are turned off in [.stylelintrc.json](../.stylelintrc.json), which cannot hold comments, so the reasoning lives here.
+Five of its rules are turned off in [.stylelintrc.json](../.stylelintrc.json), which cannot hold comments, so the reasoning lives here.
+A full audit of all 21 rules — effectiveness, violations, remediation, and impact — is in [documentation/defensive-css.md](../documentation/defensive-css.md).
 
 `defensive-css/no-unsafe-clamp-font-size` and `defensive-css/require-system-font-fallback` are off because the two rules above replace them.
 Neither upstream rule resolves `var()`, so both pass on every tokenised declaration in this repository.

--- a/stylelint/custom-properties.mjs
+++ b/stylelint/custom-properties.mjs
@@ -1,0 +1,196 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { readFileSync, statSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+import postcss from 'postcss'
+
+import { findFunction, splitTopLevelParts } from './values.mjs'
+
+/* Parsed token files, keyed by absolute path, so a lint run reads each file once instead of once
+ * per linted stylesheet. The modification time invalidates the entry when tokens are rebuilt.
+ */
+const fileCache = new Map()
+
+/* Guards against a chain of custom properties that never terminates. */
+const MAXIMUM_RESOLUTION_DEPTH = 20
+
+/**
+ * Records a custom property, marking it unresolvable when it is declared more than once with
+ * different values. Which of those declarations applies depends on the cascade, which is unknowable
+ * here, so the value is treated as unknown rather than guessed at.
+ *
+ * @param {Map<string, string | null>} customProperties - The collected custom properties.
+ * @param {string} name - The custom property name.
+ * @param {string} value - The declared value.
+ * @returns {void}
+ */
+function addCustomProperty(customProperties, name, value) {
+  if (!customProperties.has(name)) {
+    customProperties.set(name, value)
+
+    return
+  }
+
+  if (customProperties.get(name) !== value) {
+    customProperties.set(name, null)
+  }
+}
+
+/**
+ * Reads every custom property declaration from a CSS file, using a cached result when the file is
+ * unchanged.
+ *
+ * @param {string} absolutePath - The absolute path of the file.
+ * @returns {Array<[string, string]>} The declared custom properties.
+ */
+function readCustomPropertyEntries(absolutePath) {
+  const { mtimeMs } = statSync(absolutePath)
+  const cached = fileCache.get(absolutePath)
+
+  if (cached && cached.mtimeMs === mtimeMs) {
+    return cached.entries
+  }
+
+  const entries = []
+
+  postcss.parse(readFileSync(absolutePath, 'utf8')).walkDecls((declaration) => {
+    if (declaration.prop.startsWith('--')) {
+      entries.push([declaration.prop, declaration.value])
+    }
+  })
+
+  fileCache.set(absolutePath, { entries, mtimeMs })
+
+  return entries
+}
+
+/**
+ * Collects the custom properties declared in the given CSS files.
+ *
+ * @param {string[]} filePaths - Paths to CSS files, absolute or relative to the working directory.
+ * @returns {{ customProperties: Map<string, string | null>, missingFiles: string[] }} The custom
+ *   properties, and the paths that could not be read.
+ */
+export function readCustomProperties(filePaths) {
+  const customProperties = new Map()
+  const missingFiles = []
+
+  for (const filePath of filePaths) {
+    let entries
+
+    try {
+      entries = readCustomPropertyEntries(resolve(process.cwd(), filePath))
+    } catch {
+      missingFiles.push(filePath)
+
+      continue
+    }
+
+    for (const [name, value] of entries) {
+      addCustomProperty(customProperties, name, value)
+    }
+  }
+
+  return { customProperties, missingFiles }
+}
+
+/**
+ * Adds the custom properties a stylesheet declares itself to the ones read from the token files,
+ * so that component private properties such as `--_ams-…` resolve too.
+ *
+ * @param {import('postcss').Root} root - The stylesheet being linted.
+ * @param {Map<string, string | null>} customProperties - The custom properties from the token files.
+ * @returns {Map<string, string | null>} The combined custom properties.
+ */
+export function withDeclaredCustomProperties(root, customProperties) {
+  const combined = new Map(customProperties)
+
+  root.walkDecls((declaration) => {
+    if (declaration.prop.startsWith('--')) {
+      addCustomProperty(combined, declaration.prop, declaration.value)
+    }
+  })
+
+  return combined
+}
+
+/**
+ * Replaces every `var()` in a value with the value it references, following chains of custom
+ * properties. Returns null when any part of the value cannot be resolved, so that callers skip the
+ * declaration instead of judging it on an incomplete value.
+ *
+ * @param {string} value - The value to resolve.
+ * @param {Map<string, string | null>} customProperties - The known custom properties.
+ * @param {Set<string>} [seen] - The custom properties already being resolved, to detect cycles.
+ * @returns {string | null} The resolved value, or null when it is not statically knowable.
+ */
+export function resolveValue(value, customProperties, seen = new Set()) {
+  if (seen.size > MAXIMUM_RESOLUTION_DEPTH) {
+    return null
+  }
+
+  const call = findFunction(value, 'var')
+
+  if (!call) {
+    return value
+  }
+
+  const [name, ...fallbackParts] = call.args
+  const fallback = fallbackParts.join(', ')
+  let replacement = null
+
+  if (seen.has(name)) {
+    /* A custom property that references itself never resolves to a value. */
+    return null
+  }
+
+  if (customProperties.has(name)) {
+    const declaredValue = customProperties.get(name)
+
+    replacement =
+      declaredValue === null ? null : resolveValue(declaredValue, customProperties, new Set([...seen, name]))
+  } else if (fallback) {
+    /* The fallback only applies while the custom property is undefined, which is the case here. */
+    replacement = resolveValue(fallback, customProperties, seen)
+  }
+
+  if (replacement === null) {
+    return null
+  }
+
+  return resolveValue(value.slice(0, call.start) + replacement + value.slice(call.end), customProperties, seen)
+}
+
+/**
+ * Returns the custom property a value consists of, when the value is a single `var()` and nothing
+ * else. Used to name the token that carries a problem in a warning.
+ *
+ * @param {string} value - The value to inspect.
+ * @returns {string | null} The custom property name, or null when the value is something else.
+ */
+export function getReferencedCustomProperty(value) {
+  const trimmed = value.trim()
+  const call = findFunction(trimmed, 'var')
+
+  if (!call || call.start !== 0 || call.end !== trimmed.length) {
+    return null
+  }
+
+  return call.args[0]
+}
+
+/**
+ * Splits a resolved font stack into its individual family names, stripping quotes.
+ *
+ * @param {string} value - The resolved `font-family` value.
+ * @returns {string[]} The family names.
+ */
+export function parseFontStack(value) {
+  return splitTopLevelParts(value)
+    .map((family) => family.trim().replace(/^(['"])(.*)\1$/, '$2'))
+    .filter(Boolean)
+}

--- a/stylelint/custom-properties.test.mjs
+++ b/stylelint/custom-properties.test.mjs
@@ -1,0 +1,100 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { getReferencedCustomProperty, parseFontStack, resolveValue } from './custom-properties.mjs'
+
+const customProperties = new Map([
+  ['--ambiguous', null],
+  ['--cycle-a', 'var(--cycle-b)'],
+  ['--cycle-b', 'var(--cycle-a)'],
+  ['--maximum', '2rem'],
+  ['--minimum', '1rem'],
+  ['--one-hop', 'var(--minimum)'],
+  ['--self', 'var(--self)'],
+  ['--two-hops', 'var(--one-hop)'],
+])
+
+describe('resolveValue', () => {
+  it('returns a value that holds no custom property unchanged', () => {
+    expect(resolveValue('1rem', customProperties)).toBe('1rem')
+  })
+
+  it('resolves a single reference', () => {
+    expect(resolveValue('var(--minimum)', customProperties)).toBe('1rem')
+  })
+
+  it('follows a chain of references', () => {
+    expect(resolveValue('var(--two-hops)', customProperties)).toBe('1rem')
+  })
+
+  it('resolves every reference in a composite value', () => {
+    expect(resolveValue('clamp(var(--minimum), 5vw, var(--maximum))', customProperties)).toBe('clamp(1rem, 5vw, 2rem)')
+  })
+
+  it('uses the fallback when the custom property is undefined', () => {
+    expect(resolveValue('var(--undefined, 3rem)', customProperties)).toBe('3rem')
+  })
+
+  it('ignores the fallback when the custom property is defined, matching the cascade', () => {
+    expect(resolveValue('var(--minimum, 9rem)', customProperties)).toBe('1rem')
+  })
+
+  it('resolves a reference nested in a fallback', () => {
+    expect(resolveValue('var(--undefined, var(--minimum))', customProperties)).toBe('1rem')
+  })
+
+  it('returns null for an undefined custom property without a fallback', () => {
+    expect(resolveValue('var(--undefined)', customProperties)).toBeNull()
+  })
+
+  it('returns null for a custom property declared with conflicting values', () => {
+    expect(resolveValue('var(--ambiguous)', customProperties)).toBeNull()
+  })
+
+  it('returns null for a reference cycle instead of recursing forever', () => {
+    expect(resolveValue('var(--cycle-a)', customProperties)).toBeNull()
+  })
+
+  it('returns null for a custom property that references itself', () => {
+    expect(resolveValue('var(--self)', customProperties)).toBeNull()
+  })
+
+  it('returns null when one part of a composite value is unresolvable', () => {
+    expect(resolveValue('clamp(var(--minimum), 5vw, var(--undefined))', customProperties)).toBeNull()
+  })
+})
+
+describe('getReferencedCustomProperty', () => {
+  it.each([
+    ['var(--minimum)', '--minimum'],
+    ['  var(--minimum)  ', '--minimum'],
+    ['var(--minimum, 1rem)', '--minimum'],
+  ])('names the custom property in %s', (value, expected) => {
+    expect(getReferencedCustomProperty(value)).toBe(expected)
+  })
+
+  it.each([['1rem'], ['var(--a) var(--b)'], ['clamp(var(--a), 5vw, 2rem)']])(
+    'returns null for %s, which is more than one reference',
+    (value) => {
+      expect(getReferencedCustomProperty(value)).toBeNull()
+    },
+  )
+})
+
+describe('parseFontStack', () => {
+  it('splits a stack and strips quotes', () => {
+    expect(parseFontStack(`'Amsterdam Sans', Arial, sans-serif`)).toEqual(['Amsterdam Sans', 'Arial', 'sans-serif'])
+  })
+
+  it('keeps a comma inside a quoted family name', () => {
+    expect(parseFontStack(`"Foo, Bar", serif`)).toEqual(['Foo, Bar', 'serif'])
+  })
+
+  it('returns a single family', () => {
+    expect(parseFontStack('inherit')).toEqual(['inherit'])
+  })
+})

--- a/stylelint/index.mjs
+++ b/stylelint/index.mjs
@@ -1,0 +1,9 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import noUnsafeClampFontSize from './no-unsafe-clamp-font-size.mjs'
+import requireSystemFontFallback from './require-system-font-fallback.mjs'
+
+export default [noUnsafeClampFontSize, requireSystemFontFallback]

--- a/stylelint/no-unsafe-clamp-font-size.mjs
+++ b/stylelint/no-unsafe-clamp-font-size.mjs
@@ -1,0 +1,122 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import stylelint from 'stylelint'
+
+import {
+  getReferencedCustomProperty,
+  readCustomProperties,
+  resolveValue,
+  withDeclaredCustomProperties,
+} from './custom-properties.mjs'
+import { calculateRatio, findFunction, hasInterpolation, hasViewportUnit } from './values.mjs'
+
+const { createPlugin, utils } = stylelint
+
+const ruleName = 'ams/no-unsafe-clamp-font-size'
+
+/* Text must stay legible at 200% zoom. A font size that grows more than this between its smallest
+ * and largest viewport leaves too little room for the user to enlarge it further.
+ */
+const DEFAULT_MAXIMUM_RATIO = 2.5
+
+const messages = utils.ruleMessages(ruleName, {
+  missingFile: (filePath) =>
+    `Could not read "${filePath}", so font sizes that use tokens were not checked. Run \`pnpm --filter @amsterdam/design-system-tokens run build\` to generate it`,
+  rejected: (source, ratio, maximumRatio) =>
+    `Expected "${source}" to scale by at most ${maximumRatio}× between its smallest and largest size, but it scales by ${ratio}×. Text has to stay resizable to 200% (WCAG 2.2 Level AA, 1.4.4)`,
+})
+
+const meta = { url: 'https://github.com/Amsterdam/design-system/blob/develop/stylelint/README.md' }
+
+/* Token files that could not be read, so the warning is emitted once per lint run and not once per
+ * stylesheet.
+ */
+const warnedFiles = new Set()
+
+/** @type {import('stylelint').Rule} */
+const rule =
+  (primary, secondaryOptions = {}) =>
+  (root, result) => {
+    const validOptions = utils.validateOptions(
+      result,
+      ruleName,
+      { actual: primary, possible: [true] },
+      {
+        actual: secondaryOptions,
+        optional: true,
+        possible: {
+          importFrom: [(value) => typeof value === 'string'],
+          maxRatio: [(value) => typeof value === 'number' && value > 0],
+        },
+      },
+    )
+
+    if (!validOptions) {
+      return
+    }
+
+    const maximumRatio = secondaryOptions.maxRatio ?? DEFAULT_MAXIMUM_RATIO
+    const { customProperties, missingFiles } = readCustomProperties([secondaryOptions.importFrom ?? []].flat())
+
+    for (const missingFile of missingFiles) {
+      if (!warnedFiles.has(missingFile)) {
+        warnedFiles.add(missingFile)
+
+        result.warn(messages.missingFile(missingFile), { stylelintType: 'invalidOption' })
+      }
+    }
+
+    const knownCustomProperties = withDeclaredCustomProperties(root, customProperties)
+
+    root.walkDecls(/^font-size$/i, (declaration) => {
+      if (hasInterpolation(declaration.value)) {
+        return
+      }
+
+      const resolved = resolveValue(declaration.value, knownCustomProperties)
+
+      if (resolved === null) {
+        return
+      }
+
+      const clamp = findFunction(resolved, 'clamp')
+
+      if (!clamp || clamp.args.length !== 3) {
+        return
+      }
+
+      const [minimum, preferred, maximum] = clamp.args
+
+      /* Only a font size that scales with the viewport can stop the user from resizing text, because
+       * a viewport stays the same size while the user zooms in.
+       */
+      if (!hasViewportUnit(preferred)) {
+        return
+      }
+
+      const ratio = calculateRatio(minimum, maximum)
+
+      if (ratio === null || ratio <= maximumRatio) {
+        return
+      }
+
+      const source = getReferencedCustomProperty(declaration.value) ?? `clamp(${minimum}, ${preferred}, ${maximum})`
+
+      utils.report({
+        message: messages.rejected(source, Number(ratio.toFixed(2)), maximumRatio),
+        node: declaration,
+        result,
+        ruleName,
+        word: declaration.value,
+      })
+    })
+  }
+
+rule.messages = messages
+rule.meta = meta
+rule.ruleName = ruleName
+
+export default createPlugin(ruleName, rule)

--- a/stylelint/package.json
+++ b/stylelint/package.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.0.0",
+  "author": "Design System Team, City of Amsterdam <designsystem@amsterdam.nl>",
+  "description": "Stylelint rules that resolve Amsterdam Design System tokens before checking a declaration.",
+  "license": "EUPL-1.2",
+  "name": "@amsterdam/stylelint-plugin",
+  "type": "module",
+  "keywords": [],
+  "private": true,
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "postcss": "8.5.16"
+  },
+  "devDependencies": {
+    "stylelint": "17.14.0",
+    "vitest": "4.1.10"
+  }
+}

--- a/stylelint/require-system-font-fallback.mjs
+++ b/stylelint/require-system-font-fallback.mjs
@@ -1,0 +1,153 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import stylelint from 'stylelint'
+
+import {
+  getReferencedCustomProperty,
+  parseFontStack,
+  readCustomProperties,
+  resolveValue,
+  withDeclaredCustomProperties,
+} from './custom-properties.mjs'
+import { hasInterpolation } from './values.mjs'
+
+const { createPlugin, utils } = stylelint
+
+const ruleName = 'ams/require-system-font-fallback'
+
+/* The generic families from CSS Fonts Module Level 4. Each one resolves to a font that is always
+ * available, so a stack that ends in one still renders when the web font fails to load.
+ */
+const GENERIC_FAMILIES = new Set([
+  'cursive',
+  'emoji',
+  'fangsong',
+  'fantasy',
+  'math',
+  'monospace',
+  'sans-serif',
+  'serif',
+  'system-ui',
+  'ui-monospace',
+  'ui-rounded',
+  'ui-sans-serif',
+  'ui-serif',
+])
+
+/* Values that do not describe a font stack at all, so there is nothing to fall back to. */
+const GLOBAL_KEYWORDS = new Set(['inherit', 'initial', 'revert', 'revert-layer', 'unset'])
+
+/* Inside these at-rules `font-family` is a descriptor that names the font being defined, rather
+ * than a stack the browser falls through. Adding a generic family there would be meaningless.
+ */
+const FONT_DESCRIPTOR_AT_RULES = new Set(['font-face', 'font-palette-values'])
+
+/**
+ * Reports whether a declaration sits in an at-rule where `font-family` names a font.
+ *
+ * @param {import('postcss').Declaration} declaration - The declaration to inspect.
+ * @returns {boolean} True when the declaration is a font descriptor.
+ */
+function isFontDescriptor(declaration) {
+  for (let node = declaration.parent; node; node = node.parent) {
+    if (node.type === 'atrule' && FONT_DESCRIPTOR_AT_RULES.has(node.name.toLowerCase())) {
+      return true
+    }
+  }
+
+  return false
+}
+
+const messages = utils.ruleMessages(ruleName, {
+  missingFile: (filePath) =>
+    `Could not read "${filePath}", so font families that use tokens were not checked. Run \`pnpm --filter @amsterdam/design-system-tokens run build\` to generate it`,
+  rejected: (source, stack) =>
+    `Expected "${source}" to end in a generic font family, but it resolves to "${stack}". Text disappears or reflows when the web font fails to load`,
+})
+
+const meta = { url: 'https://github.com/Amsterdam/design-system/blob/develop/stylelint/README.md' }
+
+/* Token files that could not be read, so the warning is emitted once per lint run and not once per
+ * stylesheet.
+ */
+const warnedFiles = new Set()
+
+/** @type {import('stylelint').Rule} */
+const rule =
+  (primary, secondaryOptions = {}) =>
+  (root, result) => {
+    const validOptions = utils.validateOptions(
+      result,
+      ruleName,
+      { actual: primary, possible: [true] },
+      {
+        actual: secondaryOptions,
+        optional: true,
+        possible: {
+          importFrom: [(value) => typeof value === 'string'],
+        },
+      },
+    )
+
+    if (!validOptions) {
+      return
+    }
+
+    const { customProperties, missingFiles } = readCustomProperties([secondaryOptions.importFrom ?? []].flat())
+
+    for (const missingFile of missingFiles) {
+      if (!warnedFiles.has(missingFile)) {
+        warnedFiles.add(missingFile)
+
+        result.warn(messages.missingFile(missingFile), { stylelintType: 'invalidOption' })
+      }
+    }
+
+    const knownCustomProperties = withDeclaredCustomProperties(root, customProperties)
+
+    root.walkDecls(/^font-family$/i, (declaration) => {
+      if (hasInterpolation(declaration.value) || isFontDescriptor(declaration)) {
+        return
+      }
+
+      const resolved = resolveValue(declaration.value, knownCustomProperties)
+
+      if (resolved === null) {
+        return
+      }
+
+      const families = parseFontStack(resolved)
+
+      if (families.length === 0) {
+        return
+      }
+
+      if (families.length === 1 && GLOBAL_KEYWORDS.has(families[0].toLowerCase())) {
+        return
+      }
+
+      /* The generic family has to come last: any family listed after it is never reached. */
+      if (GENERIC_FAMILIES.has(families.at(-1).toLowerCase())) {
+        return
+      }
+
+      const source = getReferencedCustomProperty(declaration.value) ?? declaration.prop
+
+      utils.report({
+        message: messages.rejected(source, families.join(', ')),
+        node: declaration,
+        result,
+        ruleName,
+        word: declaration.value,
+      })
+    })
+  }
+
+rule.messages = messages
+rule.meta = meta
+rule.ruleName = ruleName
+
+export default createPlugin(ruleName, rule)

--- a/stylelint/rules.test.mjs
+++ b/stylelint/rules.test.mjs
@@ -1,0 +1,144 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import stylelint from 'stylelint'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import plugins from './index.mjs'
+
+const TOKENS = `
+:root {
+  --ams-alias-font-size: var(--ams-unsafe-font-size);
+  --ams-cycle-a-font-size: var(--ams-cycle-b-font-size);
+  --ams-cycle-b-font-size: var(--ams-cycle-a-font-size);
+  --ams-safe-font-size: clamp(1rem, 5vw, 2rem);
+  --ams-static-font-size: clamp(1rem, 2rem, 4rem);
+  --ams-unsafe-font-size: clamp(1rem, 5vw, 4rem);
+  --ams-bare-font-family: 'Amsterdam Sans';
+  --ams-generic-first-font-family: sans-serif, 'Amsterdam Sans';
+  --ams-inherit-font-family: inherit;
+  --ams-safe-font-family: 'Amsterdam Sans', Arial, sans-serif;
+}
+`
+
+let tokensPath
+
+beforeAll(() => {
+  tokensPath = join(mkdtempSync(join(tmpdir(), 'ams-stylelint-')), 'tokens.css')
+
+  writeFileSync(tokensPath, TOKENS)
+})
+
+/**
+ * Lints a snippet with a single rule of this plugin enabled.
+ *
+ * @param {string} ruleName - The rule to enable.
+ * @param {string} code - The CSS to lint.
+ * @param {object} [options] - Extra secondary options for the rule.
+ * @returns {Promise<string[]>} The warning texts.
+ */
+async function lint(ruleName, code, options = {}) {
+  const { results } = await stylelint.lint({
+    code,
+    config: {
+      plugins,
+      rules: { [ruleName]: [true, { importFrom: [tokensPath], ...options }] },
+    },
+  })
+
+  return results[0].warnings.map((warning) => warning.text)
+}
+
+describe('ams/no-unsafe-clamp-font-size', () => {
+  const ruleName = 'ams/no-unsafe-clamp-font-size'
+
+  it('rejects a clamp written straight into the declaration', async () => {
+    expect(await lint(ruleName, '.a { font-size: clamp(1rem, 5vw, 4rem); }')).toHaveLength(1)
+  })
+
+  it('rejects a clamp reached through a token, which is what a plain value check misses', async () => {
+    const warnings = await lint(ruleName, '.a { font-size: var(--ams-unsafe-font-size); }')
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('--ams-unsafe-font-size')
+    expect(warnings[0]).toContain('4×')
+  })
+
+  it('rejects a clamp reached through a chain of tokens', async () => {
+    expect(await lint(ruleName, '.a { font-size: var(--ams-alias-font-size); }')).toHaveLength(1)
+  })
+
+  it('rejects a clamp reached through the fallback of an undefined token', async () => {
+    expect(await lint(ruleName, '.a { font-size: var(--ams-absent, clamp(1rem, 5vw, 8rem)); }')).toHaveLength(1)
+  })
+
+  it('accepts a ratio within the maximum', async () => {
+    expect(await lint(ruleName, '.a { font-size: var(--ams-safe-font-size); }')).toHaveLength(0)
+  })
+
+  it('accepts a clamp that does not scale with the viewport, since zooming still resizes it', async () => {
+    expect(await lint(ruleName, '.a { font-size: var(--ams-static-font-size); }')).toHaveLength(0)
+  })
+
+  it('accepts a token it cannot resolve rather than guessing', async () => {
+    expect(await lint(ruleName, '.a { font-size: var(--ams-absent); }')).toHaveLength(0)
+  })
+
+  it('accepts a reference cycle without hanging', async () => {
+    expect(await lint(ruleName, '.a { font-size: var(--ams-cycle-a-font-size); }')).toHaveLength(0)
+  })
+
+  it('honours a stricter maxRatio', async () => {
+    expect(await lint(ruleName, '.a { font-size: var(--ams-safe-font-size); }', { maxRatio: 1.5 })).toHaveLength(1)
+  })
+
+  it('reports the file it could not read instead of passing silently', async () => {
+    const { results } = await stylelint.lint({
+      code: '.a { font-size: var(--ams-unsafe-font-size); }',
+      config: {
+        plugins,
+        rules: { [ruleName]: [true, { importFrom: ['./does-not-exist.css'] }] },
+      },
+    })
+
+    expect(results[0].invalidOptionWarnings.map((warning) => warning.text).join()).toContain('does-not-exist.css')
+  })
+})
+
+describe('ams/require-system-font-fallback', () => {
+  const ruleName = 'ams/require-system-font-fallback'
+
+  it('rejects a token whose stack has no generic family', async () => {
+    const warnings = await lint(ruleName, '.a { font-family: var(--ams-bare-font-family); }')
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('--ams-bare-font-family')
+  })
+
+  it('rejects a stack written straight into the declaration', async () => {
+    expect(await lint(ruleName, `.a { font-family: 'Amsterdam Sans'; }`)).toHaveLength(1)
+  })
+
+  it('rejects a generic family that is not last, since the families after it never apply', async () => {
+    expect(await lint(ruleName, '.a { font-family: var(--ams-generic-first-font-family); }')).toHaveLength(1)
+  })
+
+  it('accepts a stack that ends in a generic family', async () => {
+    expect(await lint(ruleName, '.a { font-family: var(--ams-safe-font-family); }')).toHaveLength(0)
+  })
+
+  it('accepts a global keyword, which is not a stack', async () => {
+    expect(await lint(ruleName, '.a { font-family: var(--ams-inherit-font-family); }')).toHaveLength(0)
+  })
+
+  it('accepts the font-family descriptor of an @font-face, which names the font being defined', async () => {
+    const code = `@font-face { font-family: 'Amsterdam Sans'; src: url(a.woff2) format('woff2'); }`
+
+    expect(await lint(ruleName, code)).toHaveLength(0)
+  })
+})

--- a/stylelint/values.mjs
+++ b/stylelint/values.mjs
@@ -1,0 +1,191 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+/* Absolute lengths expressed in pixels, used to compare two lengths that use different units.
+ * `em` is deliberately absent: it resolves against the parent font size, which is unknowable here.
+ * Two `em` values are still comparable to each other, which `calculateRatio` handles separately.
+ */
+const PIXELS_PER_UNIT = {
+  cm: 96 / 2.54,
+  in: 96,
+  mm: 96 / 25.4,
+  pc: 16,
+  pt: 96 / 72,
+  px: 1,
+  q: 96 / 101.6,
+  rem: 16,
+}
+
+const LENGTH_PATTERN = /^(-?(?:\d+\.?\d*|\.\d+))([a-z%]+)$/i
+
+/* Matches a number immediately followed by a viewport unit, including the small, large and dynamic
+ * variants. The leading digit keeps identifiers such as `--foo-vw` from matching.
+ */
+const VIEWPORT_UNIT_PATTERN = /\d\s*(?:s|l|d)?v(?:w|h|i|b|min|max)\b/i
+
+/**
+ * Splits a CSS value on its top level commas, ignoring commas nested in functions or quoted strings.
+ * Escaped quotes are not accounted for; font stacks and `clamp()` arguments do not use them.
+ *
+ * @param {string} value - The value to split.
+ * @returns {string[]} The trimmed parts.
+ */
+export function splitTopLevelParts(value) {
+  const parts = []
+  let current = ''
+  let depth = 0
+  let quote = null
+
+  for (const character of value) {
+    if (quote) {
+      current += character
+
+      if (character === quote) {
+        quote = null
+      }
+
+      continue
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character
+      current += character
+
+      continue
+    }
+
+    if (character === '(') {
+      depth += 1
+    } else if (character === ')') {
+      depth -= 1
+    }
+
+    if (character === ',' && depth === 0) {
+      parts.push(current.trim())
+      current = ''
+
+      continue
+    }
+
+    current += character
+  }
+
+  parts.push(current.trim())
+
+  return parts
+}
+
+/**
+ * Finds the first call of the given function in a value, matching parentheses so that nested calls
+ * are kept intact.
+ *
+ * @param {string} value - The value to search.
+ * @param {string} functionName - The function to look for, such as `var` or `clamp`.
+ * @returns {{ args: string[], end: number, start: number } | null} The call, or null when absent.
+ */
+export function findFunction(value, functionName) {
+  const opening = `${functionName}(`
+  let start = value.indexOf(opening)
+
+  while (start !== -1) {
+    /* Reject a match that is the tail of a longer identifier, such as `my-var(` for `var(`. */
+    const isOwnIdentifier = start === 0 || !/[\w-]/.test(value[start - 1])
+
+    if (isOwnIdentifier) {
+      let depth = 0
+
+      for (let index = start + functionName.length; index < value.length; index += 1) {
+        if (value[index] === '(') {
+          depth += 1
+        } else if (value[index] === ')') {
+          depth -= 1
+
+          if (depth === 0) {
+            const end = index + 1
+
+            return {
+              args: splitTopLevelParts(value.slice(start + opening.length, index)),
+              end,
+              start,
+            }
+          }
+        }
+      }
+
+      return null
+    }
+
+    start = value.indexOf(opening, start + 1)
+  }
+
+  return null
+}
+
+/**
+ * Parses a CSS length into its number and unit.
+ *
+ * @param {string} value - The length to parse.
+ * @returns {{ number: number, unit: string } | null} The parsed length, or null when not a length.
+ */
+export function parseLength(value) {
+  const match = LENGTH_PATTERN.exec(value.trim())
+
+  if (!match) {
+    return null
+  }
+
+  return { number: Number(match[1]), unit: match[2].toLowerCase() }
+}
+
+/**
+ * Calculates how many times larger the maximum of a `clamp()` is than its minimum.
+ * Lengths that share a unit are compared directly, so units without a fixed pixel size still work.
+ *
+ * @param {string} minimum - The minimum length.
+ * @param {string} maximum - The maximum length.
+ * @returns {number | null} The ratio, or null when the lengths cannot be compared.
+ */
+export function calculateRatio(minimum, maximum) {
+  const parsedMinimum = parseLength(minimum)
+  const parsedMaximum = parseLength(maximum)
+
+  if (!parsedMinimum || !parsedMaximum || parsedMinimum.number <= 0) {
+    return null
+  }
+
+  if (parsedMinimum.unit === parsedMaximum.unit) {
+    return parsedMaximum.number / parsedMinimum.number
+  }
+
+  const minimumPixels = PIXELS_PER_UNIT[parsedMinimum.unit]
+  const maximumPixels = PIXELS_PER_UNIT[parsedMaximum.unit]
+
+  if (!minimumPixels || !maximumPixels) {
+    return null
+  }
+
+  return (parsedMaximum.number * maximumPixels) / (parsedMinimum.number * minimumPixels)
+}
+
+/**
+ * Reports whether a value scales with the viewport.
+ *
+ * @param {string} value - The value to test.
+ * @returns {boolean} True when the value contains a viewport unit.
+ */
+export function hasViewportUnit(value) {
+  return VIEWPORT_UNIT_PATTERN.test(value)
+}
+
+/**
+ * Reports whether a value contains Sass interpolation, which only resolves when the stylesheet is
+ * compiled and therefore cannot be judged here.
+ *
+ * @param {string} value - The value to test.
+ * @returns {boolean} True when the value is interpolated.
+ */
+export function hasInterpolation(value) {
+  return value.includes('#{')
+}

--- a/stylelint/values.test.mjs
+++ b/stylelint/values.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  calculateRatio,
+  findFunction,
+  hasInterpolation,
+  hasViewportUnit,
+  parseLength,
+  splitTopLevelParts,
+} from './values.mjs'
+
+describe('splitTopLevelParts', () => {
+  it('splits on commas', () => {
+    expect(splitTopLevelParts('a, b, c')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('keeps commas nested in a function together', () => {
+    expect(splitTopLevelParts('clamp(1rem, 5vw, 2rem), b')).toEqual(['clamp(1rem, 5vw, 2rem)', 'b'])
+  })
+
+  it('keeps commas inside a quoted family name together', () => {
+    expect(splitTopLevelParts(`'Foo, Bar', sans-serif`)).toEqual([`'Foo, Bar'`, 'sans-serif'])
+  })
+
+  it('returns the whole value when there is no top level comma', () => {
+    expect(splitTopLevelParts('1rem')).toEqual(['1rem'])
+  })
+})
+
+describe('findFunction', () => {
+  it('finds a call and its arguments', () => {
+    expect(findFunction('clamp(1rem, 5vw, 2rem)', 'clamp')).toMatchObject({
+      args: ['1rem', '5vw', '2rem'],
+      end: 22,
+      start: 0,
+    })
+  })
+
+  it('keeps a nested call intact', () => {
+    expect(findFunction('clamp(var(--a), 5vw, 2rem)', 'clamp').args).toEqual(['var(--a)', '5vw', '2rem'])
+  })
+
+  it('finds a call that starts partway through a value', () => {
+    expect(findFunction('calc(2 * var(--a))', 'var')).toMatchObject({ args: ['--a'], start: 9 })
+  })
+
+  it('ignores a name that is the tail of a longer identifier', () => {
+    expect(findFunction('my-var(--a)', 'var')).toBeNull()
+  })
+
+  it('returns null when the function is absent', () => {
+    expect(findFunction('1rem', 'var')).toBeNull()
+  })
+
+  it('returns null when the parentheses are unbalanced', () => {
+    expect(findFunction('var(--a', 'var')).toBeNull()
+  })
+})
+
+describe('parseLength', () => {
+  it.each([
+    ['1rem', { number: 1, unit: 'rem' }],
+    ['.5rem', { number: 0.5, unit: 'rem' }],
+    ['-2px', { number: -2, unit: 'px' }],
+    ['16PX', { number: 16, unit: 'px' }],
+    ['50%', { number: 50, unit: '%' }],
+  ])('parses %s', (value, expected) => {
+    expect(parseLength(value)).toEqual(expected)
+  })
+
+  it.each([['0'], ['auto'], ['1rem + 2vw']])('returns null for %s', (value) => {
+    expect(parseLength(value)).toBeNull()
+  })
+})
+
+describe('calculateRatio', () => {
+  it('divides two lengths that share a unit', () => {
+    expect(calculateRatio('1rem', '2rem')).toBe(2)
+  })
+
+  it('compares units that both have a fixed pixel size', () => {
+    expect(calculateRatio('16px', '4rem')).toBe(4)
+  })
+
+  it('compares percentages to each other', () => {
+    expect(calculateRatio('50%', '200%')).toBe(4)
+  })
+
+  it('compares two em values to each other, since the parent font size cancels out', () => {
+    expect(calculateRatio('1em', '3em')).toBe(3)
+  })
+
+  it('returns null when em is mixed with another unit, since the parent font size is unknown', () => {
+    expect(calculateRatio('1em', '2rem')).toBeNull()
+  })
+
+  it('returns null when the minimum is zero, to avoid dividing by it', () => {
+    expect(calculateRatio('0rem', '2rem')).toBeNull()
+  })
+
+  it('returns null when a value is not a length', () => {
+    expect(calculateRatio('auto', '2rem')).toBeNull()
+  })
+})
+
+describe('hasViewportUnit', () => {
+  it.each([['5vw'], ['1.0893rem + 0.1786vw'], ['100dvh'], ['10svmin']])('detects %s', (value) => {
+    expect(hasViewportUnit(value)).toBe(true)
+  })
+
+  it.each([['2rem'], ['var(--foo-vw)'], ['16px']])('does not detect %s', (value) => {
+    expect(hasViewportUnit(value)).toBe(false)
+  })
+})
+
+describe('hasInterpolation', () => {
+  it('detects Sass interpolation', () => {
+    expect(hasInterpolation('#{$ams-size}')).toBe(true)
+  })
+
+  it('ignores a plain value', () => {
+    expect(hasInterpolation('1rem')).toBe(false)
+  })
+})


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## Links

- [Storybook deploy of this branch](https://amsterdam.github.io/design-system/demo-defensive-css-linting/)
- [Defensive CSS audit](https://github.com/Amsterdam/design-system/blob/develop/documentation/defensive-css.md) — the full report this PR adds
- [Stylelint plugin README](https://github.com/Amsterdam/design-system/blob/develop/stylelint/README.md) — the reasoning behind the configuration

## What

- Installs [stylelint-plugin-defensive-css](https://github.com/yuschick/stylelint-plugin-defensive-css) and extends its strict configuration, which enables all 21 of its rules.
- Adds a private workspace package with two Stylelint rules of our own that resolve design tokens before judging a declaration: `ams/no-unsafe-clamp-font-size` and `ams/require-system-font-fallback`.
- Adds a full audit of all 21 plugin rules against this repository: what each rule enforces, how effective it is here, where we violate it, and what fixing or ignoring it would cost.

## Why

Defensive CSS guards against real failure modes: hover styles sticking on touch screens, grids blown out by long words, lists losing their semantics in Safari.
The plugin can enforce this, but seven of its rules judge literal values and cannot resolve `var()` — and nearly every value in this repository is a token reference, so those rules pass silently on tokenised declarations.
The audit verifies per rule what it actually catches here, and the two `ams/` rules close the most important blind spots by following token chains to the value they end at.
This also settles, with documented reasoning, which rules we deliberately do not adopt.

## How

- The plugin runs at its strict configuration.
  Rules with an existing backlog are kept at warning severity for now (184 warnings), clean rules run at error, and five are off — the reasoning per rule lives in the plugin README, the full assessment in the audit.
- The `ams/` rules read the built token file, follow `var()` chains through as many aliases as it takes, and report at the declaration that uses the token.
  They skip anything they cannot resolve with certainty rather than guess.
- Nothing that we ship changes in this PR: it is linting and documentation only.
  Follow-up PRs work the warnings down to zero and raise each rule to error as its backlog clears.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- First of a stack of four.
  The remediation the audit proposes follows in three stacked PRs (`fix/defensive-css-safeguards`, `fix/defensive-css-hover`, `chore/defensive-css-token-rules`), each raising its rules to error once their backlog is gone.
- Since no shipped CSS changes, no visual changes are expected.
