### PR TITLE
feat(css): Give disabled form inputs a distinct background colour

### DIFF
--- a/packages-proprietary/tokens/src/common/ams/inputs.tokens.json
+++ b/packages-proprietary/tokens/src/common/ams/inputs.tokens.json
@@ -79,6 +79,13 @@
         }
       },
       "disabled": {
+        "background-color": {
+          "$value": "#e8e8e8",
+          "$description": "A tint that marks an input as unavailable. Set as a literal because the brand layer has no matching grey yet.",
+          "$extensions": {
+            "nl.amsterdam.type": "color"
+          }
+        },
         "color": {
           "$value": "{ams.color.interactive.disabled}",
           "$extensions": {

--- a/packages-proprietary/tokens/src/components/ams/date-input.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/date-input.tokens.json
@@ -78,6 +78,12 @@
         }
       },
       "disabled": {
+        "background-color": {
+          "$value": "{ams.inputs.disabled.background-color}",
+          "$extensions": {
+            "nl.amsterdam.type": "color"
+          }
+        },
         "color": {
           "$value": "{ams.inputs.disabled.color}",
           "$extensions": {

--- a/packages-proprietary/tokens/src/components/ams/password-input.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/password-input.tokens.json
@@ -78,6 +78,12 @@
         }
       },
       "disabled": {
+        "background-color": {
+          "$value": "{ams.inputs.disabled.background-color}",
+          "$extensions": {
+            "nl.amsterdam.type": "color"
+          }
+        },
         "color": {
           "$value": "{ams.inputs.disabled.color}",
           "$extensions": {

--- a/packages-proprietary/tokens/src/components/ams/select.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/select.tokens.json
@@ -90,6 +90,12 @@
         }
       },
       "disabled": {
+        "background-color": {
+          "$value": "{ams.inputs.disabled.background-color}",
+          "$extensions": {
+            "nl.amsterdam.type": "color"
+          }
+        },
         "background-image": {
           "$value": "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><path fill='%23767676' fill-rule='evenodd' d='m16 25.757-16-16 2.91-2.9L16 19.937l13.09-13.08 2.91 2.9z'/></svg>\")",
           "$extensions": {

--- a/packages-proprietary/tokens/src/components/ams/text-area.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/text-area.tokens.json
@@ -85,6 +85,12 @@
         }
       },
       "disabled": {
+        "background-color": {
+          "$value": "{ams.inputs.disabled.background-color}",
+          "$extensions": {
+            "nl.amsterdam.type": "color"
+          }
+        },
         "color": {
           "$value": "{ams.inputs.disabled.color}",
           "$extensions": {

--- a/packages-proprietary/tokens/src/components/ams/text-input.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/text-input.tokens.json
@@ -78,6 +78,12 @@
         }
       },
       "disabled": {
+        "background-color": {
+          "$value": "{ams.inputs.disabled.background-color}",
+          "$extensions": {
+            "nl.amsterdam.type": "color"
+          }
+        },
         "color": {
           "$value": "{ams.inputs.disabled.color}",
           "$extensions": {

--- a/packages-proprietary/tokens/src/components/ams/time-input.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/time-input.tokens.json
@@ -78,6 +78,12 @@
         }
       },
       "disabled": {
+        "background-color": {
+          "$value": "{ams.inputs.disabled.background-color}",
+          "$extensions": {
+            "nl.amsterdam.type": "color"
+          }
+        },
         "color": {
           "$value": "{ams.inputs.disabled.color}",
           "$extensions": {

--- a/packages/css/src/components/date-input/date-input.scss
+++ b/packages/css/src/components/date-input/date-input.scss
@@ -66,6 +66,7 @@
 }
 
 .ams-date-input:disabled {
+  background-color: var(--ams-date-input-disabled-background-color);
   color: var(--ams-date-input-disabled-color);
   cursor: var(--ams-date-input-disabled-cursor);
 }

--- a/packages/css/src/components/password-input/password-input.scss
+++ b/packages/css/src/components/password-input/password-input.scss
@@ -39,6 +39,7 @@
 }
 
 .ams-password-input:disabled {
+  background-color: var(--ams-password-input-disabled-background-color);
   color: var(--ams-password-input-disabled-color);
   cursor: var(--ams-password-input-disabled-cursor);
 }

--- a/packages/css/src/components/select/select.scss
+++ b/packages/css/src/components/select/select.scss
@@ -32,6 +32,7 @@
 }
 
 .ams-select:disabled {
+  background-color: var(--ams-select-disabled-background-color);
   color: var(--ams-select-disabled-color);
   cursor: var(--ams-select-disabled-cursor);
 

--- a/packages/css/src/components/text-area/text-area.scss
+++ b/packages/css/src/components/text-area/text-area.scss
@@ -37,6 +37,7 @@
 }
 
 .ams-text-area:disabled {
+  background-color: var(--ams-text-area-disabled-background-color);
   color: var(--ams-text-area-disabled-color);
   cursor: var(--ams-text-area-disabled-cursor);
 }

--- a/packages/css/src/components/text-input/text-input.scss
+++ b/packages/css/src/components/text-input/text-input.scss
@@ -39,6 +39,7 @@
 }
 
 .ams-text-input:disabled {
+  background-color: var(--ams-text-input-disabled-background-color);
   color: var(--ams-text-input-disabled-color);
   cursor: var(--ams-text-input-disabled-cursor);
 }

--- a/packages/css/src/components/time-input/time-input.scss
+++ b/packages/css/src/components/time-input/time-input.scss
@@ -65,6 +65,7 @@
 }
 
 .ams-time-input:disabled {
+  background-color: var(--ams-time-input-disabled-background-color);
   color: var(--ams-time-input-disabled-color);
   cursor: var(--ams-time-input-disabled-cursor);
 }

--- a/storybook/src/brand/design-tokens/inputs.docs.mdx
+++ b/storybook/src/brand/design-tokens/inputs.docs.mdx
@@ -34,6 +34,9 @@ These tokens are used by
 
 ## Disabled
 
+The background colour marks an input as unavailable in Date Input, Password Input, Select, Text Area, Text Input and Time Input.
+File Input and Search Field keep the default background.
+
 <DesignTokensTable path="ams.inputs.disabled" showDescriptions tokens={tokens} />
 
 ## Hover

--- a/storybook/src/components/DateInput/DateInput.test.stories.tsx
+++ b/storybook/src/components/DateInput/DateInput.test.stories.tsx
@@ -21,6 +21,6 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
-  render: (args, context) => renderComponentVariants(DateInput, { args }, context),
+  render: (args, context) => renderComponentVariants(DateInput, { args, variants: ['disabled'] }, context),
   tags: ['!dev', '!autodocs'],
 }

--- a/storybook/src/components/PasswordInput/PasswordInput.test.stories.tsx
+++ b/storybook/src/components/PasswordInput/PasswordInput.test.stories.tsx
@@ -21,6 +21,6 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
-  render: (args, context) => renderComponentVariants(PasswordInput, { args }, context),
+  render: (args, context) => renderComponentVariants(PasswordInput, { args, variants: ['disabled'] }, context),
   tags: ['!dev', '!autodocs'],
 }


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

## Links

- Related: #2808, which gave the disabled Switch track its own literal grey for much the same reason.

## What

- Adds a common `ams.inputs.disabled.background-color` token, set to `#e8e8e8`.
- Applies it to Date Input, Password Input, Select, Text Area, Text Input and Time Input, so a disabled field reads as unavailable from its fill rather than from its text colour alone.

## Why

Disabled inputs kept the default white background, so the only signals that a field was inactive were the grey text and border.
A filled surface is the more immediate cue, and it is the one people already expect from disabled controls elsewhere in the system.

## How

- The value is a literal with a `$description`, not a reference.
`#e8e8e8` has no alias in the brand layer at all, so there is nothing to point at.
This follows the pattern Switch and Skeleton already use for their neutral tints.
- It is wired the usual way: the common token feeds a `disabled.background-color` in each of the six component token files, and each stylesheet adds `background-color` to its existing `:disabled` rule.
- The design tokens table on the Inputs documentation page generates itself from the tokens file, so the new token and its description appear there without a change.
I did add a line to that page noting which components take the background, because it lists File Input and Search Field among the users of these tokens and that is now only partly true.
- The `Test` stories for Date Input and Password Input rendered only the default variant, so Chromatic could not see disabled-state changes for them at all.
They now pass `variants: ['disabled']`, which the four sibling form inputs already did.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- Worth a designer’s eye: this pairing puts disabled text below AA, and it cannot be fixed by darkening the text a little.
`#767676` on white is 4.54:1, which clears 4.5:1 by a hair.
On `#e8e8e8` it becomes 3.71:1.
Running the numbers, `#767676` cannot sit on *any* perceptible grey at 4.5:1 — the lightest background that still passes is `#fefefe`.
Keeping `#e8e8e8` instead would need disabled text at `#686868` or darker.
This is not a conformance failure, since WCAG 1.4.3 exempts inactive controls, but it is a deliberate trade rather than an oversight.
- Empty Date and Time Inputs in Safari are a separate problem this change makes more visible.
Safari fills them with a dimmed copy of *today’s date* (`19/07/2026`), considerably lighter than `#767676`, and that text is not reachable from author CSS.
I tested `::-webkit-datetime-edit`, each of the individual `-day-field` / `-month-field` / `-year-field` / `-hour-field` / `-minute-field` pseudo-elements, `::-webkit-datetime-edit-text`, `::-webkit-datetime-edit-fields-wrapper`, and all of them together with `!important`: only the separators respond, never the digits.
Firefox’s equivalent shadow tree is chrome-privileged and exposes nothing, though it renders at the inherited colour anyway.
Chromium does expose it, but no selector distinguishes an empty field from a filled one, so any colour would land on real dates too.
So there is no styling fix available, and darkening a token would not reach it either — worth knowing before anyone tries.
- Search Field and File Input are deliberately out of scope, as the ticket lists six components.
Separately, Search Field has no `:disabled` rule at all — a disabled search field keeps the default text colour and cursor, so it looks enabled.
That predates this change and is being handled on its own.
- Not a breaking change: no custom property disappears, and nothing that previously had a background loses one.
