### PR TITLE
fix(Description List): Let tokenised grid tracks shrink below the minimum content size

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -9,7 +9,25 @@
   ],
   "rules": {
     "alpha-value-notation": ["percentage"],
+    "ams/no-fixed-sizes": [
+      true,
+      {
+        "importFrom": ["packages-proprietary/tokens/dist/index.css"]
+      }
+    ],
+    "ams/no-list-style-none": [
+      true,
+      {
+        "importFrom": ["packages-proprietary/tokens/dist/index.css"]
+      }
+    ],
     "ams/no-unsafe-clamp-font-size": [
+      true,
+      {
+        "importFrom": ["packages-proprietary/tokens/dist/index.css"]
+      }
+    ],
+    "ams/require-grid-minmax": [
       true,
       {
         "importFrom": ["packages-proprietary/tokens/dist/index.css"]

--- a/documentation/defensive-css.md
+++ b/documentation/defensive-css.md
@@ -61,6 +61,10 @@ In a repository where nearly every value is a token reference, those rules only 
 That mostly means false _negatives_ (they silently pass tokenised declarations), which is why two of them are replaced by our own token-resolving rules.
 The blind spot is smaller than it sounds, though: because our tokens are `rem`- and `clamp()`-based by design, only two tokens hold a `px` value at all — both 1px hairlines for the Progress List connector.
 
+Since the audit, three more token-resolving rules close the remaining value blind spots: `ams/require-grid-minmax`, `ams/no-fixed-sizes`, and `ams/no-list-style-none`, each judging only what tokens resolve to while the upstream rule stays on for literal values.
+The grid rule’s first find were three Description List tokens holding bare `fr` track lists — the same blowout risk the stylesheet remediation fixed, hidden in token values — which have been fixed since.
+The remaining value rules need no token-side twin: no token holds a viewport-height unit, and `user-select`, `background-repeat` and `will-change` are never tokenised here.
+
 ## Rules with a backlog
 
 ### no-accidental-hover — 73 (72 shipped)

--- a/documentation/defensive-css.md
+++ b/documentation/defensive-css.md
@@ -62,7 +62,7 @@ That mostly means false _negatives_ (they silently pass tokenised declarations),
 The blind spot is smaller than it sounds, though: because our tokens are `rem`- and `clamp()`-based by design, only two tokens hold a `px` value at all — both 1px hairlines for the Progress List connector.
 
 Since the audit, three more token-resolving rules close the remaining value blind spots: `ams/require-grid-minmax`, `ams/no-fixed-sizes`, and `ams/no-list-style-none`, each judging only what tokens resolve to while the upstream rule stays on for literal values.
-The grid rule’s first find were three Description List tokens holding bare `fr` track lists — the same blowout risk the stylesheet remediation fixed, hidden in token values — which have been fixed since.
+The grid rule’s first finds were three Description List tokens holding bare `fr` track lists — the same blowout risk the stylesheet remediation fixed, hidden in token values — which have been fixed since.
 The remaining value rules need no token-side twin: no token holds a viewport-height unit, and `user-select`, `background-repeat` and `will-change` are never tokenised here.
 
 ## Rules with a backlog

--- a/packages-proprietary/tokens/src/components/ams/description-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/description-list.tokens.json
@@ -164,7 +164,7 @@
         },
         "narrow": {
           "grid-template-columns": {
-            "$value": "1fr 4fr",
+            "$value": "minmax(0, 1fr) minmax(0, 4fr)",
             "$extensions": {
               "nl.amsterdam.type": "gridTemplateColumns"
             }
@@ -172,7 +172,7 @@
         },
         "medium": {
           "grid-template-columns": {
-            "$value": "1fr 2fr",
+            "$value": "minmax(0, 1fr) minmax(0, 2fr)",
             "$extensions": {
               "nl.amsterdam.type": "gridTemplateColumns"
             }
@@ -180,7 +180,7 @@
         },
         "wide": {
           "grid-template-columns": {
-            "$value": "1fr 1fr",
+            "$value": "minmax(0, 1fr) minmax(0, 1fr)",
             "$extensions": {
               "nl.amsterdam.type": "gridTemplateColumns"
             }

--- a/packages/css/src/components/progress-list/progress-list.scss
+++ b/packages/css/src/components/progress-list/progress-list.scss
@@ -100,6 +100,7 @@
 /* Connector */
 
 .ams-progress-list__connector {
+  /* stylelint-disable-next-line ams/no-fixed-sizes -- A hairline connector. */
   border-inline: var(--ams-progress-list-step-connector-border-inline-width)
     var(--ams-progress-list-step-connector-border-inline-style)
     var(--ams-progress-list-step-connector-border-inline-color);
@@ -298,6 +299,7 @@
   background-color: var(--ams-progress-list-substeps-step-connector-background-color);
   border-inline-color: var(--ams-progress-list-substeps-step-connector-border-inline-color);
   border-inline-style: var(--ams-progress-list-substeps-step-connector-border-inline-style);
+  /* stylelint-disable-next-line ams/no-fixed-sizes -- A hairline connector. */
   border-inline-width: var(--ams-progress-list-substeps-step-connector-border-inline-width);
   margin-block-start: var(--ams-progress-list-substeps-step-connector-margin-block-start);
 

--- a/stylelint/README.md
+++ b/stylelint/README.md
@@ -24,6 +24,32 @@ A problem is reported at the declaration that uses the token, so the warning poi
 
 ## Rules
 
+Two kinds of rule live here.
+The two font rules _replace_ their upstream counterparts, which are turned off: they check literal values as well as tokens.
+The other three _complement_ upstream rules that stay on: the upstream rule judges literal values, the rule here only reports a problem that arrives through token resolution.
+A declaration that already violates literally is left to the upstream rule, so no declaration is ever reported twice.
+
+### `ams/no-fixed-sizes`
+
+Reports a size-related declaration whose tokens resolve to a pixel length.
+Pixels do not scale when users raise their default font size, so sizes that should follow text end up fixed.
+
+The property list is taken from the strict configuration of `defensive-css/no-fixed-sizes`, so both rules cover the same properties without maintaining the list twice — extended with the logical border shorthands (`border-inline`, `border-block`, and their start/end variants) that the upstream list misses.
+
+Options:
+
+- `importFrom` — paths to the CSS files to read tokens from, relative to the working directory.
+- `properties` — the properties to check. Defaults to the list described above.
+
+### `ams/no-list-style-none`
+
+Reports a `list-style` or `list-style-type` whose token resolves to `none`.
+Safari then removes the list from the accessibility tree, so VoiceOver no longer announces the list or its item count; `list-style-type: ""` hides markers while keeping the semantics.
+
+Options:
+
+- `importFrom` — paths to the CSS files to read tokens from, relative to the working directory.
+
 ### `ams/no-unsafe-clamp-font-size`
 
 Reports a `font-size` that resolves to a `clamp()` whose maximum is more than 2.5 times its minimum, when the preferred value scales with the viewport.
@@ -37,6 +63,16 @@ Options:
 
 - `importFrom` — paths to the CSS files to read tokens from, relative to the working directory.
 - `maxRatio` — the largest allowed ratio between the minimum and the maximum. Defaults to `2.5`.
+
+### `ams/require-grid-minmax`
+
+Reports a `grid-template-columns` or `grid-template-rows` whose tokens resolve to a track list with a bare `fr` track.
+Such a track cannot shrink below its content’s min-content size, so one long unbreakable word pushes the grid out of its container; `minmax(0, …)` lets it shrink.
+Its first find were three Description List tokens holding bare `fr` tracks, fixed since.
+
+Options:
+
+- `importFrom` — paths to the CSS files to read tokens from, relative to the working directory.
 
 ### `ams/require-system-font-fallback`
 
@@ -70,9 +106,11 @@ That plugin is installed and extended from its `strict` config, which enables al
 Six of its rules are turned off in [.stylelintrc.json](../.stylelintrc.json), which cannot hold comments, so the reasoning lives here.
 A full audit of all 21 rules — effectiveness, violations, remediation, and impact — is in [documentation/defensive-css.md](../documentation/defensive-css.md).
 
-`defensive-css/no-unsafe-clamp-font-size` and `defensive-css/require-system-font-fallback` are off because the two rules above replace them.
+`defensive-css/no-unsafe-clamp-font-size` and `defensive-css/require-system-font-fallback` are off because the two font rules above replace them.
 Neither upstream rule resolves `var()`, so both pass on every tokenised declaration in this repository.
 The rules here check the same thing and also catch literal values, so running both would only duplicate warnings on the literals.
+
+`defensive-css/no-fixed-sizes`, `defensive-css/no-list-style-none` and `defensive-css/require-grid-minmax` stay on beside their `ams/` complements: they judge the literal values, the `ams/` rules judge what tokens resolve to.
 
 `defensive-css/require-custom-property-fallback` is off.
 It asks for `var(--token, fallback)` at every use, which would restate a value that the token already defines and leave two places to change it.

--- a/stylelint/README.md
+++ b/stylelint/README.md
@@ -68,7 +68,7 @@ Options:
 
 Reports a `grid-template-columns` or `grid-template-rows` whose tokens resolve to a track list with a bare `fr` track.
 Such a track cannot shrink below its content’s min-content size, so one long unbreakable word pushes the grid out of its container; `minmax(0, …)` lets it shrink.
-Its first find were three Description List tokens holding bare `fr` tracks, fixed since.
+Its first finds were three Description List tokens holding bare `fr` tracks, fixed since.
 
 Options:
 

--- a/stylelint/index.mjs
+++ b/stylelint/index.mjs
@@ -3,7 +3,10 @@
  * Copyright Gemeente Amsterdam
  */
 
+import noFixedSizes from './no-fixed-sizes.mjs'
+import noListStyleNone from './no-list-style-none.mjs'
 import noUnsafeClampFontSize from './no-unsafe-clamp-font-size.mjs'
+import requireGridMinmax from './require-grid-minmax.mjs'
 import requireSystemFontFallback from './require-system-font-fallback.mjs'
 
-export default [noUnsafeClampFontSize, requireSystemFontFallback]
+export default [noFixedSizes, noListStyleNone, noUnsafeClampFontSize, requireGridMinmax, requireSystemFontFallback]

--- a/stylelint/no-fixed-sizes.mjs
+++ b/stylelint/no-fixed-sizes.mjs
@@ -1,0 +1,132 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { createRequire } from 'node:module'
+import stylelint from 'stylelint'
+
+import {
+  getReferencedCustomProperty,
+  readCustomProperties,
+  resolveValue,
+  withDeclaredCustomProperties,
+} from './custom-properties.mjs'
+import { hasInterpolation, hasPixelLength } from './values.mjs'
+
+const { createPlugin, utils } = stylelint
+
+const ruleName = 'ams/no-fixed-sizes'
+
+/* The size-related properties come from the strict configuration of defensive-css/no-fixed-sizes,
+ * so both rules cover the same properties without maintaining the list twice.
+ */
+const require = createRequire(import.meta.url)
+const strictConfiguration = require('stylelint-plugin-defensive-css/configs/strict')
+
+const strictProperties = strictConfiguration.rules?.['defensive-css/no-fixed-sizes']?.[1]?.properties
+
+if (!strictProperties) {
+  throw new Error(
+    `${ruleName}: could not read the property list from the strict configuration of stylelint-plugin-defensive-css. The package layout may have changed; pass the \`properties\` option explicitly`,
+  )
+}
+
+/* The upstream list has the border longhands and the physical `border` shorthand, but misses the
+ * logical shorthands, which are the only ones this repository uses.
+ */
+const LOGICAL_BORDER_SHORTHANDS = [
+  'border-block',
+  'border-block-end',
+  'border-block-start',
+  'border-inline',
+  'border-inline-end',
+  'border-inline-start',
+]
+
+const DEFAULT_PROPERTIES = [...Object.keys(strictProperties), ...LOGICAL_BORDER_SHORTHANDS]
+
+const messages = utils.ruleMessages(ruleName, {
+  missingFile: (filePath) =>
+    `Could not read "${filePath}", so sizes that use tokens were not checked. Run \`pnpm --filter @amsterdam/design-system-tokens run build\` to generate it`,
+  rejected: (source, property) =>
+    `Expected "${source}" not to resolve to a pixel length in "${property}". Relative units let sizes follow the font size that users configure`,
+})
+
+const meta = { url: 'https://github.com/Amsterdam/design-system/blob/develop/stylelint/README.md' }
+
+/* Token files that could not be read, so the warning is emitted once per lint run and not once per
+ * stylesheet.
+ */
+const warnedFiles = new Set()
+
+/** @type {import('stylelint').Rule} */
+const rule =
+  (primary, secondaryOptions = {}) =>
+  (root, result) => {
+    const validOptions = utils.validateOptions(
+      result,
+      ruleName,
+      { actual: primary, possible: [true] },
+      {
+        actual: secondaryOptions,
+        optional: true,
+        possible: {
+          importFrom: [(value) => typeof value === 'string'],
+          properties: [(value) => typeof value === 'string'],
+        },
+      },
+    )
+
+    if (!validOptions) {
+      return
+    }
+
+    const properties = new Set((secondaryOptions.properties ?? DEFAULT_PROPERTIES).map((name) => name.toLowerCase()))
+    const { customProperties, missingFiles } = readCustomProperties([secondaryOptions.importFrom ?? []].flat())
+
+    for (const missingFile of missingFiles) {
+      if (!warnedFiles.has(missingFile)) {
+        warnedFiles.add(missingFile)
+
+        result.warn(messages.missingFile(missingFile), { stylelintType: 'invalidOption' })
+      }
+    }
+
+    const knownCustomProperties = withDeclaredCustomProperties(root, customProperties)
+
+    root.walkDecls((declaration) => {
+      if (!properties.has(declaration.prop.toLowerCase()) || hasInterpolation(declaration.value)) {
+        return
+      }
+
+      /* A literal pixel length is judged by defensive-css/no-fixed-sizes; this rule only reports a
+       * pixel length that arrives through token resolution.
+       */
+      if (!declaration.value.includes('var(') || hasPixelLength(declaration.value)) {
+        return
+      }
+
+      const resolved = resolveValue(declaration.value, knownCustomProperties)
+
+      if (resolved === null || !hasPixelLength(resolved)) {
+        return
+      }
+
+      const source = getReferencedCustomProperty(declaration.value) ?? resolved.replace(/\s+/g, ' ')
+
+      utils.report({
+        message: messages.rejected(source, declaration.prop),
+        node: declaration,
+        result,
+        ruleName,
+        word: declaration.value,
+      })
+    })
+  }
+
+rule.messages = messages
+rule.meta = meta
+rule.ruleName = ruleName
+
+export default createPlugin(ruleName, rule)

--- a/stylelint/no-fixed-sizes.mjs
+++ b/stylelint/no-fixed-sizes.mjs
@@ -20,16 +20,18 @@ const ruleName = 'ams/no-fixed-sizes'
 
 /* The size-related properties come from the strict configuration of defensive-css/no-fixed-sizes,
  * so both rules cover the same properties without maintaining the list twice.
+ * A failed lookup is not fatal here: it is reported at rule execution, where an explicit
+ * `properties` option still works.
  */
 const require = createRequire(import.meta.url)
-const strictConfiguration = require('stylelint-plugin-defensive-css/configs/strict')
+let strictProperties
 
-const strictProperties = strictConfiguration.rules?.['defensive-css/no-fixed-sizes']?.[1]?.properties
-
-if (!strictProperties) {
-  throw new Error(
-    `${ruleName}: could not read the property list from the strict configuration of stylelint-plugin-defensive-css. The package layout may have changed; pass the \`properties\` option explicitly`,
-  )
+try {
+  strictProperties = require('stylelint-plugin-defensive-css/configs/strict').rules?.[
+    'defensive-css/no-fixed-sizes'
+  ]?.[1]?.properties
+} catch {
+  /* Reported at rule execution. */
 }
 
 /* The upstream list has the border longhands and the physical `border` shorthand, but misses the
@@ -44,11 +46,14 @@ const LOGICAL_BORDER_SHORTHANDS = [
   'border-inline-start',
 ]
 
-const DEFAULT_PROPERTIES = [...Object.keys(strictProperties), ...LOGICAL_BORDER_SHORTHANDS]
+const DEFAULT_PROPERTIES = strictProperties
+  ? [...Object.keys(strictProperties), ...LOGICAL_BORDER_SHORTHANDS]
+  : null
 
 const messages = utils.ruleMessages(ruleName, {
   missingFile: (filePath) =>
     `Could not read "${filePath}", so sizes that use tokens were not checked. Run \`pnpm --filter @amsterdam/design-system-tokens run build\` to generate it`,
+  missingPropertyList: `Could not read the property list from the strict configuration of stylelint-plugin-defensive-css. The package layout may have changed; pass the \`properties\` option explicitly`,
   rejected: (source, property) =>
     `Expected "${source}" not to resolve to a pixel length in "${property}". Relative units let sizes follow the font size that users configure`,
 })
@@ -59,6 +64,9 @@ const meta = { url: 'https://github.com/Amsterdam/design-system/blob/develop/sty
  * stylesheet.
  */
 const warnedFiles = new Set()
+
+/* Same once-per-run guard for a missing property list. */
+let warnedMissingPropertyList = false
 
 /** @type {import('stylelint').Rule} */
 const rule =
@@ -82,7 +90,19 @@ const rule =
       return
     }
 
-    const properties = new Set((secondaryOptions.properties ?? DEFAULT_PROPERTIES).map((name) => name.toLowerCase()))
+    const configuredProperties = secondaryOptions.properties ?? DEFAULT_PROPERTIES
+
+    if (!configuredProperties) {
+      if (!warnedMissingPropertyList) {
+        warnedMissingPropertyList = true
+
+        result.warn(messages.missingPropertyList, { stylelintType: 'invalidOption' })
+      }
+
+      return
+    }
+
+    const properties = new Set(configuredProperties.map((name) => name.toLowerCase()))
     const { customProperties, missingFiles } = readCustomProperties([secondaryOptions.importFrom ?? []].flat())
 
     for (const missingFile of missingFiles) {

--- a/stylelint/no-list-style-none.mjs
+++ b/stylelint/no-list-style-none.mjs
@@ -1,0 +1,101 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import stylelint from 'stylelint'
+
+import {
+  getReferencedCustomProperty,
+  readCustomProperties,
+  resolveValue,
+  withDeclaredCustomProperties,
+} from './custom-properties.mjs'
+import { hasInterpolation } from './values.mjs'
+
+const { createPlugin, utils } = stylelint
+
+const ruleName = 'ams/no-list-style-none'
+
+const messages = utils.ruleMessages(ruleName, {
+  missingFile: (filePath) =>
+    `Could not read "${filePath}", so list styles that use tokens were not checked. Run \`pnpm --filter @amsterdam/design-system-tokens run build\` to generate it`,
+  rejected: (source, property) =>
+    `Expected "${source}" not to resolve to "none" in "${property}". Safari then removes the list from the accessibility tree; hide markers with list-style-type: "" instead`,
+})
+
+const meta = { url: 'https://github.com/Amsterdam/design-system/blob/develop/stylelint/README.md' }
+
+/* Token files that could not be read, so the warning is emitted once per lint run and not once per
+ * stylesheet.
+ */
+const warnedFiles = new Set()
+
+/** @type {import('stylelint').Rule} */
+const rule =
+  (primary, secondaryOptions = {}) =>
+  (root, result) => {
+    const validOptions = utils.validateOptions(
+      result,
+      ruleName,
+      { actual: primary, possible: [true] },
+      {
+        actual: secondaryOptions,
+        optional: true,
+        possible: {
+          importFrom: [(value) => typeof value === 'string'],
+        },
+      },
+    )
+
+    if (!validOptions) {
+      return
+    }
+
+    const { customProperties, missingFiles } = readCustomProperties([secondaryOptions.importFrom ?? []].flat())
+
+    for (const missingFile of missingFiles) {
+      if (!warnedFiles.has(missingFile)) {
+        warnedFiles.add(missingFile)
+
+        result.warn(messages.missingFile(missingFile), { stylelintType: 'invalidOption' })
+      }
+    }
+
+    const knownCustomProperties = withDeclaredCustomProperties(root, customProperties)
+
+    root.walkDecls(/^list-style(-type)?$/i, (declaration) => {
+      if (hasInterpolation(declaration.value)) {
+        return
+      }
+
+      /* A literal `none` is judged by defensive-css/no-list-style-none; this rule only adds the
+       * tokenised declarations that rule cannot see into.
+       */
+      if (!declaration.value.includes('var(')) {
+        return
+      }
+
+      const resolved = resolveValue(declaration.value, knownCustomProperties)
+
+      if (resolved === null || resolved.trim().toLowerCase() !== 'none') {
+        return
+      }
+
+      const source = getReferencedCustomProperty(declaration.value) ?? resolved
+
+      utils.report({
+        message: messages.rejected(source, declaration.prop),
+        node: declaration,
+        result,
+        ruleName,
+        word: declaration.value,
+      })
+    })
+  }
+
+rule.messages = messages
+rule.meta = meta
+rule.ruleName = ruleName
+
+export default createPlugin(ruleName, rule)

--- a/stylelint/require-grid-minmax.mjs
+++ b/stylelint/require-grid-minmax.mjs
@@ -1,0 +1,101 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import stylelint from 'stylelint'
+
+import {
+  getReferencedCustomProperty,
+  readCustomProperties,
+  resolveValue,
+  withDeclaredCustomProperties,
+} from './custom-properties.mjs'
+import { hasBareFrTrack, hasInterpolation } from './values.mjs'
+
+const { createPlugin, utils } = stylelint
+
+const ruleName = 'ams/require-grid-minmax'
+
+const messages = utils.ruleMessages(ruleName, {
+  missingFile: (filePath) =>
+    `Could not read "${filePath}", so grid tracks that use tokens were not checked. Run \`pnpm --filter @amsterdam/design-system-tokens run build\` to generate it`,
+  rejected: (source) =>
+    `Expected "${source}" to wrap its fr tracks in minmax(0, …). A bare fr track cannot shrink below its content, so long unbreakable content pushes the grid out of its container`,
+})
+
+const meta = { url: 'https://github.com/Amsterdam/design-system/blob/develop/stylelint/README.md' }
+
+/* Token files that could not be read, so the warning is emitted once per lint run and not once per
+ * stylesheet.
+ */
+const warnedFiles = new Set()
+
+/** @type {import('stylelint').Rule} */
+const rule =
+  (primary, secondaryOptions = {}) =>
+  (root, result) => {
+    const validOptions = utils.validateOptions(
+      result,
+      ruleName,
+      { actual: primary, possible: [true] },
+      {
+        actual: secondaryOptions,
+        optional: true,
+        possible: {
+          importFrom: [(value) => typeof value === 'string'],
+        },
+      },
+    )
+
+    if (!validOptions) {
+      return
+    }
+
+    const { customProperties, missingFiles } = readCustomProperties([secondaryOptions.importFrom ?? []].flat())
+
+    for (const missingFile of missingFiles) {
+      if (!warnedFiles.has(missingFile)) {
+        warnedFiles.add(missingFile)
+
+        result.warn(messages.missingFile(missingFile), { stylelintType: 'invalidOption' })
+      }
+    }
+
+    const knownCustomProperties = withDeclaredCustomProperties(root, customProperties)
+
+    root.walkDecls(/^grid-template-(columns|rows)$/i, (declaration) => {
+      if (hasInterpolation(declaration.value)) {
+        return
+      }
+
+      /* A literal bare fr track is judged by defensive-css/require-grid-minmax; this rule only
+       * reports a bare track that arrives through token resolution.
+       */
+      if (!declaration.value.includes('var(') || hasBareFrTrack(declaration.value)) {
+        return
+      }
+
+      const resolved = resolveValue(declaration.value, knownCustomProperties)
+
+      if (resolved === null || !hasBareFrTrack(resolved)) {
+        return
+      }
+
+      const source = getReferencedCustomProperty(declaration.value) ?? resolved.replace(/\s+/g, ' ')
+
+      utils.report({
+        message: messages.rejected(source),
+        node: declaration,
+        result,
+        ruleName,
+        word: declaration.value,
+      })
+    })
+  }
+
+rule.messages = messages
+rule.meta = meta
+rule.ruleName = ruleName
+
+export default createPlugin(ruleName, rule)

--- a/stylelint/rules.test.mjs
+++ b/stylelint/rules.test.mjs
@@ -23,6 +23,16 @@ const TOKENS = `
   --ams-generic-first-font-family: sans-serif, 'Amsterdam Sans';
   --ams-inherit-font-family: inherit;
   --ams-safe-font-family: 'Amsterdam Sans', Arial, sans-serif;
+  --ams-alias-grid-template-columns: var(--ams-bare-grid-template-columns);
+  --ams-bare-grid-template-columns: 1fr 4fr;
+  --ams-repeat-grid-template-columns: repeat(7, 1fr);
+  --ams-safe-grid-template-columns: minmax(0, 1fr) minmax(0, 4fr);
+  --ams-alias-border-width: var(--ams-fixed-border-width);
+  --ams-fixed-border-width: 1px;
+  --ams-quoted-px-content: '10px';
+  --ams-safe-inline-size: 1rem;
+  --ams-marker-list-style-type: '\\2022';
+  --ams-none-list-style-type: none;
 }
 `
 
@@ -140,5 +150,119 @@ describe('ams/require-system-font-fallback', () => {
     const code = `@font-face { font-family: 'Amsterdam Sans'; src: url(a.woff2) format('woff2'); }`
 
     expect(await lint(ruleName, code)).toHaveLength(0)
+  })
+})
+
+describe('ams/require-grid-minmax', () => {
+  const ruleName = 'ams/require-grid-minmax'
+
+  it('rejects a bare fr track reached through a token, which is what a plain value check misses', async () => {
+    const warnings = await lint(ruleName, '.a { grid-template-columns: var(--ams-bare-grid-template-columns); }')
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('--ams-bare-grid-template-columns')
+  })
+
+  it('rejects a bare fr track reached through a chain of tokens', async () => {
+    expect(await lint(ruleName, '.a { grid-template-columns: var(--ams-alias-grid-template-columns); }')).toHaveLength(
+      1,
+    )
+  })
+
+  it('rejects a bare fr track inside a repeat()', async () => {
+    expect(await lint(ruleName, '.a { grid-template-columns: var(--ams-repeat-grid-template-columns); }')).toHaveLength(
+      1,
+    )
+  })
+
+  it('accepts a literal fr track beside a token, which defensive-css/require-grid-minmax judges', async () => {
+    expect(await lint(ruleName, '.a { grid-template-rows: var(--ams-safe-inline-size) 1fr; }')).toHaveLength(0)
+  })
+
+  it('accepts tracks wrapped in minmax()', async () => {
+    expect(await lint(ruleName, '.a { grid-template-columns: var(--ams-safe-grid-template-columns); }')).toHaveLength(0)
+  })
+
+  it('accepts a literal track list, which defensive-css/require-grid-minmax judges', async () => {
+    expect(await lint(ruleName, '.a { grid-template-columns: 1fr 4fr; }')).toHaveLength(0)
+  })
+
+  it('accepts a token it cannot resolve rather than guessing', async () => {
+    expect(await lint(ruleName, '.a { grid-template-columns: var(--ams-absent); }')).toHaveLength(0)
+  })
+})
+
+describe('ams/no-fixed-sizes', () => {
+  const ruleName = 'ams/no-fixed-sizes'
+
+  it('rejects a pixel length reached through a token, which is what a plain value check misses', async () => {
+    const warnings = await lint(ruleName, '.a { border-inline-width: var(--ams-fixed-border-width); }')
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('--ams-fixed-border-width')
+    expect(warnings[0]).toContain('border-inline-width')
+  })
+
+  it('rejects a pixel length reached through a chain of tokens', async () => {
+    expect(await lint(ruleName, '.a { border-inline-width: var(--ams-alias-border-width); }')).toHaveLength(1)
+  })
+
+  it('rejects a pixel length in a shorthand beside other tokens', async () => {
+    expect(
+      await lint(ruleName, '.a { border-inline: var(--ams-fixed-border-width) solid currentColor; }'),
+    ).toHaveLength(1)
+  })
+
+  it('accepts a token that resolves to a relative unit', async () => {
+    expect(await lint(ruleName, '.a { inline-size: var(--ams-safe-inline-size); }')).toHaveLength(0)
+  })
+
+  it('accepts a literal pixel length, which defensive-css/no-fixed-sizes judges', async () => {
+    expect(await lint(ruleName, '.a { inline-size: 1px; }')).toHaveLength(0)
+  })
+
+  it('accepts a literal pixel length beside a token, which defensive-css/no-fixed-sizes judges', async () => {
+    expect(await lint(ruleName, '.a { outline: 1px dashed var(--ams-safe-inline-size); }')).toHaveLength(0)
+  })
+
+  it('accepts a pixel length inside a quoted string', async () => {
+    expect(await lint(ruleName, '.a { inline-size: var(--ams-quoted-px-content); }')).toHaveLength(0)
+  })
+
+  it('accepts a property outside the size list', async () => {
+    expect(await lint(ruleName, '.a { content: var(--ams-quoted-px-content); }')).toHaveLength(0)
+  })
+
+  it('honours an explicit property list', async () => {
+    const code = '.a { border-inline-width: var(--ams-fixed-border-width); }'
+
+    expect(await lint(ruleName, code, { properties: ['inline-size'] })).toHaveLength(0)
+  })
+})
+
+describe('ams/no-list-style-none', () => {
+  const ruleName = 'ams/no-list-style-none'
+
+  it('rejects a token that resolves to none, which is what a plain value check misses', async () => {
+    const warnings = await lint(ruleName, 'ul { list-style-type: var(--ams-none-list-style-type); }')
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('--ams-none-list-style-type')
+  })
+
+  it('rejects the list-style shorthand resolving to none', async () => {
+    expect(await lint(ruleName, 'ul { list-style: var(--ams-none-list-style-type); }')).toHaveLength(1)
+  })
+
+  it('accepts a token that resolves to a marker', async () => {
+    expect(await lint(ruleName, 'ul { list-style-type: var(--ams-marker-list-style-type); }')).toHaveLength(0)
+  })
+
+  it('accepts a literal none, which defensive-css/no-list-style-none judges', async () => {
+    expect(await lint(ruleName, 'ul { list-style-type: none; }')).toHaveLength(0)
+  })
+
+  it('accepts a token it cannot resolve rather than guessing', async () => {
+    expect(await lint(ruleName, 'ul { list-style-type: var(--ams-absent); }')).toHaveLength(0)
   })
 })

--- a/stylelint/values.mjs
+++ b/stylelint/values.mjs
@@ -180,6 +180,48 @@ export function hasViewportUnit(value) {
 }
 
 /**
+ * Blanks out every call of the given function in a value, keeping the string length intact so that
+ * positions elsewhere in the value stay valid.
+ *
+ * @param {string} value - The value to blank in.
+ * @param {string} functionName - The function whose calls to blank.
+ * @returns {string} The value with each call replaced by spaces.
+ */
+function blankFunction(value, functionName) {
+  let result = value
+  let call
+
+  while ((call = findFunction(result, functionName))) {
+    result = result.slice(0, call.start) + ' '.repeat(call.end - call.start) + result.slice(call.end)
+  }
+
+  return result
+}
+
+/**
+ * Reports whether a track list contains a flexible track that is not wrapped in `minmax()`.
+ * Such a track cannot shrink below its content’s min-content size, so long unbreakable content
+ * pushes the grid out of its container.
+ *
+ * @param {string} value - The resolved track list to test.
+ * @returns {boolean} True when a bare `fr` track is present.
+ */
+export function hasBareFrTrack(value) {
+  return /(?:^|[\s,(])\d*\.?\d+fr\b/i.test(blankFunction(value, 'minmax'))
+}
+
+/**
+ * Reports whether a value contains a length in pixels.
+ * Quoted strings are ignored, so a font name or content string cannot produce a match.
+ *
+ * @param {string} value - The resolved value to test.
+ * @returns {boolean} True when a pixel length is present.
+ */
+export function hasPixelLength(value) {
+  return /(?:^|[^\w.-])-?\d*\.?\d+px\b/i.test(value.replace(/(['"]).*?\1/g, ' '))
+}
+
+/**
  * Reports whether a value contains Sass interpolation, which only resolves when the stylesheet is
  * compiled and therefore cannot be judged here.
  *


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## Links

- [Storybook deploy of this branch](https://amsterdam.github.io/design-system/demo-defensive-css-token-rules/)
- [Defensive CSS audit](https://github.com/Amsterdam/design-system/blob/develop/documentation/defensive-css.md) — the per-rule assessment behind this work
- [Stylelint plugin README](https://github.com/Amsterdam/design-system/blob/develop/stylelint/README.md) — the reasoning behind the configuration

## What

- Fixes three Description List tokens whose responsive column templates held bare `fr` tracks (`1fr 4fr` and friends), so one long unbreakable term can no longer push the grid out of its container — the same defect the earlier remediation fixed in the stylesheets, hidden in token values no lint rule could see.
- Adds three Stylelint rules that close that blind spot for good: `ams/require-grid-minmax` (which found the tokens above), `ams/no-fixed-sizes`, and `ams/no-list-style-none` resolve `var()` chains against the built token file and judge the value a declaration ends at.
- Annotates the two Progress List connector hairlines the new pixel rule surfaces — the only pixel values in all 1,185 tokens, and deliberate ones.

## Why

Seven of the plugin’s rules judge literal values and cannot resolve `var()`.
A probe of every token showed the remaining exposure: three grid-template tokens with bare `fr` tracks (a real, shipping blowout risk), two deliberate hairline pixels, and nothing else — no token holds a viewport-height unit, and `user-select`, `background-repeat` and `will-change` are never tokenised.
The token fix removes the one real risk; the rules make sure none of these can come back unnoticed.

## How

- Unlike the two font rules, these complement rather than replace their upstream counterparts, which stay on for literal values: a problem is only reported here when it arrives through token resolution, so no declaration is ever reported twice.
- `ams/no-fixed-sizes` reads its property list straight from the upstream strict configuration — no ninety-entry list to maintain — extended with the logical border shorthands the upstream list misses.
- All three share the existing resolution machinery: alias chains, cycle guards, and skip-rather-than-guess behaviour. Covered by unit tests.
- A visual diff can only appear if a story exercises the Description List blowout case at the affected breakpoints; otherwise the columns resolve to the same widths as before.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Last of the stack of four: with this, every value-checking rule either sees through our tokens or is documented as not needing to.
- This PR releases a tokens fix; the rest is development tooling and documentation.
