### PR TITLE
fix(css): Apply hover styles on hover-capable devices only

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -52,7 +52,6 @@
         "text-align": ["left", "right"]
       }
     ],
-    "defensive-css/no-accidental-hover": [true, { "severity": "warning" }],
     "defensive-css/no-fixed-sizes": [true, { "severity": "warning" }],
     "defensive-css/no-unsafe-clamp-font-size": null,
     "defensive-css/no-user-select-none": [true, { "severity": "warning" }],

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -55,7 +55,7 @@
     "defensive-css/no-unsafe-clamp-font-size": null,
     "defensive-css/require-at-layer": null,
     "defensive-css/require-custom-property-fallback": null,
-    "defensive-css/require-named-grid-lines": [true, { "severity": "warning" }],
+    "defensive-css/require-named-grid-lines": null,
     "defensive-css/require-pure-selectors": null,
     "defensive-css/require-system-font-fallback": null,
     "font-family-name-quotes": "always-unless-keyword",

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -52,14 +52,10 @@
         "text-align": ["left", "right"]
       }
     ],
-    "defensive-css/no-fixed-sizes": [true, { "severity": "warning" }],
     "defensive-css/no-unsafe-clamp-font-size": null,
-    "defensive-css/no-user-select-none": [true, { "severity": "warning" }],
     "defensive-css/require-at-layer": null,
     "defensive-css/require-custom-property-fallback": null,
-    "defensive-css/require-focus-visible": [true, { "severity": "warning" }],
     "defensive-css/require-named-grid-lines": [true, { "severity": "warning" }],
-    "defensive-css/require-prefers-reduced-motion": [true, { "severity": "warning" }],
     "defensive-css/require-pure-selectors": null,
     "defensive-css/require-system-font-fallback": null,
     "font-family-name-quotes": "always-unless-keyword",

--- a/documentation/defensive-css.md
+++ b/documentation/defensive-css.md
@@ -29,29 +29,32 @@ We violate 16 of the 21 rules somewhere; 5 are clean.
 Of the 1,991 violations, 86% come from two rules we have deliberately turned off (`require-custom-property-fallback` and `require-at-layer`).
 Outside the five disabled rules, 191 violations remain, 167 of them in shipped CSS — and roughly a quarter of those are false positives or deliberate patterns to annotate rather than fix.
 
-| Rule                             | packages/css | storybook | Effectiveness caveat                      | Status  | Recommendation                                 |
-| -------------------------------- | -----------: | --------: | ----------------------------------------- | ------- | ---------------------------------------------- |
-| require-custom-property-fallback |         1103 |        45 | flags same-file private properties        | off     | keep off                                       |
-| require-at-layer                 |          492 |        82 | —                                         | off     | keep off, revisit as architecture decision     |
-| require-pure-selectors           |           49 |        29 | many false positives                      | off     | keep off                                       |
-| no-accidental-hover              |           72 |         1 | —                                         | warning | fix, then error                                |
-| require-flex-wrap                |           36 |         4 | —                                         | warning | fix (mostly `nowrap`), then error              |
-| require-named-grid-lines         |           14 |         3 | mismatch with span-based APIs             | warning | turn off                                       |
-| no-fixed-sizes                   |            7 |         8 | cannot resolve tokens                     | warning | annotate, then error                           |
-| require-grid-minmax              |           11 |         1 | cannot resolve tokens                     | warning | fix, then error                                |
-| require-background-repeat        |            9 |         1 | flags same-element state swaps            | warning | fix 3, annotate rest, then error               |
-| require-scrollbar-gutter         |            6 |         2 | flags hidden and horizontal scrollbars    | warning | fix 1, annotate rest, then error               |
-| no-user-select-none              |            8 |         0 | cannot resolve tokens                     | warning | annotate (all deliberate), then error          |
-| require-overscroll-behavior      |            0 |         2 | —                                         | warning | fix Storybook, then error                      |
-| require-focus-visible            |            2 |         0 | —                                         | warning | fix 1, annotate 1, then error                  |
-| require-dynamic-viewport-height  |            1 |         1 | flags the fallback of the correct pattern | warning | annotate, fix Storybook, then error            |
-| no-list-style-none               |            0 |         1 | cannot see into mixins                    | warning | fix mixins + Storybook, then error             |
-| require-prefers-reduced-motion   |            1 |         0 | only recognises the positive pattern      | warning | refactor, then error                           |
-| no-mixed-vendor-prefixes         |            0 |         0 | —                                         | error   | keep                                           |
-| no-unsafe-will-change            |            0 |         0 | —                                         | error   | keep                                           |
-| require-forced-colors-focus      |            0 |         0 | —                                         | error   | keep                                           |
-| no-unsafe-clamp-font-size        |            0 |         0 | cannot resolve tokens                     | off     | replaced by `ams/no-unsafe-clamp-font-size`    |
-| require-system-font-fallback     |            0 |         0 | cannot resolve tokens                     | off     | replaced by `ams/require-system-font-fallback` |
+The remediation described below has since been carried out in full.
+The violation counts in this table record the state at the audit date; the Status column shows the configuration as it now stands: 15 rules at error, 6 off with documented reasons, and no standing warnings.
+
+| Rule                             | packages/css | storybook | Effectiveness caveat                      | Status | Recommendation                                 |
+| -------------------------------- | -----------: | --------: | ----------------------------------------- | ------ | ---------------------------------------------- |
+| require-custom-property-fallback |         1103 |        45 | flags same-file private properties        | off    | keep off                                       |
+| require-at-layer                 |          492 |        82 | —                                         | off    | keep off, revisit as architecture decision     |
+| require-pure-selectors           |           49 |        29 | many false positives                      | off    | keep off                                       |
+| no-accidental-hover              |           72 |         1 | —                                         | error  | fix, then error                                |
+| require-flex-wrap                |           36 |         4 | —                                         | error  | fix (mostly `nowrap`), then error              |
+| require-named-grid-lines         |           14 |         3 | mismatch with span-based APIs             | off    | turn off                                       |
+| no-fixed-sizes                   |            7 |         8 | cannot resolve tokens                     | error  | annotate, then error                           |
+| require-grid-minmax              |           11 |         1 | cannot resolve tokens                     | error  | fix, then error                                |
+| require-background-repeat        |            9 |         1 | flags same-element state swaps            | error  | fix 3, annotate rest, then error               |
+| require-scrollbar-gutter         |            6 |         2 | flags hidden and horizontal scrollbars    | error  | fix 1, annotate rest, then error               |
+| no-user-select-none              |            8 |         0 | cannot resolve tokens                     | error  | annotate (all deliberate), then error          |
+| require-overscroll-behavior      |            0 |         2 | —                                         | error  | fix Storybook, then error                      |
+| require-focus-visible            |            2 |         0 | —                                         | error  | fix 1, annotate 1, then error                  |
+| require-dynamic-viewport-height  |            1 |         1 | flags the fallback of the correct pattern | error  | annotate, fix Storybook, then error            |
+| no-list-style-none               |            0 |         1 | cannot see into mixins                    | error  | fix mixins + Storybook, then error             |
+| require-prefers-reduced-motion   |            1 |         0 | only recognises the positive pattern      | error  | refactor, then error                           |
+| no-mixed-vendor-prefixes         |            0 |         0 | —                                         | error  | keep                                           |
+| no-unsafe-will-change            |            0 |         0 | —                                         | error  | keep                                           |
+| require-forced-colors-focus      |            0 |         0 | —                                         | error  | keep                                           |
+| no-unsafe-clamp-font-size        |            0 |         0 | cannot resolve tokens                     | off    | replaced by `ams/no-unsafe-clamp-font-size`    |
+| require-system-font-fallback     |            0 |         0 | cannot resolve tokens                     | off    | replaced by `ams/require-system-font-fallback` |
 
 A recurring theme: seven rules judge declaration _values_, and none of them resolve `var()`.
 In a repository where nearly every value is a token reference, those rules only ever see literal values.
@@ -299,6 +302,7 @@ Storybook CSS ships to nobody.
 
 The complete remediation set above — 72 hover media queries, 36 flex-wrap declarations, 11 minmax substitutions, 3 background-repeats, 1 scrollbar-gutter, 13 compiled list-style changes, and the focus-visible swap — measures **+2,682 B raw (+2.0%)** and, because the additions are highly repetitive, approximately **+86 B gzipped (+0.5%)** when appended to the real stylesheet.
 Interleaving the additions where they actually belong will compress slightly worse than this synthetic measurement, but the order of magnitude stands: roughly a tenth of a kilobyte on the wire.
+Measured after the remediation landed: **+2,571 B raw (+1.9%)** and **+271 B gzipped (+1.7%)** — the raw estimate held, and the interleaving penalty on compression stayed within a quarter of a kilobyte.
 
 For contrast, the one rule that would be expensive is off: `require-custom-property-fallback` would add 36 KB raw (+26.6%).
 
@@ -322,6 +326,6 @@ By audience:
 2. **Flex-wrap intent pass** — 36 explicit declarations, mostly `nowrap`; the handful of toolbar judgment calls reviewed individually.
 3. **Hover media queries** — the 72-site wrap, as its own PR for reviewability.
 4. **Annotations** — `stylelint-disable-next-line` with reasons on the ~30 deliberate patterns and false positives documented above, each in the same PR as the fix that makes its rule clean.
-5. **Ratchet** — as each rule’s backlog reaches zero, raise it from warning to error in `.stylelintrc.json` (restating strict’s options where severity overrides would narrow them).
-   End state: 16 rules at error, 5 off with documented reasons, no standing warnings.
-6. **Separately** — decide on `require-named-grid-lines` (this report recommends off), and treat cascade layers as the architecture discussion it is.
+5. **Ratchet** — as each rule’s backlog reaches zero, raise it from warning to error in `.stylelintrc.json` by removing its warning-severity override, which also restores strict’s options where the override had narrowed them.
+   End state: 15 rules at error, 6 off with documented reasons, no standing warnings.
+6. **Separately** — `require-named-grid-lines` is turned off as recommended above; cascade layers remain the architecture discussion they are.

--- a/documentation/defensive-css.md
+++ b/documentation/defensive-css.md
@@ -25,9 +25,9 @@ All counts below use the strict options.
 
 ## Summary
 
