### PR TITLE
chore(Storybook): Snapshot page templates in Chromatic

### DIFF
--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -158,3 +158,7 @@ Page templates have no test stories.
 Chromatic snapshots their presentation stories directly, so every story under `Pages/` is a snapshot.
 A page has no single component and no variant props, so `renderComponentVariants` cannot build a matrix for one; collapsing several pages into one Test story would mean either duplicating their markup or reaching into another story’s `render`.
 Snapshotting the presentation stories avoids both, and guarantees the image matches the page we document.
+
+Both page families set a Chromatic mode in their `commonMeta` so the snapshot width matches the maximum width of the Page: 1440px for public pages (`ams.page.max-inline-size`) and 1920px for internal ones (`ams.page.with-menu.max-inline-size`).
+Chromatic’s default viewport is 1200px, narrower than either, so without this the widest layout we design for would never be tested.
+One mode is one snapshot, so setting the width does not change the snapshot count.

--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -156,6 +156,7 @@ Note that `renderComponentVariants` reads the meta’s argTypes to build its var
 
 Page templates have no test stories.
 Chromatic snapshots their presentation stories directly, so every story under `Pages/` is a snapshot.
+Only stories, though: Chromatic skips docs entries, so the `Introduction` pages and the generated `Docs` tab of each template cost nothing.
 A page has no single component and no variant props, so `renderComponentVariants` cannot build a matrix for one; collapsing several pages into one Test story would mean either duplicating their markup or reaching into another story’s `render`.
 Snapshotting the presentation stories avoids both, and guarantees the image matches the page we document.
 

--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -65,8 +65,9 @@ Follow these guidelines:
    Leave the arg out instead.
 3. Hide args with `table: { disable: true }` in the `argTypes` object if they don’t apply to the story, e.g. if the story composes multiple instances of the component.
    We don’t hide ‘less relevant’ args in other cases, not even in stories that focus on a single prop.
