### PR TITLE
feat(Tab Navigation): Underline the link text on hover

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/tab-navigation.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/tab-navigation.tokens.json
@@ -101,6 +101,26 @@
             "nl.amsterdam.subtype": "space"
           }
         },
+        "text-decoration-line": {
+          "$value": "{ams.links.subtle.text-decoration-line}",
+          "$extensions": {
+            "nl.amsterdam.type": "textDecorationLine"
+          }
+        },
+        "text-decoration-thickness": {
+          "$value": "{ams.links.text-decoration-thickness}",
+          "$type": "dimension",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space"
+          }
+        },
+        "text-underline-offset": {
+          "$value": "{ams.links.text-underline-offset}",
+          "$type": "dimension",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space"
+          }
+        },
         "hover": {
           "box-shadow": {
             "$type": "shadow",
@@ -110,7 +130,10 @@
                 "value": 0,
                 "unit": "rem"
               },
-              "offsetY": "{ams.border.width.negative.m}",
+              "offsetY": {
+                "value": 0,
+                "unit": "rem"
+              },
               "blur": {
                 "value": 0,
                 "unit": "rem"
@@ -125,6 +148,12 @@
           "color": {
             "$value": "{ams.color.interactive.hover}",
             "$type": "color"
+          },
+          "text-decoration-line": {
+            "$value": "{ams.links.subtle.hover.text-decoration-line}",
+            "$extensions": {
+              "nl.amsterdam.type": "textDecorationLine"
+            }
           }
         },
         "current": {
@@ -159,7 +188,10 @@
               "$type": "shadow",
               "$value": {
                 "inset": true,
-                "offsetX": "{ams.border.width.negative.m}",
+                "offsetX": {
+                  "value": 0,
+                  "unit": "rem"
+                },
                 "offsetY": {
                   "value": 0,
                   "unit": "rem"

--- a/packages/css/src/components/tab-navigation/tab-navigation.scss
+++ b/packages/css/src/components/tab-navigation/tab-navigation.scss
@@ -53,17 +53,19 @@
   outline-offset: var(--ams-tab-navigation-link-outline-offset);
   padding-block: var(--ams-tab-navigation-link-padding-block);
   padding-inline: var(--ams-tab-navigation-link-padding-inline);
-  text-decoration-line: none;
+  text-decoration-line: var(--ams-tab-navigation-link-text-decoration-line);
+  text-decoration-thickness: var(--ams-tab-navigation-link-text-decoration-thickness);
+  text-underline-offset: var(--ams-tab-navigation-link-text-underline-offset);
 
   @media (hover: hover) {
     &:hover {
       color: var(--ams-tab-navigation-link-hover-color);
     }
-  }
 
-  @media (hover: hover) {
+    // The current link keeps its stroke instead: an underline as well would look odd.
     &:hover:not([aria-current="page"]) {
       box-shadow: var(--ams-tab-navigation-link-hover-box-shadow);
+      text-decoration-line: var(--ams-tab-navigation-link-hover-text-decoration-line);
     }
   }
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## Links

- [Storybook deploy of this branch](https://amsterdam.github.io/design-system/demo-DES-1941-underline-tab-navigation-links-on-hover/)
- [Tab Navigation in that deploy](https://amsterdam.github.io/design-system/demo-DES-1941-underline-tab-navigation-links-on-hover/?path=/docs/components-navigation-tab-navigation--docs) — hover a link other than “Gegevens” to see the change
- [The Vertical story](https://amsterdam.github.io/design-system/demo-DES-1941-underline-tab-navigation-links-on-hover/?path=/story/components-navigation-tab-navigation--vertical) — the orientation the design did not cover, which now follows the same rule

## What

- Replaces the stroke a Tab Navigation link draws along its bottom edge on hover with an underline beneath the link text, in both orientations.
- Leaves the current link alone on hover: it keeps its stroke and gains no underline.
- Adds `text-decoration-line`, `text-decoration-thickness` and `text-underline-offset` tokens for the link, plus `hover.text-decoration-line`, all referencing the shared `ams.links` values.
- Zeroes the two hover `box-shadow` tokens instead of removing them, so a theme can still restore a stroke on hover.

## Why

This makes the hover affordance the same underline every other navigation link already uses.
`ams.links.subtle` describes exactly this behaviour — “No underline by default; underline appears on hover” — and Menu, Breadcrumb, Link List, Table of Contents, Pagination and both the Page Header and Page Footer menus consume it.
Tab Navigation was the one that opted out, hardcoding `text-decoration-line: none` and reaching for a box shadow instead.

The current link is exempt because an underline on top of the thicker stroke that marks the current page would read as a double underline.
That stroke has to stay, since it is what tells you which page you are on.

There is an accessibility gain too.
`box-shadow` is forced to `none` in forced-colors mode, so the old hover affordance was invisible in Windows High Contrast.
An underline survives, so hover now carries an indication it previously lacked there.

## How

- The underline sits on the link element, matching Link List and Standalone Link.
- Both hover `box-shadow` tokens keep their declarations in the stylesheet: a token nothing reads would be a dead theming hook. With every offset, blur and spread at zero they render identically to `none`.
- A theme that wants a stroke and no underline can set `--ams-tab-navigation-link-hover-text-decoration-line` to `none`.
- The vertical hover token is zeroed and kept for the same reason as the horizontal one. Without it, a theme overriding only the horizontal token would get a bottom stroke in the vertical layout, where the indicator belongs on the inline-start edge.

Three things were worth checking, and all hold:

- The underline hugs the visible label rather than the hidden bold copy that reserves width for the current state, even though that copy is wider and stretches the grid area.
- It does not run under the icon.
- Link widths are identical between rest and hover in both orientations, so nothing shifts.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Not a breaking change: no public custom property disappears, and an existing override of the hover box shadow keeps working exactly as before. Such an override will now show its stroke alongside the new underline.
- The design tokens table on the documentation page generates itself from the tokens file, and the `Test` story already hovers a link in both orientations, so no documentation or story changes were needed.
- The forced-colors improvement follows from the specification; it has not been verified on an actual high contrast setup.