-We violate 16 of the 21 rules somewhere; 5 are clean.
-Of the 1,991 violations, 86% come from two rules we have deliberately turned off (`require-custom-property-fallback` and `require-at-layer`).
-Outside the five disabled rules, 191 violations remain, 167 of them in shipped CSS — and roughly a quarter of those are false positives or deliberate patterns to annotate rather than fix.
+At the audit date, we violated 16 of the 21 rules somewhere; 5 were clean.
+Of the 1,991 violations, 86% came from two rules deliberately turned off (`require-custom-property-fallback` and `require-at-layer`).
+Outside the five then-disabled rules, 191 violations remained, 167 of them in shipped CSS — roughly a quarter of them false positives or deliberate patterns to annotate rather than fix.
 
 The remediation described below has since been carried out in full.
 The violation counts in this table record the state at the audit date; the Status column shows the configuration as it now stands: 15 rules at error, 6 off with documented reasons, and no standing warnings.

--- a/packages/css/src/common/input-label-focus.scss
+++ b/packages/css/src/common/input-label-focus.scss
@@ -11,7 +11,7 @@
   */
 
 @mixin input-label-focus {
-  /* stylelint-disable-next-line defensive-css/require-focus-visible -- Progressive enhancement: the styling on :focus is undone below when :focus-visible does not match, so older Safari keeps a focus ring. */
+  /* stylelint-disable-next-line defensive-css/require-focus-visible -- Progressive enhancement. */
   &:focus + label {
     outline: auto;
   }

--- a/packages/css/src/common/input-label-focus.scss
+++ b/packages/css/src/common/input-label-focus.scss
@@ -11,6 +11,7 @@
   */
 
 @mixin input-label-focus {
+  /* stylelint-disable-next-line defensive-css/require-focus-visible -- Progressive enhancement: the styling on :focus is undone below when :focus-visible does not match, so older Safari keeps a focus ring. */
   &:focus + label {
     outline: auto;
   }

--- a/packages/css/src/components/accordion/accordion.scss
+++ b/packages/css/src/components/accordion/accordion.scss
@@ -35,8 +35,10 @@
   padding-inline: var(--ams-accordion-button-padding-inline);
   text-align: start;
 
-  &:hover {
-    color: var(--ams-accordion-button-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-accordion-button-hover-color);
+    }
   }
 }
 

--- a/packages/css/src/components/breadcrumb/breadcrumb.scss
+++ b/packages/css/src/components/breadcrumb/breadcrumb.scss
@@ -51,8 +51,10 @@
   text-decoration-thickness: var(--ams-breadcrumb-link-text-decoration-thickness);
   text-underline-offset: var(--ams-breadcrumb-link-text-underline-offset);
 
-  &:hover {
-    color: var(--ams-breadcrumb-link-hover-color);
-    text-decoration-line: var(--ams-breadcrumb-link-hover-text-decoration-line);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-breadcrumb-link-hover-color);
+      text-decoration-line: var(--ams-breadcrumb-link-hover-text-decoration-line);
+    }
   }
 }

--- a/packages/css/src/components/button/button.scss
+++ b/packages/css/src/components/button/button.scss
@@ -51,9 +51,11 @@
     border-color: var(--ams-button-primary-disabled-border-color);
   }
 
-  &:hover:not(:disabled, [aria-disabled="true"]) {
-    background-color: var(--ams-button-primary-hover-background-color);
-    border-color: var(--ams-button-primary-hover-border-color);
+  @media (hover: hover) {
+    &:hover:not(:disabled, [aria-disabled="true"]) {
+      background-color: var(--ams-button-primary-hover-background-color);
+      border-color: var(--ams-button-primary-hover-border-color);
+    }
   }
 }
 
@@ -68,9 +70,11 @@
     color: var(--ams-button-secondary-disabled-color);
   }
 
-  &:hover:not(:disabled, [aria-disabled="true"]) {
-    box-shadow: var(--ams-button-secondary-hover-box-shadow);
-    color: var(--ams-button-secondary-hover-color);
+  @media (hover: hover) {
+    &:hover:not(:disabled, [aria-disabled="true"]) {
+      box-shadow: var(--ams-button-secondary-hover-box-shadow);
+      color: var(--ams-button-secondary-hover-color);
+    }
   }
 }
 
@@ -84,9 +88,11 @@
     color: var(--ams-button-tertiary-disabled-color);
   }
 
-  &:hover:not(:disabled, [aria-disabled="true"]) {
-    border-color: var(--ams-button-tertiary-hover-border-color);
-    color: var(--ams-button-tertiary-hover-color);
+  @media (hover: hover) {
+    &:hover:not(:disabled, [aria-disabled="true"]) {
+      border-color: var(--ams-button-tertiary-hover-border-color);
+      color: var(--ams-button-tertiary-hover-color);
+    }
   }
 }
 

--- a/packages/css/src/components/calendar/calendar.scss
+++ b/packages/css/src/components/calendar/calendar.scss
@@ -48,9 +48,11 @@
   text-decoration-thickness: var(--ams-calendar-day-link-text-decoration-thickness);
   text-underline-offset: var(--ams-calendar-day-link-text-underline-offset);
 
-  &:hover {
-    color: var(--ams-calendar-day-link-hover-color);
-    text-decoration-line: var(--ams-calendar-day-link-hover-text-decoration-line);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-calendar-day-link-hover-color);
+      text-decoration-line: var(--ams-calendar-day-link-hover-text-decoration-line);
+    }
   }
 }
 

--- a/packages/css/src/components/call-to-action-link/call-to-action-link.scss
+++ b/packages/css/src/components/call-to-action-link/call-to-action-link.scss
@@ -27,9 +27,11 @@
   @include print-exact;
   @include text-rendering;
 
-  &:hover {
-    background-color: var(--ams-call-to-action-link-hover-background-color);
-    text-decoration-thickness: var(--ams-call-to-action-link-hover-text-decoration-thickness);
-    text-underline-offset: var(--ams-call-to-action-link-hover-text-underline-offset);
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--ams-call-to-action-link-hover-background-color);
+      text-decoration-thickness: var(--ams-call-to-action-link-hover-text-decoration-thickness);
+      text-underline-offset: var(--ams-call-to-action-link-hover-text-underline-offset);
+    }
   }
 }

--- a/packages/css/src/components/card/card.scss
+++ b/packages/css/src/components/card/card.scss
@@ -54,9 +54,11 @@
     position: absolute;
   }
 
-  &:hover {
-    color: var(--ams-card-link-hover-color);
-    text-decoration-line: var(--ams-card-link-hover-text-decoration-line);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-card-link-hover-color);
+      text-decoration-line: var(--ams-card-link-hover-text-decoration-line);
+    }
   }
 
   /*

--- a/packages/css/src/components/checkbox/checkbox.scss
+++ b/packages/css/src/components/checkbox/checkbox.scss
@@ -126,19 +126,21 @@
   }
 
   // Default hover
-  &:hover:not(:disabled) + * {
-    color: var(--ams-checkbox-hover-color);
-    text-decoration-line: var(--ams-checkbox-hover-text-decoration-line);
+  @media (hover: hover) {
+    &:hover:not(:disabled) + * {
+      color: var(--ams-checkbox-hover-color);
+      text-decoration-line: var(--ams-checkbox-hover-text-decoration-line);
 
-    .ams-checkbox__rectangle {
-      @media (forced-colors: none) {
-        stroke: var(--ams-checkbox-rectangle-hover-stroke);
+      .ams-checkbox__rectangle {
+        @media (forced-colors: none) {
+          stroke: var(--ams-checkbox-rectangle-hover-stroke);
+        }
       }
-    }
 
-    .ams-checkbox__hover-indicator {
-      @media (forced-colors: none) {
-        stroke: var(--ams-checkbox-hover-indicator-hover-stroke);
+      .ams-checkbox__hover-indicator {
+        @media (forced-colors: none) {
+          stroke: var(--ams-checkbox-hover-indicator-hover-stroke);
+        }
       }
     }
   }
@@ -181,43 +183,53 @@
   // HOVER
 
   // Indeterminate hover
-  &:indeterminate:not(:disabled) + *:hover .ams-checkbox__rectangle {
-    fill: var(--ams-checkbox-rectangle-indeterminate-hover-fill);
+  @media (hover: hover) {
+    &:indeterminate:not(:disabled) + *:hover .ams-checkbox__rectangle {
+      fill: var(--ams-checkbox-rectangle-indeterminate-hover-fill);
 
-    @include forced-colors-selected;
+      @include forced-colors-selected;
+    }
   }
 
   // Checked hover
-  &:checked:not(:disabled, :indeterminate) + *:hover .ams-checkbox__rectangle {
-    fill: var(--ams-checkbox-rectangle-checked-hover-fill);
+  @media (hover: hover) {
+    &:checked:not(:disabled, :indeterminate) + *:hover .ams-checkbox__rectangle {
+      fill: var(--ams-checkbox-rectangle-checked-hover-fill);
 
-    @include forced-colors-selected;
+      @include forced-colors-selected;
+    }
   }
 
   // Invalid hover
-  :is(&:invalid, &[aria-invalid="true"]):not(:disabled) + *:hover {
-    .ams-checkbox__rectangle {
-      stroke: var(--ams-checkbox-rectangle-invalid-hover-stroke);
-    }
+  @media (hover: hover) {
+    :is(&:invalid, &[aria-invalid="true"]):not(:disabled) + *:hover {
+      .ams-checkbox__rectangle {
+        stroke: var(--ams-checkbox-rectangle-invalid-hover-stroke);
+      }
 
-    .ams-checkbox__hover-indicator {
-      @media (forced-colors: none) {
-        stroke: var(--ams-checkbox-hover-indicator-invalid-hover-stroke);
+      .ams-checkbox__hover-indicator {
+        @media (forced-colors: none) {
+          stroke: var(--ams-checkbox-hover-indicator-invalid-hover-stroke);
+        }
       }
     }
   }
 
   // Invalid indeterminate hover
-  :is(&:invalid, &[aria-invalid="true"]):indeterminate:not(:disabled) + *:hover .ams-checkbox__rectangle {
-    fill: var(--ams-checkbox-rectangle-indeterminate-invalid-hover-fill);
+  @media (hover: hover) {
+    :is(&:invalid, &[aria-invalid="true"]):indeterminate:not(:disabled) + *:hover .ams-checkbox__rectangle {
+      fill: var(--ams-checkbox-rectangle-indeterminate-invalid-hover-fill);
 
-    @include forced-colors-selected;
+      @include forced-colors-selected;
+    }
   }
 
   // Invalid checked hover
-  :is(&:invalid, &[aria-invalid="true"]):checked:not(:disabled) + *:hover .ams-checkbox__rectangle {
-    fill: var(--ams-checkbox-rectangle-checked-invalid-hover-fill);
+  @media (hover: hover) {
+    :is(&:invalid, &[aria-invalid="true"]):checked:not(:disabled) + *:hover .ams-checkbox__rectangle {
+      fill: var(--ams-checkbox-rectangle-checked-invalid-hover-fill);
 
-    @include forced-colors-selected;
+      @include forced-colors-selected;
+    }
   }
 }

--- a/packages/css/src/components/date-input/date-input.scss
+++ b/packages/css/src/components/date-input/date-input.scss
@@ -58,9 +58,11 @@
   cursor: var(--ams-date-input-calendar-picker-indicator-cursor);
 }
 
-.ams-date-input:hover::-webkit-calendar-picker-indicator {
-  /* stylelint-disable-next-line defensive-css/require-background-repeat -- The base rule for this element declares background-repeat; this only swaps the image. */
-  background-image: var(--ams-date-input-hover-calendar-picker-indicator-background-image);
+@media (hover: hover) {
+  .ams-date-input:hover::-webkit-calendar-picker-indicator {
+    /* stylelint-disable-next-line defensive-css/require-background-repeat -- The base rule for this element declares background-repeat; this only swaps the image. */
+    background-image: var(--ams-date-input-hover-calendar-picker-indicator-background-image);
+  }
 }
 
 .ams-date-input:disabled {
@@ -73,12 +75,16 @@
   border-color: var(--ams-date-input-invalid-border-color);
 }
 