-4. Note that the args and argTypes of the meta feed the Test story, which is the only story Chromatic snapshots – see [Test stories](#test-stories).
-   Changing them can therefore change snapshots; the args of individual stories don’t reach Chromatic.
+4. Note that the args and argTypes of the meta feed the Test story, which is the only story Chromatic snapshots for a component – see [Test stories](#test-stories).
+   Changing them can therefore change snapshots; the args of an individual component story don’t reach Chromatic.
+   This does not hold for page templates, whose stories Chromatic snapshots one by one.
 
 ### Choosing a control
 
@@ -149,6 +150,11 @@ It unhides the arg, offers a text control, and sets the description – `childre
 
 ## Test stories
 
-Test stories (`*.test.stories.tsx`) render all states of a component in the single story named ‘Test’, which is the only story Chromatic snapshots.
+Test stories (`*.test.stories.tsx`) render all states of a component in the single story named ‘Test’, which is the only story Chromatic snapshots for a component.
 They inherit the component’s meta and must not define argTypes of their own.
 Note that `renderComponentVariants` reads the meta’s argTypes to build its variant matrix – changing options or hiding args can change what the Test story renders and snapshots.
+
+Page templates have no test stories.
+Chromatic snapshots their presentation stories directly, so every story under `Pages/` is a snapshot.
+A page has no single component and no variant props, so `renderComponentVariants` cannot build a matrix for one; collapsing several pages into one Test story would mean either duplicating their markup or reaching into another story’s `render`.
+Snapshotting the presentation stories avoids both, and guarantees the image matches the page we document.

--- a/documentation/tests.md
+++ b/documentation/tests.md
@@ -57,7 +57,7 @@ With each pull request there are two actions:
 1. [Unit Tests](https://github.com/Amsterdam/design-system/actions/workflows/check-build-and-tests.yml)
 2. [Interaction, Visual, Accessibility tests](https://github.com/Amsterdam/design-system/actions/workflows/check-visual-regressions.yml)
 
-The interaction, visual, and accessibility tests are run by [Chromatic](https://chromatic.com). Chromatic runs these tests on each story labeled ‘Test’. If any changes are detected, they must be approved before merging the pull request. You can accept changes directly through the Chromatic dashboard. Once the changes are accepted, the pull request can be merged.
+The interaction, visual, and accessibility tests are run by [Chromatic](https://chromatic.com). Chromatic runs these tests on each component story labeled ‘Test’, and on every story of a page template. If any changes are detected, they must be approved before merging the pull request. You can accept changes directly through the Chromatic dashboard. Once the changes are accepted, the pull request can be merged.
 
 These actions are required to succeed before merging a pull-request.
 

--- a/storybook/AGENTS.md
+++ b/storybook/AGENTS.md
@@ -46,6 +46,7 @@ See [documentation/component-docs.md](../documentation/component-docs.md) for th
 
 - One story per visual variant / state in `<Name>.test.stories.tsx`.
 - Tag test stories with `['!dev', '!autodocs']` to exclude them from docs and development views.
+- This applies to components only. Page templates have no test stories: Chromatic snapshots every story under `Pages/` directly, so a new page story is a new snapshot. Do not add `<Name>.test.stories.tsx` under `src/pages/`.
 - The CSS pseudo-state simulation addon (`:hover`, `:focus`, etc.) loads only in Chromatic CI, via `IS_CHROMATIC` (set by `build:chromatic`). It is deliberately not loaded in local development, where its CSS rewrite breaks focus-hidden selectors like the Skip Link's. See `config/main.ts`. Do not set `IS_CHROMATIC` manually.
 - Visual changes must be reviewed and approved in the Chromatic dashboard before merging.
 - **Never approve Chromatic changes as an agent** — visual approval is a human responsibility.

--- a/storybook/AGENTS.md
+++ b/storybook/AGENTS.md
@@ -46,7 +46,7 @@ See [documentation/component-docs.md](../documentation/component-docs.md) for th
 
 - One story per visual variant / state in `<Name>.test.stories.tsx`.
 - Tag test stories with `['!dev', '!autodocs']` to exclude them from docs and development views.
-- This applies to components only. Page templates have no test stories: Chromatic snapshots every story under `Pages/` directly, so a new page story is a new snapshot. Do not add `<Name>.test.stories.tsx` under `src/pages/`.
+- This applies to components only. Page templates have no test stories: Chromatic snapshots every story under `Pages/` directly, so a new page story is a new snapshot. Docs entries are not snapshotted, so `Introduction` pages and generated `Docs` tabs are free. Do not add `<Name>.test.stories.tsx` under `src/pages/`.
 - The CSS pseudo-state simulation addon (`:hover`, `:focus`, etc.) loads only in Chromatic CI, via `IS_CHROMATIC` (set by `build:chromatic`). It is deliberately not loaded in local development, where its CSS rewrite breaks focus-hidden selectors like the Skip Link's. See `config/main.ts`. Do not set `IS_CHROMATIC` manually.
 - Visual changes must be reviewed and approved in the Chromatic dashboard before merging.
 - **Never approve Chromatic changes as an agent** — visual approval is a human responsibility.

--- a/storybook/chromatic.config.json
+++ b/storybook/chromatic.config.json
@@ -2,6 +2,6 @@
   "buildCommand": "pnpm run build:chromatic",
   "outputDir": "dist/",
   "projectId": "68db9df886b46f139748c074",
-  "onlyStoryNames": ["Components/**/**/Test"],
+  "onlyStoryNames": ["Components/**/**/Test", "Pages/**"],
   "storybookConfigDir": "./config"
 }

--- a/storybook/src/pages/internal/common/config.tsx
+++ b/storybook/src/pages/internal/common/config.tsx
@@ -20,6 +20,9 @@ export const commonMeta = {
     ),
   ],
   parameters: {
+    // Snapshot at the maximum Page width with a menu (`ams.page.with-menu.max-inline-size`, 120rem)
+    // instead of Chromatic’s 1200px default, so the visual test covers the widest layout we design for.
+    chromatic: { modes: { '1920px': { viewport: 1920 } } },
     layout: 'fullscreen',
     themes: { themeOverride: 'Compact' },
   },

--- a/storybook/src/pages/public/common/config.tsx
+++ b/storybook/src/pages/public/common/config.tsx
@@ -20,6 +20,9 @@ export const commonMeta = {
     ),
   ],
   parameters: {
+    // Snapshot at the maximum Page width (`ams.page.max-inline-size`, 90rem) instead of Chromatic’s
+    // 1200px default, so the visual test covers the widest layout we design for.
+    chromatic: { modes: { '1440px': { viewport: 1440 } } },
     layout: 'fullscreen',
     themes: { themeOverride: 'Spacious' },
   },


### PR DESCRIPTION
## Links

- [Storybook preview on main](https://designsystem.amsterdam/)
- [Article Page, one of the newly covered templates](https://designsystem.amsterdam/?path=/story/pages-public-article-page--default)
- [Chromatic’s `onlyStoryNames` reference](https://www.chromatic.com/docs/configure/#configuration-options)

## What

Page templates now have visual regression coverage. `onlyStoryNames` in `storybook/chromatic.config.json` gains a second entry, `Pages/**`, so Chromatic snapshots every story under `Pages/Public/*` and `Pages/Internal/*` — 22 in total, 18 public and 4 internal.

There are no new story files. The presentation stories we already publish are the snapshots, so the images are by definition the pages we document. The three places in our documentation that stated the `Test` story is the only thing Chromatic captures are updated, since that is no longer true for pages.

A second commit sets the snapshot width per page family, because Chromatic’s default viewport is 1200px — narrower than either family’s Page, so the widest layout we actually design for would never have been tested. The widths come straight from the Page tokens rather than being picked by hand: 1440px for public pages (`ams.page.max-inline-size`, 90rem) and 1920px for internal ones (`ams.page.with-menu.max-inline-size`, 120rem). Each is one Chromatic mode, and one mode is one snapshot, so this does not change the snapshot count.

## Why

Page templates were not snapshotted at all. `onlyStoryNames` matched `Components/**/**/Test` only, and page stories live under `Pages/`, so nothing in `storybook/src/pages/` had ever been captured. A regression in a page template shipped silently.

That is the wrong gap to have. Page templates are the most composed artefacts in the library — they put the grid, typography, header, footer and a dozen components together on one canvas — so they are exactly where a token change or a layout regression shows up first, and often the only place a cross-component interaction is visible at all.

## How

The change itself is one line. The design question was whether page templates should follow the component convention of a sibling `*.test.stories.tsx` exporting a single `Test` story that stacks every variant.

They should not, for three reasons:

Stacking variants would require either duplicating the page markup into the test file or importing another story’s `render`. Duplication drifts the moment someone edits the source story, which breaks the one property that makes these snapshots worth having. Importing another story’s internals couples the test to a shape that can change silently. Both routes undermine the goal.

`renderComponentVariants` cannot help here. It reads `context.argTypes` and calls `createElement(component, props)` — it enumerates prop values on a single component. A page has neither a single component nor variant props, so the analogy with component test stories is only surface deep.

The `commonMeta` decorators in `src/pages/{public,internal}/common/config.tsx` wrap each story individually in `<Page><Layout>`, which supplies the app header, skip links and footer. A stacked `Test` story would render one header and footer around several `<main>` elements — a DOM we never ship, so the snapshot would diff something that does not exist.

Snapshotting the presentation stories directly avoids all three. `Pages/**` is also Chromatic’s own documented idiom for this; their reference uses `Forms/**` to mean “any story whose title path starts with Forms”.

I verified the globs with picomatch rather than relying on the docs: all 22 page stories match, component `Test` stories are unaffected, and the negative controls (component non-`Test` stories, `Utilities/*`) stay excluded. The first Chromatic run confirms it end to end — it reports `Snapshots will be limited to stories matching 'Components/**/**/Test', 'Pages/**'` and runs exactly 100 tests.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

**This costs Chromatic usage, deliberately, and the first run has now measured it.** Build 1459 on this branch ran 100 tests and captured 200 snapshots, against 78 tests and 156 snapshots before the change. So the true cost is **44 additional snapshots, not 22** — Chromatic captures two per story, and that multiplier comes from the project’s Chromatic settings rather than anything in this repo. That is a 28% increase, and page snapshots are full page, so they sit at the large end.

Given we introduced the `/chromatic test` comment gate precisely because we were bumping into usage limits, this is worth a conscious yes or no rather than waving through. My argument for yes is that untested page templates are how a regression reaches a consuming team, and a snapshot is the only test that catches a purely visual one. If we would rather cap it, the lever is per-story `chromatic: { disableSnapshot: true }` on the variants we care least about — though that leaves the error and loading states uncovered, which are the ones most likely to break unnoticed.

The glob is not over-broad: the 14 autodocs entries under `Pages/` are not snapshotted, because Chromatic skips docs entries. The 100 tests are exactly the 78 component `Test` stories plus the 22 page stories.

`UI Tests` reports 22 changes to accept as baselines. That is expected — they are the 22 newly covered stories, not regressions.

**Please do not accept those baselines yet.** They were captured at Chromatic’s 1200px default, before the width commit landed. Chromatic does not re-run on a push, so the widths are not yet verified against a real build; whenever it next runs, the same 22 stories will come back at 1440px and 1920px and supersede them. Accepting the current set would only mean accepting them twice.

Determinism was checked before widening the glob: there are no `play` functions under `pages/`, the only timer is Loading Page’s three second swap which fires on submit rather than on load, and Table Page’s pagination reads a URL parameter that is absent by default. Skeleton’s heartbeat animation is not a problem either — Chromatic pauses CSS animations at their last frame, and `Components/Feedback/Skeleton/Test` has been snapshotting the same animated blocks without trouble.

One gap this does not close: `Utilities/CSS/*` matches neither pattern and has no test stories, so the CSS utilities still have no visual coverage. It is a different problem — nothing to snapshot yet, rather than snapshots being filtered out — so I have left it out of this PR.
