### PR TITLE
fix(Button): Apply disabled styles to aria-disabled buttons

### DIFF
--- a/packages/css/src/components/button/button.scss
+++ b/packages/css/src/components/button/button.scss
@@ -46,7 +46,7 @@
   color: var(--ams-button-primary-color);
 
   &:disabled,
-  [aria-disabled="true"] {
+  &[aria-disabled="true"] {
     background-color: var(--ams-button-primary-disabled-background-color);
     border-color: var(--ams-button-primary-disabled-border-color);
   }
@@ -65,7 +65,7 @@
   color: var(--ams-button-secondary-color);
 
   &:disabled,
-  [aria-disabled="true"] {
+  &[aria-disabled="true"] {
     border-color: var(--ams-button-secondary-disabled-border-color);
     color: var(--ams-button-secondary-disabled-color);
   }
@@ -84,7 +84,7 @@
   color: var(--ams-button-tertiary-color);
 
   &:disabled,
-  [aria-disabled="true"] {
+  &[aria-disabled="true"] {
     color: var(--ams-button-tertiary-disabled-color);
   }
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Apply disabled styles to aria-disabled buttons

## What

Add the missing `&` to the `[aria-disabled="true"]` selector in the primary, secondary and tertiary Button variants.

## Why

Without it, the selector compiled to a descendant combinator: `.ams-button--primary [aria-disabled="true"]`. The disabled styles of the three variants therefore never reached a button carrying `aria-disabled`, and applied instead to any descendant that happened to have the attribute.

Only the base `.ams-button` rule had it right, so such a button picked up the disabled cursor and otherwise kept its enabled appearance: full background, full border, full text colour.

## How

One character per variant. The base rule at the top of the same file already had the intended form, so this brings the three variants in line with it.

Components in the React package pass the `disabled` attribute, so nothing changes there. This matters for the CSS package, where the stylesheet deliberately targets `aria-disabled` alongside `:disabled` — the attribute is how you disable a button while keeping it focusable.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- No story renders a button with `aria-disabled`, so Chromatic will not show a diff for this.
- Split off from the branch that gives disabled controls a grey background. The bug predates that work and stands on its own, but the two do meet: that branch adds a `background-color` to these same three rules, and those additions only reach `aria-disabled` buttons once this is merged.