-.ams-date-input:not(:disabled):hover {
-  box-shadow: var(--ams-date-input-hover-box-shadow);
+@media (hover: hover) {
+  .ams-date-input:not(:disabled):hover {
+    box-shadow: var(--ams-date-input-hover-box-shadow);
+  }
 }
 
-.ams-date-input:not(:disabled):invalid:hover,
-.ams-date-input:not(:disabled)[aria-invalid="true"]:hover {
-  border-color: var(--ams-date-input-invalid-hover-border-color);
-  box-shadow: var(--ams-date-input-invalid-hover-box-shadow);
+@media (hover: hover) {
+  .ams-date-input:not(:disabled):invalid:hover,
+  .ams-date-input:not(:disabled)[aria-invalid="true"]:hover {
+    border-color: var(--ams-date-input-invalid-hover-border-color);
+    box-shadow: var(--ams-date-input-invalid-hover-box-shadow);
+  }
 }

--- a/packages/css/src/components/date-input/date-input.scss
+++ b/packages/css/src/components/date-input/date-input.scss
@@ -60,7 +60,7 @@
 
 @media (hover: hover) {
   .ams-date-input:hover::-webkit-calendar-picker-indicator {
-    /* stylelint-disable-next-line defensive-css/require-background-repeat -- The base rule for this element declares background-repeat; this only swaps the image. */
+    /* stylelint-disable-next-line defensive-css/require-background-repeat -- Satisfied in the base rule. */
     background-image: var(--ams-date-input-hover-calendar-picker-indicator-background-image);
   }
 }

--- a/packages/css/src/components/date-picker/date-picker.scss
+++ b/packages/css/src/components/date-picker/date-picker.scss
@@ -58,9 +58,11 @@
   outline-offset: var(--ams-date-picker-day-outline-offset);
   text-align: center;
 
-  &:not([aria-disabled="true"]):hover {
-    background-color: var(--ams-date-picker-day-hover-background-color);
-    color: var(--ams-date-picker-day-hover-color);
+  @media (hover: hover) {
+    &:not([aria-disabled="true"]):hover {
+      background-color: var(--ams-date-picker-day-hover-background-color);
+      color: var(--ams-date-picker-day-hover-color);
+    }
   }
 }
 
@@ -72,11 +74,14 @@
   background-color: var(--ams-date-picker-day-selected-background-color);
   color: var(--ams-date-picker-day-selected-color);
 
-  &:hover {
-    background-color: var(--ams-date-picker-day-selected-hover-background-color);
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--ams-date-picker-day-selected-hover-background-color);
+    }
   }
 
   @media (forced-colors: active) {
+    /* stylelint-disable-next-line defensive-css/no-accidental-hover -- Applies identical styling with and without hover, neutralising hover feedback in forced colors mode. */
     &,
     & *,
     &:hover {

--- a/packages/css/src/components/date-picker/date-picker.scss
+++ b/packages/css/src/components/date-picker/date-picker.scss
@@ -81,7 +81,7 @@
   }
 
   @media (forced-colors: active) {
-    /* stylelint-disable-next-line defensive-css/no-accidental-hover -- Applies identical styling with and without hover, neutralising hover feedback in forced colors mode. */
+    /* stylelint-disable-next-line defensive-css/no-accidental-hover -- Identical styling with and without hover. */
     &,
     & *,
     &:hover {

--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -80,6 +80,7 @@ so do not apply these styles without an `open` attribute. */
   @media (forced-colors: active) {
     border-block-end-color: currentColor;
     border-block-end-style: solid;
+    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- A forced-colors hairline separator; 1px works at every text size. */
     border-block-end-width: 1px;
   }
 
@@ -121,6 +122,7 @@ so do not apply these styles without an `open` attribute. */
   @media (forced-colors: active) {
     border-block-start-color: currentColor;
     border-block-start-style: solid;
+    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- A forced-colors hairline separator; 1px works at every text size. */
     border-block-start-width: 1px;
   }
 

--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -80,7 +80,7 @@ so do not apply these styles without an `open` attribute. */
   @media (forced-colors: active) {
     border-block-end-color: currentColor;
     border-block-end-style: solid;
-    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- A forced-colors hairline separator; 1px works at every text size. */
+    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- A hairline separator. */
     border-block-end-width: 1px;
   }
 
@@ -122,7 +122,7 @@ so do not apply these styles without an `open` attribute. */
   @media (forced-colors: active) {
     border-block-start-color: currentColor;
     border-block-start-style: solid;
-    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- A forced-colors hairline separator; 1px works at every text size. */
+    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- A hairline separator. */
     border-block-start-width: 1px;
   }
 

--- a/packages/css/src/components/file-input/file-input.scss
+++ b/packages/css/src/components/file-input/file-input.scss
@@ -57,7 +57,9 @@
   cursor: var(--ams-file-input-file-selector-button-disabled-cursor);
 }
 
-.ams-file-input:not(:disabled):hover::file-selector-button {
-  box-shadow: var(--ams-file-input-file-selector-button-hover-box-shadow);
-  color: var(--ams-file-input-file-selector-button-hover-color);
+@media (hover: hover) {
+  .ams-file-input:not(:disabled):hover::file-selector-button {
+    box-shadow: var(--ams-file-input-file-selector-button-hover-box-shadow);
+    color: var(--ams-file-input-file-selector-button-hover-color);
+  }
 }

--- a/packages/css/src/components/icon-button/icon-button.scss
+++ b/packages/css/src/components/icon-button/icon-button.scss
@@ -16,9 +16,11 @@
   outline-offset: var(--ams-icon-button-outline-offset);
   touch-action: manipulation;
 
-  &:hover {
-    background-color: var(--ams-icon-button-hover-background-color);
-    color: var(--ams-icon-button-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--ams-icon-button-hover-background-color);
+      color: var(--ams-icon-button-hover-color);
+    }
   }
 
   &:disabled {
@@ -31,9 +33,11 @@
 .ams-icon-button--contrast {
   color: var(--ams-icon-button-contrast-color);
 
-  &:hover {
-    background-color: var(--ams-icon-button-contrast-hover-background-color);
-    color: var(--ams-icon-button-contrast-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--ams-icon-button-contrast-hover-background-color);
+      color: var(--ams-icon-button-contrast-hover-color);
+    }
   }
 
   &:disabled {
@@ -46,9 +50,11 @@
   background-color: var(--ams-icon-button-inverse-background-color);
   color: var(--ams-icon-button-inverse-color);
 
-  &:hover {
-    background-color: var(--ams-icon-button-inverse-hover-background-color);
-    color: var(--ams-icon-button-inverse-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--ams-icon-button-inverse-hover-background-color);
+      color: var(--ams-icon-button-inverse-hover-color);
+    }
   }
 
   &:disabled {

--- a/packages/css/src/components/image-slider/image-slider.scss
+++ b/packages/css/src/components/image-slider/image-slider.scss
@@ -25,7 +25,7 @@
   grid-column: 1/-1;
   grid-row: 1;
   outline-offset: var(--ams-image-slider-scroller-outline-offset);
-  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- The scrollbar is hidden entirely, so it never claims space. */
+  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- The scrollbar is hidden. */
   overflow-x: auto;
   /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
   overscroll-behavior-x: contain;

--- a/packages/css/src/components/image-slider/image-slider.scss
+++ b/packages/css/src/components/image-slider/image-slider.scss
@@ -87,8 +87,10 @@
   opacity: var(--ams-image-slider-thumbnails-thumbnail-opacity);
   outline-offset: var(--ams-button-outline-offset);
 
-  &:hover {
-    opacity: var(--ams-image-slider-thumbnails-thumbnail-hover-opacity);
+  @media (hover: hover) {
+    &:hover {
+      opacity: var(--ams-image-slider-thumbnails-thumbnail-hover-opacity);
+    }
   }
 }
 

--- a/packages/css/src/components/link-list/link-list.scss
+++ b/packages/css/src/components/link-list/link-list.scss
@@ -33,9 +33,11 @@
   text-decoration-thickness: var(--ams-link-list-link-text-decoration-thickness);
   text-underline-offset: var(--ams-link-list-link-text-underline-offset);
 
-  &:hover {
-    color: var(--ams-link-list-link-hover-color);
-    text-decoration-line: var(--ams-link-list-link-hover-text-decoration-line);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-link-list-link-hover-color);
+      text-decoration-line: var(--ams-link-list-link-hover-text-decoration-line);
+    }
   }
 }
 
@@ -52,15 +54,19 @@
 .ams-link-list__link--contrast {
   color: var(--ams-link-list-link-contrast-color);
 
-  &:hover {
-    color: var(--ams-link-list-link-contrast-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-link-list-link-contrast-hover-color);
+    }
   }
 }
 
 .ams-link-list__link--inverse {
   color: var(--ams-link-list-link-inverse-color);
 
-  &:hover {
-    color: var(--ams-link-list-link-inverse-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-link-list-link-inverse-hover-color);
+    }
   }
 }

