### PR TITLE
chore(Storybook): Keep page template content stable in Chromatic

### DIFF
--- a/storybook/src/_common/exampleContent.test.ts
+++ b/storybook/src/_common/exampleContent.test.ts
@@ -6,7 +6,7 @@
 import isChromatic from 'chromatic/isChromatic'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { exampleParagraph } from './exampleContent'
+import { exampleImageSource, exampleParagraph } from './exampleContent'
 
 vi.mock('chromatic/isChromatic', () => ({ default: vi.fn(() => false) }))
 
@@ -33,5 +33,37 @@ describe('example content', () => {
     vi.mocked(isChromatic).mockReturnValue(true)
     vi.spyOn(Math, 'random').mockReturnValue(0.999)
     expect(exampleParagraph()).toBe(firstEntry)
+  })
+})
+
+describe('exampleImageSource', () => {
+  const photoId = (source: string) => source.split('/')[4]
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('requests a random photo outside Chromatic', () => {
+    vi.mocked(isChromatic).mockReturnValue(false)
+
+    expect(exampleImageSource(640, 360, 1)).toBe('https://picsum.photos/640/360?random=1')
+  })
+
+  it('names a specific photo in Chromatic', () => {
+    vi.mocked(isChromatic).mockReturnValue(true)
+
+    expect(exampleImageSource(640, 360, 1)).toMatch(/^https:\/\/picsum\.photos\/id\/\d+\/640\/360$/)
+  })
+
+  it('shows one photo at several sizes for the same index', () => {
+    vi.mocked(isChromatic).mockReturnValue(true)
+
+    expect(photoId(exampleImageSource(640, 200, 3))).toBe(photoId(exampleImageSource(1440, 450, 3)))
+  })
+
+  it('shows different photos for different indexes', () => {
+    vi.mocked(isChromatic).mockReturnValue(true)
+
+    expect(photoId(exampleImageSource(640, 360, 0))).not.toBe(photoId(exampleImageSource(640, 360, 1)))
   })
 })

--- a/storybook/src/_common/exampleContent.test.ts
+++ b/storybook/src/_common/exampleContent.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import isChromatic from 'chromatic/isChromatic'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { exampleParagraph } from './exampleContent'
+
+vi.mock('chromatic/isChromatic', () => ({ default: vi.fn(() => false) }))
+
+describe('example content', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('picks a random entry outside Chromatic', () => {
+    vi.mocked(isChromatic).mockReturnValue(false)
+
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const firstEntry = exampleParagraph()
+
+    vi.spyOn(Math, 'random').mockReturnValue(0.999)
+    expect(exampleParagraph()).not.toBe(firstEntry)
+  })
+
+  it('always picks the first entry in Chromatic', () => {
+    vi.mocked(isChromatic).mockReturnValue(false)
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const firstEntry = exampleParagraph()
+
+    vi.mocked(isChromatic).mockReturnValue(true)
+    vi.spyOn(Math, 'random').mockReturnValue(0.999)
+    expect(exampleParagraph()).toBe(firstEntry)
+  })
+})

--- a/storybook/src/_common/exampleContent.ts
+++ b/storybook/src/_common/exampleContent.ts
@@ -91,6 +91,18 @@ export const exampleGivenName = () =>
     'Yassine',
   ])
 
