### PR TITLE
chore(Storybook): Offer the 2xl size in the Margin control

### DIFF
--- a/storybook/src/utilities/Margin/Margin.stories.tsx
+++ b/storybook/src/utilities/Margin/Margin.stories.tsx
@@ -29,7 +29,7 @@ const meta = {
   argTypes: {
     size: {
       control: {
-        labels: { xs: 'x-small', s: 'small', m: 'medium', l: 'large', xl: 'x-large' },
+        labels: { xs: 'x-small', s: 'small', m: 'medium', l: 'large', xl: 'x-large', '2xl': '2x-large' },
         type: 'radio',
       },
     },

--- a/storybook/src/utilities/Margin/Margin.tsx
+++ b/storybook/src/utilities/Margin/Margin.tsx
@@ -7,7 +7,7 @@ import type { HTMLAttributes, PropsWithChildren } from 'react'
 
 export type MarginProps = {
   /** The amount of space below the element. */
-  readonly size: 'xs' | 's' | 'm' | 'l' | 'xl'
+  readonly size: 'xs' | 's' | 'm' | 'l' | 'xl' | '2xl'
 } & Readonly<PropsWithChildren<HTMLAttributes<HTMLSpanElement>>>
 
 /** Mock component to render examples in Storybook. Not for reuse. */


### PR DESCRIPTION
## Links

- [Margin utility documentation](https://designsystem.amsterdam/docs/utilities-css-margin--docs)

## What

The Storybook mock behind the Margin utility documentation now accepts `2xl`, so the size control offers all six options that `margin.scss` actually ships.

## Why

`margin.scss` generates classes for `xs`, `s`, `m`, `l`, `xl` and `2xl`, and the README rendered directly above the control already documents all six. The mock’s `size` type stopped at `xl`, though, and Storybook infers the radio options from that type — so `ams-mb-2xl` was documented in prose but impossible to try out interactively.

Gap deliberately offers five sizes, as `gap.scss` records that we don’t provide a `2xl` gap on purpose. That asymmetry is intentional and is left untouched here.

## How

Added `'2xl'` to the `size` union in the mock component, which is what drives the radio options, and `'2xl': '2x-large'` to the control’s `labels` map. The long form matches the naming already used for the Grid padding props, and the key comes last rather than alphabetically because the perfectionist ESLint groups sort these by size.

No visual regressions are expected. The Test story that Chromatic snapshots already hardcodes all six sizes, so the rendered output is unchanged and only the Controls panel gains an option.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

This surfaced while adding Chromatic coverage for the CSS utilities in #2816, whose Test story hardcodes all six sizes precisely because the mock type only allowed five.
