### PR TITLE
fix(Storybook): Correct the vertical space in the public page templates

### DIFF
--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -28,6 +28,7 @@ const meta = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -36,6 +37,7 @@ const meta = {
           </Breadcrumb>
         </Grid.Cell>
       </Grid>
+      {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
       <main id="inhoud">
         <Grid paddingBottom="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -51,6 +53,10 @@ const meta = {
             </Paragraph>
           </Grid.Cell>
         </Grid>
+        {/*
+         * A full-width hero image. srcSet lets the browser pick a size for the viewport, loading="lazy" defers
+         * loading until it is near the viewport, and aspectRatio reserves its space so the layout does not jump.
+         */}
         <Image
           alt=""
           aspectRatio="16:5"
@@ -59,6 +65,7 @@ const meta = {
           srcSet={`${exampleImageSource(640, 200)} 640w, ${exampleImageSource(1280, 400)} 1280w, ${exampleImageSource(1440, 450)} 1440w`}
         />
         <Grid paddingVertical="x-large">
+          {/* ams-prose applies article typography and vertical rhythm to the headings, paragraphs, and links. */}
           <Grid.Cell
             className="ams-prose"
             span={{ narrow: 4, medium: 6, wide: 7 }}
@@ -115,9 +122,12 @@ const meta = {
           </Grid.Cell>
         </Grid>
       </main>
+      {/* A newsletter call-out set apart as a labelled aside (aria-labelledby) on a green Spotlight. */}
+      {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
       <Spotlight aria-labelledby="blijf-op-de-hoogte" as="aside" color="green">
         <Grid paddingVertical="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+            {/* On the green Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
             <Heading className="ams-mb-s" color="inverse" id="blijf-op-de-hoogte" level={2} size="level-3">
               Blijf op de hoogte!
             </Heading>
@@ -131,6 +141,8 @@ const meta = {
           </Grid.Cell>
         </Grid>
       </Spotlight>
+      {/* Related articles as a labelled aside (Grid as="aside"), outside the article’s <main>. */}
+      {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
       <Grid aria-labelledby="meer-nieuws" as="aside" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span="all">
           <Heading id="meer-nieuws" level={2} size="level-1">
@@ -201,6 +213,7 @@ export const Default: StoryObj = {
       </Breadcrumb>
     </Grid.Cell>
   </Grid>
+  {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
   <main id="inhoud">
     <Grid paddingBottom="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -265,10 +278,11 @@ export const Default: StoryObj = {
     </Grid>
   </main>
   {/* A newsletter call-out set apart as a labelled aside (aria-labelledby) on a green Spotlight. */}
+  {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
   <Spotlight aria-labelledby="blijf-op-de-hoogte" as="aside" color="green">
     <Grid paddingVertical="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-        {/* color="inverse" adapts the heading, text, and link to the dark Spotlight background. */}
+        {/* On the green Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
         <Heading className="ams-mb-s" color="inverse" id="blijf-op-de-hoogte" level={2} size="level-3">
           Blijf op de hoogte!
         </Heading>
@@ -280,6 +294,7 @@ export const Default: StoryObj = {
     </Grid>
   </Spotlight>
   {/* Related articles as a labelled aside (Grid as="aside"), outside the article’s <main>. */}
+  {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
   <Grid aria-labelledby="meer-nieuws" as="aside" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span="all">
       <Heading id="meer-nieuws" level={2} size="level-1">Meer nieuws</Heading>

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -131,7 +131,7 @@ const meta = {
           </Grid.Cell>
         </Grid>
       </Spotlight>
-      <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="large" paddingBottom="2x-large" paddingTop="x-large">
+      <Grid aria-labelledby="meer-nieuws" as="aside" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span="all">
           <Heading id="meer-nieuws" level={2} size="level-1">
             Meer nieuws
@@ -280,7 +280,7 @@ export const Default: StoryObj = {
     </Grid>
   </Spotlight>
   {/* Related articles as a labelled aside (Grid as="aside"), outside the article’s <main>. */}
-  <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="large" paddingBottom="2x-large" paddingTop="x-large">
+  <Grid aria-labelledby="meer-nieuws" as="aside" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span="all">
       <Heading id="meer-nieuws" level={2} size="level-1">Meer nieuws</Heading>
     </Grid.Cell>

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -131,7 +131,7 @@ const meta = {
           </Grid.Cell>
         </Grid>
       </Spotlight>
-      <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="large" paddingVertical="x-large">
+      <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="large" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span="all">
           <Heading id="meer-nieuws" level={2} size="level-1">
             Meer nieuws
@@ -280,7 +280,7 @@ export const Default: StoryObj = {
     </Grid>
   </Spotlight>
   {/* Related articles as a labelled aside (Grid as="aside"), outside the article’s <main>. */}
-  <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="large" paddingVertical="x-large">
+  <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="large" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span="all">
       <Heading id="meer-nieuws" level={2} size="level-1">Meer nieuws</Heading>
     </Grid.Cell>

--- a/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
+++ b/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
@@ -58,7 +58,8 @@ export const LandingPage: StoryObj = {
       source: {
         // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
         // comments. Provide the source by hand so the guidance below stays visible in the panel.
-        code: `<Grid as="main" id="inhoud" paddingBottom="2x-large" paddingTop="large">
+        code: `// One Grid for the whole page combines both rules: a paddingTop of large and a paddingBottom of 2x-large.
+<Grid as="main" id="inhoud" paddingBottom="2x-large" paddingTop="large">
   <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
     <Heading className="ams-mb-m" level={1}>Waar u dit formulier voor gebruikt</Heading>
     <Paragraph size="large">
@@ -90,6 +91,7 @@ export const LandingPage: StoryObj = {
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
+    // One Grid for the whole page combines both rules: a paddingTop of large and a paddingBottom of 2x-large.
     <Grid as="main" id="inhoud" paddingBottom="2x-large" paddingTop="large">
       <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading className="ams-mb-m" level={1}>
@@ -100,6 +102,7 @@ export const LandingPage: StoryObj = {
         </Paragraph>
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+        {/* Show the steps up front so people know what to expect before they start. */}
         <Heading className="ams-mb-s" level={2}>
           De stappen in dit formulier
         </Heading>
@@ -115,6 +118,7 @@ export const LandingPage: StoryObj = {
             <strong>Controleren</strong> - Controleer de gegevens die u heeft ingevuld. Verstuur de aanvraag.
           </OrderedList.Item>
         </OrderedList>
+        {/* A single, prominent call to action that starts the form. */}
         <CallToActionLink href="#">Start het formulier</CallToActionLink>
       </Grid.Cell>
     </Grid>
@@ -127,7 +131,7 @@ export const SingleQuestion: StoryObj = {
     docs: {
       source: {
         // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the accessibility guidance below stays in the panel.
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
         code: `<>
   {/* The back link is in its own Grid, because it should be outside of the main section. */}
   <Grid paddingTop="large">
@@ -142,6 +146,7 @@ export const SingleQuestion: StoryObj = {
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
   </Grid>
+  {/* The back link is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
   <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
@@ -160,7 +165,7 @@ export const SingleQuestion: StoryObj = {
       {/*
        * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
        * the user too little. Validate on the server and return the result, or use client-side validation.
-       * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/
+       * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
        */}
       <form noValidate onSubmit={(e) => e.preventDefault()}>
         {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
@@ -195,50 +200,47 @@ export const SingleQuestion: StoryObj = {
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * We add a back link to allow users to navigate between form pages, without having to worry about losing their progress.
-           * Using the browser back button should also work without losing progress, but users do not always trust it (for some applications, rightfully so).
-           * For more info, see: https://design-system.service.gov.uk/components/back-link/
-           *
-           * We use a link here instead of a button, because multiple submit buttons in a form can cause unexpected behavior.
-           * For more info, see: https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+           * A back link lets users move between form pages without worrying about losing their progress. The
+           * browser back button should keep progress too, but users do not always trust it. Use a link, not a
+           * button: multiple submit buttons in a form can cause unexpected behaviour.
+           * See https://design-system.service.gov.uk/components/back-link/ and
+           * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
            */}
           <StandaloneLink href="#" icon={ChevronBackwardIcon}>
             Vorige vraag
           </StandaloneLink>
         </Grid.Cell>
       </Grid>
+      {/* The back link is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
       <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * We use a header here that is labelled by an aria-hidden heading, so that we communicate a labelled
-           * section to screen readers, without adding an unnecessary heading to the heading hierarchy.
-           * Furthermore, if CSS fails to load, we still have a clearly labelled section.
+           * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
+           * an extra entry to the heading hierarchy – and it stays clearly labelled if CSS fails to load.
            */}
           <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
             <Heading aria-hidden id="form-header" level={2} size="level-4">
               Afspraak maken
             </Heading>
             {/*
-             * Start by testing your form without a progress indicator to see if it’s simple enough that users do not need one.
-             * If you do, use a simple one like this one.
-             * For more info, see: https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
+             * First test the form without a progress indicator to see whether it is simple enough to go without
+             * one. If not, use a plain one like this.
+             * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
              */}
             <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
           </header>
           {/*
-           * Do not use HTML5 form validation, because it is not consistent across browsers and devices,
-           * and often gives the user too little information.
-           * Preferably validate user input on the server and return it to the client.
-           * If that is not possible, use client-side validation.
-           * For more info, see: https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
+           * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
+           * the user too little. Validate on the server and return the result, or use client-side validation.
+           * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
            */}
           <form noValidate onSubmit={(e) => e.preventDefault()}>
-            {/* See the docs on specific form components on https://designsystem.amsterdam for more information on how to use them */}
+            {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
             <FieldSet
               aria-required="true"
               className="ams-mb-xl"
               legend="Kies waar u voor wilt langskomen op het Stadsloket"
-              // When a page consists of a single question, its label or legend should be treated as the main page heading (`h1`).
+              // When a page is a single question, treat its legend as the main page heading (h1).
               legendIsPageHeading
               role="radiogroup"
             >
@@ -271,30 +273,42 @@ export const SingleQuestionWithSubquestions: StoryObj = {
     docs: {
       source: {
         // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the accessibility guidance below stays in the panel.
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
         code: `<>
   {/* The back link is in its own Grid, because it should be outside of the main section. */}
   <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
-       * A back link lets users move between form pages without worrying about losing their progress. Use a
-       * link, not a button: multiple submit buttons in a form can cause unexpected behaviour.
-       * See https://design-system.service.gov.uk/components/back-link/
+       * A back link lets users move between form pages without worrying about losing their progress. The
+       * browser back button should keep progress too, but users do not always trust it. Use a link, not a
+       * button: multiple submit buttons in a form can cause unexpected behaviour.
+       * See https://design-system.service.gov.uk/components/back-link/ and
+       * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
        */}
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
   </Grid>
+  {/* The back link is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
   <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
        * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
-       * an extra entry to the heading hierarchy – and it stays labelled if CSS fails to load.
+       * an extra entry to the heading hierarchy – and it stays clearly labelled if CSS fails to load.
        */}
       <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
         <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
+        {/*
+         * First test the form without a progress indicator to see whether it is simple enough to go without
+         * one. If not, use a plain one like this.
+         * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
+         */}
         <Paragraph>Stap 2 van 3: Uw gegevens</Paragraph>
       </header>
-      {/* Do not rely on HTML5 form validation; validate on the server or client-side and return clear errors. */}
+      {/*
+       * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
+       * the user too little. Validate on the server and return the result, or use client-side validation.
+       * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
+       */}
       <form noValidate onSubmit={(e) => e.preventDefault()}>
         {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
         <FieldSet legend="Contactgegevens" legendIsPageHeading>
@@ -305,7 +319,7 @@ export const SingleQuestionWithSubquestions: StoryObj = {
               autoCorrect="off"
               id="email-input"
               name="email"
-              // A generous size, per https://design-system.service.gov.uk/patterns/email-addresses/
+              // A generous size, per https://design-system.service.gov.uk/patterns/email-addresses/#help-users-to-enter-a-valid-email-address
               size={30}
               spellCheck="false"
               type="email"
@@ -313,14 +327,8 @@ export const SingleQuestionWithSubquestions: StoryObj = {
           </Field>
           <Field className="ams-mb-xl">
             <Label htmlFor="tel-input" inFieldSet optional>Telefoonnummer</Label>
-            <TextInput
-              autoComplete="tel"
-              id="tel-input"
-              name="phone"
-              // Phone numbers are at most 15 characters (E.164): https://en.wikipedia.org/wiki/E.164
-              size={15}
-              type="tel"
-            />
+            {/* Phone numbers are at most 15 characters (E.164): https://en.wikipedia.org/wiki/E.164 */}
+            <TextInput autoComplete="tel" id="tel-input" name="phone" size={15} type="tel" />
           </Field>
         </FieldSet>
         <Button type="submit">Volgende vraag</Button>
@@ -339,45 +347,42 @@ export const SingleQuestionWithSubquestions: StoryObj = {
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * We add a back link to allow users to navigate between form pages, without having to worry about losing their progress.
-           * Using the browser back button should also work without losing progress, but users do not always trust it (for some applications, rightfully so).
-           * For more info, see: https://design-system.service.gov.uk/components/back-link/
-           *
-           * We use a link here instead of a button, because multiple submit buttons in a form can cause unexpected behavior.
-           * For more info, see: https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+           * A back link lets users move between form pages without worrying about losing their progress. The
+           * browser back button should keep progress too, but users do not always trust it. Use a link, not a
+           * button: multiple submit buttons in a form can cause unexpected behaviour.
+           * See https://design-system.service.gov.uk/components/back-link/ and
+           * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
            */}
           <StandaloneLink href="#" icon={ChevronBackwardIcon}>
             Vorige vraag
           </StandaloneLink>
         </Grid.Cell>
       </Grid>
+      {/* The back link is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
       <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * We use a header here that is labelled by an aria-hidden heading, so that we communicate a labelled
-           * section to screen readers, without adding an unnecessary heading to the heading hierarchy.
-           * Furthermore, if CSS fails to load, we still have a clearly labelled section.
+           * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
+           * an extra entry to the heading hierarchy – and it stays clearly labelled if CSS fails to load.
            */}
           <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
             <Heading aria-hidden id="form-header" level={2} size="level-4">
               Afspraak maken
             </Heading>
             {/*
-             * Start by testing your form without a progress indicator to see if it’s simple enough that users do not need one.
-             * If you do, use a simple one like this one.
-             * For more info, see: https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
+             * First test the form without a progress indicator to see whether it is simple enough to go without
+             * one. If not, use a plain one like this.
+             * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
              */}
             <Paragraph>Stap 2 van 3: Uw gegevens</Paragraph>
           </header>
           {/*
-           * Do not use HTML5 form validation, because it is not consistent across browsers and devices,
-           * and often gives the user too little information.
-           * Preferably validate user input on the server and return it to the client.
-           * If that is not possible, use client-side validation.
-           * For more info, see: https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
+           * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
+           * the user too little. Validate on the server and return the result, or use client-side validation.
+           * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
            */}
           <form noValidate onSubmit={(e) => e.preventDefault()}>
-            {/* See the docs on specific form components on https://designsystem.amsterdam for more information on how to use them */}
+            {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
             <FieldSet legend="Contactgegevens" legendIsPageHeading>
               <Field>
                 <Label htmlFor="email-input" inFieldSet optional>
@@ -388,7 +393,8 @@ export const SingleQuestionWithSubquestions: StoryObj = {
                   autoCorrect="off"
                   id="email-input"
                   name="email"
-                  size={30} // Based on this recommendation: https://design-system.service.gov.uk/patterns/email-addresses/#help-users-to-enter-a-valid-email-address
+                  // A generous size, per https://design-system.service.gov.uk/patterns/email-addresses/#help-users-to-enter-a-valid-email-address
+                  size={30}
                   spellCheck="false"
                   type="email"
                 />
@@ -397,13 +403,8 @@ export const SingleQuestionWithSubquestions: StoryObj = {
                 <Label htmlFor="tel-input" inFieldSet optional>
                   Telefoonnummer
                 </Label>
-                <TextInput
-                  autoComplete="tel"
-                  id="tel-input"
-                  name="phone"
-                  size={15} // Phone numbers have a maximum length of 15 characters, as per E.164 standard: https://en.wikipedia.org/wiki/E.164
-                  type="tel"
-                />
+                {/* Phone numbers are at most 15 characters (E.164): https://en.wikipedia.org/wiki/E.164 */}
+                <TextInput autoComplete="tel" id="tel-input" name="phone" size={15} type="tel" />
               </Field>
             </FieldSet>
             <Button type="submit">Volgende vraag</Button>
@@ -420,24 +421,31 @@ export const MultipleQuestions: StoryObj = {
     docs: {
       source: {
         // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the accessibility guidance below stays in the panel.
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
         code: `<>
   {/* The back link is in its own Grid, because it should be outside of the main section. */}
   <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
-       * A back link lets users move between form pages without worrying about losing their progress. Use a
-       * link, not a button: multiple submit buttons in a form can cause unexpected behaviour.
-       * See https://design-system.service.gov.uk/components/back-link/
+       * A back link lets users move between form pages without worrying about losing their progress. The
+       * browser back button should keep progress too, but users do not always trust it. Use a link, not a
+       * button: multiple submit buttons in a form can cause unexpected behaviour.
+       * See https://design-system.service.gov.uk/components/back-link/ and
+       * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
        */}
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
   </Grid>
+  {/* The back link is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
   <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/* A form with multiple questions has a level 1 heading before it that describes the whole group. */}
       <Heading className="ams-mb-xl" level={1}>Inschrijven</Heading>
-      {/* Do not rely on HTML5 form validation; validate on the server or client-side and return clear errors. */}
+      {/*
+       * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
+       * the user too little. Validate on the server and return the result, or use client-side validation.
+       * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
+       */}
       <form noValidate onSubmit={(e) => e.preventDefault()}>
         {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
         <Field className="ams-mb-l">
@@ -469,33 +477,31 @@ export const MultipleQuestions: StoryObj = {
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * We add a back link to allow users to navigate between form pages, without having to worry about losing their progress.
-           * Using the browser back button should also work without losing progress, but users do not always trust it (for some applications, rightfully so).
-           * For more info, see: https://design-system.service.gov.uk/components/back-link/
-           *
-           * We use a link here instead of a button, because multiple submit buttons in a form can cause unexpected behavior.
-           * For more info, see: https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+           * A back link lets users move between form pages without worrying about losing their progress. The
+           * browser back button should keep progress too, but users do not always trust it. Use a link, not a
+           * button: multiple submit buttons in a form can cause unexpected behaviour.
+           * See https://design-system.service.gov.uk/components/back-link/ and
+           * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
            */}
           <StandaloneLink href="#" icon={ChevronBackwardIcon}>
             Vorige vraag
           </StandaloneLink>
         </Grid.Cell>
       </Grid>
+      {/* The back link is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
       <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-          {/* A form with multiple questions has a level 1 heading preceding it, which describes the group of questions. */}
+          {/* A form with multiple questions has a level 1 heading before it that describes the whole group. */}
           <Heading className="ams-mb-xl" level={1}>
             Inschrijven
           </Heading>
           {/*
-           * Do not use HTML5 form validation, because it is not consistent across browsers and devices,
-           * and often gives the user too little information.
-           * Preferably validate user input on the server and return it to the client.
-           * If that is not possible, use client-side validation.
-           * For more info, see: https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
+           * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
+           * the user too little. Validate on the server and return the result, or use client-side validation.
+           * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
            */}
           <form noValidate onSubmit={(e) => e.preventDefault()}>
-            {/* See the docs on specific form components on https://designsystem.amsterdam for more information on how to use them */}
+            {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
             <Field className="ams-mb-l">
               <Label htmlFor="name-input">Naam</Label>
               <TextInput
@@ -511,13 +517,8 @@ export const MultipleQuestions: StoryObj = {
               <Label htmlFor="tel-input" optional>
                 Telefoonnummer
               </Label>
-              <TextInput
-                autoComplete="tel"
-                id="tel-input"
-                name="tel"
-                size={15} // Phone numbers have a maximum length of 15 characters, as per E.164 standard: https://en.wikipedia.org/wiki/E.164
-                type="tel"
-              />
+              {/* Phone numbers are at most 15 characters (E.164): https://en.wikipedia.org/wiki/E.164 */}
+              <TextInput autoComplete="tel" id="tel-input" name="tel" size={15} type="tel" />
             </Field>
             <Field className="ams-mb-xl">
               <Label htmlFor="date">Datum</Label>
@@ -537,14 +538,22 @@ export const WithValidationError: StoryObj = {
     docs: {
       source: {
         // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the error-handling guidance below stays in the panel.
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
         code: `<>
   {/* The back link is in its own Grid, because it should be outside of the main section. */}
   <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+      {/*
+       * A back link lets users move between form pages without worrying about losing their progress. The
+       * browser back button should keep progress too, but users do not always trust it. Use a link, not a
+       * button: multiple submit buttons in a form can cause unexpected behaviour.
+       * See https://design-system.service.gov.uk/components/back-link/ and
+       * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+       */}
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
   </Grid>
+  {/* The back link is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
   <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
@@ -561,14 +570,24 @@ export const WithValidationError: StoryObj = {
       />
       {/*
        * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
-       * an extra entry to the heading hierarchy – and it stays labelled if CSS fails to load.
+       * an extra entry to the heading hierarchy – and it stays clearly labelled if CSS fails to load.
        */}
       <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
         <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
+        {/*
+         * First test the form without a progress indicator to see whether it is simple enough to go without
+         * one. If not, use a plain one like this.
+         * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
+         */}
         <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
       </header>
-      {/* Do not rely on HTML5 form validation; validate on the server or client-side and return clear errors. */}
+      {/*
+       * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
+       * the user too little. Validate on the server and return the result, or use client-side validation.
+       * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
+       */}
       <form noValidate onSubmit={(e) => e.preventDefault()}>
+        {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
         <FieldSet
           // Only link the error message to the field set while the message is in the DOM. Referencing a
           // non-existent element can trip up accessibility evaluation tools.
@@ -577,6 +596,7 @@ export const WithValidationError: StoryObj = {
           className="ams-mb-xl"
           invalid
           legend="Kies waar u voor wilt langskomen op het Stadsloket"
+          // When a page is a single question, treat its legend as the main page heading (h1).
           legendIsPageHeading
           role="radiogroup"
         >
@@ -604,26 +624,26 @@ export const WithValidationError: StoryObj = {
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * We add a back link to allow users to navigate between form pages, without having to worry about losing their progress.
-           * Using the browser back button should also work without losing progress, but users do not always trust it (for some applications, rightfully so).
-           * For more info, see: https://design-system.service.gov.uk/components/back-link/
-           *
-           * We use a link here instead of a button, because multiple submit buttons in a form can cause unexpected behavior.
-           * For more info, see: https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+           * A back link lets users move between form pages without worrying about losing their progress. The
+           * browser back button should keep progress too, but users do not always trust it. Use a link, not a
+           * button: multiple submit buttons in a form can cause unexpected behaviour.
+           * See https://design-system.service.gov.uk/components/back-link/ and
+           * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
            */}
           <StandaloneLink href="#" icon={ChevronBackwardIcon}>
             Vorige vraag
           </StandaloneLink>
         </Grid.Cell>
       </Grid>
+      {/* The back link is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
       <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
            * Notifying a user of errors is threefold:
-           * - We add the error count to the document title, so it is the first thing a screen reader user hears.
-           * - We show the Invalid Form Alert at the top of the main container.
-           * - We add error messages next to the relevant form fields.
-           * For more info, see: https://designsystem.amsterdam/?path=/docs/components-forms-invalid-form-alert--docs
+           * - Add the error count to the document title, so a screen reader announces it first.
+           * - Show the Invalid Form Alert at the top of the main container.
+           * - Add error messages next to the relevant form fields.
+           * See https://designsystem.amsterdam/?path=/docs/components-forms-invalid-form-alert--docs
            */}
           <InvalidFormAlert
             className="ams-mb-m"
@@ -631,39 +651,36 @@ export const WithValidationError: StoryObj = {
             headingLevel={2}
           />
           {/*
-           * We use a header here that is labelled by an aria-hidden heading, so that we communicate a labelled
-           * section to screen readers, without adding an unnecessary heading to the heading hierarchy.
-           * Furthermore, if CSS fails to load, we still have a clearly labelled section.
+           * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
+           * an extra entry to the heading hierarchy – and it stays clearly labelled if CSS fails to load.
            */}
           <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
             <Heading aria-hidden id="form-header" level={2} size="level-4">
               Afspraak maken
             </Heading>
             {/*
-             * Start by testing your form without a progress indicator to see if it’s simple enough that users do not need one.
-             * If you do, use a simple one like this one.
-             * For more info, see: https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
+             * First test the form without a progress indicator to see whether it is simple enough to go without
+             * one. If not, use a plain one like this.
+             * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
              */}
             <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
           </header>
           {/*
-           * Do not use HTML5 form validation, because it is not consistent across browsers and devices,
-           * and often gives the user too little information.
-           * Preferably validate user input on the server and return it to the client.
-           * If that is not possible, use client-side validation.
-           * For more info, see: https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
+           * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
+           * the user too little. Validate on the server and return the result, or use client-side validation.
+           * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
            */}
           <form noValidate onSubmit={(e) => e.preventDefault()}>
-            {/* See the docs on specific form components on https://designsystem.amsterdam for more information on how to use them */}
+            {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
             <FieldSet
-              // Make sure you only link the error message to the field set when the error message is in the DOM.
-              // Referencing a non-existent element can cause errors in accessibility evaluation tools.
+              // Only link the error message to the field set while the message is in the DOM. Referencing a
+              // non-existent element can trip up accessibility evaluation tools.
               aria-describedby="error"
               aria-required="true"
               className="ams-mb-xl"
               invalid
               legend="Kies waar u voor wilt langskomen op het Stadsloket"
-              // When a page consists of a single question, its label or legend should be treated as the main page heading (`h1`).
+              // When a page is a single question, treat its legend as the main page heading (h1).
               legendIsPageHeading
               role="radiogroup"
             >

--- a/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
+++ b/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
@@ -130,7 +130,7 @@ export const SingleQuestion: StoryObj = {
         // comments. Provide the source by hand so the accessibility guidance below stays in the panel.
         code: `<>
   {/* The back link is in its own Grid, because it should be outside of the main section. */}
-  <Grid className="ams-mb-xl">
+  <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
        * A back link lets users move between form pages without worrying about losing their progress. The
@@ -192,7 +192,7 @@ export const SingleQuestion: StoryObj = {
   render: (args) => (
     <>
       {/* The back link is in its own Grid, because it should be outside of the main section. */}
-      <Grid className="ams-mb-xl">
+      <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
            * We add a back link to allow users to navigate between form pages, without having to worry about losing their progress.
@@ -274,7 +274,7 @@ export const SingleQuestionWithSubquestions: StoryObj = {
         // comments. Provide the source by hand so the accessibility guidance below stays in the panel.
         code: `<>
   {/* The back link is in its own Grid, because it should be outside of the main section. */}
-  <Grid className="ams-mb-xl">
+  <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
        * A back link lets users move between form pages without worrying about losing their progress. Use a
@@ -336,7 +336,7 @@ export const SingleQuestionWithSubquestions: StoryObj = {
   render: (args) => (
     <>
       {/* The back link is in its own Grid, because it should be outside of the main section. */}
-      <Grid className="ams-mb-xl">
+      <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
            * We add a back link to allow users to navigate between form pages, without having to worry about losing their progress.
@@ -423,7 +423,7 @@ export const MultipleQuestions: StoryObj = {
         // comments. Provide the source by hand so the accessibility guidance below stays in the panel.
         code: `<>
   {/* The back link is in its own Grid, because it should be outside of the main section. */}
-  <Grid className="ams-mb-xl">
+  <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
        * A back link lets users move between form pages without worrying about losing their progress. Use a
@@ -466,7 +466,7 @@ export const MultipleQuestions: StoryObj = {
   render: (args) => (
     <>
       {/* The back link is in its own Grid, because it should be outside of the main section. */}
-      <Grid className="ams-mb-xl">
+      <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
            * We add a back link to allow users to navigate between form pages, without having to worry about losing their progress.
@@ -540,7 +540,7 @@ export const WithValidationError: StoryObj = {
         // comments. Provide the source by hand so the error-handling guidance below stays in the panel.
         code: `<>
   {/* The back link is in its own Grid, because it should be outside of the main section. */}
-  <Grid className="ams-mb-xl">
+  <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
@@ -601,7 +601,7 @@ export const WithValidationError: StoryObj = {
   render: (args) => (
     <>
       {/* The back link is in its own Grid, because it should be outside of the main section. */}
-      <Grid className="ams-mb-xl">
+      <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
            * We add a back link to allow users to navigate between form pages, without having to worry about losing their progress.

--- a/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
+++ b/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
@@ -142,7 +142,7 @@ export const SingleQuestion: StoryObj = {
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
   </Grid>
-  <Grid as="main" paddingBottom="2x-large">
+  <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
        * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
@@ -207,7 +207,7 @@ export const SingleQuestion: StoryObj = {
           </StandaloneLink>
         </Grid.Cell>
       </Grid>
-      <Grid as="main" paddingBottom="2x-large">
+      <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
            * We use a header here that is labelled by an aria-hidden heading, so that we communicate a labelled
@@ -284,7 +284,7 @@ export const SingleQuestionWithSubquestions: StoryObj = {
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
   </Grid>
-  <Grid as="main" paddingBottom="2x-large">
+  <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
        * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
@@ -351,7 +351,7 @@ export const SingleQuestionWithSubquestions: StoryObj = {
           </StandaloneLink>
         </Grid.Cell>
       </Grid>
-      <Grid as="main" paddingBottom="2x-large">
+      <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
            * We use a header here that is labelled by an aria-hidden heading, so that we communicate a labelled
@@ -433,7 +433,7 @@ export const MultipleQuestions: StoryObj = {
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
   </Grid>
-  <Grid as="main" paddingBottom="2x-large">
+  <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/* A form with multiple questions has a level 1 heading before it that describes the whole group. */}
       <Heading className="ams-mb-xl" level={1}>Inschrijven</Heading>
@@ -481,7 +481,7 @@ export const MultipleQuestions: StoryObj = {
           </StandaloneLink>
         </Grid.Cell>
       </Grid>
-      <Grid as="main" paddingBottom="2x-large">
+      <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/* A form with multiple questions has a level 1 heading preceding it, which describes the group of questions. */}
           <Heading className="ams-mb-xl" level={1}>
@@ -545,7 +545,7 @@ export const WithValidationError: StoryObj = {
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
   </Grid>
-  <Grid as="main" paddingBottom="2x-large">
+  <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
        * Notifying a user of errors is threefold:
@@ -616,7 +616,7 @@ export const WithValidationError: StoryObj = {
           </StandaloneLink>
         </Grid.Cell>
       </Grid>
-      <Grid as="main" paddingBottom="2x-large">
+      <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
            * Notifying a user of errors is threefold:

--- a/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
@@ -94,6 +94,7 @@ export const Default: StoryObj = {
     const currentPage = findPage(currentSlug) ?? pages[0]
 
     return (
+      /* One Grid for the whole page combines both rules: a paddingTop of large and a paddingBottom of 2x-large. */
       <Grid paddingBottom="2x-large" paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 3, wide: 4 }}>
           <TableOfContents collapsible heading="Inhoudsopgave" id="inhoudsopgave">

--- a/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
@@ -94,7 +94,7 @@ export const Default: StoryObj = {
     const currentPage = findPage(currentSlug) ?? pages[0]
 
     return (
-      <Grid paddingBottom="2x-large" paddingTop="x-large">
+      <Grid paddingBottom="2x-large" paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 3, wide: 4 }}>
           <TableOfContents collapsible heading="Inhoudsopgave" id="inhoudsopgave">
             {renderTocList(pages, { currentSlug, expandedSlugs, onSelect: handleSelect, onToggle: handleToggle })}

--- a/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
@@ -67,6 +67,65 @@ const renderTocList = (list: Array<HandbookPage>, options: RenderTocOptions) => 
 )
 
 export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // A `render` without arguments prints the story’s own source, including its state and handlers.
+        // Provide the source by hand so the panel shows the markup to compose, without that scaffolding.
+        code: `// handleSelect sets the current page; handleToggle opens and closes a branch. Both keep the Table of Contents controlled.
+
+// One Grid for the whole page combines both rules: a paddingTop of large and a paddingBottom of 2x-large.
+<Grid paddingBottom="2x-large" paddingTop="large">
+  <Grid.Cell span={{ narrow: 4, medium: 3, wide: 4 }}>
+    <TableOfContents collapsible heading="Inhoudsopgave" id="inhoudsopgave">
+      <TableOfContents.List>
+        <TableOfContents.Link href="#s1" label="Inleiding" onClick={handleSelect} />
+        <TableOfContents.Link
+          expanded
+          href="#s2"
+          label="Vaststellen en waarderen van functies"
+          onClick={handleSelect}
+          onToggle={handleToggle}
+        >
+          <TableOfContents.List>
+            <TableOfContents.Link href="#s2-1" label="Algemeen" onClick={handleSelect} />
+            <TableOfContents.Link
+              expanded
+              href="#s2-2"
+              label="Waardering van functies"
+              onClick={handleSelect}
+              onToggle={handleToggle}
+            >
+              <TableOfContents.List>
+                <TableOfContents.Link aria-current="page" href="#s2-2-1" label="Methode" onClick={handleSelect} />
+                <TableOfContents.Link href="#s2-2-2" label="Procedure" onClick={handleSelect} />
+                {/* … a Bezwaar page … */}
+              </TableOfContents.List>
+            </TableOfContents.Link>
+            {/* … a Herwaardering branch with its own pages … */}
+          </TableOfContents.List>
+        </TableOfContents.Link>
+        {/* … Salaristoelagen, with two pages, and Vergoedingen … */}
+      </TableOfContents.List>
+    </TableOfContents>
+  </Grid.Cell>
+  <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+    <main className="ams-prose" id="inhoud">
+      <Heading level={1}>Methode</Heading>
+      <Paragraph size="large">
+        We gebruiken de HR21-systematiek om functies objectief en vergelijkbaar te waarderen.
+      </Paragraph>
+      <Paragraph>
+        De methode kent punten toe aan gezichtspunten zoals kennis, zelfstandigheid, contacten en afbreukrisico.
+        De som van de punten bepaalt de indeling in een salarisschaal. Deze werkwijze is landelijk afgestemd.
+      </Paragraph>
+    </main>
+  </Grid.Cell>
+</Grid>`,
+        language: 'tsx',
+      },
+    },
+  },
   render: () => {
     const [currentSlug, setCurrentSlug] = useState(initialSlug)
     const [expandedSlugs, setExpandedSlugs] = useState(() => branchFor(initialSlug))

--- a/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
@@ -94,7 +94,7 @@ export const Default: StoryObj = {
     const currentPage = findPage(currentSlug) ?? pages[0]
 
     return (
-      <Grid paddingVertical="x-large">
+      <Grid paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 3, wide: 4 }}>
           <TableOfContents collapsible heading="Inhoudsopgave" id="inhoudsopgave">
             {renderTocList(pages, { currentSlug, expandedSlugs, onSelect: handleSelect, onToggle: handleToggle })}

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
     <main id="inhoud">
       <h1 className="ams-visually-hidden">Homepage van de gemeente Amsterdam</h1>
       <Overlap>{OverlapStory.args?.children}</Overlap>
-      <Grid gapVertical="large" paddingVertical="x-large">
+      <Grid paddingVertical="x-large">
         <Grid.Cell span="all">
           <Heading level={2} size="level-1">
             {topTaskSection.title}
@@ -53,7 +53,7 @@ const meta = {
           ))}
         </Grid>
       </Spotlight>
-      <Grid gapVertical="large" paddingBottom="2x-large" paddingTop="x-large">
+      <Grid paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span="all">
           <Heading level={2} size="level-1">
             {newsSection.title}
@@ -94,7 +94,7 @@ export const Default: StoryObj = {
   <h1 className="ams-visually-hidden">Homepage van de gemeente Amsterdam</h1>
   {/* A hero that overlaps a full-width image with the block beneath it – see the Overlap component. */}
   <Overlap>{/* … */}</Overlap>
-  <Grid gapVertical="large" paddingVertical="x-large">
+  <Grid paddingVertical="x-large">
     <Grid.Cell span="all">
       {/* Second level in the outline (the hidden h1 is first), shown at the largest size. */}
       <Heading level={2} size="level-1">{topTaskSection.title}</Heading>
@@ -123,7 +123,7 @@ export const Default: StoryObj = {
       ))}
     </Grid>
   </Spotlight>
-  <Grid gapVertical="large" paddingBottom="2x-large" paddingTop="x-large">
+  <Grid paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span="all">
       <Heading level={2} size="level-1">{newsSection.title}</Heading>
     </Grid.Cell>

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -53,7 +53,7 @@ const meta = {
           ))}
         </Grid>
       </Spotlight>
-      <Grid gapVertical="large" paddingVertical="x-large">
+      <Grid gapVertical="large" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span="all">
           <Heading level={2} size="level-1">
             {newsSection.title}
@@ -123,7 +123,7 @@ export const Default: StoryObj = {
       ))}
     </Grid>
   </Spotlight>
-  <Grid gapVertical="large" paddingVertical="x-large">
+  <Grid gapVertical="large" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span="all">
       <Heading level={2} size="level-1">{newsSection.title}</Heading>
     </Grid.Cell>

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -17,10 +17,16 @@ const meta = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args: unknown) => (
     <main id="inhoud">
+      {/*
+       * The homepage’s visible headings start at the section level, so give the page one visually hidden
+       * h1. Screen readers still announce a page title and the heading outline keeps a single top level.
+       */}
       <h1 className="ams-visually-hidden">Homepage van de gemeente Amsterdam</h1>
+      {/* A hero that overlaps a full-width image with the block beneath it – see the Overlap component. */}
       <Overlap>{OverlapStory.args?.children}</Overlap>
       <Grid paddingVertical="x-large">
         <Grid.Cell span="all">
+          {/* Second level in the outline (the hidden h1 is first), shown at the largest size. */}
           <Heading level={2} size="level-1">
             {topTaskSection.title}
           </Heading>
@@ -28,6 +34,7 @@ const meta = {
         {topTaskSection.tasks.map(({ title, description }) => (
           <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
             <Card>
+              {/* Card.Link stretches over the whole Card, so the entire Card is one clickable link. */}
               <Card.Heading level={3}>
                 <Card.Link href="#">{title}</Card.Link>
               </Card.Heading>
@@ -36,10 +43,12 @@ const meta = {
           </Grid.Cell>
         ))}
       </Grid>
+      {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
       <Spotlight>
         <Grid paddingVertical="x-large">
           {spotlightSections.map(({ title, description, link }) => (
             <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 6 }}>
+              {/* On the dark Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
               <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
                 {title}
               </Heading>
@@ -53,6 +62,7 @@ const meta = {
           ))}
         </Grid>
       </Spotlight>
+      {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
       <Grid paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span="all">
           <Heading level={2} size="level-1">
@@ -63,6 +73,7 @@ const meta = {
           <Grid.Cell key={title} span={4}>
             <Card>
               <Card.Image alt="" src={image} />
+              {/* Card.HeadingGroup adds a short tagline above the Card’s heading. */}
               <Card.HeadingGroup tagline="Nieuws">
                 <Card.Heading level={3}>
                   <Card.Link href="#">{title}</Card.Link>
@@ -84,8 +95,8 @@ export const Default: StoryObj = {
     docs: {
       source: {
         // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments and expands each `map` into repeated blocks. Provide the source by hand so the
-        // guidance stays visible and the `map` pattern reads the way a developer would write it.
+        // comments and expands each `map`. Provide the source by hand so the guidance below stays
+        // visible in the panel.
         code: `<main id="inhoud">
   {/*
    * The homepage’s visible headings start at the section level, so give the page one visually hidden
@@ -102,7 +113,7 @@ export const Default: StoryObj = {
     {topTaskSection.tasks.map(({ title, description }) => (
       <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
         <Card>
-          {/* Card.Link stretches over the whole Card, so the entire card is one clickable link. */}
+          {/* Card.Link stretches over the whole Card, so the entire Card is one clickable link. */}
           <Card.Heading level={3}>
             <Card.Link href="#">{title}</Card.Link>
           </Card.Heading>
@@ -111,11 +122,12 @@ export const Default: StoryObj = {
       </Grid.Cell>
     ))}
   </Grid>
+  {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
   <Spotlight>
     <Grid paddingVertical="x-large">
       {spotlightSections.map(({ title, description, link }) => (
         <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 6 }}>
-          {/* On the dark Spotlight, color="inverse" switches text and links to their light variant. */}
+          {/* On the dark Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
           <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">{title}</Heading>
           <Paragraph className="ams-mb-m" color="inverse">{description}</Paragraph>
           <StandaloneLink color="inverse" href="#">{link}</StandaloneLink>
@@ -123,6 +135,7 @@ export const Default: StoryObj = {
       ))}
     </Grid>
   </Spotlight>
+  {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
   <Grid paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span="all">
       <Heading level={2} size="level-1">{newsSection.title}</Heading>
@@ -131,7 +144,7 @@ export const Default: StoryObj = {
       <Grid.Cell key={title} span={4}>
         <Card>
           <Card.Image alt="" src={image} />
-          {/* Card.HeadingGroup adds a short tagline above the card’s heading. */}
+          {/* Card.HeadingGroup adds a short tagline above the Card’s heading. */}
           <Card.HeadingGroup tagline="Nieuws">
             <Card.Heading level={3}>
               <Card.Link href="#">{title}</Card.Link>

--- a/storybook/src/pages/public/Introduction.docs.mdx
+++ b/storybook/src/pages/public/Introduction.docs.mdx
@@ -81,6 +81,9 @@ Between two plain Grids, leave the padding off one of the touching sides, unless
 
 The last Grid before the Page Footer has a `paddingBottom` of `2x-large`.
 
+A last section that is not a Grid has no Grid after it to take its space from.
+Give it the `ams-mb-2xl` [Margin](/docs/utilities-css-margin--docs) utility class instead, for the same amount of space.
+
 A page that needs only one Grid combines both rules: a `paddingTop` of `large` and a `paddingBottom` of `2x-large`.
 
 ### Vertical gaps

--- a/storybook/src/pages/public/Introduction.docs.mdx
+++ b/storybook/src/pages/public/Introduction.docs.mdx
@@ -46,6 +46,43 @@ The general structure for a page is:
 Public websites cannot use the [Menu](/docs/components-navigation-menu--docs) component.
 They should offer navigation using the Page Header only.
 
+## Vertical space between sections
+
+The direct children of the Page, apart from the Page Header and the Page Footer, are its sections.
+Most sections are a Grid, but a section can also be a Spotlight, an Image, or an Overlap.
+A Spotlight contains a Grid, which in that position also spaces the content against the edges of the coloured band.
+
+Sections create this space with the padding props of the Grid.
+A section that is not a Grid has no padding props and takes its space from the Grids around it.
+
+### The first Grid
+
+The first Grid has a `paddingTop` of `large` and no `paddingBottom`.
+On most pages it contains only the Breadcrumb.
+The Grid that follows it has no `paddingTop`, so that the breadcrumb and the page title read as a single block.
+
+Not every page type has a breadcrumb.
+The Home Page opens with an Overlap, the Loading Page with its search field, and the Handbook Page relies on its table of contents.
+Where the first Grid holds content instead of a breadcrumb, it still takes the `large` top padding.
+
+### The Grids in between
+
+Every other Grid uses a `paddingVertical` of `x-large`, including the Grid inside a Spotlight.
+
+Two adjacent Grids therefore add up to twice that amount.
+Across a Spotlight this is intentional, because the coloured band separates the two paddings.
+Between two plain Grids, leave the padding off one of the touching sides, unless the extra whitespace is deliberate.
+
+### The last Grid
+
+The last Grid before the Page Footer has a `paddingBottom` of `2x-large`.
+
+A page that needs only one Grid combines both rules: a `paddingTop` of `large` and a `paddingBottom` of `2x-large`.
+
+### Vertical gaps
+
+Leave `gapVertical` at its default of `x-large`.
+
 ## How to size the Grid Cells
 
 Everything on the page is wrapped in a [Grid Cell](/docs/components-layout-grid--docs).

--- a/storybook/src/pages/public/Introduction.docs.mdx
+++ b/storybook/src/pages/public/Introduction.docs.mdx
@@ -54,11 +54,12 @@ A Spotlight contains a Grid, which in that position also spaces the content agai
 
 Sections create this space with the padding props of the Grid.
 A section that is not a Grid has no padding props and takes its space from the Grids around it.
+The Page Header and the Page Footer add no vertical space of their own, so the first and the last Grid provide it.
 
 ### The first Grid
 
 The first Grid has a `paddingTop` of `large` and no `paddingBottom`.
-On most pages it contains only the Breadcrumb.
+On most pages it contains only the Breadcrumb, and on the question pages of a Form Flow only the back link.
 The Grid that follows the Breadcrumb has no `paddingTop`, so that the breadcrumb and the page title read as a single block.
 
 Not every page type has a breadcrumb.
@@ -66,7 +67,7 @@ The Home Page opens with an Overlap, the Loading Page with its search field, and
 Where the first Grid holds content instead of a breadcrumb, it still takes the `large` top padding.
 
 Only the Breadcrumb closes the gap below itself.
-The back link of the Form Flow, for example, keeps the regular `x-large` between itself and the section that follows.
+The back link keeps the regular `x-large` between itself and the section that follows.
 
 ### The Grids in between
 

--- a/storybook/src/pages/public/Introduction.docs.mdx
+++ b/storybook/src/pages/public/Introduction.docs.mdx
@@ -63,8 +63,12 @@ On most pages it contains only the Breadcrumb, and on the question pages of a Fo
 The Grid that follows the Breadcrumb has no `paddingTop`, so that the breadcrumb and the page title read as a single block.
 
 Not every page type has a breadcrumb.
-The Home Page opens with an Overlap, the Loading Page with its search field, and the Handbook Page relies on its table of contents.
+The Loading Page opens with its search field, and the Handbook Page relies on its table of contents.
 Where the first Grid holds content instead of a breadcrumb, it still takes the `large` top padding.
+
+A page may also open with a section that is not a Grid.
+The Home Page starts with an Overlap, which sits flush against the Page Header.
+The Grid that follows such a section is a regular one, with a `paddingVertical` of `x-large`.
 
 Only the Breadcrumb closes the gap below itself.
 The back link keeps the regular `x-large` between itself and the section that follows.

--- a/storybook/src/pages/public/Introduction.docs.mdx
+++ b/storybook/src/pages/public/Introduction.docs.mdx
@@ -59,11 +59,14 @@ A section that is not a Grid has no padding props and takes its space from the G
 
 The first Grid has a `paddingTop` of `large` and no `paddingBottom`.
 On most pages it contains only the Breadcrumb.
-The Grid that follows it has no `paddingTop`, so that the breadcrumb and the page title read as a single block.
+The Grid that follows the Breadcrumb has no `paddingTop`, so that the breadcrumb and the page title read as a single block.
 
 Not every page type has a breadcrumb.
 The Home Page opens with an Overlap, the Loading Page with its search field, and the Handbook Page relies on its table of contents.
 Where the first Grid holds content instead of a breadcrumb, it still takes the `large` top padding.
+
+Only the Breadcrumb closes the gap below itself.
+The back link of the Form Flow, for example, keeps the regular `x-large` between itself and the section that follows.
 
 ### The Grids in between
 

--- a/storybook/src/pages/public/Introduction.docs.mdx
+++ b/storybook/src/pages/public/Introduction.docs.mdx
@@ -48,9 +48,13 @@ They should offer navigation using the Page Header only.
 
 ## Vertical space between sections
 
-The direct children of the Page, apart from the Page Header and the Page Footer, are its sections.
+Between the Page Header and the Page Footer, the Page holds a sequence of sections.
 Most sections are a Grid, but a section can also be a Spotlight, an Image, or an Overlap.
 A Spotlight contains a Grid, which in that position also spaces the content against the edges of the coloured band.
+
+A landmark is not always a section itself.
+A page either sets `as="main"` on the Grid that holds its content, wraps several sections in a `main` element, or places `main` in a Grid Cell beside a sidebar.
+Such a wrapper takes no padding of its own, and the Grids inside and around it keep theirs.
 
 Sections create this space with the padding props of the Grid.
 A section that is not a Grid has no padding props and takes its space from the Grids around it.

--- a/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
+++ b/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
@@ -99,6 +99,7 @@ const meta = {
 
     return (
       <main id="inhoud">
+        {/* The first Grid holds the search field instead of a breadcrumb, so it still takes the large top padding. */}
         <Grid paddingTop="large">
           <Grid.Cell span="all">
             <Heading level={1}>Zoeken op amsterdam.nl</Heading>
@@ -172,12 +173,98 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+const pageShell = (busy: string, status: string, results: string) => `<main id="inhoud">
+  {/* The first Grid holds the search field instead of a breadcrumb, so it still takes the large top padding. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span="all">
+      <Heading level={1}>Zoeken op amsterdam.nl</Heading>
+    </Grid.Cell>
+    <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }}>
+      <SearchField onSubmit={search}>
+        <SearchField.Input defaultValue="woningbouw" label="Zoek op de website" name="search" />
+        <SearchField.Button />
+      </SearchField>
+    </Grid.Cell>
+  </Grid>
+
+  {/*
+   * Mark the whole results region busy while it loads and let it announce once, rather than once per
+   * Skeleton – which would repeat the message for every card. The Skeletons are hidden from assistive
+   * technologies, so this region is all a screen reader hears.
+   */}
+  {/* The search field is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
+  {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+  <Grid aria-busy={${busy}} paddingBottom="2x-large" paddingTop="x-large">
+    <Grid.Cell span="all">
+      {/*
+       * Keep one status message in the DOM at all times and only change its text – from a loading
+       * message to the result count – so screen readers reliably announce the update. A Loading Region
+       * component to wrap this pattern is planned; until then it is plain HTML.
+       */}
+      <p className="ams-visually-hidden" role="status">${status}</p>${results}
+  </Grid>
+</main>`
+
+// The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+// comments. Provide the source by hand so the guidance above the results region stays visible.
+const idleSource = pageShell(
+  'false',
+  '',
+  `
+      <Paragraph>Klik op de zoekknop om de resultaten te laden.</Paragraph>
+    </Grid.Cell>`,
+)
+
+const loadingSource = pageShell(
+  'true',
+  'Zoekresultaten voor ‘woningbouw’ worden geladen',
+  `
+    </Grid.Cell>
+
+    {/*
+     * Compose each Skeleton from the same parts, in the same Grid cell, as the Card that will replace
+     * it: an image of the same aspect ratio, a heading, and two paragraph lines for the description.
+     * Mirroring the shape keeps the layout from shifting when the real content arrives.
+     */}
+    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
+      <Skeleton>
+        <Skeleton.Image />
+        <Skeleton.Heading />
+        <Skeleton.Paragraph lines={2} />
+      </Skeleton>
+    </Grid.Cell>
+    {/* … five more Skeleton cells, one for each result that is loading … */}`,
+)
+
+const loadedSource = pageShell(
+  'false',
+  '6 resultaten voor ‘woningbouw’ gevonden',
+  `
+      <Heading level={2} size="level-3">6 resultaten voor ‘woningbouw’</Heading>
+    </Grid.Cell>
+
+    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
+      <Card>
+        <Card.Image alt="" aspectRatio="16:9" src="https://picsum.photos/id/1015/640/360" />
+        <Card.Heading level={3}>
+          <Card.Link href="#">Nederlands eerste houten woonwijk komt in Zuidoost</Card.Link>
+        </Card.Heading>
+        <Paragraph>Een levendige, groene en duurzame woonbuurt tussen de Gooiseweg en het Nelson Mandelapark.</Paragraph>
+      </Card>
+    </Grid.Cell>
+    {/* … five more Cards, in the same cells the Skeletons occupied … */}`,
+)
+
+export const Default: Story = {
+  parameters: { docs: { source: { code: idleSource, language: 'tsx' } } },
+}
 
 export const Loading: Story = {
   args: { initialPhase: 'loading' },
+  parameters: { docs: { source: { code: loadingSource, language: 'tsx' } } },
 }
 
 export const Loaded: Story = {
   args: { initialPhase: 'loaded' },
+  parameters: { docs: { source: { code: loadedSource, language: 'tsx' } } },
 }

--- a/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
+++ b/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
@@ -173,7 +173,14 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-const pageShell = (busy: string, status: string, results: string) => `<main id="inhoud">
+type PageSourceOptions = {
+  busy: string
+  extraCells?: string
+  status: string
+  statusCell?: string
+}
+
+const pageShell = ({ busy, extraCells = '', status, statusCell = '' }: PageSourceOptions) => `<main id="inhoud">
   {/* The first Grid holds the search field instead of a breadcrumb, so it still takes the large top padding. */}
   <Grid paddingTop="large">
     <Grid.Cell span="all">
@@ -201,25 +208,23 @@ const pageShell = (busy: string, status: string, results: string) => `<main id="
        * message to the result count – so screen readers reliably announce the update. A Loading Region
        * component to wrap this pattern is planned; until then it is plain HTML.
        */}
-      <p className="ams-visually-hidden" role="status">${status}</p>${results}
+      <p className="ams-visually-hidden" role="status">${status}</p>${statusCell}
+    </Grid.Cell>${extraCells}
   </Grid>
 </main>`
 
 // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
 // comments. Provide the source by hand so the guidance above the results region stays visible.
-const idleSource = pageShell(
-  'false',
-  '',
-  `
-      <Paragraph>Klik op de zoekknop om de resultaten te laden.</Paragraph>
-    </Grid.Cell>`,
-)
+const idleSource = pageShell({
+  busy: 'false',
+  status: '',
+  statusCell: `
+      <Paragraph>Klik op de zoekknop om de resultaten te laden.</Paragraph>`,
+})
 
-const loadingSource = pageShell(
-  'true',
-  'Zoekresultaten voor ‘woningbouw’ worden geladen',
-  `
-    </Grid.Cell>
+const loadingSource = pageShell({
+  busy: 'true',
+  extraCells: `
 
     {/*
      * Compose each Skeleton from the same parts, in the same Grid cell, as the Card that will replace
@@ -234,14 +239,12 @@ const loadingSource = pageShell(
       </Skeleton>
     </Grid.Cell>
     {/* … five more Skeleton cells, one for each result that is loading … */}`,
-)
+  status: 'Zoekresultaten voor ‘woningbouw’ worden geladen',
+})
 
-const loadedSource = pageShell(
-  'false',
-  '6 resultaten voor ‘woningbouw’ gevonden',
-  `
-      <Heading level={2} size="level-3">6 resultaten voor ‘woningbouw’</Heading>
-    </Grid.Cell>
+const loadedSource = pageShell({
+  busy: 'false',
+  extraCells: `
 
     <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
       <Card>
@@ -253,7 +256,10 @@ const loadedSource = pageShell(
       </Card>
     </Grid.Cell>
     {/* … five more Cards, in the same cells the Skeletons occupied … */}`,
-)
+  status: '6 resultaten voor ‘woningbouw’ gevonden',
+  statusCell: `
+      <Heading level={2} size="level-3">6 resultaten voor ‘woningbouw’</Heading>`,
+})
 
 export const Default: Story = {
   parameters: { docs: { source: { code: idleSource, language: 'tsx' } } },

--- a/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
+++ b/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
@@ -116,6 +116,8 @@ const meta = {
          * Skeleton – which would repeat the message for every card. The Skeletons are hidden from assistive
          * technologies, so this region is all a screen reader hears.
          */}
+        {/* The search field is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
+        {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
         <Grid aria-busy={phase === 'loading'} paddingBottom="2x-large" paddingTop="x-large">
           <Grid.Cell span="all">
             {/*

--- a/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
+++ b/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
@@ -99,7 +99,7 @@ const meta = {
 
     return (
       <main id="inhoud">
-        <Grid gapVertical="large" paddingTop="x-large">
+        <Grid paddingTop="large">
           <Grid.Cell span="all">
             <Heading level={1}>Zoeken op amsterdam.nl</Heading>
           </Grid.Cell>

--- a/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
+++ b/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
@@ -116,7 +116,7 @@ const meta = {
          * Skeleton – which would repeat the message for every card. The Skeletons are hidden from assistive
          * technologies, so this region is all a screen reader hears.
          */}
-        <Grid aria-busy={phase === 'loading'} paddingVertical="x-large">
+        <Grid aria-busy={phase === 'loading'} paddingBottom="2x-large" paddingTop="x-large">
           <Grid.Cell span="all">
             {/*
              * Keep one status message in the DOM at all times and only change its text – from a loading

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -56,8 +56,7 @@ export const Default: StoryObj = {
     docs: {
       source: {
         // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments and expands each `map`. Provide the source by hand so the guidance stays visible and
-        // the `map` and `getLinks` patterns read the way a developer would write them.
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
         code: `// getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
 
 <>
@@ -69,6 +68,8 @@ export const Default: StoryObj = {
       </Breadcrumb>
     </Grid.Cell>
   </Grid>
+  {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+  {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
   <Grid as="main" id="inhoud" paddingBottom="2x-large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Heading className="ams-mb-m" level={1}>Burgerzaken</Heading>
@@ -77,10 +78,7 @@ export const Default: StoryObj = {
         geboorte aangeven? Op deze pagina vindt u alle informatie en regelzaken rondom Burgerzaken.
       </Paragraph>
     </Grid.Cell>
-    {/*
-     * Two columns of link groups. On the even-indexed cells, start pins them to the content column; the
-     * odd-indexed cells (start undefined) fall in beside them.
-     */}
+    {/* start pins the even-indexed cells to the content column; odd-indexed cells fall in beside them. */}
     {burgerzakenLinks.map(({ heading, links }, index) => (
       <Grid.Cell
         key={heading}
@@ -99,7 +97,9 @@ export const Default: StoryObj = {
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
+    // getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
     <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -107,6 +107,8 @@ export const Default: StoryObj = {
           </Breadcrumb>
         </Grid.Cell>
       </Grid>
+      {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+      {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
       <Grid as="main" id="inhoud" paddingBottom="2x-large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-m" level={1}>
@@ -117,6 +119,7 @@ export const Default: StoryObj = {
             aangeven? Op deze pagina vindt u alle informatie en regelzaken rondom Burgerzaken.
           </Paragraph>
         </Grid.Cell>
+        {/* start pins the even-indexed cells to the content column; odd-indexed cells fall in beside them. */}
         {burgerzakenLinks.map(({ heading, links }, index) => (
           <Grid.Cell
             key={heading}
@@ -138,6 +141,8 @@ export const WithTopTasks: StoryObj = {
   parameters: {
     docs: {
       source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
         code: `// getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
 
 <>
@@ -149,6 +154,8 @@ export const WithTopTasks: StoryObj = {
       </Breadcrumb>
     </Grid.Cell>
   </Grid>
+  {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+  {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
   <Grid as="main" id="inhoud" paddingBottom="2x-large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Heading className="ams-mb-m" level={1}>Leefomgeving</Heading>
@@ -192,7 +199,9 @@ export const WithTopTasks: StoryObj = {
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
+    // getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
     <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -200,12 +209,15 @@ export const WithTopTasks: StoryObj = {
           </Breadcrumb>
         </Grid.Cell>
       </Grid>
+      {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+      {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
       <Grid as="main" id="inhoud" paddingBottom="2x-large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-m" level={1}>
             Leefomgeving
           </Heading>
         </Grid.Cell>
+        {/* The two most important tasks get a full Card each; the groups below are plain heading + links. */}
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Card>
             <Card.Heading level={2}>
@@ -225,6 +237,7 @@ export const WithTopTasks: StoryObj = {
             <Paragraph>Een demonstratie of manifestatie meldt u vooraf bij de gemeente.</Paragraph>
           </Card>
         </Grid.Cell>
+        {/* start pins the even-indexed cells to the content column; odd-indexed cells fall in beside them. */}
         {topTaskLinks.map(({ heading, links }, index) => (
           <Grid.Cell
             key={heading}
@@ -246,6 +259,8 @@ export const WithInteractiveElement: StoryObj = {
   parameters: {
     docs: {
       source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
         code: `// getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
 
 <>
@@ -257,6 +272,7 @@ export const WithInteractiveElement: StoryObj = {
       </Breadcrumb>
     </Grid.Cell>
   </Grid>
+  {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
   <main id="inhoud">
     <Grid paddingBottom="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -265,6 +281,7 @@ export const WithInteractiveElement: StoryObj = {
           Vind informatie over parkeervergunningen, parkeertarieven en betaald parkeren in Amsterdam.
         </Paragraph>
       </Grid.Cell>
+      {/* start pins the even-indexed cells to the content column; odd-indexed cells fall in beside them. */}
       {parkerenLinks.map(({ heading, links }, index) => (
         <Grid.Cell
           key={heading}
@@ -276,11 +293,13 @@ export const WithInteractiveElement: StoryObj = {
         </Grid.Cell>
       ))}
     </Grid>
+    {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
     <Spotlight>
       <Grid paddingVertical="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+          {/* On the dark Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
           <Heading className="ams-mb-m" color="inverse" level={2} size="level-3">Parkeertarieven</Heading>
-          {/* An interactive element in the page: a search field. On the dark Spotlight, its links take color="inverse". */}
+          {/* An interactive element in the page: a search field. */}
           <SearchField className="ams-mb-m">
             <SearchField.Input label="Zoek op adres" placeholder="Zoek op adres" />
             <SearchField.Button />
@@ -292,6 +311,7 @@ export const WithInteractiveElement: StoryObj = {
         </Grid.Cell>
       </Grid>
     </Spotlight>
+    {/* A last section that is not a Grid takes ams-mb-2xl instead of a Grid’s paddingBottom. */}
     <Image alt="" aspectRatio="16:9" className="ams-mb-2xl" src="https://picsum.photos/id/133/1440/810" />
   </main>
 </>`,
@@ -301,7 +321,9 @@ export const WithInteractiveElement: StoryObj = {
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
+    // getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
     <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -309,6 +331,7 @@ export const WithInteractiveElement: StoryObj = {
           </Breadcrumb>
         </Grid.Cell>
       </Grid>
+      {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
       <main id="inhoud">
         <Grid paddingBottom="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -319,6 +342,7 @@ export const WithInteractiveElement: StoryObj = {
               {exampleParagraph()}
             </Paragraph>
           </Grid.Cell>
+          {/* start pins the even-indexed cells to the content column; odd-indexed cells fall in beside them. */}
           {parkerenLinks.map(({ heading, links }, index) => (
             <Grid.Cell
               key={heading}
@@ -332,12 +356,15 @@ export const WithInteractiveElement: StoryObj = {
             </Grid.Cell>
           ))}
         </Grid>
+        {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
         <Spotlight>
           <Grid paddingVertical="x-large">
             <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+              {/* On the dark Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
               <Heading className="ams-mb-m" color="inverse" level={2} size="level-3">
                 Parkeertarieven
               </Heading>
+              {/* An interactive element in the page: a search field. */}
               <SearchField className="ams-mb-m">
                 <SearchField.Input label="Zoek op adres" placeholder="Zoek op adres" />
                 <SearchField.Button />
@@ -353,6 +380,7 @@ export const WithInteractiveElement: StoryObj = {
             </Grid.Cell>
           </Grid>
         </Spotlight>
+        {/* A last section that is not a Grid takes ams-mb-2xl instead of a Grid’s paddingBottom. */}
         <Image alt="" aspectRatio="16:9" className="ams-mb-2xl" src="https://picsum.photos/id/133/1440/810" />
       </main>
     </>
@@ -363,6 +391,8 @@ export const WithImageGallery: StoryObj = {
   parameters: {
     docs: {
       source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
         code: `<>
   {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
   <Grid paddingTop="large">
@@ -373,6 +403,7 @@ export const WithImageGallery: StoryObj = {
       </Breadcrumb>
     </Grid.Cell>
   </Grid>
+  {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
   <main id="inhoud">
     <Grid paddingBottom="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -383,7 +414,7 @@ export const WithImageGallery: StoryObj = {
         </Paragraph>
       </Grid.Cell>
     </Grid>
-    {/* A full-width banner image spans all columns; aspectRatio keeps it from shifting the layout. */}
+    {/* A full-width banner image sits outside the Grid and runs full-bleed; aspectRatio keeps it from shifting the layout. */}
     <Image alt="" aspectRatio="16:5" src="https://picsum.photos/1440/450" />
     <Grid paddingVertical="x-large">
       {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
@@ -427,10 +458,11 @@ export const WithImageGallery: StoryObj = {
         <StandaloneLink href="#">Coalitieakkoord en Uitvoeringsagenda</StandaloneLink>
       </Grid.Cell>
     </Grid>
+    {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
     <Spotlight>
       <Grid paddingVertical="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          {/* On the dark Spotlight, color="inverse" switches the heading and links to their light variant. */}
+          {/* On the dark Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
           <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Persberichten en nieuws</Heading>
           <LinkList className="ams-mb-m">
             <LinkList.Link color="inverse" href="#">
@@ -451,6 +483,7 @@ export const WithImageGallery: StoryObj = {
         </Grid.Cell>
       </Grid>
     </Spotlight>
+    {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
     <Grid paddingBottom="2x-large" paddingTop="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading className="ams-mb-s" level={2} size="level-3">Pers en woordvoering</Heading>
@@ -489,6 +522,7 @@ export const WithImageGallery: StoryObj = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -497,6 +531,7 @@ export const WithImageGallery: StoryObj = {
           </Breadcrumb>
         </Grid.Cell>
       </Grid>
+      {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
       <main id="inhoud">
         <Grid paddingBottom="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -509,6 +544,7 @@ export const WithImageGallery: StoryObj = {
             </Paragraph>
           </Grid.Cell>
         </Grid>
+        {/* A full-width banner image sits outside the Grid and runs full-bleed; aspectRatio keeps it from shifting the layout. */}
         <Image alt="" aspectRatio="16:5" src={exampleImageSource(1440, 450, 11)} />
         <Grid paddingVertical="x-large">
           {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
@@ -521,6 +557,10 @@ export const WithImageGallery: StoryObj = {
               gemeentesecretaris.
             </Paragraph>
           </Grid.Cell>
+          {/*
+           * The image gallery. Each card spans 4 columns; the computed start lays them out two per row on
+           * medium ([1, 5]) and three per row on wide ([1, 5, 9]) screens.
+           */}
           {persons.map(({ imageSource, name, role, suffix }, index) => (
             <Grid.Cell
               key={name}
@@ -554,9 +594,11 @@ export const WithImageGallery: StoryObj = {
             <StandaloneLink href="#">Coalitieakkoord en Uitvoeringsagenda</StandaloneLink>
           </Grid.Cell>
         </Grid>
+        {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
         <Spotlight>
           <Grid paddingVertical="x-large">
             <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+              {/* On the dark Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
               <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
                 Persberichten en nieuws
               </Heading>
@@ -593,6 +635,7 @@ export const WithImageGallery: StoryObj = {
             </Grid.Cell>
           </Grid>
         </Spotlight>
+        {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
         <Grid paddingBottom="2x-large" paddingTop="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
             <Heading className="ams-mb-s" level={2} size="level-3">
@@ -647,6 +690,8 @@ export const SubnavigationPage: StoryObj = {
   parameters: {
     docs: {
       source: {
+        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
+        // comments. Provide the source by hand so the guidance below stays visible in the panel.
         code: `// getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
 
 <>
@@ -659,6 +704,7 @@ export const SubnavigationPage: StoryObj = {
       </Breadcrumb>
     </Grid.Cell>
   </Grid>
+  {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
   <main id="inhoud">
     <Grid paddingBottom="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -708,9 +754,11 @@ export const SubnavigationPage: StoryObj = {
         <StandaloneLink href="#">Lees meer</StandaloneLink>
       </Grid.Cell>
     </Grid>
+    {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
     <Spotlight color="magenta">
       <Grid paddingVertical="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+          {/* On the magenta Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
           <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Titel</Heading>
           <Paragraph color="inverse">Voorbeeldtekst bij dit onderwerp.</Paragraph>
         </Grid.Cell>
@@ -720,12 +768,14 @@ export const SubnavigationPage: StoryObj = {
         </Grid.Cell>
       </Grid>
     </Spotlight>
+    {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
     <Grid paddingBottom="2x-large" paddingTop="x-large">
       {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading className="ams-mb-s" level={2}>L2 Paragraaf titel</Heading>
         <Paragraph>Voorbeeldtekst bij dit onderwerp.</Paragraph>
       </Grid.Cell>
+      {/* start pins the even-indexed cells to the content column; odd-indexed cells fall in beside them. */}
       {burgerzakenLinks.slice(4, 8).map(({ heading, links }, index) => (
         <Grid.Cell
           key={heading}
@@ -745,7 +795,9 @@ export const SubnavigationPage: StoryObj = {
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
+    // getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
     <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -754,6 +806,7 @@ export const SubnavigationPage: StoryObj = {
           </Breadcrumb>
         </Grid.Cell>
       </Grid>
+      {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
       <main id="inhoud">
         <Grid paddingBottom="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -775,6 +828,7 @@ export const SubnavigationPage: StoryObj = {
             </Heading>
             <Paragraph>{exampleParagraph()}</Paragraph>
           </Grid.Cell>
+          {/* start pins the even-indexed cells to the content column; odd-indexed cells fall in beside them. */}
           {burgerzakenLinks.slice(0, 6).map(({ heading, links }, index) => (
             <Grid.Cell
               key={heading}
@@ -816,9 +870,11 @@ export const SubnavigationPage: StoryObj = {
             <StandaloneLink href="#">{exampleStandaloneLink()}</StandaloneLink>
           </Grid.Cell>
         </Grid>
+        {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
         <Spotlight color="magenta">
           <Grid paddingVertical="x-large">
             <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+              {/* On the magenta Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
               <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
                 {exampleHeading()}
               </Heading>
@@ -832,6 +888,7 @@ export const SubnavigationPage: StoryObj = {
             </Grid.Cell>
           </Grid>
         </Spotlight>
+        {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
         <Grid paddingBottom="2x-large" paddingTop="x-large">
           {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -840,6 +897,7 @@ export const SubnavigationPage: StoryObj = {
             </Heading>
             <Paragraph>{exampleParagraph()}</Paragraph>
           </Grid.Cell>
+          {/* start pins the even-indexed cells to the content column; odd-indexed cells fall in beside them. */}
           {burgerzakenLinks.slice(4, 8).map(({ heading, links }, index) => (
             <Grid.Cell
               key={heading}

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -69,7 +69,7 @@ export const Default: StoryObj = {
       </Breadcrumb>
     </Grid.Cell>
   </Grid>
-  <Grid as="main" id="inhoud" paddingBottom="x-large">
+  <Grid as="main" id="inhoud" paddingBottom="2x-large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Heading className="ams-mb-m" level={1}>Burgerzaken</Heading>
       <Paragraph size="large">
@@ -107,7 +107,7 @@ export const Default: StoryObj = {
           </Breadcrumb>
         </Grid.Cell>
       </Grid>
-      <Grid as="main" id="inhoud" paddingBottom="x-large">
+      <Grid as="main" id="inhoud" paddingBottom="2x-large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-m" level={1}>
             Burgerzaken
@@ -149,7 +149,7 @@ export const WithTopTasks: StoryObj = {
       </Breadcrumb>
     </Grid.Cell>
   </Grid>
-  <Grid as="main" id="inhoud" paddingBottom="x-large">
+  <Grid as="main" id="inhoud" paddingBottom="2x-large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Heading className="ams-mb-m" level={1}>Leefomgeving</Heading>
     </Grid.Cell>
@@ -200,7 +200,7 @@ export const WithTopTasks: StoryObj = {
           </Breadcrumb>
         </Grid.Cell>
       </Grid>
-      <Grid as="main" id="inhoud" paddingBottom="x-large">
+      <Grid as="main" id="inhoud" paddingBottom="2x-large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-m" level={1}>
             Leefomgeving
@@ -451,7 +451,7 @@ export const WithImageGallery: StoryObj = {
         </Grid.Cell>
       </Grid>
     </Spotlight>
-    <Grid paddingVertical="x-large">
+    <Grid paddingBottom="2x-large" paddingTop="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading className="ams-mb-s" level={2} size="level-3">Pers en woordvoering</Heading>
         <Paragraph className="ams-mb-s">Voor vragen van journalisten aan de afdeling Bestuursvoorlichting.</Paragraph>
@@ -593,7 +593,7 @@ export const WithImageGallery: StoryObj = {
             </Grid.Cell>
           </Grid>
         </Spotlight>
-        <Grid paddingVertical="x-large">
+        <Grid paddingBottom="2x-large" paddingTop="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
             <Heading className="ams-mb-s" level={2} size="level-3">
               Pers en woordvoering
@@ -720,7 +720,7 @@ export const SubnavigationPage: StoryObj = {
         </Grid.Cell>
       </Grid>
     </Spotlight>
-    <Grid paddingVertical="large">
+    <Grid paddingBottom="2x-large" paddingTop="large">
       {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading className="ams-mb-s" level={2}>L2 Paragraaf titel</Heading>
@@ -832,7 +832,7 @@ export const SubnavigationPage: StoryObj = {
             </Grid.Cell>
           </Grid>
         </Spotlight>
-        <Grid paddingVertical="large">
+        <Grid paddingBottom="2x-large" paddingTop="large">
           {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
             <Heading className="ams-mb-s" level={2}>

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -277,7 +277,7 @@ export const WithInteractiveElement: StoryObj = {
       ))}
     </Grid>
     <Spotlight>
-      <Grid paddingVertical="large">
+      <Grid paddingVertical="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-m" color="inverse" level={2} size="level-3">Parkeertarieven</Heading>
           {/* An interactive element in the page: a search field. On the dark Spotlight, its links take color="inverse". */}
@@ -333,7 +333,7 @@ export const WithInteractiveElement: StoryObj = {
           ))}
         </Grid>
         <Spotlight>
-          <Grid paddingVertical="large">
+          <Grid paddingVertical="x-large">
             <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
               <Heading className="ams-mb-m" color="inverse" level={2} size="level-3">
                 Parkeertarieven
@@ -670,7 +670,7 @@ export const SubnavigationPage: StoryObj = {
       </Grid.Cell>
     </Grid>
     <Image alt="" aspectRatio="16:5" src="https://picsum.photos/1440/450" />
-    <Grid paddingVertical="large">
+    <Grid paddingVertical="x-large">
       {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading className="ams-mb-s" level={2}>L2 Paragraaf titel</Heading>
@@ -709,7 +709,7 @@ export const SubnavigationPage: StoryObj = {
       </Grid.Cell>
     </Grid>
     <Spotlight color="magenta">
-      <Grid paddingVertical="large">
+      <Grid paddingVertical="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Titel</Heading>
           <Paragraph color="inverse">Voorbeeldtekst bij dit onderwerp.</Paragraph>
@@ -720,7 +720,7 @@ export const SubnavigationPage: StoryObj = {
         </Grid.Cell>
       </Grid>
     </Spotlight>
-    <Grid paddingBottom="2x-large" paddingTop="large">
+    <Grid paddingBottom="2x-large" paddingTop="x-large">
       {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading className="ams-mb-s" level={2}>L2 Paragraaf titel</Heading>
@@ -767,7 +767,7 @@ export const SubnavigationPage: StoryObj = {
           </Grid.Cell>
         </Grid>
         <Image alt="" aspectRatio="16:5" src={exampleImageSource(1440, 450)} />
-        <Grid paddingVertical="large">
+        <Grid paddingVertical="x-large">
           {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
             <Heading className="ams-mb-s" level={2}>
@@ -817,7 +817,7 @@ export const SubnavigationPage: StoryObj = {
           </Grid.Cell>
         </Grid>
         <Spotlight color="magenta">
-          <Grid paddingVertical="large">
+          <Grid paddingVertical="x-large">
             <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
               <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
                 {exampleHeading()}
@@ -832,7 +832,7 @@ export const SubnavigationPage: StoryObj = {
             </Grid.Cell>
           </Grid>
         </Spotlight>
-        <Grid paddingBottom="2x-large" paddingTop="large">
+        <Grid paddingBottom="2x-large" paddingTop="x-large">
           {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
             <Heading className="ams-mb-s" level={2}>

--- a/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
+++ b/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
@@ -24,6 +24,7 @@ const meta = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -32,7 +33,10 @@ const meta = {
           </Breadcrumb>
         </Grid.Cell>
       </Grid>
+      {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+      {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
       <Grid as="main" id="inhoud" paddingBottom="2x-large">
+        {/* The title and lead span the wide intro column. */}
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-xl" level={1}>
             Gratis laptop of tablet voor de basisschool aanvragen
@@ -41,6 +45,10 @@ const meta = {
             U krijgt per huishouden 1 keer per 5 schooljaren een gratis laptop of tablet op de basisschool.
           </Paragraph>
         </Grid.Cell>
+        {/*
+         * The body sits in a narrower cell, indented one column on wider screens, for a comfortable reading
+         * measure.
+         */}
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           <Heading className="ams-mb-s" level={2}>
             Voorwaarden
@@ -73,6 +81,7 @@ const meta = {
             <OrderedList.Item>Kies welke regelingen u wilt aanvragen voor u en uw gezinsleden.</OrderedList.Item>
             <OrderedList.Item>Hierna moet u inloggen met uw DigiD.</OrderedList.Item>
           </OrderedList>
+          {/* A prominent call to action for the main task on the page. */}
           <CallToActionLink className="ams-mb-xl" href="#">
             Start de check en vraag aan
           </CallToActionLink>
@@ -85,6 +94,7 @@ const meta = {
               Ga naar <Link href="#">www.digid.nl</Link> en vraag uw DigID aan.
             </UnorderedList.Item>
             <UnorderedList.Item>
+              {/* download hints the browser to save the PDF rather than open it in a new tab. */}
               Lees eerst{' '}
               <Link download href="#">
                 Toelichting Gratis laptop of tablet basisschool Schooljaar 2024-2025.pdf
@@ -168,6 +178,8 @@ export const Default: StoryObj = {
       </Breadcrumb>
     </Grid.Cell>
   </Grid>
+  {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+  {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
   <Grid as="main" id="inhoud" paddingBottom="2x-large">
     {/* The title and lead span the wide intro column. */}
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>

--- a/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
+++ b/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
@@ -91,7 +91,7 @@ const meta = {
           </Heading>
           <UnorderedList className="ams-mb-xl">
             <UnorderedList.Item>
-              Ga naar <Link href="#">www.digid.nl</Link> en vraag uw DigID aan.
+              Ga naar <Link href="#">www.digid.nl</Link> en vraag uw DigiD aan.
             </UnorderedList.Item>
             <UnorderedList.Item>
               {/* download hints the browser to save the PDF rather than open it in a new tab. */}

--- a/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
+++ b/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
@@ -32,7 +32,7 @@ const meta = {
           </Breadcrumb>
         </Grid.Cell>
       </Grid>
-      <Grid as="main" id="inhoud" paddingBottom="x-large">
+      <Grid as="main" id="inhoud" paddingBottom="2x-large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-xl" level={1}>
             Gratis laptop of tablet voor de basisschool aanvragen
@@ -168,7 +168,7 @@ export const Default: StoryObj = {
       </Breadcrumb>
     </Grid.Cell>
   </Grid>
-  <Grid as="main" id="inhoud" paddingBottom="x-large">
+  <Grid as="main" id="inhoud" paddingBottom="2x-large">
     {/* The title and lead span the wide intro column. */}
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Heading className="ams-mb-xl" level={1}>Gratis laptop of tablet voor de basisschool aanvragen</Heading>

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -470,7 +470,8 @@ export const Default: StoryObj = {
       <Image alt="" className="ams-mb-m" src="https://picsum.photos/id/385/640/360" />
       <StandaloneLink href="#">Meer video’s</StandaloneLink>
     </Grid.Cell>
-    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+    {/* … a Plannen en publicaties cell, start-aligned to the left like Meer informatie … */}
+    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
       <Heading className="ams-mb-s" level={2} size="level-3">Blijf op de hoogte</Heading>
       <LinkList>
         <LinkList.Link href="#">Nieuwsbrief ontwikkeling IJburg</LinkList.Link>

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -35,6 +35,7 @@ const meta = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -43,11 +44,13 @@ const meta = {
           </Breadcrumb>
         </Grid.Cell>
       </Grid>
+      {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
       <Grid as="main" id="inhoud" paddingBottom="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading level={1}>Centrumeiland: hét zelfbouweiland van Amsterdam</Heading>
         </Grid.Cell>
         <Grid.Cell span="all">
+          {/* ImageSlider takes an array of images; each entry has an alt text, an aspectRatio, and a src. */}
           <ImageSlider images={images} />
         </Grid.Cell>
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
@@ -94,6 +97,10 @@ const meta = {
             ontwikkelaars, bouwgroepen en zelfbouwers ook met de bouw van hun nieuwe woningen. We verwachten dat bijna
             alle woningen en voorzieningen klaar zijn in 2028. Het laatste woonblok wordt opgeleverd in 2029.
           </Paragraph>
+          {/*
+           * A ProgressList shows a timeline. status="completed" marks a finished step, status="current" the one
+           * in progress, and a step with no status is still to come. hasSubsteps nests a ProgressList.Substeps.
+           */}
           <ProgressList collapsible headingLevel={3}>
             <ProgressList.Step hasSubsteps heading="2021" status="completed">
               <ProgressList.Substeps>
@@ -180,6 +187,7 @@ const meta = {
             </ProgressList.Step>
           </ProgressList>
         </Grid.Cell>
+        {/* Two link lists side by side, each start-aligned to its own half of the grid. */}
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-s" level={2} size="level-3">
             Nieuws
@@ -199,6 +207,7 @@ const meta = {
           </LinkList>
         </Grid.Cell>
       </Grid>
+      {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
       <Spotlight color="azure">
         <Grid paddingVertical="x-large">
           <Grid.Cell span="all">
@@ -206,6 +215,10 @@ const meta = {
               Zelfbouw
             </Heading>
           </Grid.Cell>
+          {/*
+           * The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens.
+           * On the azure Spotlight, color="inverse" switches the heading, text, and links to their light variant.
+           */}
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
             <Paragraph className="ams-mb-s" color="inverse">
               Meer over de verschillende vormen van zelfbouw vindt u op:
@@ -285,6 +298,7 @@ const meta = {
           </LinkList>
         </Grid.Cell>
       </Grid>
+      {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
       <Spotlight>
         <Grid paddingVertical="x-large">
           <Grid.Cell span="all">
@@ -304,6 +318,7 @@ const meta = {
             </Paragraph>
           </Grid.Cell>
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+            {/* <br /> holds a contact block’s lines together inside one Paragraph. */}
             <Paragraph color="inverse">
               Maud van Esch
               <br />
@@ -322,6 +337,7 @@ const meta = {
           </Grid.Cell>
         </Grid>
       </Spotlight>
+      {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
       <Grid paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Image alt="" src={exampleImageSource(1280, 720)} />
@@ -339,7 +355,7 @@ export const Default: StoryObj = {
       source: {
         // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
         // comments. Provide the source by hand so the guidance below stays visible in the panel. Repetitive
-        // sections are shortened with `{/* … */}` markers to keep the timeline and grid patterns readable.
+        // sections are shortened with `{/* … */}` markers.
         code: `<>
   {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
   <Grid paddingTop="large">
@@ -350,6 +366,7 @@ export const Default: StoryObj = {
       </Breadcrumb>
     </Grid.Cell>
   </Grid>
+  {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
   <Grid as="main" id="inhoud" paddingBottom="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Heading level={1}>Centrumeiland: hét zelfbouweiland van Amsterdam</Heading>
@@ -420,12 +437,16 @@ export const Default: StoryObj = {
       </LinkList>
     </Grid.Cell>
   </Grid>
+  {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
   <Spotlight color="azure">
     <Grid paddingVertical="x-large">
       <Grid.Cell span="all">
         <Heading color="inverse" level={2}>Zelfbouw</Heading>
       </Grid.Cell>
-      {/* Four equal columns of promo links; on the azure Spotlight, color="inverse" adapts their content. */}
+      {/*
+       * The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens.
+       * On the azure Spotlight, color="inverse" switches the heading, text, and links to their light variant.
+       */}
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
         <Paragraph className="ams-mb-s" color="inverse">
           Meer over de verschillende vormen van zelfbouw vindt u op:
@@ -457,6 +478,7 @@ export const Default: StoryObj = {
       </LinkList>
     </Grid.Cell>
   </Grid>
+  {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
   <Spotlight>
     <Grid paddingVertical="x-large">
       <Grid.Cell span="all">
@@ -480,6 +502,7 @@ export const Default: StoryObj = {
       </Grid.Cell>
     </Grid>
   </Spotlight>
+  {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
   <Grid paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Image alt="" src="https://picsum.photos/1280/720" />

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -322,7 +322,7 @@ const meta = {
           </Grid.Cell>
         </Grid>
       </Spotlight>
-      <Grid paddingVertical="x-large">
+      <Grid paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Image alt="" src={exampleImageSource(1280, 720)} />
         </Grid.Cell>
@@ -480,7 +480,7 @@ export const Default: StoryObj = {
       </Grid.Cell>
     </Grid>
   </Spotlight>
-  <Grid paddingVertical="x-large">
+  <Grid paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Image alt="" src="https://picsum.photos/1280/720" />
     </Grid.Cell>

--- a/storybook/src/pages/public/common/FormPageLayout.tsx
+++ b/storybook/src/pages/public/common/FormPageLayout.tsx
@@ -12,7 +12,7 @@ type FormPageLayoutProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 export const FormPageLayout = ({ children, ...restProps }: FormPageLayoutProps) => (
   <Page {...restProps}>
     {/* Keep the Page Header as simple as possible, to avoid distractions and to prevent users from accidentally navigating away from the form flow. */}
-    <PageHeader className="ams-mb-xl" />
+    <PageHeader />
     {children}
     <PageFooter>
       {/* Keep the Page Footer as simple as possible, to avoid distractions and to prevent users from accidentally navigating away from the form flow. */}


### PR DESCRIPTION
## Links

- [Preview deploy](https://designsystem.amsterdam/) — the whole Storybook on main
- [Pages/Public/Introduction](https://designsystem.amsterdam/?path=/docs/pages-public-introduction--docs) — the spacing rules this PR applies and documents

Templates whose spacing changed:

- [Article Page](https://designsystem.amsterdam/?path=/story/pages-public-article-page--default)
- [Form Flow — Single Question](https://designsystem.amsterdam/?path=/story/pages-public-form-flow--single-question) — back link and main Grid
- [Handbook Page](https://designsystem.amsterdam/?path=/story/pages-public-handbook-page--default) — single Grid, both rules at once
- [Home Page](https://designsystem.amsterdam/?path=/story/pages-public-home-page--default)
- [Loading Page — Loaded](https://designsystem.amsterdam/?path=/story/pages-public-loading-page--loaded)
- [Navigation Page — Subnavigation Page](https://designsystem.amsterdam/?path=/story/pages-public-navigation-page--subnavigation-page) — the most sections in one page
- [Product Page](https://designsystem.amsterdam/?path=/story/pages-public-product-page--default)
- [Project Page](https://designsystem.amsterdam/?path=/story/pages-public-project-page--default)

## What

Two related things, both about the public page templates.

**The spacing itself.** The vertical space between sections is now consistent across every template, and the rules it follows are written into the `Pages/Public` introduction page. Visibly: the last Grid before the Page Footer always gets a `paddingBottom` of `2x-large`, the remaining `large` paddings and `gapVertical` overrides are gone, and the Form Flow no longer positions anything with margin utility classes.

**The comments that explain it.** Once the rules were written down it became clear the stories did not explain the decisions they demonstrate, so the comments across all eight templates were brought into line and the spacing choices are now commented where they are made. Two templates also gained a Code Panel source they were missing.

## Why

The templates had drifted apart. The same structural position — the first Grid, a Grid between two others, the last Grid before the footer — could look different depending on which template you opened. Some Grids used a `paddingVertical` of `large` where the surrounding ones used `x-large`, several carried a `gapVertical="large"` override, and the space above the Page Footer varied between `x-large` and `2x-large`.

The Form Flow was the furthest out. It positioned its back link with `ams-mb-xl` on the Grid and put a second `ams-mb-xl` on the Page Header, so its spacing was expressed in a different vocabulary than every other template and did not respond to the Grid padding scale at all.

Underneath all of that, none of the rules were written down, so there was nothing to check a new template against.

The comments had drifted for a related reason. Most of these stories hold their guidance twice — once as JSX in `render`, once in a hand-written `parameters.docs.source.code` string — and nothing keeps the two in step. Several comments existed in only one of the copies, four templates had none at all in their `render`, and a handful of shared sentences had forked into five or six wordings. The shortened copies had also quietly dropped external links.

## How

Sections take their vertical space from the padding props of the Grid, and nothing else. The first Grid takes a `paddingTop` of `large`, Grids in between take a `paddingVertical` of `x-large`, and the last one before the Page Footer takes a `paddingBottom` of `2x-large`. `gapVertical` stays at its default.

For the Form Flow that meant replacing both margin utilities. The back link's Grid takes the regular `paddingTop` of `large` as the first Grid, and the main Grid takes a `paddingTop` of `x-large` — the back link is not a Breadcrumb, so it does not close the gap below itself. Removing the Page Header's margin then leaves the first Grid's padding as the only thing spacing the content from the header, which is how every other template already worked.

On the comments: every one now appears in both copies with the same wording, the forked sentences are unified, and the dropped links are restored. New comments were added only for the spacing decisions — including the absent `paddingTop` after a Breadcrumb, which no code can show. Accessibility and prop-value gaps were deliberately left for a separate pass.

The Handbook Page and the Loading Page had no Code Panel source. The Handbook Page's `render` takes no arguments, so the panel was printing the story verbatim, state and event handlers included. The Loading Page's three stories share one render, so the panel dropped their guidance entirely; each phase now has its own source.

Worth knowing while reading the diff: because most stories carry that second copy, every spacing change and every comment appears twice. Both were kept in step.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Chromatic diffs are expected, and they should all come from the spacing commits — a section boundary growing or shrinking to the documented value. The comment and Code Panel work changes no rendered output, so a diff that looks like reflowed content rather than changed spacing is worth flagging.

Two content corrections rode along, both found while reading the templates closely. The Project Page's Code Panel snippet omits a cell, and the cell after it had picked up the dropped cell's left-column `start`, so the panel showed a layout the page does not have. And the Product Page said `DigID` where it means `DigiD`.

The Home Page keeps a `paddingVertical` of `x-large` on the Grid after its hero. It opens with an Overlap rather than a first Grid, and the Overlap is meant to sit flush against the Page Header, so that Grid is a regular one. The introduction page said this ambiguously and now spells it out.

This branch was rebased after #2824, which renamed the layout modules it touches.