--- a/packages/css/src/components/link/link.scss
+++ b/packages/css/src/components/link/link.scss
@@ -18,25 +18,31 @@
 
   @include text-rendering;
 
-  &:hover {
-    color: var(--ams-link-hover-color);
-    text-decoration-thickness: var(--ams-link-hover-text-decoration-thickness);
-    text-underline-offset: var(--ams-link-hover-text-underline-offset);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-link-hover-color);
+      text-decoration-thickness: var(--ams-link-hover-text-decoration-thickness);
+      text-underline-offset: var(--ams-link-hover-text-underline-offset);
+    }
   }
 }
 
 .ams-link--contrast {
   color: var(--ams-link-contrast-color);
 
-  &:hover {
-    color: var(--ams-link-contrast-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-link-contrast-hover-color);
+    }
   }
 }
 
 .ams-link--inverse {
   color: var(--ams-link-inverse-color);
 
-  &:hover {
-    color: var(--ams-link-inverse-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-link-inverse-hover-color);
+    }
   }
 }

--- a/packages/css/src/components/menu/menu.scss
+++ b/packages/css/src/components/menu/menu.scss
@@ -75,9 +75,11 @@
   text-decoration-thickness: var(--ams-menu-link-text-decoration-thickness);
   text-underline-offset: var(--ams-menu-link-text-underline-offset);
 
-  &:hover {
-    color: var(--ams-menu-link-hover-color);
-    text-decoration-line: var(--ams-menu-link-hover-text-decoration-line);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-menu-link-hover-color);
+      text-decoration-line: var(--ams-menu-link-hover-text-decoration-line);
+    }
   }
 
   .ams-menu__icon {

--- a/packages/css/src/components/page-footer/page-footer.scss
+++ b/packages/css/src/components/page-footer/page-footer.scss
@@ -55,8 +55,10 @@
   @include hyphenation;
   @include text-rendering;
 
-  &:hover {
-    color: var(--ams-page-footer-menu-link-hover-color);
-    text-decoration-line: var(--ams-page-footer-menu-link-hover-text-decoration-line);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-page-footer-menu-link-hover-color);
+      text-decoration-line: var(--ams-page-footer-menu-link-hover-text-decoration-line);
+    }
   }
 }

--- a/packages/css/src/components/page-header/page-header.scss
+++ b/packages/css/src/components/page-header/page-header.scss
@@ -56,10 +56,11 @@
 
 .ams-page-header__logo-link--hidden {
   opacity: 0%;
+  /* stylelint-disable-next-line defensive-css/no-user-select-none -- Selecting this invisible duplicate logo link would put duplicate text on the clipboard. */
   -webkit-user-select: none;
 
   /* Safari support is added with the prefixed property. */
-  /* stylelint-disable-next-line plugin/use-baseline */
+  /* stylelint-disable-next-line plugin/use-baseline, defensive-css/no-user-select-none -- Selecting this invisible duplicate logo link would put duplicate text on the clipboard. */
   user-select: none; // The hidden logo link section should not be selectable
 }
 
@@ -222,19 +223,19 @@
 .ams-page-header__menu-icon-middle,
 .ams-page-header__menu-icon-bottom {
   transform-origin: center;
-  transition:
-    opacity 0.1s ease-in-out,
-    rotate 0.2s ease-in-out,
-    translate 0.1s ease-in-out;
 
-  @media (prefers-reduced-motion) {
-    transition: none;
+  @media (prefers-reduced-motion: no-preference) {
+    transition:
+      opacity 0.1s ease-in-out,
+      rotate 0.2s ease-in-out,
+      translate 0.1s ease-in-out;
   }
 }
 
 .ams-page-header__menu-icon--open {
   .ams-page-header__menu-icon-top {
     rotate: 45deg;
+    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- The fixed nudge is part of the menu icon’s geometry, not a text-relative size. */
     translate: -4px 4px;
   }
 
@@ -244,6 +245,7 @@
 
   .ams-page-header__menu-icon-bottom {
     rotate: -45deg;
+    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- The fixed nudge is part of the menu icon’s geometry, not a text-relative size. */
     translate: -4px -4px;
   }
 }

--- a/packages/css/src/components/page-header/page-header.scss
+++ b/packages/css/src/components/page-header/page-header.scss
@@ -56,11 +56,11 @@
 
 .ams-page-header__logo-link--hidden {
   opacity: 0%;
-  /* stylelint-disable-next-line defensive-css/no-user-select-none -- Selecting this invisible duplicate logo link would put duplicate text on the clipboard. */
+  /* stylelint-disable-next-line defensive-css/no-user-select-none -- Prevents copying invisible text. */
   -webkit-user-select: none;
 
   /* Safari support is added with the prefixed property. */
-  /* stylelint-disable-next-line plugin/use-baseline, defensive-css/no-user-select-none -- Selecting this invisible duplicate logo link would put duplicate text on the clipboard. */
+  /* stylelint-disable-next-line plugin/use-baseline, defensive-css/no-user-select-none -- Prevents copying invisible text. */
   user-select: none; // The hidden logo link section should not be selectable
 }
 
@@ -235,7 +235,7 @@
 .ams-page-header__menu-icon--open {
   .ams-page-header__menu-icon-top {
     rotate: 45deg;
-    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- The fixed nudge is part of the menu icon’s geometry, not a text-relative size. */
+    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- Part of the icon’s geometry. */
     translate: -4px 4px;
   }
 
@@ -245,7 +245,7 @@
 
   .ams-page-header__menu-icon-bottom {
     rotate: -45deg;
-    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- The fixed nudge is part of the menu icon’s geometry, not a text-relative size. */
+    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- Part of the icon’s geometry. */
     translate: -4px -4px;
   }
 }

--- a/packages/css/src/components/page-header/page-header.scss
+++ b/packages/css/src/components/page-header/page-header.scss
@@ -151,8 +151,10 @@
 
   @include text-rendering;
 
-  &:hover {
-    color: var(--ams-page-header-menu-item-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-page-header-menu-item-hover-color);
+    }
   }
 }
 
@@ -167,8 +169,10 @@
   text-decoration-thickness: var(--ams-page-header-menu-link-text-decoration-thickness);
   text-underline-offset: var(--ams-page-header-menu-link-text-underline-offset);
 
-  &:hover {
-    text-decoration-line: var(--ams-page-header-menu-link-hover-text-decoration-line);
+  @media (hover: hover) {
+    &:hover {
+      text-decoration-line: var(--ams-page-header-menu-link-hover-text-decoration-line);
+    }
   }
 }
 
@@ -197,9 +201,11 @@
 
   @include print-exact;
 
-  &:hover {
-    background-color: var(--ams-page-header-mega-menu-button-hover-background-color);
-    color: var(--ams-page-header-mega-menu-button-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--ams-page-header-mega-menu-button-hover-background-color);
+      color: var(--ams-page-header-mega-menu-button-hover-color);
+    }
   }
 
   &[aria-expanded="true"] {

--- a/packages/css/src/components/page/page.scss
+++ b/packages/css/src/components/page/page.scss
@@ -9,7 +9,7 @@
   container-type: var(--ams-page-container-type);
   margin-inline: auto;
   max-inline-size: var(--ams-page-max-inline-size);
-  /* stylelint-disable-next-line defensive-css/require-dynamic-viewport-height -- Fallback for browsers that do not support dvh; the next declaration upgrades it. */
+  /* stylelint-disable-next-line defensive-css/require-dynamic-viewport-height -- Fallback for browsers without dvh support. */
   min-block-size: 100vh;
   min-block-size: 100dvh;
 }

--- a/packages/css/src/components/pagination/pagination.scss
+++ b/packages/css/src/components/pagination/pagination.scss
@@ -53,10 +53,12 @@
   text-underline-offset: var(--ams-pagination-link-text-underline-offset);
   touch-action: manipulation;
 
-  &:hover {
-    background-color: var(--ams-pagination-link-hover-background-color);
-    color: var(--ams-pagination-link-hover-color);
-    text-decoration-line: var(--ams-pagination-link-hover-text-decoration-line);
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--ams-pagination-link-hover-background-color);
+      color: var(--ams-pagination-link-hover-color);
+      text-decoration-line: var(--ams-pagination-link-hover-text-decoration-line);
+    }
   }
 
   &:active {
@@ -84,10 +86,12 @@
   text-underline-offset: var(--ams-pagination-relative-link-text-underline-offset);
   touch-action: manipulation;
 
-  &:hover {
-    background-color: var(--ams-pagination-relative-link-hover-background-color);
-    color: var(--ams-pagination-relative-link-hover-color);
-    text-decoration-line: var(--ams-pagination-relative-link-hover-text-decoration-line);
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--ams-pagination-relative-link-hover-background-color);
+      color: var(--ams-pagination-relative-link-hover-color);
+      text-decoration-line: var(--ams-pagination-relative-link-hover-text-decoration-line);
+    }
   }
 
   &:active {
@@ -109,9 +113,11 @@
   color: var(--ams-pagination-link-current-color);
   font-weight: var(--ams-pagination-link-current-font-weight);
 
-  &:hover {
-    background-color: var(--ams-pagination-link-current-hover-background-color);
-    color: var(--ams-pagination-link-current-hover-color);
-    text-decoration: none;
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--ams-pagination-link-current-hover-background-color);
+      color: var(--ams-pagination-link-current-hover-color);
+      text-decoration: none;
+    }
   }
 }

--- a/packages/css/src/components/password-input/password-input.scss
+++ b/packages/css/src/components/password-input/password-input.scss
@@ -48,12 +48,16 @@
   border-color: var(--ams-password-input-invalid-border-color);
 }
 
