### PR TITLE
fix(css, tokens, assets): Declare which files each package publishes to npm

### DIFF
--- a/.npmpackagejsonlintrc.json
+++ b/.npmpackagejsonlintrc.json
@@ -39,5 +39,13 @@
     "valid-values-private": "off",
     "version-format": "error",
     "version-type": "error"
-  }
+  },
+  "overrides": [
+    {
+      "patterns": ["packages/*/package.json"],
+      "rules": {
+        "require-files": "error"
+      }
+    }
+  ]
 }

--- a/packages-proprietary/.npmpackagejsonlintrc.json
+++ b/packages-proprietary/.npmpackagejsonlintrc.json
@@ -1,5 +1,6 @@
 {
   "rules": {
+    "require-files": "error",
     "valid-values-license": ["error", ["SEE LICENSE IN LICENSE.md"]]
   }
 }

--- a/packages-proprietary/assets/package.json
+++ b/packages-proprietary/assets/package.json
@@ -17,6 +17,14 @@
     "access": "public",
     "provenance": true
   },
+  "files": [
+    "app-icons/",
+    "favicon/",
+    "font/",
+    "icons/",
+    "logo/",
+    "manifest/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/Amsterdam/design-system.git",

--- a/packages-proprietary/tokens/package.json
+++ b/packages-proprietary/tokens/package.json
@@ -18,6 +18,9 @@
     "access": "public",
     "provenance": true
   },
+  "files": [
+    "dist/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/Amsterdam/design-system.git",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -17,6 +17,10 @@
     "access": "public",
     "provenance": true
   },
+  "files": [
+    "dist/",
+    "src/"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/Amsterdam/design-system.git",


### PR DESCRIPTION
# Describe the pull request

## Links

- [npm-package-json-lint `require-files`](https://npmpackagejsonlint.org/docs/rules/required-node/require-files)
- No preview deploy link: this PR changes only `package.json` and lint configuration, so Storybook is unaffected.

## What

Adds a `files` field to the three published packages that lacked one, and turns on the lint rule that requires it.

| Package | `files` | Tarball before | Tarball after |
| --- | --- | --- | --- |
| Tokens | `["dist/"]` | 113 files, 883.0 kB | 15 files, 513.2 kB |
| CSS | `["dist/", "src/"]` | 241 files, 618.6 kB | 238 files, 532.9 kB |
| Assets | the six content directories | 408 files, 666.8 kB | 404 files, 642.9 kB |

React and React Icons already declared `files: ["dist/"]` and are unchanged.

Consumers of Tokens stop receiving the DTCG sources, the Style Dictionary transforms, `build.js`, and the newly added `lint/` directory. All three packages stop shipping `AGENTS.md`, `CONTRIBUTING.md`, `CHANGELOG.md` and the svgo configuration, none of which mean anything inside `node_modules`.

## Why

Without a `files` field, a package publishes whatever happens to be tracked in git inside its directory, plus the gitignored `dist/` that CI builds. Nothing states what the package is meant to contain, so the contents drift silently whenever someone adds a file.

That is not hypothetical. #2820 added `packages-proprietary/tokens/lint/` last week, so the next Tokens release would have published an allowlist and a vitest test file to npm, and no review step would have flagged it.

Everything each package documents stays reachable. I checked every documented entry point against the proposed values before applying them.

## How

I measured the current tarballs with `npm pack --dry-run --json` on a clean build rather than reasoning from the file tree, and cross-checked against the published tarballs on the registry.

**CSS keeps `src/` deliberately.** Our own developer guide, under “Use them in your own components → With Sass” in `responsive-design.docs.mdx`, tells people to import the breakpoint variables from `src/common/breakpoint.scss`. Those are Sass variables because custom properties cannot be used in media queries, so they can never exist in compiled CSS — and `sass src/components:dist/` never compiles `src/common/` at all. Two repositories import it today, `mijn-amsterdam-frontend` (which also `@import`s 38 component partials from `src/`) and `ee-react-form-demos`, and the former is on `^4.2.0`, so a patch release reaches it automatically. Narrowing CSS to `dist/` would break them with no migration path available.

**Tokens drops `src/`.** Nothing documents it as an import, no public code imports it, and `dist/index.json` already offers the same data through a supported path. The README links to the sources to browse them on GitHub, not to import them.

**Assets keeps all six content directories.** Every one is documented. `font/index.css` reaches its seven `.woff2` siblings through relative URLs, and `favicon/`, `app-icons/` and `manifest/` are consumed by `cp` and `ln -s` in our own snippets, so breaking any of them would produce no build error anywhere.

The lint rule needs two entries because `npmPkgJsonLint` uses the nearest config file and does not merge with the ones above it. `packages-proprietary/.npmpackagejsonlintrc.json` already shadowed the root config, so the rule goes there directly. For `packages/` I used an `overrides` block in the root config instead of a new config file, because adding one there would have silently disabled every root rule for CSS and React.

I verified this by removing `files` from each of the five packages in turn and confirming `require-files` fires, and by removing `author` from CSS and confirming `require-author` still fires, which proves the root rules are not shadowed. The private packages, which have no `files` field, still pass.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

I used `fix` rather than `chore` because this changes what consumers receive and so should reach them in a patch release. Happy to switch it if you would rather it not trigger one.

`CHANGELOG.md` no longer ships for these three packages. That matches React and React Icons, which have never shipped one, and every README links to the changelog on GitHub.

Two things I left out of this PR, both worth a follow-up:

- `packages-proprietary/.npmpackagejsonlintrc.json` shadows the root config entirely, so Tokens, Assets and React Icons have only ever been checked against `valid-values-license`. I tried merging the root rules in and it produces zero violations, so closing that gap looks free.
- Tokens builds `dist/index.mjs` and `dist/index.d.ts` but declares no `main` or `types`, so the bare import does not resolve and nothing documents those files. Pointing them there would be purely additive.

An `exports` map would make the supported surface explicit rather than implicit, but it is breaking on its own and belongs in a major. It would also be the moment to stop leaking `dist/` into public import paths.
