### PR TITLE
feat(Icon Button): Give the disabled contrast variant a grey background

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/icon-button.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/icon-button.tokens.json
@@ -66,8 +66,14 @@
           }
         },
         "disabled": {
-          "color": {
+          "background-color": {
             "$value": "{ams.color.interactive.disabled}",
+            "$extensions": {
+              "nl.amsterdam.type": "color"
+            }
+          },
+          "color": {
+            "$value": "{ams.color.interactive.inverse}",
             "$extensions": {
               "nl.amsterdam.type": "color"
             }

--- a/packages/css/src/components/icon-button/icon-button.scss
+++ b/packages/css/src/components/icon-button/icon-button.scss
@@ -42,6 +42,7 @@
 
   &:disabled,
   &[aria-disabled="true"] {
+    background-color: var(--ams-icon-button-contrast-disabled-background-color);
     color: var(--ams-icon-button-contrast-disabled-color);
   }
 }

--- a/packages/css/src/components/icon-button/icon-button.scss
+++ b/packages/css/src/components/icon-button/icon-button.scss
@@ -23,7 +23,8 @@
     }
   }
 
-  &:disabled {
+  &:disabled,
+  &[aria-disabled="true"] {
     background-color: transparent;
     color: var(--ams-icon-button-disabled-color);
     cursor: var(--ams-icon-button-disabled-cursor);
@@ -40,7 +41,8 @@
     }
   }
 
-  &:disabled {
+  &:disabled,
+  &[aria-disabled="true"] {
     background-color: transparent;
     color: var(--ams-icon-button-contrast-disabled-color);
   }
@@ -57,7 +59,8 @@
     }
   }
 
-  &:disabled {
+  &:disabled,
+  &[aria-disabled="true"] {
     background-color: var(--ams-icon-button-inverse-disabled-background-color);
     color: var(--ams-icon-button-inverse-disabled-color);
   }

--- a/packages/css/src/components/icon-button/icon-button.scss
+++ b/packages/css/src/components/icon-button/icon-button.scss
@@ -17,7 +17,7 @@
   touch-action: manipulation;
 
   @media (hover: hover) {
-    &:hover {
+    &:hover:not(:disabled, [aria-disabled="true"]) {
       background-color: var(--ams-icon-button-hover-background-color);
       color: var(--ams-icon-button-hover-color);
     }
@@ -25,7 +25,6 @@
 
   &:disabled,
   &[aria-disabled="true"] {
-    background-color: transparent;
     color: var(--ams-icon-button-disabled-color);
     cursor: var(--ams-icon-button-disabled-cursor);
   }
@@ -35,7 +34,7 @@
   color: var(--ams-icon-button-contrast-color);
 
   @media (hover: hover) {
-    &:hover {
+    &:hover:not(:disabled, [aria-disabled="true"]) {
       background-color: var(--ams-icon-button-contrast-hover-background-color);
       color: var(--ams-icon-button-contrast-hover-color);
     }
@@ -43,7 +42,6 @@
 
   &:disabled,
   &[aria-disabled="true"] {
-    background-color: transparent;
     color: var(--ams-icon-button-contrast-disabled-color);
   }
 }
@@ -53,7 +51,7 @@
   color: var(--ams-icon-button-inverse-color);
 
   @media (hover: hover) {
-    &:hover {
+    &:hover:not(:disabled, [aria-disabled="true"]) {
       background-color: var(--ams-icon-button-inverse-hover-background-color);
       color: var(--ams-icon-button-inverse-hover-color);
     }


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Give the disabled contrast variant a grey background

## Links

- [Storybook on main](https://designsystem.amsterdam/)
- [Contrast Colour story](https://designsystem.amsterdam/?path=/story/components-buttons-icon-button--contrast-colour) — the state this PR changes, toggle `disabled` in the controls
- [Icon Button docs in this branch](https://designsystem.amsterdam/?path=/docs/components-buttons-icon-button--docs)
- [Icon Button docs on the published site](https://designsystem.amsterdam/?path=/docs/components-buttons-icon-button--docs)
- Related: #2809 (six form inputs), #2808 (Switch track), #2812 (the same `aria-disabled` fix for Button)

## What

Three changes to Icon Button’s disabled state.

The contrast variant now gets a grey background with a white icon when disabled, exactly matching what the inverse variant already did. The disabled styles of all three variants now also apply to `[aria-disabled="true"]`, not only to `:disabled`. And the hover styles no longer reach a disabled button.

The default variant is deliberately unchanged — see the notes at the bottom.

## Why

This is the Icon Button part of DES-1942, which gives disabled controls a distinct background instead of signalling “unavailable” through text colour alone.

The contrast variant sits on coloured backgrounds, so the light grey used by the form inputs is the wrong instrument: an opaque light chip cannot adapt to an unknown backdrop, and on the more saturated brand colours it ends up reading louder than the enabled state, which inverts the signal. The mid-grey chip with a white icon carries its own internal contrast, so what sits behind it stops mattering. That is why copying the inverse variant’s design is the right move rather than inventing a third one.

The `aria-disabled` change mirrors #2812. The attribute is how you disable a button while keeping it focusable, and the CSS package is consumed directly by other stacks, so the stylesheet should honour it.

The hover guard fixes a latent fragility. `.ams-icon-button:hover` and `.ams-icon-button:disabled` both have specificity (0,2,0), so the `background-color: transparent` in the disabled rules was winning purely on source order. Anyone reordering those blocks, or deleting a declaration that looks redundant, would have made disabled buttons light up on hover.

## How

In the tokens package, `ams.icon-button.contrast.disabled.background-color` is new and `contrast.disabled.color` now points at `{ams.color.interactive.inverse}`. Both reference brand colour tokens directly rather than `{ams.inputs.disabled.background-color}`, since `ams.inputs` is scoped to form input components and a button should not reach into it.

In the CSS package, every `&:hover` became `&:hover:not(:disabled, [aria-disabled="true"])` and every `&:disabled` became `&:disabled, &[aria-disabled="true"]`, matching Button.

The `background-color: transparent` declarations in the disabled rules are gone. They existed only to beat the unguarded hover rule on source order, so once hover can no longer match a disabled element they are dead code, and the base rule’s `transparent` covers the actual appearance. That also satisfies the convention that pseudo-class blocks list only the properties they change.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- **The default variant keeps its current appearance on purpose.** `DatePickerHeader` disables its four navigation buttons at the range limits, so filling them would turn the whole month and year navigation into solid grey chips whenever you reach a boundary. Its disabled and enabled renderings are byte-identical to develop, so Date Picker is untouched. That does leave the default variant as an open DES-1942 gap: it still signals disabled through icon colour alone, and closing it properly probably needs either a lighter treatment than a fill or a change on the Date Picker side. Happy to raise that separately.
- No story change was needed — `IconButton.test.stories.tsx` already renders the `disabled` variant, so Chromatic picks this up. It reports exactly one change awaiting a baseline, which matches the expectation that only the contrast variant moves.
- The two `fix` commits stand on their own and predate this work, much like #2812 did. Say the word if you would rather have them as a separate PR so they get their own changelog entries.
- Verified by compiling develop’s stylesheet alongside this one and hashing headless renders of each state: default disabled and enabled are unchanged, inverse is unchanged, and contrast disabled now hashes identically to inverse disabled. `pnpm run lint:css` and `lint:js` are clean and all 1378 React tests pass.
