### PR TITLE
fix(Switch): Use Neutral 20 for the disabled track

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/switch.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/switch.tokens.json
@@ -92,7 +92,8 @@
       },
       "disabled": {
         "background-color": {
-          "$value": "{ams.color.interactive.disabled}",
+          "$value": "#d1d1d1",
+          "$description": "A lighter grey than the default track, so a disabled switch reads as distinct from an enabled one.",
           "$extensions": {
             "nl.amsterdam.type": "color"
           }


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## Links

- [Storybook deploy of this branch](https://amsterdam.github.io/design-system/demo-DES-1940-switch-disabled-track-colour/)
- [Switch in that deploy](https://amsterdam.github.io/design-system/demo-DES-1940-switch-disabled-track-colour/?path=/docs/components-forms-switch--docs) — toggle `disabled` in the controls to compare it with the default

## What

- Changes the disabled Switch track from Neutral 60 to Neutral 20, so a disabled Switch no longer looks exactly like an enabled one.

## Why

Both tracks resolved to the same grey.
`ams.switch.background-color` holds `#767676` directly, and `ams.switch.disabled.background-color` referenced `ams.color.interactive.disabled`, which is that same Neutral 60.
An unchecked Switch and a disabled unchecked Switch were therefore identical, with nothing to tell a reader the control was inactive.

Neutral 20 also lines the component up with how the rest of the system signals “inactive”, and the change carries to the disabled checked state, which the disabled rule already recoloured.

## How

- Sets the literal `#d1d1d1` with a `$description` explaining it, rather than pointing at a brand token.
  Neutral 20’s only alias is `ams.color.separator`, documented as “For row borders in tables”, so referencing it would attach the wrong meaning to the value.
  Skeleton already holds this exact colour as a literal for the same reason.
- The design tokens table on the documentation page generates itself from the tokens file, so the new description shows up there without a documentation change.
- The `Test` story renders a disabled cell already, because `disabled` is a boolean prop in the controls and the variant matrix expands booleans to both values. Chromatic diffs the change without a story change.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- The ticket also asks for the label text to become Neutral 60, which is not in this PR.
  Switch renders no text of its own — its `<label>` is the track, and it is empty.
  The text beside a Switch is a separate `Label`, which has no disabled state at all: no prop, and no `ams.label.disabled.*` token.
  That is a real gap beyond Switch, since a disabled Checkbox and Radio do grey their labels, and closing it means adding a state to a component every form control uses.
  It seemed better to decide that on its own rather than fold it into a colour fix.
- Worth a designer’s eye: the thumb stays white, so against the lighter track its contrast drops from 4.54:1 to 1.53:1 and the disabled Switch reads as quite faint.
  That is not a failure — WCAG 1.4.11 exempts disabled controls, and a ghosted look is a normal way to signal one — but it is a marked change in how prominent the component is.
- The variant matrix varies one prop at a time, so it covers disabled unchecked but not disabled combined with checked.
  Both take the new colour.
- Not a breaking change: no custom property disappears, and a theme overriding `--ams-switch-disabled-background-color` keeps working.