+// Lorem Picsum serves a random photo unless you name one, and it has gaps, so these ids are known to resolve.
+const exampleImageIds = [64, 101, 122, 123, 133, 153, 159, 385, 1015, 1016, 1029, 1039, 1043, 1044]
+
+/**
+ * Returns the source for a placeholder photo.
+ * Pass the same index to show one photo at several sizes, and different ones to show different photos side by side.
+ */
+export const exampleImageSource = (width: number, height: number, index = 0) =>
+  isChromatic()
+    ? `https://picsum.photos/id/${exampleImageIds[index % exampleImageIds.length]}/${width}/${height}`
+    : `https://picsum.photos/${width}/${height}?random=${index}`
+
 export const exampleLinkList = () =>
   pickRandomContent<Array<string>>([
     ['Contactformulier', 'Adressen en openingstijden', 'Bel 14 020'],

--- a/storybook/src/_common/exampleContent.ts
+++ b/storybook/src/_common/exampleContent.ts
@@ -96,7 +96,8 @@ const exampleImageIds = [64, 101, 122, 123, 133, 153, 159, 385, 1015, 1016, 1029
 
 /**
  * Returns the source for a placeholder photo.
- * Pass the same index to show one photo at several sizes, and different ones to show different photos side by side.
+ * Give each photo on a page its own index, and reuse one index across the sizes in a `srcSet`.
+ * Only Chromatic resolves those indexes to fixed photos; elsewhere every source is a fresh random one.
  */
 export const exampleImageSource = (width: number, height: number, index = 0) =>
   isChromatic()

--- a/storybook/src/_common/exampleContent.ts
+++ b/storybook/src/_common/exampleContent.ts
@@ -3,6 +3,8 @@
  * Copyright Gemeente Amsterdam
  */
 
+import isChromatic from 'chromatic/isChromatic'
+
 export const districts: ReadonlyArray<string> = [
   'Centrum',
   'Nieuw-West',
@@ -14,7 +16,10 @@ export const districts: ReadonlyArray<string> = [
   'Zuidoost',
 ]
 
-const pickRandomContent = <T>(list: Array<T>): T => list[Math.floor(Math.random() * list.length)]
+// Chromatic captures every Pages story, so varying content would report differences that aren’t regressions.
+// It gets the first entry of each list; everywhere else keeps picking at random.
+const pickRandomContent = <T>(list: Array<T>): T =>
+  isChromatic() ? list[0] : list[Math.floor(Math.random() * list.length)]
 
 export const exampleAccordionHeading = () =>
   pickRandomContent([

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -18,6 +18,8 @@ import {
   StandaloneLink,
 } from '@amsterdam/design-system-react'
 
+import { exampleImageSource } from '#storybook/_common/exampleContent'
+
 import { commonMeta } from '../common/config'
 
 const meta = {
@@ -53,8 +55,8 @@ const meta = {
           alt=""
           aspectRatio="16:5"
           loading="lazy"
-          src="https://picsum.photos/1440/450"
-          srcSet="https://picsum.photos/640/200 640w, https://picsum.photos/1280/400 1280w, https://picsum.photos/1440/450 1440w"
+          src={exampleImageSource(1440, 450)}
+          srcSet={`${exampleImageSource(640, 200)} 640w, ${exampleImageSource(1280, 400)} 1280w, ${exampleImageSource(1440, 450)} 1440w`}
         />
         <Grid paddingVertical="x-large">
           <Grid.Cell
@@ -137,7 +139,7 @@ const meta = {
         </Grid.Cell>
         <Grid.Cell span={4}>
           <Card>
-            <Card.Image alt="" src="https://picsum.photos/640/360?random=1" />
+            <Card.Image alt="" src={exampleImageSource(640, 360, 1)} />
             <Card.HeadingGroup tagline="Nieuws">
               <Card.Heading level={3}>
                 <Card.Link href="#">Waarom we op zoek zijn naar vleermuizen</Card.Link>
@@ -151,7 +153,7 @@ const meta = {
         </Grid.Cell>
         <Grid.Cell span={4}>
           <Card>
-            <Card.Image alt="" src="https://picsum.photos/640/360?random=2" />
+            <Card.Image alt="" src={exampleImageSource(640, 360, 2)} />
             <Card.HeadingGroup tagline="Nieuws">
               <Card.Heading level={3}>
                 <Card.Link href="#">Meer aandacht voor voetgangers, een jaar lang</Card.Link>
@@ -164,7 +166,7 @@ const meta = {
         </Grid.Cell>
         <Grid.Cell span={4}>
           <Card>
-            <Card.Image alt="" src="https://picsum.photos/640/360?random=3" />
+            <Card.Image alt="" src={exampleImageSource(640, 360, 3)} />
             <Card.HeadingGroup tagline="Nieuws">
               <Card.Heading level={3}>
                 <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>

--- a/storybook/src/pages/public/HomePage/data.ts
+++ b/storybook/src/pages/public/HomePage/data.ts
@@ -1,3 +1,5 @@
+import { exampleImageSource } from '#storybook/_common/exampleContent'
+
 export const topTaskSection = {
   title: 'Direct naar',
   tasks: [
@@ -60,19 +62,19 @@ export const newsSection = {
       title: 'Waarom we op zoek zijn naar vleermuizen',
       description:
         'U kunt ’s avonds ecologen in oranje hesjes tegenkomen. Zij zijn op zoek naar vleermuizen. Dat heeft te maken met het verduurzamen van woningen.',
-      image: 'https://picsum.photos/640/360?random=1',
+      image: exampleImageSource(640, 360, 0),
     },
     {
       title: 'Meer aandacht voor voetgangers, een jaar lang',
       description:
         'We gaan de veiligheid voor voetgangers verbeteren, meer ruimte maken, en lopen en wandelen stimuleren.',
-      image: 'https://picsum.photos/640/360?random=2',
+      image: exampleImageSource(640, 360, 1),
     },
     {
       title: 'Nieuwe manieren om afval op te halen',
       description:
         'Afvalboten, bakfietsen en ondergrondse containers. We experimenteren met nieuwe manieren om afval op te halen in het centrum.',
-      image: 'https://picsum.photos/640/360?random=3',
+      image: exampleImageSource(640, 360, 2),
     },
   ],
 }

--- a/storybook/src/pages/public/HomePage/data.ts
+++ b/storybook/src/pages/public/HomePage/data.ts
@@ -1,3 +1,8 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
 import { exampleImageSource } from '#storybook/_common/exampleContent'
 
 export const topTaskSection = {

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -21,7 +21,12 @@ import {
   UnorderedList,
 } from '@amsterdam/design-system-react'
 
-import { exampleHeading, exampleParagraph, exampleStandaloneLink } from '#storybook/_common/exampleContent'
+import {
+  exampleHeading,
+  exampleImageSource,
+  exampleParagraph,
+  exampleStandaloneLink,
+} from '#storybook/_common/exampleContent'
 
 import { commonMeta } from '../common/config'
 import { burgerzakenLinks, parkerenLinks, persons, topTaskLinks } from './data'
@@ -504,7 +509,7 @@ export const WithImageGallery: StoryObj = {
             </Paragraph>
           </Grid.Cell>
         </Grid>
-        <Image alt="" aspectRatio="16:5" src="https://picsum.photos/1440/450" />
+        <Image alt="" aspectRatio="16:5" src={exampleImageSource(1440, 450, 11)} />
         <Grid paddingVertical="x-large">
           {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }}>
@@ -630,7 +635,7 @@ export const WithImageGallery: StoryObj = {
             <Heading className="ams-mb-s" level={2} size="level-3">
               Rechtenvrije foto’s
             </Heading>
-            <Image alt="" src="https://picsum.photos/640/360" />
+            <Image alt="" src={exampleImageSource(640, 360, 12)} />
           </Grid.Cell>
         </Grid>
       </main>
@@ -761,7 +766,7 @@ export const SubnavigationPage: StoryObj = {
             </Paragraph>
           </Grid.Cell>
         </Grid>
-        <Image alt="" aspectRatio="16:5" src="https://picsum.photos/1440/450" />
+        <Image alt="" aspectRatio="16:5" src={exampleImageSource(1440, 450)} />
         <Grid paddingVertical="large">
           {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>

--- a/storybook/src/pages/public/NavigationPage/data.ts
+++ b/storybook/src/pages/public/NavigationPage/data.ts
@@ -153,57 +153,57 @@ type Person = {
 export const persons: Person[] = [
   {
     imageSource: exampleImageSource(480, 270, 0),
-    name: 'Femke Halsema',
+    name: 'Aicha Bayraktar',
     role: 'Burgemeester',
   },
   {
     imageSource: exampleImageSource(480, 270, 1),
-    name: 'Marjolein Moorman',
+    name: 'Laurens Dijkstra',
     role: 'Wethouder',
   },
   {
     imageSource: exampleImageSource(480, 270, 2),
-    name: 'Rutger Groot Wassink',
+    name: 'Yassine El Idrissi',
     role: 'Wethouder',
   },
   {
     imageSource: exampleImageSource(480, 270, 3),
-    name: 'Hester van Buren',
+    name: 'Lisette Janssen',
     role: 'Wethouder',
   },
   {
     imageSource: exampleImageSource(480, 270, 4),
-    name: 'Sofyan Mbarki',
+    name: 'Abdulaziz Farooq',
     role: 'Wethouder',
   },
   {
     imageSource: exampleImageSource(480, 270, 5),
-    name: 'Touria Meliani',
+    name: 'Angelique Pieterse',
     role: 'Wethouder',
   },
   {
     imageSource: exampleImageSource(480, 270, 6),
-    name: 'Melanie van der Horst',
+    name: 'Ruben op den Akker',
     role: 'Wethouder',
   },
   {
     imageSource: exampleImageSource(480, 270, 7),
-    name: 'Alexander Scholtes',
+    name: 'Meryam Laghmani',
     role: 'Wethouder',
   },
   {
     imageSource: exampleImageSource(480, 270, 8),
-    name: 'Zita Pels',
+    name: 'Sebastiaan van Harinxma thoe Slooten',
     role: 'Wethouder',
   },
   {
     imageSource: exampleImageSource(480, 270, 9),
-    name: 'Steven van Weyenberg',
+    name: 'William Moussaoui',
     role: 'Wethouder',
   },
   {
     imageSource: exampleImageSource(480, 270, 10),
-    name: 'Thea de Vries',
+    name: 'Nora Veldkamp',
     role: 'Gemeentesecretaris',
     suffix: 'waarnemend',
   },

--- a/storybook/src/pages/public/NavigationPage/data.ts
+++ b/storybook/src/pages/public/NavigationPage/data.ts
@@ -3,6 +3,8 @@
  * Copyright Gemeente Amsterdam
  */
 
+import { exampleImageSource } from '#storybook/_common/exampleContent'
+
 export type LinkGroup = {
   heading: string
   links: string[]
@@ -150,57 +152,57 @@ type Person = {
 
 export const persons: Person[] = [
   {
-    imageSource: 'https://picsum.photos/480/270',
+    imageSource: exampleImageSource(480, 270, 0),
     name: 'Femke Halsema',
     role: 'Burgemeester',
   },
   {
-    imageSource: 'https://picsum.photos/480/270',
+    imageSource: exampleImageSource(480, 270, 1),
     name: 'Marjolein Moorman',
     role: 'Wethouder',
   },
   {
-    imageSource: 'https://picsum.photos/480/270',
+    imageSource: exampleImageSource(480, 270, 2),
     name: 'Rutger Groot Wassink',
     role: 'Wethouder',
   },
   {
-    imageSource: 'https://picsum.photos/480/270',
+    imageSource: exampleImageSource(480, 270, 3),
     name: 'Hester van Buren',
     role: 'Wethouder',
   },
   {
-    imageSource: 'https://picsum.photos/480/270',
+    imageSource: exampleImageSource(480, 270, 4),
     name: 'Sofyan Mbarki',
     role: 'Wethouder',
   },
   {
-    imageSource: 'https://picsum.photos/480/270',
+    imageSource: exampleImageSource(480, 270, 5),
     name: 'Touria Meliani',
     role: 'Wethouder',
   },
   {
-    imageSource: 'https://picsum.photos/480/270',
+    imageSource: exampleImageSource(480, 270, 6),
     name: 'Melanie van der Horst',
     role: 'Wethouder',
   },
   {
-    imageSource: 'https://picsum.photos/480/270',
+    imageSource: exampleImageSource(480, 270, 7),
     name: 'Alexander Scholtes',
     role: 'Wethouder',
   },
   {
-    imageSource: 'https://picsum.photos/480/270',
+    imageSource: exampleImageSource(480, 270, 8),
     name: 'Zita Pels',
     role: 'Wethouder',
   },
   {
-    imageSource: 'https://picsum.photos/480/270',
+    imageSource: exampleImageSource(480, 270, 9),
     name: 'Steven van Weyenberg',
     role: 'Wethouder',
   },
   {
-    imageSource: 'https://picsum.photos/480/270',
+    imageSource: exampleImageSource(480, 270, 10),
     name: 'Thea de Vries',
     role: 'Gemeentesecretaris',
     suffix: 'waarnemend',

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -19,6 +19,8 @@ import {
   StandaloneLink,
 } from '@amsterdam/design-system-react'
 
+import { exampleImageSource } from '#storybook/_common/exampleContent'
+
 import { commonMeta } from '../common/config'
 
 const images = [268, 12, 267, 164, 128].map((id) => ({
@@ -322,7 +324,7 @@ const meta = {
       </Spotlight>
       <Grid paddingVertical="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Image alt="" src="https://picsum.photos/1280/720" />
+          <Image alt="" src={exampleImageSource(1280, 720)} />
         </Grid.Cell>
       </Grid>
     </>


### PR DESCRIPTION
## Links

- [Navigation Page](https://designsystem.amsterdam/docs/pages-public-navigation-page--docs)
- [Article Page](https://designsystem.amsterdam/docs/pages-public-article-page--docs)

## What

Makes the page templates render the same thing on every build, so Chromatic stops reporting differences that aren’t regressions. Example text now resolves to a fixed entry under Chromatic, placeholder photos resolve to a named photo instead of a random one, and the Navigation Page’s college is a group of invented people rather than the sitting officials.

## Why

We started snapshotting every `Pages/**` story in #2816, but the templates were never deterministic. All the `example*()` helpers pick at random, and the Lorem Picsum URLs served a fresh photo on every request. The Navigation Page’s lead paragraph was simply the first thing to get flagged — the Subnavigation Page alone calls the random helpers about ten more times, so there were plenty more queued up behind it.

Randomness is worth keeping for everyone reading Storybook, so the fix makes the helpers aware of where they’re running rather than removing the variety.

## How

`pickRandomContent` now returns the first entry of its list when `isChromatic()` is true, and keeps picking at random otherwise. Since every `example*()` helper funnels through that one function, this covers all 19 story files that use them without touching any markup.

Images get a matching helper, `exampleImageSource(width, height, index)`, which names a photo under Chromatic and requests a random one otherwise. Passing the same index gives you one photo at several sizes, and different indexes give you different photos, which is what the card grids need. The ids it draws from are the ones already used elsewhere in the repo, each verified to still resolve — Lorem Picsum has gaps in its range, and a missing id would bake a broken image into every snapshot.

Two deliberate choices worth a look. Roughly a third of the Picsum URLs live inside `docs.source.code` template literals rather than in a render, so they never execute and can’t affect a snapshot; those keep their literal URLs, because the Code Panel should show markup you can copy without reaching for our internal helper. And the Article Page hero previously pointed `src` and its three `srcSet` entries at four different random photos, which isn’t what `srcSet` means — they now share an index and resolve to one photo at four sizes.

The names are drawn from the `exampleGivenName` and `exampleFamilyName` lists we already keep for this purpose, with one addition. Every office stays as it was.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Expect a large batch of Chromatic diffs on the first run. Every page template changes what it renders, so this is a one-time baseline reset rather than a set of regressions — after accepting it, the snapshots should stop moving on their own.

One change is visible outside Chromatic too. The Navigation Page’s eleven person cards all shared an identical URL, so the browser cache almost certainly showed the same photo eleven times. They each get their own photo now.

The new unit tests cover both helpers, including the case that matters most: that a fixed entry comes back under Chromatic even when `Math.random` would have chosen otherwise.