-.ams-password-input:not(:disabled):hover {
-  box-shadow: var(--ams-password-input-hover-box-shadow);
+@media (hover: hover) {
+  .ams-password-input:not(:disabled):hover {
+    box-shadow: var(--ams-password-input-hover-box-shadow);
+  }
 }
 
-.ams-password-input:not(:disabled):invalid:hover,
-.ams-password-input:not(:disabled)[aria-invalid="true"]:hover {
-  border-color: var(--ams-password-input-invalid-hover-border-color);
-  box-shadow: var(--ams-password-input-invalid-hover-box-shadow);
+@media (hover: hover) {
+  .ams-password-input:not(:disabled):invalid:hover,
+  .ams-password-input:not(:disabled)[aria-invalid="true"]:hover {
+    border-color: var(--ams-password-input-invalid-hover-border-color);
+    box-shadow: var(--ams-password-input-invalid-hover-box-shadow);
+  }
 }

--- a/packages/css/src/components/progress-list/progress-list.scss
+++ b/packages/css/src/components/progress-list/progress-list.scss
@@ -186,8 +186,10 @@
   padding-inline: var(--ams-progress-list-button-padding-inline);
   text-align: start;
 
-  &:hover {
-    color: var(--ams-progress-list-button-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-progress-list-button-hover-color);
+    }
   }
 }
 

--- a/packages/css/src/components/radio/radio.scss
+++ b/packages/css/src/components/radio/radio.scss
@@ -55,20 +55,22 @@
 }
 
 // Default hover
