### PR TITLE
chore(Storybook): Use the current Amsterdam logo asset

### DIFF
--- a/storybook/config/manager.js
+++ b/storybook/config/manager.js
@@ -1,7 +1,7 @@
 import { addons } from 'storybook/manager-api'
 import { create } from 'storybook/theming/create'
 
-import Logo from '../../packages-proprietary/assets/logo/amsterdam.svg'
+import Logo from '../../packages-proprietary/assets/logo/amsterdam-logo.svg'
 
 import '@amsterdam/design-system-assets/font/index.css'
 import '../src/_styles/manager.css'


### PR DESCRIPTION
## Links

- [The deprecation entry in the assets changelog (2.3.0)](https://github.com/Amsterdam/design-system/blob/develop/packages-proprietary/assets/CHANGELOG.md)

## What

The Storybook manager used `packages-proprietary/assets/logo/amsterdam.svg` for its sidebar brand image. We deprecated that file in assets 2.3.0 in favour of `amsterdam-logo.svg`, and it is scheduled for removal on or after 20 October 2026. This points the import at the current asset.

## Why

We deprecated these files ourselves, so our own Storybook shouldn’t be the thing still consuming them. Beyond the principle, the import would break outright once the file is removed in October.

## How

A one-line change to the import in `storybook/config/manager.js`.

The replacement isn’t byte-identical to the old file, so it’s worth being explicit about what differs. Apart from the deprecation comment, the new file flattens `<g class="ams-logo__emblem"><path …/></g>` into `<path class="ams-logo__emblem" …/>`. The `viewBox`, path data, `fill` values and class names are all unchanged, and both files carry inline fills, so nothing in the rendered result depended on the wrapper that went away.

I checked the brand image three ways. First by comparing every `viewBox`, `d`, `fill` and `class` value between the two files, which came out identical. Then by rendering both as an `<img>` at sidebar width and confirming the two screenshots are byte-identical. Finally by building Storybook and decoding the data URI that the manager bundle inlines for `brandImage` — it matches `amsterdam-logo.svg` on disk exactly, and no deprecation comment survives anywhere in the shipped bundle.

While in there I went through the rest of the folder. Eight files carry the same notice — seven brands, plus a second `museum_weesp.svg` alias sitting alongside `museum-weesp.svg` — and this import turned out to be the only reference to any of them in the repo. The generated React `Logo` components were never affected, because `generate-logos` globs `*-logo.svg` only.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

One thing I left alone on purpose: `staticDirs` in `storybook/config/main.ts` mounts the whole logo folder, so the built Storybook still serves all eight deprecated files at `/logo/*.svg`. Nothing links to them, and removing them before the deprecation window closes would break external consumers of the published assets package, so that clean-up belongs with deleting the source files on or after 20 October.