-.ams-radio__label:hover {
-  color: var(--ams-radio-hover-color);
-  text-decoration-line: var(--ams-radio-hover-text-decoration-line);
+@media (hover: hover) {
+  .ams-radio__label:hover {
+    color: var(--ams-radio-hover-color);
+    text-decoration-line: var(--ams-radio-hover-text-decoration-line);
 
-  .ams-radio__circle {
-    stroke: var(--ams-radio-circle-hover-stroke);
-  }
+    .ams-radio__circle {
+      stroke: var(--ams-radio-circle-hover-stroke);
+    }
 
-  .ams-radio__hover-indicator {
-    stroke: var(--ams-radio-hover-indicator-hover-stroke);
-  }
+    .ams-radio__hover-indicator {
+      stroke: var(--ams-radio-hover-indicator-hover-stroke);
+    }
 
-  .ams-radio__checked-indicator {
-    fill: var(--ams-radio-checked-indicator-hover-fill);
+    .ams-radio__checked-indicator {
+      fill: var(--ams-radio-checked-indicator-hover-fill);
+    }
   }
 }
 
@@ -120,42 +122,48 @@
 // HOVER
 
 // Disabled hover
-.ams-radio__input:disabled + .ams-radio__label:hover {
-  text-decoration: none;
+@media (hover: hover) {
+  .ams-radio__input:disabled + .ams-radio__label:hover {
+    text-decoration: none;
 
-  .ams-radio__hover-indicator {
-    stroke: transparent;
+    .ams-radio__hover-indicator {
+      stroke: transparent;
+    }
   }
 }
 
 // Invalid hover
-.ams-radio__input[aria-invalid="true"] + .ams-radio__label:hover {
-  .ams-radio__circle {
-    stroke: var(--ams-radio-circle-invalid-hover-stroke);
-  }
+@media (hover: hover) {
+  .ams-radio__input[aria-invalid="true"] + .ams-radio__label:hover {
+    .ams-radio__circle {
+      stroke: var(--ams-radio-circle-invalid-hover-stroke);
+    }
 
-  .ams-radio__hover-indicator {
-    stroke: var(--ams-radio-hover-indicator-invalid-hover-stroke);
-  }
+    .ams-radio__hover-indicator {
+      stroke: var(--ams-radio-hover-indicator-invalid-hover-stroke);
+    }
 
-  .ams-radio__checked-indicator {
-    fill: var(--ams-radio-checked-indicator-invalid-hover-fill);
+    .ams-radio__checked-indicator {
+      fill: var(--ams-radio-checked-indicator-invalid-hover-fill);
+    }
   }
 }
 
 // Disabled invalid hover
-.ams-radio__input[aria-invalid="true"]:disabled + .ams-radio__label:hover {
-  .ams-radio__circle {
-    // TODO: currently disabled invalid gets the same styling as disabled. This should get its own styling.
-    stroke: var(--ams-radio-circle-disabled-invalid-hover-stroke);
-  }
+@media (hover: hover) {
+  .ams-radio__input[aria-invalid="true"]:disabled + .ams-radio__label:hover {
+    .ams-radio__circle {
+      // TODO: currently disabled invalid gets the same styling as disabled. This should get its own styling.
+      stroke: var(--ams-radio-circle-disabled-invalid-hover-stroke);
+    }
 
-  .ams-radio__hover-indicator {
-    stroke: transparent;
-  }
-  .ams-radio__checked-indicator {
-    // TODO: currently disabled invalid gets the same styling as disabled. This should get its own styling.
-    fill: var(--ams-radio-checked-indicator-disabled-invalid-hover-fill);
+    .ams-radio__hover-indicator {
+      stroke: transparent;
+    }
+    .ams-radio__checked-indicator {
+      // TODO: currently disabled invalid gets the same styling as disabled. This should get its own styling.
+      fill: var(--ams-radio-checked-indicator-disabled-invalid-hover-fill);
+    }
   }
 }
 
@@ -163,6 +171,7 @@
 
 // Default
 @media (forced-colors: active) {
+  /* stylelint-disable-next-line defensive-css/no-accidental-hover -- Applies identical styling with and without hover, neutralising hover feedback in forced colors mode. */
   .ams-radio__label,
   .ams-radio__label:hover,
   .ams-radio__input[aria-invalid="true"] + .ams-radio__label,
@@ -184,6 +193,7 @@
 
 // Checked
 @media (forced-colors: active) {
+  /* stylelint-disable-next-line defensive-css/no-accidental-hover -- Applies identical styling with and without hover, neutralising hover feedback in forced colors mode. */
   .ams-radio__input:checked + .ams-radio__label,
   .ams-radio__input[aria-invalid="true"]:checked + .ams-radio__label:hover {
     .ams-radio__circle {
@@ -198,6 +208,7 @@
 
 // Disabled
 @media (forced-colors: active) {
+  /* stylelint-disable-next-line defensive-css/no-accidental-hover -- Applies identical styling with and without hover, neutralising hover feedback in forced colors mode. */
   .ams-radio__input:disabled + .ams-radio__label,
   .ams-radio__input[aria-invalid="true"]:disabled + .ams-radio__label,
   .ams-radio__input[aria-invalid="true"]:disabled + .ams-radio__label:hover {

--- a/packages/css/src/components/radio/radio.scss
+++ b/packages/css/src/components/radio/radio.scss
@@ -171,7 +171,7 @@
 
 // Default
 @media (forced-colors: active) {
-  /* stylelint-disable-next-line defensive-css/no-accidental-hover -- Applies identical styling with and without hover, neutralising hover feedback in forced colors mode. */
+  /* stylelint-disable-next-line defensive-css/no-accidental-hover -- Identical styling with and without hover. */
   .ams-radio__label,
   .ams-radio__label:hover,
   .ams-radio__input[aria-invalid="true"] + .ams-radio__label,
@@ -193,7 +193,7 @@
 
 // Checked
 @media (forced-colors: active) {
-  /* stylelint-disable-next-line defensive-css/no-accidental-hover -- Applies identical styling with and without hover, neutralising hover feedback in forced colors mode. */
+  /* stylelint-disable-next-line defensive-css/no-accidental-hover -- Identical styling with and without hover. */
   .ams-radio__input:checked + .ams-radio__label,
   .ams-radio__input[aria-invalid="true"]:checked + .ams-radio__label:hover {
     .ams-radio__circle {
@@ -208,7 +208,7 @@
 
 // Disabled
 @media (forced-colors: active) {
-  /* stylelint-disable-next-line defensive-css/no-accidental-hover -- Applies identical styling with and without hover, neutralising hover feedback in forced colors mode. */
+  /* stylelint-disable-next-line defensive-css/no-accidental-hover -- Identical styling with and without hover. */
   .ams-radio__input:disabled + .ams-radio__label,
   .ams-radio__input[aria-invalid="true"]:disabled + .ams-radio__label,
   .ams-radio__input[aria-invalid="true"]:disabled + .ams-radio__label:hover {

--- a/packages/css/src/components/search-field/search-field.scss
+++ b/packages/css/src/components/search-field/search-field.scss
@@ -35,7 +35,7 @@
   @include print-exact;
   @include text-rendering;
 
-  &:focus {
+  &:focus-visible {
     z-index: 1; // Make sure the focus outline isn’t cut off by the adjacent button
   }
 }

--- a/packages/css/src/components/search-field/search-field.scss
+++ b/packages/css/src/components/search-field/search-field.scss
@@ -51,14 +51,18 @@
   border-color: var(--ams-search-field-input-invalid-border-color);
 }
 
-.ams-search-field__input:not(:disabled):hover {
-  box-shadow: var(--ams-search-field-input-hover-box-shadow);
+@media (hover: hover) {
+  .ams-search-field__input:not(:disabled):hover {
+    box-shadow: var(--ams-search-field-input-hover-box-shadow);
+  }
 }
 
-.ams-search-field__input:not(:disabled):invalid:hover,
-.ams-search-field__input:not(:disabled)[aria-invalid="true"]:hover {
-  border-color: var(--ams-search-field-input-invalid-hover-border-color);
-  box-shadow: var(--ams-search-field-input-invalid-hover-box-shadow);
+@media (hover: hover) {
+  .ams-search-field__input:not(:disabled):invalid:hover,
+  .ams-search-field__input:not(:disabled)[aria-invalid="true"]:hover {
+    border-color: var(--ams-search-field-input-invalid-hover-border-color);
+    box-shadow: var(--ams-search-field-input-invalid-hover-box-shadow);
+  }
 }
 
 .ams-search-field__input::-webkit-search-cancel-button {

--- a/packages/css/src/components/select/select.scss
+++ b/packages/css/src/components/select/select.scss
@@ -46,19 +46,23 @@
   border-color: var(--ams-select-invalid-border-color);
 }
 
-.ams-select:not(:disabled):hover {
-  box-shadow: var(--ams-select-hover-box-shadow);
+@media (hover: hover) {
+  .ams-select:not(:disabled):hover {
+    box-shadow: var(--ams-select-hover-box-shadow);
 
-  &:not([multiple]) {
-    /* stylelint-disable-next-line defensive-css/require-background-repeat -- The base rule for this element declares background-repeat; this only swaps the image. */
-    background-image: var(--ams-select-hover-background-image);
+    &:not([multiple]) {
+      /* stylelint-disable-next-line defensive-css/require-background-repeat -- The base rule for this element declares background-repeat; this only swaps the image. */
+      background-image: var(--ams-select-hover-background-image);
+    }
   }
 }
 
-.ams-select:not(:disabled):invalid:hover,
-.ams-select:not(:disabled)[aria-invalid="true"]:hover {
-  border-color: var(--ams-select-invalid-hover-border-color);
-  box-shadow: var(--ams-select-invalid-hover-box-shadow);
+@media (hover: hover) {
+  .ams-select:not(:disabled):invalid:hover,
+  .ams-select:not(:disabled)[aria-invalid="true"]:hover {
+    border-color: var(--ams-select-invalid-hover-border-color);
+    box-shadow: var(--ams-select-invalid-hover-box-shadow);
+  }
 }
 
 .ams-select__option:disabled {

--- a/packages/css/src/components/select/select.scss
+++ b/packages/css/src/components/select/select.scss
@@ -36,7 +36,7 @@
   cursor: var(--ams-select-disabled-cursor);
 
   &:not([multiple]) {
-    /* stylelint-disable-next-line defensive-css/require-background-repeat -- The base rule for this element declares background-repeat; this only swaps the image. */
+    /* stylelint-disable-next-line defensive-css/require-background-repeat -- Satisfied in the base rule. */
     background-image: var(--ams-select-disabled-background-image);
   }
 }
@@ -51,7 +51,7 @@
     box-shadow: var(--ams-select-hover-box-shadow);
 
     &:not([multiple]) {
-      /* stylelint-disable-next-line defensive-css/require-background-repeat -- The base rule for this element declares background-repeat; this only swaps the image. */
+      /* stylelint-disable-next-line defensive-css/require-background-repeat -- Satisfied in the base rule. */
       background-image: var(--ams-select-hover-background-image);
     }
   }

--- a/packages/css/src/components/skeleton/skeleton.scss
+++ b/packages/css/src/components/skeleton/skeleton.scss
@@ -11,6 +11,7 @@
 // A stack of these blocks occupies exactly as much space as the same number of lines of the mimicked text.
 @mixin text-line($font-size, $line-height) {
   block-size: $font-size;
+  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- Computed from the mimicked text’s own font size and line height. */
   margin-block: calc((#{$line-height} - 1) / 2 * #{$font-size});
 }
 

--- a/packages/css/src/components/skeleton/skeleton.scss
+++ b/packages/css/src/components/skeleton/skeleton.scss
@@ -11,7 +11,7 @@
 // A stack of these blocks occupies exactly as much space as the same number of lines of the mimicked text.
 @mixin text-line($font-size, $line-height) {
   block-size: $font-size;
-  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- Computed from the mimicked text’s own font size and line height. */
+  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- Computed from the mimicked text. */
   margin-block: calc((#{$line-height} - 1) / 2 * #{$font-size});
 }
 

--- a/packages/css/src/components/skip-link/skip-link.scss
+++ b/packages/css/src/components/skip-link/skip-link.scss
@@ -17,7 +17,9 @@
   text-align: center;
   text-decoration: none;
 
-  &:hover {
-    background-color: var(--ams-skip-link-hover-background-color);
+  @media (hover: hover) {
+    &:hover {
+      background-color: var(--ams-skip-link-hover-background-color);
+    }
   }
 }

--- a/packages/css/src/components/standalone-link/standalone-link.scss
+++ b/packages/css/src/components/standalone-link/standalone-link.scss
@@ -23,24 +23,30 @@
   @include hyphenation;
   @include text-rendering;
 
-  &:hover {
-    color: var(--ams-standalone-link-hover-color);
-    text-decoration-line: var(--ams-standalone-link-hover-text-decoration-line);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-standalone-link-hover-color);
+      text-decoration-line: var(--ams-standalone-link-hover-text-decoration-line);
+    }
   }
 }
 
 .ams-standalone-link--contrast {
   color: var(--ams-standalone-link-contrast-color);
 
-  &:hover {
-    color: var(--ams-standalone-link-contrast-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-standalone-link-contrast-hover-color);
+    }
   }
 }
 
 .ams-standalone-link--inverse {
   color: var(--ams-standalone-link-inverse-color);
 
-  &:hover {
-    color: var(--ams-standalone-link-inverse-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-standalone-link-inverse-hover-color);
+    }
   }
 }

--- a/packages/css/src/components/switch/switch.scss
+++ b/packages/css/src/components/switch/switch.scss
@@ -65,6 +65,8 @@
   transform: translate(calc(100% - 2 * var(--_ams-switch-label-border-width)));
 }
 
-.ams-switch:hover .ams-switch__input:enabled + .ams-switch__label::before {
-  box-shadow: var(--ams-switch-thumb-hover-box-shadow);
+@media (hover: hover) {
+  .ams-switch:hover .ams-switch__input:enabled + .ams-switch__label::before {
+    box-shadow: var(--ams-switch-thumb-hover-box-shadow);
+  }
 }

--- a/packages/css/src/components/tab-navigation/tab-navigation.scss
+++ b/packages/css/src/components/tab-navigation/tab-navigation.scss
@@ -55,12 +55,16 @@
   padding-inline: var(--ams-tab-navigation-link-padding-inline);
   text-decoration-line: none;
 
-  &:hover {
-    color: var(--ams-tab-navigation-link-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-tab-navigation-link-hover-color);
+    }
   }
 
-  &:hover:not([aria-current="page"]) {
-    box-shadow: var(--ams-tab-navigation-link-hover-box-shadow);
+  @media (hover: hover) {
+    &:hover:not([aria-current="page"]) {
+      box-shadow: var(--ams-tab-navigation-link-hover-box-shadow);
+    }
   }
 
   &[aria-current="page"] {
@@ -73,8 +77,10 @@
   }
 
   @media (min-width: $ams-breakpoint-medium) {
-    .ams-tab-navigation--vertical &:hover:not([aria-current="page"]) {
-      box-shadow: var(--ams-tab-navigation-link-vertical-hover-box-shadow);
+    @media (hover: hover) {
+      .ams-tab-navigation--vertical &:hover:not([aria-current="page"]) {
+        box-shadow: var(--ams-tab-navigation-link-vertical-hover-box-shadow);
+      }
     }
 
     .ams-tab-navigation--vertical &[aria-current="page"] {

--- a/packages/css/src/components/tab-navigation/tab-navigation.scss
+++ b/packages/css/src/components/tab-navigation/tab-navigation.scss
@@ -104,10 +104,11 @@
 .ams-tab-navigation__link-label-hidden {
   font-weight: var(--ams-tab-navigation-link-current-font-weight);
   pointer-events: none;
+  /* stylelint-disable-next-line defensive-css/no-user-select-none -- Selecting this hidden bold copy would put invisible duplicate text on the clipboard. */
   -webkit-user-select: none;
 
   /* Safari support is added with the prefixed property. */
-  /* stylelint-disable-next-line plugin/use-baseline */
+  /* stylelint-disable-next-line plugin/use-baseline, defensive-css/no-user-select-none -- Selecting this hidden bold copy would put invisible duplicate text on the clipboard. */
   user-select: none;
   visibility: hidden;
 }

--- a/packages/css/src/components/tab-navigation/tab-navigation.scss
+++ b/packages/css/src/components/tab-navigation/tab-navigation.scss
@@ -13,7 +13,7 @@
   box-shadow: var(--ams-tab-navigation-list-box-shadow);
   display: flex;
   flex-wrap: nowrap;
-  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- This scrolls horizontally only; scrollbar-gutter reserves space for a vertical scrollbar. */
+  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- This scrolls horizontally only. */
   overflow-x: auto;
   overflow-y: hidden;
   /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
@@ -104,11 +104,11 @@
 .ams-tab-navigation__link-label-hidden {
   font-weight: var(--ams-tab-navigation-link-current-font-weight);
   pointer-events: none;
-  /* stylelint-disable-next-line defensive-css/no-user-select-none -- Selecting this hidden bold copy would put invisible duplicate text on the clipboard. */
+  /* stylelint-disable-next-line defensive-css/no-user-select-none -- Prevents copying invisible text. */
   -webkit-user-select: none;
 
   /* Safari support is added with the prefixed property. */
-  /* stylelint-disable-next-line plugin/use-baseline, defensive-css/no-user-select-none -- Selecting this hidden bold copy would put invisible duplicate text on the clipboard. */
+  /* stylelint-disable-next-line plugin/use-baseline, defensive-css/no-user-select-none -- Prevents copying invisible text. */
   user-select: none;
   visibility: hidden;
 }

--- a/packages/css/src/components/table-of-contents/table-of-contents.scss
+++ b/packages/css/src/components/table-of-contents/table-of-contents.scss
@@ -47,9 +47,11 @@
   text-decoration-thickness: var(--ams-table-of-contents-link-text-decoration-thickness);
   text-underline-offset: var(--ams-table-of-contents-link-text-underline-offset);
 
-  &:hover {
-    color: var(--ams-table-of-contents-link-hover-color);
-    text-decoration-line: var(--ams-table-of-contents-link-hover-text-decoration-line);
+  @media (hover: hover) {
+    &:hover {
+      color: var(--ams-table-of-contents-link-hover-color);
+      text-decoration-line: var(--ams-table-of-contents-link-hover-text-decoration-line);
+    }
   }
 
   &[aria-current="page"] {
@@ -61,9 +63,11 @@
 .ams-table-of-contents__button {
   color: var(--ams-table-of-contents-button-color);
 
-  &:hover {
-    background-color: transparent;
-    color: var(--ams-table-of-contents-button-hover-color);
+  @media (hover: hover) {
+    &:hover {
+      background-color: transparent;
+      color: var(--ams-table-of-contents-button-hover-color);
+    }
   }
 }
 

--- a/packages/css/src/components/table-of-contents/table-of-contents.scss
+++ b/packages/css/src/components/table-of-contents/table-of-contents.scss
@@ -88,7 +88,7 @@
   display: none;
 
   @media print {
-    /* stylelint-disable-next-line defensive-css/require-flex-wrap -- The base rule makes this a column flex container; this only restores visibility for print. */
+    /* stylelint-disable-next-line defensive-css/require-flex-wrap -- The base rule makes this a column container. */
     display: flex;
   }
 }

--- a/packages/css/src/components/table/table.scss
+++ b/packages/css/src/components/table/table.scss
@@ -4,7 +4,7 @@
  */
 
 .ams-table {
-  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- This scrolls horizontally only; scrollbar-gutter reserves space for a vertical scrollbar. */
+  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- This scrolls horizontally only. */
   overflow-x: auto;
   overflow-y: hidden;
   /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */

--- a/packages/css/src/components/tabs/tabs.scss
+++ b/packages/css/src/components/tabs/tabs.scss
@@ -81,10 +81,11 @@
 .ams-tabs__button-label-hidden {
   font-weight: var(--ams-tabs-button-selected-font-weight);
   pointer-events: none;
+  /* stylelint-disable-next-line defensive-css/no-user-select-none -- Selecting this hidden bold copy would put invisible duplicate text on the clipboard. */
   -webkit-user-select: none;
 
   /* Safari support is added with the prefixed property. */
-  /* stylelint-disable-next-line plugin/use-baseline */
+  /* stylelint-disable-next-line plugin/use-baseline, defensive-css/no-user-select-none -- Selecting this hidden bold copy would put invisible duplicate text on the clipboard. */
   user-select: none;
   visibility: hidden;
 }

--- a/packages/css/src/components/tabs/tabs.scss
+++ b/packages/css/src/components/tabs/tabs.scss
@@ -15,7 +15,7 @@
   box-shadow: var(--ams-tabs-list-box-shadow);
   display: flex;
   flex-wrap: nowrap;
-  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- This scrolls horizontally only; scrollbar-gutter reserves space for a vertical scrollbar. */
+  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- This scrolls horizontally only. */
   overflow-x: auto;
   overflow-y: hidden;
   /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
@@ -81,17 +81,17 @@
 .ams-tabs__button-label-hidden {
   font-weight: var(--ams-tabs-button-selected-font-weight);
   pointer-events: none;
-  /* stylelint-disable-next-line defensive-css/no-user-select-none -- Selecting this hidden bold copy would put invisible duplicate text on the clipboard. */
+  /* stylelint-disable-next-line defensive-css/no-user-select-none -- Prevents copying invisible text. */
   -webkit-user-select: none;
 
   /* Safari support is added with the prefixed property. */
-  /* stylelint-disable-next-line plugin/use-baseline, defensive-css/no-user-select-none -- Selecting this hidden bold copy would put invisible duplicate text on the clipboard. */
+  /* stylelint-disable-next-line plugin/use-baseline, defensive-css/no-user-select-none -- Prevents copying invisible text. */
   user-select: none;
   visibility: hidden;
 }
 
 .ams-tabs__panel {
-  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- This scrolls horizontally only; scrollbar-gutter reserves space for a vertical scrollbar. */
+  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- This scrolls horizontally only. */
   overflow-x: auto;
   overflow-y: hidden;
   /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */

--- a/packages/css/src/components/tabs/tabs.scss
+++ b/packages/css/src/components/tabs/tabs.scss
@@ -49,12 +49,16 @@
     }
   }
 
-  &:hover:not([disabled]) {
-    color: var(--ams-tabs-button-hover-color);
+  @media (hover: hover) {
+    &:hover:not([disabled]) {
+      color: var(--ams-tabs-button-hover-color);
+    }
   }
 
-  &:hover:not([aria-selected="true"], [disabled]) {
-    box-shadow: var(--ams-tabs-button-hover-box-shadow);
+  @media (hover: hover) {
+    &:hover:not([aria-selected="true"], [disabled]) {
+      box-shadow: var(--ams-tabs-button-hover-box-shadow);
+    }
   }
 
   &[aria-selected="true"] {

--- a/packages/css/src/components/text-area/text-area.scss
+++ b/packages/css/src/components/text-area/text-area.scss
@@ -46,14 +46,18 @@
   border-color: var(--ams-text-area-invalid-border-color);
 }
 
-.ams-text-area:not(:disabled):hover {
-  box-shadow: var(--ams-text-area-hover-box-shadow);
+@media (hover: hover) {
+  .ams-text-area:not(:disabled):hover {
+    box-shadow: var(--ams-text-area-hover-box-shadow);
+  }
 }
 
-.ams-text-area:not(:disabled):invalid:hover,
-.ams-text-area:not(:disabled)[aria-invalid="true"]:hover {
-  border-color: var(--ams-text-area-invalid-hover-border-color);
-  box-shadow: var(--ams-text-area-invalid-hover-box-shadow);
+@media (hover: hover) {
+  .ams-text-area:not(:disabled):invalid:hover,
+  .ams-text-area:not(:disabled)[aria-invalid="true"]:hover {
+    border-color: var(--ams-text-area-invalid-hover-border-color);
+    box-shadow: var(--ams-text-area-invalid-hover-box-shadow);
+  }
 }
 
 /*

--- a/packages/css/src/components/text-input/text-input.scss
+++ b/packages/css/src/components/text-input/text-input.scss
@@ -48,12 +48,16 @@
   border-color: var(--ams-text-input-invalid-border-color);
 }
 
-.ams-text-input:not(:disabled):hover {
-  box-shadow: var(--ams-text-input-hover-box-shadow);
+@media (hover: hover) {
+  .ams-text-input:not(:disabled):hover {
+    box-shadow: var(--ams-text-input-hover-box-shadow);
+  }
 }
 
-.ams-text-input:not(:disabled):invalid:hover,
-.ams-text-input:not(:disabled)[aria-invalid="true"]:hover {
-  border-color: var(--ams-text-input-invalid-hover-border-color);
-  box-shadow: var(--ams-text-input-invalid-hover-box-shadow);
+@media (hover: hover) {
+  .ams-text-input:not(:disabled):invalid:hover,
+  .ams-text-input:not(:disabled)[aria-invalid="true"]:hover {
+    border-color: var(--ams-text-input-invalid-hover-border-color);
+    box-shadow: var(--ams-text-input-invalid-hover-box-shadow);
+  }
 }

--- a/packages/css/src/components/time-input/time-input.scss
+++ b/packages/css/src/components/time-input/time-input.scss
@@ -59,7 +59,7 @@
 
 @media (hover: hover) {
   .ams-time-input:hover::-webkit-calendar-picker-indicator {
-    /* stylelint-disable-next-line defensive-css/require-background-repeat -- The base rule for this element declares background-repeat; this only swaps the image. */
+    /* stylelint-disable-next-line defensive-css/require-background-repeat -- Satisfied in the base rule. */
     background-image: var(--ams-time-input-hover-calendar-picker-indicator-background-image);
   }
 }

--- a/packages/css/src/components/time-input/time-input.scss
+++ b/packages/css/src/components/time-input/time-input.scss
@@ -57,9 +57,11 @@
   cursor: var(--ams-time-input-calendar-picker-indicator-cursor);
 }
 
-.ams-time-input:hover::-webkit-calendar-picker-indicator {
-  /* stylelint-disable-next-line defensive-css/require-background-repeat -- The base rule for this element declares background-repeat; this only swaps the image. */
-  background-image: var(--ams-time-input-hover-calendar-picker-indicator-background-image);
+@media (hover: hover) {
+  .ams-time-input:hover::-webkit-calendar-picker-indicator {
+    /* stylelint-disable-next-line defensive-css/require-background-repeat -- The base rule for this element declares background-repeat; this only swaps the image. */
+    background-image: var(--ams-time-input-hover-calendar-picker-indicator-background-image);
+  }
 }
 
 .ams-time-input:disabled {
@@ -72,12 +74,16 @@
   border-color: var(--ams-time-input-invalid-border-color);
 }
 
-.ams-time-input:not(:disabled):hover {
-  box-shadow: var(--ams-time-input-hover-box-shadow);
+@media (hover: hover) {
+  .ams-time-input:not(:disabled):hover {
+    box-shadow: var(--ams-time-input-hover-box-shadow);
+  }
 }
 
-.ams-time-input:not(:disabled):invalid:hover,
-.ams-time-input:not(:disabled)[aria-invalid="true"]:hover {
-  border-color: var(--ams-time-input-invalid-hover-border-color);
-  box-shadow: var(--ams-time-input-invalid-hover-box-shadow);
+@media (hover: hover) {
+  .ams-time-input:not(:disabled):invalid:hover,
+  .ams-time-input:not(:disabled)[aria-invalid="true"]:hover {
+    border-color: var(--ams-time-input-invalid-hover-border-color);
+    box-shadow: var(--ams-time-input-invalid-hover-box-shadow);
+  }
 }

--- a/packages/css/src/components/visually-hidden/visually-hidden.scss
+++ b/packages/css/src/components/visually-hidden/visually-hidden.scss
@@ -5,18 +5,18 @@
 
 // Source: https://css-tricks.com/inclusively-hidden/
 .ams-visually-hidden:not(:active, :focus) {
-  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- The canonical inclusively-hidden pattern uses a 1px box; scaling it serves nobody. */
+  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- The canonical inclusively-hidden pattern. */
   block-size: 1px;
   clip-path: inset(50%);
-  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- The canonical inclusively-hidden pattern uses a 1px box; scaling it serves nobody. */
+  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- The canonical inclusively-hidden pattern. */
   inline-size: 1px;
   overflow: hidden;
   position: absolute;
-  /* stylelint-disable-next-line defensive-css/no-user-select-none -- Keeps screen-reader-only text out of copied selections. */
+  /* stylelint-disable-next-line defensive-css/no-user-select-none -- Prevents copying invisible text. */
   -webkit-user-select: none;
 
   /* Safari support is added with the prefixed property. */
-  /* stylelint-disable-next-line plugin/use-baseline, defensive-css/no-user-select-none -- Keeps screen-reader-only text out of copied selections. */
+  /* stylelint-disable-next-line plugin/use-baseline, defensive-css/no-user-select-none -- Prevents copying invisible text. */
   user-select: none;
   white-space: nowrap;
 }

--- a/packages/css/src/components/visually-hidden/visually-hidden.scss
+++ b/packages/css/src/components/visually-hidden/visually-hidden.scss
@@ -5,15 +5,18 @@
 
 // Source: https://css-tricks.com/inclusively-hidden/
 .ams-visually-hidden:not(:active, :focus) {
+  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- The canonical inclusively-hidden pattern uses a 1px box; scaling it serves nobody. */
   block-size: 1px;
   clip-path: inset(50%);
+  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- The canonical inclusively-hidden pattern uses a 1px box; scaling it serves nobody. */
   inline-size: 1px;
   overflow: hidden;
   position: absolute;
+  /* stylelint-disable-next-line defensive-css/no-user-select-none -- Keeps screen-reader-only text out of copied selections. */
   -webkit-user-select: none;
 
   /* Safari support is added with the prefixed property. */
-  /* stylelint-disable-next-line plugin/use-baseline */
+  /* stylelint-disable-next-line plugin/use-baseline, defensive-css/no-user-select-none -- Keeps screen-reader-only text out of copied selections. */
   user-select: none;
   white-space: nowrap;
 }

--- a/storybook/src/_components/Code/code.css
+++ b/storybook/src/_components/Code/code.css
@@ -4,7 +4,7 @@
  */
 
 /*  Replicates the styles of the Code preview in Storybook Docs */
-/* stylelint-disable defensive-css/no-fixed-sizes -- Deliberately replicates Storybook’s pixel-based docs styling. */
+/* stylelint-disable defensive-css/no-fixed-sizes -- Replicates Storybook’s docs styling. */
 ._ams-code {
   background-color: rgb(247 250 252);
   border-color: rgb(236 244 249);

--- a/storybook/src/_components/Code/code.css
+++ b/storybook/src/_components/Code/code.css
@@ -4,6 +4,7 @@
  */
 
 /*  Replicates the styles of the Code preview in Storybook Docs */
+/* stylelint-disable defensive-css/no-fixed-sizes -- Deliberately replicates Storybook’s pixel-based docs styling. */
 ._ams-code {
   background-color: rgb(247 250 252);
   border-color: rgb(236 244 249);

--- a/storybook/src/_components/ColorPalette/color-palette.css
+++ b/storybook/src/_components/ColorPalette/color-palette.css
@@ -38,7 +38,7 @@
 
 ._ams-color-palette-name,
 ._ams-color-palette-level {
-  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- Matches Storybook’s own pixel-based docs styling. */
+  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- Matches Storybook’s docs styling. */
   font-size: 14px !important;
   text-align: center;
 }

--- a/storybook/src/_components/ColorPalette/color-palette.css
+++ b/storybook/src/_components/ColorPalette/color-palette.css
@@ -38,6 +38,7 @@
 
 ._ams-color-palette-name,
 ._ams-color-palette-level {
+  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- Matches Storybook’s own pixel-based docs styling. */
   font-size: 14px !important;
   text-align: center;
 }

--- a/storybook/src/_components/DesignTokensTable/design-tokens-table.css
+++ b/storybook/src/_components/DesignTokensTable/design-tokens-table.css
@@ -4,7 +4,7 @@
  */
 
 ._ams-design-tokens-table {
-  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- This scrolls horizontally only; scrollbar-gutter reserves space for a vertical scrollbar. */
+  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- This scrolls horizontally only. */
   overflow-x: auto;
   /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
   overscroll-behavior-x: contain;

--- a/storybook/src/_styles/authoring.css
+++ b/storybook/src/_styles/authoring.css
@@ -104,6 +104,7 @@
 }
 
 ._ams-resize-horizontal {
+  /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- A hairline dev-tool outline. */
   outline: 1px dashed var(--_ams-color-pink);
   overflow: auto;
   /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */

--- a/storybook/src/_styles/docs.css
+++ b/storybook/src/_styles/docs.css
@@ -59,10 +59,12 @@
   text-underline-offset: 0.125rem;
 }
 
-.sbdocs-content.sbdocs-content .sbdocs-a:hover {
-  color: var(--ams-color-interactive-hover);
-  text-decoration-thickness: 0.125rem;
-  text-underline-offset: 0.0625rem;
+@media (hover: hover) {
+  .sbdocs-content.sbdocs-content .sbdocs-a:hover {
+    color: var(--ams-color-interactive-hover);
+    text-decoration-thickness: 0.125rem;
+    text-underline-offset: 0.0625rem;
+  }
 }
 
 .sbdocs-content.sbdocs-content > :is(h1, h2, h3, h4, h5, h6),

--- a/stylelint/README.md
+++ b/stylelint/README.md
@@ -89,7 +89,7 @@ Our grids place children by span (`grid-column-end: span n`, `grid-column: 1 / -
 The rule also fires on `grid-template-columns: var(--…)` declarations it cannot inspect, and double-reports the tracks that `require-grid-minmax` already covers.
 
 Every remaining rule runs at `error` severity, and the repository has no outstanding violations.
-Deliberate patterns the rules cannot recognise carry a `stylelint-disable-next-line` comment stating the reason at the site.
+Deliberate patterns the rules cannot recognise carry a `stylelint-disable` comment stating the reason at the site, scoped as narrowly as practical — usually a single line.
 
 Two of the upstream rules are narrower than they look:
 

--- a/stylelint/README.md
+++ b/stylelint/README.md
@@ -67,7 +67,7 @@ A component that redeclares a token under one selector is therefore treated as a
 ## Relationship to `stylelint-plugin-defensive-css`
 
 That plugin is installed and extended from its `strict` config, which enables all 21 of its rules.
-Five of its rules are turned off in [.stylelintrc.json](../.stylelintrc.json), which cannot hold comments, so the reasoning lives here.
+Six of its rules are turned off in [.stylelintrc.json](../.stylelintrc.json), which cannot hold comments, so the reasoning lives here.
 A full audit of all 21 rules — effectiveness, violations, remediation, and impact — is in [documentation/defensive-css.md](../documentation/defensive-css.md).
 
 `defensive-css/no-unsafe-clamp-font-size` and `defensive-css/require-system-font-fallback` are off because the two rules above replace them.
@@ -84,12 +84,17 @@ That is an architecture decision, not a lint fix.
 `defensive-css/require-pure-selectors` is off.
 It reports `> *`, `+ *`, `[aria-expanded="true"] &` and `.ams-date-input:not(:disabled):invalid` as element tags, none of which are.
 
-Every remaining rule runs at `warning` severity where the repository still has violations, so they are visible without failing `lint:css`, and at `error` where it has none.
+`defensive-css/require-named-grid-lines` is off.
+Our grids place children by span (`grid-column-end: span n`, `grid-column: 1 / -1`), by auto-placement, or into named areas, so line names would add bytes without any consumer being able to use them — the classes are the API, not the grid lines.
+The rule also fires on `grid-template-columns: var(--…)` declarations it cannot inspect, and double-reports the tracks that `require-grid-minmax` already covers.
+
+Every remaining rule runs at `error` severity, and the repository has no outstanding violations.
+Deliberate patterns the rules cannot recognise carry a `stylelint-disable-next-line` comment stating the reason at the site.
 
 Two of the upstream rules are narrower than they look:
 
-- `no-fixed-sizes` only checks its default properties once its severity is overridden, which drops coverage of borders, outlines and `translate`. Restoring the full list means restating all ninety properties in the config. It reports 8 violations as configured, against 15 with the full list.
-- `no-list-style-none` misses both uses of `list-style: none` in [resets.scss](../packages/css/src/common/resets.scss), because they sit in `@mixin` blocks where it cannot see a list element in the selector.
+- `no-fixed-sizes` silently resets its property list to the ~40 defaults when any option — including `severity` — is overridden, dropping coverage of borders, outlines and `translate`. The config therefore leaves the strict preset's ninety-property configuration untouched.
+- `no-list-style-none` cannot see into `@mixin` blocks, so it misses the `reset-ol`/`reset-ul` mixins in [resets.scss](../packages/css/src/common/resets.scss). Those mixins hide markers with `list-style-type: ""`, which keeps list semantics; the rule only guards literal future uses.
 
 ## Requirements
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## Links

- [Storybook deploy of this branch](https://amsterdam.github.io/design-system/demo-defensive-css-hover/)
- [Defensive CSS audit](https://github.com/Amsterdam/design-system/blob/develop/documentation/defensive-css.md) — the per-rule assessment behind these fixes

## What

- Wraps every hover rule — 73 across 32 components and the Storybook docs styles — in `@media (hover: hover)`, so hover styling only applies on devices that can actually hover.
- Search Field raises its z-index on `:focus-visible` instead of `:focus`; Page Header’s menu icon moves its transition into a `prefers-reduced-motion: no-preference` query, matching the positive pattern its siblings use.
  Both are behaviour-preserving.
- Annotates the deliberate patterns the linter cannot recognise, each with a short reason at the site: the `user-select: none` ghost elements, every intentional pixel value, the input-label focus enhancement, and four forced-colors rules that apply identical styling with and without hover.
- Turns `require-named-grid-lines` off: our grids place children by span, auto-placement, or named areas, so line names would be bytes no consumer can use.
- Raises the remaining rules to error.
  This completes the audit’s remediation: every defensive-css rule now runs at error or is off with a documented reason, and the standing warning count drops from 109 to zero.

## Why

On touch screens, a tap can leave hover styling stuck on an element until the next tap elsewhere, which reads as a glitch.
Mouse users see no difference.
The four forced-colors rules are annotated rather than wrapped deliberately: gating them would strip forced-colors styling from touch devices.

## How

- The wrap is mechanical, and verified rather than assumed: the compiled stylesheet was compared against the previous build and is byte-identical once the hover gating is factored out (one shared media query block splits in two, same conditions and order).
- Chromatic captures in a hover-capable browser, so no visual changes are expected in the snapshots either.
- With the backlog gone, the rules ratchet to error, which locks all of this in for future changes.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Third of the stack of four.
  The closing PR (`chore/defensive-css-token-rules`) fixes three Description List tokens and adds three token-aware rules that guard what tokens resolve to.
