### PR TITLE
chore(Storybook): Explain the page template decisions and document them per component

### DIFF
--- a/storybook/src/components/FieldSet/FieldSet.docs.mdx
+++ b/storybook/src/components/FieldSet/FieldSet.docs.mdx
@@ -70,7 +70,7 @@ Do not use rich text (such as links or lists) in an Error Message. [Find out why
 
 ### With Heading in Legend
 
-If the Field Set is the only content on the page, its Legend serves as the main heading as well.
+If the Field Set holds the only question on the page, its Legend serves as the main heading as well.
 Set `legendIsPageHeading` to include an `h1` element to reflect this.
 
 <Canvas of={FieldSetStories.WithHeadingInLegend} />
@@ -86,6 +86,12 @@ Use the `inFieldSet` prop to show the legend in a lighter style.
 
 There’s no need to add white space between the children of a Field Set.
 The component does this automatically.
+
+## Accessibility
+
+A Field Set has the implicit ARIA role `group`.
+Set `role="radiogroup"` when it groups [Radio](/docs/components-forms-radio--docs) buttons, so that screen readers announce it as a radio group.
+That role also permits `aria-required` on the Field Set, which the `group` role does not allow.
 
 ## See also
 

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -54,6 +54,10 @@ Follow the [optimal sizes of Grid Cells](/docs/pages-public-introduction--docs#h
 Use the `as` prop to give a Grid or a Grid Cell a meaningful HTML element when one applies.
 For example, set a top-level Cell that holds the main content of the page to `as="main"`, or a sidebar Cell to `as="aside"`.
 
+Put `as="main"` on the Grid itself when the main content of a page is a single section: the Grid then is that region.
+Wrap the sections in a plain `main` element instead when the region holds several of them, such as more Grids, a [Spotlight](/docs/components-containers-spotlight--docs), or a full-bleed [Image](/docs/components-media-image--docs).
+Next to a sidebar, the main content goes in its own Grid Cell.
+
 Ensure the `span` and `start` values for a cell never exceed the number of columns available at that breakpoint.
 The browser would add columns to fit, which breaks the layout.
 

--- a/storybook/src/components/Heading/Heading.docs.mdx
+++ b/storybook/src/components/Heading/Heading.docs.mdx
@@ -30,6 +30,9 @@ Use [Margin](/docs/utilities-css-margin--docs) or [Prose](/docs/utilities-css-pr
 
 Use the `size` prop to make a Heading visually larger or smaller, but sparingly and consistently.
 
+The `level` prop picks the `h1` to `h4` element and gives the Heading the appearance that matches that level.
+The `size` prop overrides that appearance without changing the element.
+
 The `level` prop has no default; determine the correct level for each instance.
 Every page should have one Heading with level 1.
 Do not skip levels: a level 2 Heading must be followed by level 3, not level 4.

--- a/storybook/src/components/Image/Image.docs.mdx
+++ b/storybook/src/components/Image/Image.docs.mdx
@@ -25,6 +25,9 @@ The `alt` attribute is required.
 Use `alt=""` for decorative images – images that add little to the nearby text or contribute only to the visual atmosphere of the page.
 Non-decorative images need a text description.
 
+Leaving out `aspectRatio` falls back to the default ratio; no value preserves the proportions of the source file.
+Do not set `loading="lazy"` on an image in the first screenful of the page: there it delays the largest image in the viewport.
+
 ### How to write
 
 Describe the content of the image.
@@ -56,6 +59,8 @@ Optionally specify multiple candidates for the image through the `srcSet` attrib
 For example, provide small, medium, and large variants for various screen sizes.
 This prevents unnecessary downloading of large files.
 Do this especially for the main image of a page, where the difference between sizes on a narrow and wide screen is most significant.
+
+An Image fills the width of its container and always has an aspect ratio, so the browser reserves its box before the file loads and the layout does not shift.
 
 ## Design
 

--- a/storybook/src/components/ImageSlider/ImageSlider.docs.mdx
+++ b/storybook/src/components/ImageSlider/ImageSlider.docs.mdx
@@ -30,6 +30,9 @@ Display all images separately if you want each of them to receive attention.
 
 ### How to use
 
+Each entry in `images` accepts the props of an [Image](/docs/components-media-image--docs), such as `aspectRatio` and `srcSet`, plus an optional `caption`.
+Every image needs its own `alt`.
+
 Provide at least 2 images and at most 5.
 Feature the most essential image first.
 

--- a/storybook/src/components/InvalidFormAlert/InvalidFormAlert.docs.mdx
+++ b/storybook/src/components/InvalidFormAlert/InvalidFormAlert.docs.mdx
@@ -34,6 +34,8 @@ If you do not know which field contains an error, link to the `id` of the first 
 
 For questions that require a user to select one or more options from a list using Radios or Checkboxes, link to the `id` of the first Radio or Checkbox.
 
+Each `id` becomes the `href` of a link, so it needs a leading number sign (`#`).
+
 Put the Invalid Form Alert directly above the first question on the page.
 Place it outside of the `<form>`-tag, [to make sure screen readers do not skip it](https://nldesignsystem.nl/richtlijnen/formulieren/meerdere-stappen/#plaats-de-informatie-over-waar-de-gebruiker-is-in-de-stappen-boven-het-formulier).
 

--- a/storybook/src/components/Label/Label.docs.mdx
+++ b/storybook/src/components/Label/Label.docs.mdx
@@ -28,6 +28,12 @@ Always associate a form element (such as an `input` or `textarea`) with a Label.
 Set `optional` to `true` if the input is not required.
 Use `hint` to show a custom hint text.
 
+Mark the optional fields rather than the required ones, as [the NL Design System guideline on required fields](https://nldesignsystem.nl/richtlijnen/formulieren/voorkom-fouten/verplichte-velden/) recommends.
+A form should ask only what it needs, so most of its fields are required.
+Mark the required fields instead when most fields are optional.
+
+Despite its name, `inFieldSet` has no structural effect: it only changes how the Label and its hint look.
+
 ## Examples
 
 ### Optional
@@ -47,7 +53,7 @@ For the same reason, the default hint text in Dutch is ‘niet verplicht’, not
 
 ### With Heading
 
-If the parent Field is the only content on the page, its Label serves as the main heading as well.
+If the parent Field holds the only question on the page, its Label serves as the main heading as well.
 Set `isPageHeading` to include an `h1` element to reflect this.
 
 <Canvas of={LabelStories.WithHeading} />

--- a/storybook/src/components/Link/Link.docs.mdx
+++ b/storybook/src/components/Link/Link.docs.mdx
@@ -44,6 +44,9 @@ Too many links on the same page may confuse the user.
 Always include `rel="external"` for an external link.
 Avoid `target="_blank"`, but use `rel="external noopener"` if necessary.
 
+Add `download` to ask the browser to save the linked file instead of navigating to it.
+Browsers honour it for same-origin URLs only.
+
 ## Examples
 
 ### On a coloured background

--- a/storybook/src/components/Page/Page.docs.mdx
+++ b/storybook/src/components/Page/Page.docs.mdx
@@ -46,6 +46,8 @@ For elements inside a [Grid Cell](/docs/components-layout-grid--docs) or [Dialog
 The Page is centered horizontally and sets a maximum width of 90 rems (usually 1440 pixels).
 With a Menu, that becomes 120 rems (1920 pixels).
 
+An element placed directly in the Page, outside a [Grid](/docs/components-layout-grid--docs), spans the full width of the Page rather than the full width of the window.
+
 ## See also
 
 - [Page Header](/docs/components-containers-page-header--docs) – sits at the top of the Page.

--- a/storybook/src/components/ProgressList/ProgressList.docs.mdx
+++ b/storybook/src/components/ProgressList/ProgressList.docs.mdx
@@ -55,6 +55,8 @@ Only one step may be `current`; all preceding steps must be `completed`.
 
 Choose a `headingLevel` that fits the document outline.
 
+Nesting a Substeps element inside a step does not set that step’s `hasSubsteps` prop for you: the prop is what tells the CSS to draw the connecting lines correctly.
+
 Use on a white background only.
 
 ## Examples

--- a/storybook/src/components/Radio/Radio.docs.mdx
+++ b/storybook/src/components/Radio/Radio.docs.mdx
@@ -44,6 +44,9 @@ It also increases the chance of submitting a wrong answer.
 
 Wrap a list of Radios in a Field Set so they share a legend and any description or Error Message.
 
+When a group of Radios fails validation, set `invalid` on every Radio in it.
+The group as a whole lacks a valid answer; no single option is at fault.
+
 ### How to write
 
 Labels should be concise.

--- a/storybook/src/components/SearchField/SearchField.docs.mdx
+++ b/storybook/src/components/SearchField/SearchField.docs.mdx
@@ -61,6 +61,8 @@ Use `autofocus` only if the search field is at the beginning of a page and there
 For more information: [Accessibility Tips: Be Cautious When Using Autofocus](https://www.boia.org/blog/accessibility-tips-be-cautious-when-using-autofocus)
 
 Provide a label that describes the purpose of the search.
+There is no way to show that label: the Input always renders it visually hidden.
+A placeholder is therefore the only visible text the field can carry, and it disappears on the first keystroke.
 
 ## Examples
 

--- a/storybook/src/components/Skeleton/Skeleton.docs.mdx
+++ b/storybook/src/components/Skeleton/Skeleton.docs.mdx
@@ -138,6 +138,8 @@ It sits behind a single design token, so a theme can retime it, point it at its 
 
 A Skeleton renders with `aria-hidden="true"`, so screen readers skip the grey blocks entirely.
 Because the loading announcement belongs to the region that is loading rather than to each block, the Skeleton stays silent; the application announces the state once for the region, as shown under ‘How to use’, to meet [WCAG 4.1.3](https://www.w3.org/TR/WCAG22/#status-messages).
+Setting `aria-busy="true"` on that region also permits assistive technology to hold back updates to the status message inside it and deliver them as one update once it turns false.
+The ARIA spec allows this rather than requiring it, so not every screen reader does.
 A Loading Region component to encapsulate that pattern is planned.
 The animation runs only for users who have not asked for reduced motion; everyone else sees the static blocks.
 In forced colours mode, the blocks remain visible through the system colour for disabled text.

--- a/storybook/src/components/SkipLink/SkipLink.docs.mdx
+++ b/storybook/src/components/SkipLink/SkipLink.docs.mdx
@@ -58,6 +58,11 @@ The Skip Link sits above the Page Header and is as wide as the Page container.
 It remains hidden until activated with the ‘Tab’ key.
 After appearing, it pushes the rest of the page down.
 
+## Accessibility
+
+Following a Skip Link moves the starting point for sequential focus navigation to the target, so the next ‘Tab’ press continues from there.
+The target itself does not receive focus, and it does not need to: an `id` is enough, so leave `tabindex` off.
+
 ## See also
 
 - [Page](/docs/components-containers-page--docs) – contains the Skip Link as its first element.

--- a/storybook/src/components/Spotlight/Spotlight.docs.mdx
+++ b/storybook/src/components/Spotlight/Spotlight.docs.mdx
@@ -45,6 +45,17 @@ Use a Spotlight to direct the user’s attention to the most important or action
 
 <Canvas of={SpotlightStories.HighlightContent} />
 
+## Accessibility
+
+Which foreground colour to use depends on the highlight colour behind it.
+Follow [Pairing foreground with background colours](/docs/brand-design-tokens-colour--docs#pairing-foreground-with-background-colours).
+
+On a dark background, set `color="inverse"` on every Heading, Paragraph, and Link inside the Spotlight.
+On a light one, keep the default colour for headings and paragraphs, and set `color="contrast"` on links.
+
+`as="aside"` makes the Spotlight a complementary landmark, and `as="section"` makes it a region once it has an accessible name.
+Point `aria-labelledby` at the `id` of the heading inside the Spotlight to name that landmark, so users of assistive technology can tell it apart from the other landmarks on the page.
+
 ## See also
 
 - [Page](/docs/components-containers-page--docs) – contains the Spotlight.

--- a/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
+++ b/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
@@ -49,6 +49,7 @@ Use a [Link List](/docs/components-navigation-link-list--docs) for a flat group 
 
 Give it a `heading` (such as 'Op deze pagina') and a `headingLevel` that fits the document outline.
 Set `aria-current="page"` on the link for the active section or page to highlight it and announce it to screen readers.
+Pass `undefined` on every other link so the attribute is dropped; `"false"` is valid ARIA but leaves an explicit negative on each of them.
 
 ## Examples
 

--- a/storybook/src/components/TextInput/TextInput.docs.mdx
+++ b/storybook/src/components/TextInput/TextInput.docs.mdx
@@ -60,12 +60,21 @@ The component does apply the correct font and colour for third party websites us
 ### How to use
 
 The width of the Text Input should be appropriate for the information to be entered.
+The `size` attribute sets how many characters are visible; it does not limit how many the user can enter.
 
 Use `spellcheck="false"` for fields that may contain sensitive information, such as personal data.
 Some browser extensions for spell-checking send this information to external servers.
 
+Set `autocorrect="off"` on those fields too.
+Some browsers underline a correctly spelled name, and autocorrection can replace what the user typed.
+Browsers already force autocorrection off for `email`, `url` and `password` inputs, so setting the attribute there only makes it explicit.
+
 Apply automatic assistance where possible.
 For example, in logged-in systems, pre-filling known values can prevent errors and save time.
+
+Set `autocomplete` on every field that collects information about the user.
+Naming the purpose of a field makes it programmatically determinable, which is what [WCAG 1.3.5](https://www.w3.org/TR/WCAG22/#identify-input-purpose) Identify Input Purpose asks for.
+Browsers offering to fill the field in follows from that; it is not the requirement itself.
 
 A Text Input must have a Label, and in most cases, this label should be visible.
 

--- a/storybook/src/pages/internal/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/internal/HomePage/HomePage.stories.tsx
@@ -46,8 +46,9 @@ export const Default: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear. Provide the source by hand so the panel shows a trimmed,
+        // annotated version of the page.
         code: `<Grid paddingBottom="x-large" paddingTop="large">
   {/*
    * appearance="transparent" removes the cell’s background and padding, so the page title sits directly

--- a/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
@@ -114,9 +114,9 @@ export const Default: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments and resolves the interactive state. Provide the source by hand so the guidance stays
-        // visible and the layout reads the way a developer would write it.
+        // Because the `render` of this story lives on the shared meta, its own source is nothing but these parameters,
+        // and that is all the Code Panel would print. Provide the source by hand so the layout reads the way a
+        // developer would write it, without the interactive state.
         code: `<Grid paddingVertical="x-large">
   <Grid.Cell appearance="transparent" span="all">
     <Breadcrumb>

--- a/storybook/src/pages/internal/TablePage/TablePage.stories.tsx
+++ b/storybook/src/pages/internal/TablePage/TablePage.stories.tsx
@@ -53,8 +53,9 @@ export const SortingWithSelect: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, dropping JSX
-        // comments and expanding the map. Provide the source by hand so the guidance stays in the panel.
+        // Because this story’s `render` takes no argument, the Code Panel prints its source as written, sorting
+        // scaffolding and all. Provide the source by hand so the panel shows the table markup on its own, with the
+        // guidance kept short.
         code: `<Grid paddingBottom="x-large" paddingTop="large">
   <Grid.Cell appearance="transparent" span="all">
     <Heading level={1}>Vergunninghouders 2026/2027</Heading>
@@ -230,8 +231,9 @@ export const WithPagination = () => {
 WithPagination.parameters = {
   docs: {
     source: {
-      // The Code Panel regenerates a `render` story’s source from the rendered tree, dropping JSX
-      // comments. Provide the source by hand so the guidance below stays visible in the panel.
+      // Because this story’s `render` takes no argument, the Code Panel prints its source as written, pagination
+      // scaffolding and all. Provide the source by hand so the panel shows the table markup on its own, with the
+      // guidance kept short.
       code: `<Grid paddingBottom="x-large" paddingTop="large">
   <Grid.Cell appearance="transparent" span="all">
     <Heading level={1}>Vergunninghouders 2026/2027</Heading>

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -64,7 +64,6 @@ const meta = {
         <Image
           alt=""
           aspectRatio="16:5"
-          loading="lazy"
           src={exampleImageSource(1440, 450)}
           srcSet={`${exampleImageSource(640, 200)} 640w, ${exampleImageSource(1280, 400)} 1280w, ${exampleImageSource(1440, 450)} 1440w`}
         />
@@ -255,7 +254,6 @@ export const Default: StoryObj = {
     <Image
       alt=""
       aspectRatio="16:5"
-      loading="lazy"
       src="https://picsum.photos/1440/450"
       srcSet="https://picsum.photos/640/200 640w, https://picsum.photos/1280/400 1280w, https://picsum.photos/1440/450 1440w"
     />

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -38,6 +38,7 @@ const meta = {
         </Grid.Cell>
       </Grid>
       {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+      {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
       <main id="inhoud">
         <Grid paddingBottom="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -45,6 +46,7 @@ const meta = {
               Met korting van A naar B op de deelscooter of -bakfiets
             </Heading>
             <Paragraph className="ams-mb-xl">
+              {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
               <time dateTime="2025-07-29">29 juli 2025</time>
             </Paragraph>
             <Paragraph size="large">
@@ -54,9 +56,11 @@ const meta = {
           </Grid.Cell>
         </Grid>
         {/*
-         * A full-width hero image. srcSet lets the browser pick a size for the viewport, loading="lazy" defers
-         * loading until it is near the viewport, and aspectRatio reserves its space so the layout does not jump.
+         * A full-width hero image. srcSet lets the browser pick a size for the viewport, and aspectRatio crops
+         * it to a wide band. It sits in the first screenful, so it is not lazy-loaded: lazy loading suits
+         * images below the top of the page, and here it would delay the largest image in the viewport.
          */}
+        {/* This image carries no information the text does not, so it takes an empty alt. */}
         <Image
           alt=""
           aspectRatio="16:5"
@@ -65,7 +69,14 @@ const meta = {
           srcSet={`${exampleImageSource(640, 200)} 640w, ${exampleImageSource(1280, 400)} 1280w, ${exampleImageSource(1440, 450)} 1440w`}
         />
         <Grid paddingVertical="x-large">
-          {/* ams-prose applies article typography and vertical rhythm to the headings, paragraphs, and links. */}
+          {/*
+           * The body sits in a narrower cell, indented one column on wider screens, for a comfortable reading
+           * measure.
+           */}
+          {/*
+           * ams-prose sets the vertical rhythm between the direct children of this cell: the headings,
+           * paragraphs, and the link list. Typography comes from each component’s own class.
+           */}
           <Grid.Cell
             className="ams-prose"
             span={{ narrow: 4, medium: 6, wide: 7 }}
@@ -122,12 +133,13 @@ const meta = {
           </Grid.Cell>
         </Grid>
       </main>
-      {/* A newsletter call-out set apart as a labelled aside (aria-labelledby) on a green Spotlight. */}
-      {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
+      {/*
+       * A newsletter call-out outside <main>: as="aside" makes it a complementary landmark, and aria-labelledby
+       * names that landmark after the heading below, whose id exists only to be referenced here.
+       */}
       <Spotlight aria-labelledby="blijf-op-de-hoogte" as="aside" color="green">
         <Grid paddingVertical="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-            {/* On the green Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
             <Heading className="ams-mb-s" color="inverse" id="blijf-op-de-hoogte" level={2} size="level-3">
               Blijf op de hoogte!
             </Heading>
@@ -141,7 +153,10 @@ const meta = {
           </Grid.Cell>
         </Grid>
       </Spotlight>
-      {/* Related articles as a labelled aside (Grid as="aside"), outside the article’s <main>. */}
+      {/*
+       * Related articles outside the article’s <main>: as="aside" makes it a complementary landmark, and
+       * aria-labelledby names that landmark after the heading below, whose id exists only to be referenced here.
+       */}
       {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
       <Grid aria-labelledby="meer-nieuws" as="aside" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span="all">
@@ -151,6 +166,7 @@ const meta = {
         </Grid.Cell>
         <Grid.Cell span={4}>
           <Card>
+            {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
             <Card.Image alt="" src={exampleImageSource(640, 360, 1)} />
             <Card.HeadingGroup tagline="Nieuws">
               <Card.Heading level={3}>
@@ -201,8 +217,9 @@ export const Default: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear. Provide the source by hand so the panel shows a trimmed,
+        // annotated version of the page.
         code: `<>
   {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
   <Grid paddingTop="large">
@@ -214,11 +231,13 @@ export const Default: StoryObj = {
     </Grid.Cell>
   </Grid>
   {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+  {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
   <main id="inhoud">
     <Grid paddingBottom="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading className="ams-mb-s" level={1}>Met korting van A naar B op de deelscooter of -bakfiets</Heading>
         <Paragraph className="ams-mb-xl">
+          {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
           <time dateTime="2025-07-29">29 juli 2025</time>
         </Paragraph>
         <Paragraph size="large">
@@ -228,9 +247,11 @@ export const Default: StoryObj = {
       </Grid.Cell>
     </Grid>
     {/*
-     * A full-width hero image. srcSet lets the browser pick a size for the viewport, loading="lazy" defers
-     * loading until it is near the viewport, and aspectRatio reserves its space so the layout does not jump.
+     * A full-width hero image. srcSet lets the browser pick a size for the viewport, and aspectRatio crops
+     * it to a wide band. It sits in the first screenful, so it is not lazy-loaded: lazy loading suits
+     * images below the top of the page, and here it would delay the largest image in the viewport.
      */}
+    {/* This image carries no information the text does not, so it takes an empty alt. */}
     <Image
       alt=""
       aspectRatio="16:5"
@@ -239,7 +260,14 @@ export const Default: StoryObj = {
       srcSet="https://picsum.photos/640/200 640w, https://picsum.photos/1280/400 1280w, https://picsum.photos/1440/450 1440w"
     />
     <Grid paddingVertical="x-large">
-      {/* ams-prose applies article typography and vertical rhythm to the headings, paragraphs, and links. */}
+      {/*
+       * The body sits in a narrower cell, indented one column on wider screens, for a comfortable reading
+       * measure.
+       */}
+      {/*
+       * ams-prose sets the vertical rhythm between the direct children of this cell: the headings,
+       * paragraphs, and the link list. Typography comes from each component’s own class.
+       */}
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
         <Paragraph>
           U kunt gebruikmaken van de kortingsacties via Amsterdam Bereikbaar. De actie geldt voor
@@ -277,12 +305,13 @@ export const Default: StoryObj = {
       </Grid.Cell>
     </Grid>
   </main>
-  {/* A newsletter call-out set apart as a labelled aside (aria-labelledby) on a green Spotlight. */}
-  {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
+  {/*
+   * A newsletter call-out outside <main>: as="aside" makes it a complementary landmark, and aria-labelledby
+   * names that landmark after the heading below, whose id exists only to be referenced here.
+   */}
   <Spotlight aria-labelledby="blijf-op-de-hoogte" as="aside" color="green">
     <Grid paddingVertical="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-        {/* On the green Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
         <Heading className="ams-mb-s" color="inverse" id="blijf-op-de-hoogte" level={2} size="level-3">
           Blijf op de hoogte!
         </Heading>
@@ -293,7 +322,10 @@ export const Default: StoryObj = {
       </Grid.Cell>
     </Grid>
   </Spotlight>
-  {/* Related articles as a labelled aside (Grid as="aside"), outside the article’s <main>. */}
+  {/*
+   * Related articles outside the article’s <main>: as="aside" makes it a complementary landmark, and
+   * aria-labelledby names that landmark after the heading below, whose id exists only to be referenced here.
+   */}
   {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
   <Grid aria-labelledby="meer-nieuws" as="aside" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span="all">
@@ -301,6 +333,7 @@ export const Default: StoryObj = {
     </Grid.Cell>
     <Grid.Cell span={4}>
       <Card>
+        {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
         <Card.Image alt="" src="https://picsum.photos/640/360?random=1" />
         <Card.HeadingGroup tagline="Nieuws">
           <Card.Heading level={3}>

--- a/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
+++ b/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
@@ -56,9 +56,11 @@ export const LandingPage: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear and every `map` is expanded. Provide the source by hand so the panel shows the form
+        // markup on its own, with the accessibility guidance kept short.
         code: `// One Grid for the whole page combines both rules: a paddingTop of large and a paddingBottom of 2x-large.
+// The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content.
 <Grid as="main" id="inhoud" paddingBottom="2x-large" paddingTop="large">
   <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
     <Heading className="ams-mb-m" level={1}>Waar u dit formulier voor gebruikt</Heading>
@@ -67,7 +69,12 @@ export const LandingPage: StoryObj = {
     </Paragraph>
   </Grid.Cell>
   <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-    {/* Show the steps up front so people know what to expect before they start. */}
+    {/*
+     * Listing the steps is a choice, not a rule: GOV.UK asks a start page for what the service does,
+     * what it costs, how long it takes and one call to action, and warns against making it too
+     * complicated. Test whether users need the list, as you would a progress indicator.
+     * See https://design-system.service.gov.uk/patterns/start-using-a-service/
+     */}
     <Heading className="ams-mb-s" level={2}>De stappen in dit formulier</Heading>
     <OrderedList className="ams-mb-l">
       <OrderedList.Item>
@@ -92,6 +99,7 @@ export const LandingPage: StoryObj = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     // One Grid for the whole page combines both rules: a paddingTop of large and a paddingBottom of 2x-large.
+    // The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content.
     <Grid as="main" id="inhoud" paddingBottom="2x-large" paddingTop="large">
       <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading className="ams-mb-m" level={1}>
@@ -102,7 +110,12 @@ export const LandingPage: StoryObj = {
         </Paragraph>
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-        {/* Show the steps up front so people know what to expect before they start. */}
+        {/*
+         * Listing the steps is a choice, not a rule: GOV.UK asks a start page for what the service does,
+         * what it costs, how long it takes and one call to action, and warns against making it too
+         * complicated. Test whether users need the list, as you would a progress indicator.
+         * See https://design-system.service.gov.uk/patterns/start-using-a-service/
+         */}
         <Heading className="ams-mb-s" level={2}>
           De stappen in dit formulier
         </Heading>
@@ -130,51 +143,63 @@ export const SingleQuestion: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear and every `map` is expanded. Provide the source by hand so the panel shows the form
+        // markup on its own, with the accessibility guidance kept short.
         code: `<>
-  {/* The back link is in its own Grid, because it should be outside of the main section. */}
+  {/* Padding is a Grid prop, so the back link needs its own Grid to take the large top padding. */}
   <Grid paddingTop="large">
+    {/* This cell repeats the span and start of the cell below, so the back link lines up with the form. */}
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
-       * A back link lets users move between form pages without worrying about losing their progress. The
-       * browser back button should keep progress too, but users do not always trust it. Use a link, not a
-       * button: multiple submit buttons in a form can cause unexpected behaviour.
-       * See https://design-system.service.gov.uk/components/back-link/ and
-       * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+       * A back link gives users a dependable way back: some sites break the browser back button, so many
+       * users avoid it rather than risk losing their progress, and not all users know it is there. The link
+       * preserves nothing by itself, so return users to the previous page in the state they last saw it.
+       * Use a link, not a button: going back navigates to another page.
+       * See https://design-system.service.gov.uk/components/back-link/
        */}
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
   </Grid>
   {/* The back link is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
+  {/* A form page keeps its header minimal and ships no Skip Link, so this main Grid needs no id. */}
   <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
-       * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
-       * an extra entry to the heading hierarchy – and it stays clearly labelled if CSS fails to load.
+       * The aria-hidden heading stays out of the heading hierarchy, and aria-labelledby re-exposes its text as the
+       * header’s accessible name. That is not a labelled section, though: a header inside main is no landmark –
+       * Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is prohibited
+       * and dropped. Label a landmark instead when a named section is what you need.
        */}
       <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
         <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
         {/*
          * First test the form without a progress indicator to see whether it is simple enough to go without
-         * one. If not, use a plain one like this.
+         * one, and try improving the order, type or number of questions first. Only if people still have
+         * difficulty, add a plain indicator like this, and state a total only if you can do so reliably.
          * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
          */}
         <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
       </header>
       {/*
-       * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
-       * the user too little. Validate on the server and return the result, or use client-side validation.
+       * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
+       * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
+       * (WCAG 3.3.1 Error Identification, level A). Validate on the server and return the result, and add
+       * client-side validation on top of that when there is time to do it well.
        * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
        */}
+      {/* The onSubmit handler only keeps this example from navigating; a real form submits. */}
       <form noValidate onSubmit={(e) => e.preventDefault()}>
-        {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
         <FieldSet
+          // Mark the group required with ARIA. The native required attribute is left off so that nothing here
+          // depends on HTML5 validation.
           aria-required="true"
           className="ams-mb-xl"
           legend="Kies waar u voor wilt langskomen op het Stadsloket"
           // When a page is a single question, treat its legend as the main page heading (h1).
           legendIsPageHeading
+          // Every Radio already carries the ARIA radio role, which is what conveys that only one can be chosen.
+          // This role has the field set announced as a radio group, and it permits the aria-required above.
           role="radiogroup"
         >
           <Column gap="x-small">
@@ -196,15 +221,16 @@ export const SingleQuestion: StoryObj = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
-      {/* The back link is in its own Grid, because it should be outside of the main section. */}
+      {/* Padding is a Grid prop, so the back link needs its own Grid to take the large top padding. */}
       <Grid paddingTop="large">
+        {/* This cell repeats the span and start of the cell below, so the back link lines up with the form. */}
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * A back link lets users move between form pages without worrying about losing their progress. The
-           * browser back button should keep progress too, but users do not always trust it. Use a link, not a
-           * button: multiple submit buttons in a form can cause unexpected behaviour.
-           * See https://design-system.service.gov.uk/components/back-link/ and
-           * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+           * A back link gives users a dependable way back: some sites break the browser back button, so many
+           * users avoid it rather than risk losing their progress, and not all users know it is there. The link
+           * preserves nothing by itself, so return users to the previous page in the state they last saw it.
+           * Use a link, not a button: going back navigates to another page.
+           * See https://design-system.service.gov.uk/components/back-link/
            */}
           <StandaloneLink href="#" icon={ChevronBackwardIcon}>
             Vorige vraag
@@ -212,11 +238,14 @@ export const SingleQuestion: StoryObj = {
         </Grid.Cell>
       </Grid>
       {/* The back link is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
+      {/* A form page keeps its header minimal and ships no Skip Link, so this main Grid needs no id. */}
       <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
-           * an extra entry to the heading hierarchy – and it stays clearly labelled if CSS fails to load.
+           * The aria-hidden heading stays out of the heading hierarchy, and aria-labelledby re-exposes its text as
+           * the header’s accessible name. That is not a labelled section, though: a header inside main is no landmark
+           * – Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is
+           * prohibited and dropped. Label a landmark instead when a named section is what you need.
            */}
           <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
             <Heading aria-hidden id="form-header" level={2} size="level-4">
@@ -224,24 +253,31 @@ export const SingleQuestion: StoryObj = {
             </Heading>
             {/*
              * First test the form without a progress indicator to see whether it is simple enough to go without
-             * one. If not, use a plain one like this.
+             * one, and try improving the order, type or number of questions first. Only if people still have
+             * difficulty, add a plain indicator like this, and state a total only if you can do so reliably.
              * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
              */}
             <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
           </header>
           {/*
-           * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
-           * the user too little. Validate on the server and return the result, or use client-side validation.
+           * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
+           * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
+           * (WCAG 3.3.1 Error Identification, level A). Validate on the server and return the result, and add
+           * client-side validation on top of that when there is time to do it well.
            * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
            */}
+          {/* The onSubmit handler only keeps this example from navigating; a real form submits. */}
           <form noValidate onSubmit={(e) => e.preventDefault()}>
-            {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
             <FieldSet
+              // Mark the group required with ARIA. The native required attribute is left off so that nothing here
+              // depends on HTML5 validation.
               aria-required="true"
               className="ams-mb-xl"
               legend="Kies waar u voor wilt langskomen op het Stadsloket"
               // When a page is a single question, treat its legend as the main page heading (h1).
               legendIsPageHeading
+              // Every Radio already carries the ARIA radio role, which is what conveys that only one can be chosen.
+              // This role has the field set announced as a radio group, and it permits the aria-required above.
               role="radiogroup"
             >
               <Column gap="x-small">
@@ -272,18 +308,20 @@ export const SingleQuestionWithSubquestions: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear and every `map` is expanded. Provide the source by hand so the panel shows the form
+        // markup on its own, with the accessibility guidance kept short.
         code: `<>
-  {/* The back link is in its own Grid, because it should be outside of the main section. */}
+  {/* Padding is a Grid prop, so the back link needs its own Grid to take the large top padding. */}
   <Grid paddingTop="large">
+    {/* This cell repeats the span and start of the cell below, so the back link lines up with the form. */}
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
-       * A back link lets users move between form pages without worrying about losing their progress. The
-       * browser back button should keep progress too, but users do not always trust it. Use a link, not a
-       * button: multiple submit buttons in a form can cause unexpected behaviour.
-       * See https://design-system.service.gov.uk/components/back-link/ and
-       * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+       * A back link gives users a dependable way back: some sites break the browser back button, so many
+       * users avoid it rather than risk losing their progress, and not all users know it is there. The link
+       * preserves nothing by itself, so return users to the previous page in the state they last saw it.
+       * Use a link, not a button: going back navigates to another page.
+       * See https://design-system.service.gov.uk/components/back-link/
        */}
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
@@ -292,34 +330,53 @@ export const SingleQuestionWithSubquestions: StoryObj = {
   <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
-       * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
-       * an extra entry to the heading hierarchy – and it stays clearly labelled if CSS fails to load.
+       * The aria-hidden heading stays out of the heading hierarchy, and aria-labelledby re-exposes its text as the
+       * header’s accessible name. That is not a labelled section, though: a header inside main is no landmark –
+       * Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is prohibited
+       * and dropped. Label a landmark instead when a named section is what you need.
        */}
       <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
         <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
         {/*
          * First test the form without a progress indicator to see whether it is simple enough to go without
-         * one. If not, use a plain one like this.
+         * one, and try improving the order, type or number of questions first. Only if people still have
+         * difficulty, add a plain indicator like this, and state a total only if you can do so reliably.
          * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
          */}
         <Paragraph>Stap 2 van 3: Uw gegevens</Paragraph>
       </header>
       {/*
-       * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
-       * the user too little. Validate on the server and return the result, or use client-side validation.
+       * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
+       * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
+       * (WCAG 3.3.1 Error Identification, level A). Validate on the server and return the result, and add
+       * client-side validation on top of that when there is time to do it well.
        * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
        */}
+      {/* The onSubmit handler only keeps this example from navigating; a real form submits. */}
       <form noValidate onSubmit={(e) => e.preventDefault()}>
-        {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
         <FieldSet legend="Contactgegevens" legendIsPageHeading>
           <Field>
+            {/*
+             * inFieldSet has no structural effect, despite its name: it makes the label lighter and, through the
+             * Hint, greys out ‘(niet verplicht)’. Marking the optional fields is the default, because a form
+             * should ask only what it needs, so most fields are required. Mark the required ones instead when
+             * most fields are optional.
+             * See https://nldesignsystem.nl/richtlijnen/formulieren/voorkom-fouten/verplichte-velden/
+             */}
             <Label htmlFor="email-input" inFieldSet optional>E-mailadres</Label>
             <TextInput
+              // Naming the purpose of a field makes it programmatically determinable, as WCAG 2.2 SC 1.3.5
+              // Identify Input Purpose asks for on fields about the user. Browsers can then offer to fill it in.
               autoComplete="email"
+              // An email address is not prose, so turn spell checking off: it applies to email fields, and
+              // extensions may send what they check to their own servers. Autocorrection does not apply:
+              // browsers force it off for email, url and password inputs, so autocorrect="off" only makes
+              // that explicit. Our Text Input guidance asks only for autocomplete on a phone number.
               autoCorrect="off"
               id="email-input"
               name="email"
-              // A generous size, per https://design-system.service.gov.uk/patterns/email-addresses/#help-users-to-enter-a-valid-email-address
+              // Keep at least 30 characters of an email address visible, per
+              // https://design-system.service.gov.uk/patterns/email-addresses/#help-users-to-enter-a-valid-email-address
               size={30}
               spellCheck="false"
               type="email"
@@ -327,7 +384,7 @@ export const SingleQuestionWithSubquestions: StoryObj = {
           </Field>
           <Field className="ams-mb-xl">
             <Label htmlFor="tel-input" inFieldSet optional>Telefoonnummer</Label>
-            {/* Phone numbers are at most 15 characters (E.164): https://en.wikipedia.org/wiki/E.164 */}
+            {/* size sets the visible width, not a maximum: 15 is the rule of thumb for a phone number. */}
             <TextInput autoComplete="tel" id="tel-input" name="phone" size={15} type="tel" />
           </Field>
         </FieldSet>
@@ -343,15 +400,16 @@ export const SingleQuestionWithSubquestions: StoryObj = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
-      {/* The back link is in its own Grid, because it should be outside of the main section. */}
+      {/* Padding is a Grid prop, so the back link needs its own Grid to take the large top padding. */}
       <Grid paddingTop="large">
+        {/* This cell repeats the span and start of the cell below, so the back link lines up with the form. */}
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * A back link lets users move between form pages without worrying about losing their progress. The
-           * browser back button should keep progress too, but users do not always trust it. Use a link, not a
-           * button: multiple submit buttons in a form can cause unexpected behaviour.
-           * See https://design-system.service.gov.uk/components/back-link/ and
-           * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+           * A back link gives users a dependable way back: some sites break the browser back button, so many
+           * users avoid it rather than risk losing their progress, and not all users know it is there. The link
+           * preserves nothing by itself, so return users to the previous page in the state they last saw it.
+           * Use a link, not a button: going back navigates to another page.
+           * See https://design-system.service.gov.uk/components/back-link/
            */}
           <StandaloneLink href="#" icon={ChevronBackwardIcon}>
             Vorige vraag
@@ -362,8 +420,10 @@ export const SingleQuestionWithSubquestions: StoryObj = {
       <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
-           * an extra entry to the heading hierarchy – and it stays clearly labelled if CSS fails to load.
+           * The aria-hidden heading stays out of the heading hierarchy, and aria-labelledby re-exposes its text as
+           * the header’s accessible name. That is not a labelled section, though: a header inside main is no landmark
+           * – Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is
+           * prohibited and dropped. Label a landmark instead when a named section is what you need.
            */}
           <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
             <Heading aria-hidden id="form-header" level={2} size="level-4">
@@ -371,29 +431,46 @@ export const SingleQuestionWithSubquestions: StoryObj = {
             </Heading>
             {/*
              * First test the form without a progress indicator to see whether it is simple enough to go without
-             * one. If not, use a plain one like this.
+             * one, and try improving the order, type or number of questions first. Only if people still have
+             * difficulty, add a plain indicator like this, and state a total only if you can do so reliably.
              * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
              */}
             <Paragraph>Stap 2 van 3: Uw gegevens</Paragraph>
           </header>
           {/*
-           * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
-           * the user too little. Validate on the server and return the result, or use client-side validation.
+           * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
+           * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
+           * (WCAG 3.3.1 Error Identification, level A). Validate on the server and return the result, and add
+           * client-side validation on top of that when there is time to do it well.
            * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
            */}
+          {/* The onSubmit handler only keeps this example from navigating; a real form submits. */}
           <form noValidate onSubmit={(e) => e.preventDefault()}>
-            {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
             <FieldSet legend="Contactgegevens" legendIsPageHeading>
               <Field>
+                {/*
+                 * inFieldSet has no structural effect, despite its name: it makes the label lighter and, through the
+                 * Hint, greys out ‘(niet verplicht)’. Marking the optional fields is the default, because a form
+                 * should ask only what it needs, so most fields are required. Mark the required ones instead when
+                 * most fields are optional.
+                 * See https://nldesignsystem.nl/richtlijnen/formulieren/voorkom-fouten/verplichte-velden/
+                 */}
                 <Label htmlFor="email-input" inFieldSet optional>
                   E-mailadres
                 </Label>
                 <TextInput
+                  // Naming the purpose of a field makes it programmatically determinable, as WCAG 2.2 SC 1.3.5
+                  // Identify Input Purpose asks for on fields about the user. Browsers can then offer to fill it in.
                   autoComplete="email"
+                  // An email address is not prose, so turn spell checking off: it applies to email fields, and
+                  // extensions may send what they check to their own servers. Autocorrection does not apply:
+                  // browsers force it off for email, url and password inputs, so autocorrect="off" only makes
+                  // that explicit. Our Text Input guidance asks only for autocomplete on a phone number.
                   autoCorrect="off"
                   id="email-input"
                   name="email"
-                  // A generous size, per https://design-system.service.gov.uk/patterns/email-addresses/#help-users-to-enter-a-valid-email-address
+                  // Keep at least 30 characters of an email address visible, per
+                  // https://design-system.service.gov.uk/patterns/email-addresses/#help-users-to-enter-a-valid-email-address
                   size={30}
                   spellCheck="false"
                   type="email"
@@ -403,7 +480,7 @@ export const SingleQuestionWithSubquestions: StoryObj = {
                 <Label htmlFor="tel-input" inFieldSet optional>
                   Telefoonnummer
                 </Label>
-                {/* Phone numbers are at most 15 characters (E.164): https://en.wikipedia.org/wiki/E.164 */}
+                {/* size sets the visible width, not a maximum: 15 is the rule of thumb for a phone number. */}
                 <TextInput autoComplete="tel" id="tel-input" name="phone" size={15} type="tel" />
               </Field>
             </FieldSet>
@@ -420,18 +497,20 @@ export const MultipleQuestions: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear and every `map` is expanded. Provide the source by hand so the panel shows the form
+        // markup on its own, with the accessibility guidance kept short.
         code: `<>
-  {/* The back link is in its own Grid, because it should be outside of the main section. */}
+  {/* Padding is a Grid prop, so the back link needs its own Grid to take the large top padding. */}
   <Grid paddingTop="large">
+    {/* This cell repeats the span and start of the cell below, so the back link lines up with the form. */}
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
-       * A back link lets users move between form pages without worrying about losing their progress. The
-       * browser back button should keep progress too, but users do not always trust it. Use a link, not a
-       * button: multiple submit buttons in a form can cause unexpected behaviour.
-       * See https://design-system.service.gov.uk/components/back-link/ and
-       * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+       * A back link gives users a dependable way back: some sites break the browser back button, so many
+       * users avoid it rather than risk losing their progress, and not all users know it is there. The link
+       * preserves nothing by itself, so return users to the previous page in the state they last saw it.
+       * Use a link, not a button: going back navigates to another page.
+       * See https://design-system.service.gov.uk/components/back-link/
        */}
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
@@ -439,22 +518,47 @@ export const MultipleQuestions: StoryObj = {
   {/* The back link is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
   <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-      {/* A form with multiple questions has a level 1 heading before it that describes the whole group. */}
+      {/*
+       * A form with multiple questions has a level 1 heading that describes the whole group. Placing it before
+       * the form follows GOV.UK’s question pages: a convention, not a requirement, as a form takes no
+       * accessible name from its content anyway. Questions that fit under one legend go in a field set
+       * instead, whose legend is that heading – as the Single Question stories show.
+       * See https://design-system.service.gov.uk/patterns/question-pages/
+       */}
       <Heading className="ams-mb-xl" level={1}>Inschrijven</Heading>
       {/*
-       * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
-       * the user too little. Validate on the server and return the result, or use client-side validation.
+       * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
+       * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
+       * (WCAG 3.3.1 Error Identification, level A). Validate on the server and return the result, and add
+       * client-side validation on top of that when there is time to do it well.
        * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
        */}
+      {/* The onSubmit handler only keeps this example from navigating; a real form submits. */}
       <form noValidate onSubmit={(e) => e.preventDefault()}>
-        {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
         <Field className="ams-mb-l">
           <Label htmlFor="name-input">Naam</Label>
-          <TextInput autoComplete="name" autoCorrect="off" id="name-input" name="name" spellCheck="false" type="text" />
+          <TextInput
+            // Naming the purpose of a field makes it programmatically determinable, as WCAG 2.2 SC 1.3.5
+            // Identify Input Purpose asks for on fields about the user. Browsers can then offer to fill it in.
+            autoComplete="name"
+            // Some browsers underline a correctly spelled name, and autocorrect can replace it. Switching both
+            // off also keeps personal data away from spell checkers that send text to their own servers.
+            // Our Text Input guidance asks only for autocomplete on a phone number.
+            autoCorrect="off"
+            id="name-input"
+            name="name"
+            spellCheck="false"
+            type="text"
+          />
         </Field>
         <Field className="ams-mb-l">
+          {/*
+           * Marking the optional fields is the default, because a form should ask only what it needs, so most
+           * fields are required. Mark the required ones instead when most fields are optional.
+           * See https://nldesignsystem.nl/richtlijnen/formulieren/voorkom-fouten/verplichte-velden/
+           */}
           <Label htmlFor="tel-input" optional>Telefoonnummer</Label>
-          {/* Phone numbers are at most 15 characters (E.164): https://en.wikipedia.org/wiki/E.164 */}
+          {/* size sets the visible width, not a maximum: 15 is the rule of thumb for a phone number. */}
           <TextInput autoComplete="tel" id="tel-input" name="tel" size={15} type="tel" />
         </Field>
         <Field className="ams-mb-xl">
@@ -473,15 +577,16 @@ export const MultipleQuestions: StoryObj = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
-      {/* The back link is in its own Grid, because it should be outside of the main section. */}
+      {/* Padding is a Grid prop, so the back link needs its own Grid to take the large top padding. */}
       <Grid paddingTop="large">
+        {/* This cell repeats the span and start of the cell below, so the back link lines up with the form. */}
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * A back link lets users move between form pages without worrying about losing their progress. The
-           * browser back button should keep progress too, but users do not always trust it. Use a link, not a
-           * button: multiple submit buttons in a form can cause unexpected behaviour.
-           * See https://design-system.service.gov.uk/components/back-link/ and
-           * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+           * A back link gives users a dependable way back: some sites break the browser back button, so many
+           * users avoid it rather than risk losing their progress, and not all users know it is there. The link
+           * preserves nothing by itself, so return users to the previous page in the state they last saw it.
+           * Use a link, not a button: going back navigates to another page.
+           * See https://design-system.service.gov.uk/components/back-link/
            */}
           <StandaloneLink href="#" icon={ChevronBackwardIcon}>
             Vorige vraag
@@ -491,21 +596,34 @@ export const MultipleQuestions: StoryObj = {
       {/* The back link is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
       <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-          {/* A form with multiple questions has a level 1 heading before it that describes the whole group. */}
+          {/*
+           * A form with multiple questions has a level 1 heading that describes the whole group. Placing it before
+           * the form follows GOV.UK’s question pages: a convention, not a requirement, as a form takes no
+           * accessible name from its content anyway. Questions that fit under one legend go in a field set
+           * instead, whose legend is that heading – as the Single Question stories show.
+           * See https://design-system.service.gov.uk/patterns/question-pages/
+           */}
           <Heading className="ams-mb-xl" level={1}>
             Inschrijven
           </Heading>
           {/*
-           * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
-           * the user too little. Validate on the server and return the result, or use client-side validation.
+           * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
+           * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
+           * (WCAG 3.3.1 Error Identification, level A). Validate on the server and return the result, and add
+           * client-side validation on top of that when there is time to do it well.
            * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
            */}
+          {/* The onSubmit handler only keeps this example from navigating; a real form submits. */}
           <form noValidate onSubmit={(e) => e.preventDefault()}>
-            {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
             <Field className="ams-mb-l">
               <Label htmlFor="name-input">Naam</Label>
               <TextInput
+                // Naming the purpose of a field makes it programmatically determinable, as WCAG 2.2 SC 1.3.5
+                // Identify Input Purpose asks for on fields about the user. Browsers can then offer to fill it in.
                 autoComplete="name"
+                // Some browsers underline a correctly spelled name, and autocorrect can replace it. Switching both
+                // off also keeps personal data away from spell checkers that send text to their own servers.
+                // Our Text Input guidance asks only for autocomplete on a phone number.
                 autoCorrect="off"
                 id="name-input"
                 name="name"
@@ -514,10 +632,15 @@ export const MultipleQuestions: StoryObj = {
               />
             </Field>
             <Field className="ams-mb-l">
+              {/*
+               * Marking the optional fields is the default, because a form should ask only what it needs, so most
+               * fields are required. Mark the required ones instead when most fields are optional.
+               * See https://nldesignsystem.nl/richtlijnen/formulieren/voorkom-fouten/verplichte-velden/
+               */}
               <Label htmlFor="tel-input" optional>
                 Telefoonnummer
               </Label>
-              {/* Phone numbers are at most 15 characters (E.164): https://en.wikipedia.org/wiki/E.164 */}
+              {/* size sets the visible width, not a maximum: 15 is the rule of thumb for a phone number. */}
               <TextInput autoComplete="tel" id="tel-input" name="tel" size={15} type="tel" />
             </Field>
             <Field className="ams-mb-xl">
@@ -537,18 +660,20 @@ export const WithValidationError: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear and every `map` is expanded. Provide the source by hand so the panel shows the form
+        // markup on its own, with the accessibility guidance kept short.
         code: `<>
-  {/* The back link is in its own Grid, because it should be outside of the main section. */}
+  {/* Padding is a Grid prop, so the back link needs its own Grid to take the large top padding. */}
   <Grid paddingTop="large">
+    {/* This cell repeats the span and start of the cell below, so the back link lines up with the form. */}
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
-       * A back link lets users move between form pages without worrying about losing their progress. The
-       * browser back button should keep progress too, but users do not always trust it. Use a link, not a
-       * button: multiple submit buttons in a form can cause unexpected behaviour.
-       * See https://design-system.service.gov.uk/components/back-link/ and
-       * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+       * A back link gives users a dependable way back: some sites break the browser back button, so many
+       * users avoid it rather than risk losing their progress, and not all users know it is there. The link
+       * preserves nothing by itself, so return users to the previous page in the state they last saw it.
+       * Use a link, not a button: going back navigates to another page.
+       * See https://design-system.service.gov.uk/components/back-link/
        */}
       <StandaloneLink href="#" icon={ChevronBackwardIcon}>Vorige vraag</StandaloneLink>
     </Grid.Cell>
@@ -557,50 +682,67 @@ export const WithValidationError: StoryObj = {
   <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
-       * Notifying a user of errors is threefold:
-       * - Add the error count to the document title, so a screen reader announces it first.
-       * - Show the Invalid Form Alert at the top of the main container.
+       * If answers fail validation, notify the user in four ways:
+       * - Show the page again, with the fields as the user filled them in.
+       * - Show the Invalid Form Alert at the top of the main container. It takes focus as it appears, so a
+       *   screen reader reads it out first.
+       * - Prefix the document title with the error count, so a screen reader reads it out when the page loads
+       *   after server-side validation. The Invalid Form Alert does this by itself.
        * - Add error messages next to the relevant form fields.
-       * See https://designsystem.amsterdam/?path=/docs/components-forms-invalid-form-alert--docs
+       * See https://design-system.service.gov.uk/patterns/validation/#how-to-tell-the-user-about-validation-errors
        */}
       <InvalidFormAlert
         className="ams-mb-m"
+        // Each id becomes the href of a link, so it needs the leading number sign. It points at the first
+        // Radio, whose id sits on the input element, so following it moves focus to an answerable control –
+        // though, unlike GOV.UK’s error summary, nothing scrolls the legend and error message into view first.
         errors={[{ id: '#passport-id-driving-license', label: 'Geef aan waar u voor wilt langskomen.' }]}
+        // The legend of the field set below is the page’s h1, so this heading is a level 2.
         headingLevel={2}
       />
       {/*
-       * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
-       * an extra entry to the heading hierarchy – and it stays clearly labelled if CSS fails to load.
+       * The aria-hidden heading stays out of the heading hierarchy, and aria-labelledby re-exposes its text as the
+       * header’s accessible name. That is not a labelled section, though: a header inside main is no landmark –
+       * Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is prohibited
+       * and dropped. Label a landmark instead when a named section is what you need.
        */}
       <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
         <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
         {/*
          * First test the form without a progress indicator to see whether it is simple enough to go without
-         * one. If not, use a plain one like this.
+         * one, and try improving the order, type or number of questions first. Only if people still have
+         * difficulty, add a plain indicator like this, and state a total only if you can do so reliably.
          * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
          */}
         <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
       </header>
       {/*
-       * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
-       * the user too little. Validate on the server and return the result, or use client-side validation.
+       * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
+       * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
+       * (WCAG 3.3.1 Error Identification, level A). Validate on the server and return the result, and add
+       * client-side validation on top of that when there is time to do it well.
        * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
        */}
+      {/* The onSubmit handler only keeps this example from navigating; a real form submits. */}
       <form noValidate onSubmit={(e) => e.preventDefault()}>
-        {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
         <FieldSet
-          // Only link the error message to the field set while the message is in the DOM. Referencing a
-          // non-existent element can trip up accessibility evaluation tools.
+          // Only link the error message to the field set while the message is in the DOM. Browsers ignore
+          // a reference to a missing element, but some evaluation tools flag it for review.
           aria-describedby="error"
+          // Mark the group required with ARIA. The native required attribute is left off so that nothing here
+          // depends on HTML5 validation.
           aria-required="true"
           className="ams-mb-xl"
           invalid
           legend="Kies waar u voor wilt langskomen op het Stadsloket"
           // When a page is a single question, treat its legend as the main page heading (h1).
           legendIsPageHeading
+          // Every Radio already carries the ARIA radio role, which is what conveys that only one can be chosen.
+          // This role has the field set announced as a radio group, and it permits the aria-required above.
           role="radiogroup"
         >
           <ErrorMessage id="error">Geef aan waar u voor wilt langskomen.</ErrorMessage>
+          {/* All Radios turn red: it is the group that lacks an answer, not the option the alert links to. */}
           <Column gap="x-small">
             <Radio aria-required="true" id="passport-id-driving-license" invalid name="reasonForVisit" value="passport-id-driving-license">Paspoort / ID / Rijbewijs</Radio>
             <Radio aria-required="true" invalid name="reasonForVisit" value="permits">Vergunningen</Radio>
@@ -620,15 +762,16 @@ export const WithValidationError: StoryObj = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
-      {/* The back link is in its own Grid, because it should be outside of the main section. */}
+      {/* Padding is a Grid prop, so the back link needs its own Grid to take the large top padding. */}
       <Grid paddingTop="large">
+        {/* This cell repeats the span and start of the cell below, so the back link lines up with the form. */}
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * A back link lets users move between form pages without worrying about losing their progress. The
-           * browser back button should keep progress too, but users do not always trust it. Use a link, not a
-           * button: multiple submit buttons in a form can cause unexpected behaviour.
-           * See https://design-system.service.gov.uk/components/back-link/ and
-           * https://adamsilver.io/blog/forms-with-multiple-submit-buttons-are-problematic/
+           * A back link gives users a dependable way back: some sites break the browser back button, so many
+           * users avoid it rather than risk losing their progress, and not all users know it is there. The link
+           * preserves nothing by itself, so return users to the previous page in the state they last saw it.
+           * Use a link, not a button: going back navigates to another page.
+           * See https://design-system.service.gov.uk/components/back-link/
            */}
           <StandaloneLink href="#" icon={ChevronBackwardIcon}>
             Vorige vraag
@@ -639,20 +782,29 @@ export const WithValidationError: StoryObj = {
       <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * Notifying a user of errors is threefold:
-           * - Add the error count to the document title, so a screen reader announces it first.
-           * - Show the Invalid Form Alert at the top of the main container.
+           * If answers fail validation, notify the user in four ways:
+           * - Show the page again, with the fields as the user filled them in.
+           * - Show the Invalid Form Alert at the top of the main container. It takes focus as it appears, so a
+           *   screen reader reads it out first.
+           * - Prefix the document title with the error count, so a screen reader reads it out when the page loads
+           *   after server-side validation. The Invalid Form Alert does this by itself.
            * - Add error messages next to the relevant form fields.
-           * See https://designsystem.amsterdam/?path=/docs/components-forms-invalid-form-alert--docs
+           * See https://design-system.service.gov.uk/patterns/validation/#how-to-tell-the-user-about-validation-errors
            */}
           <InvalidFormAlert
             className="ams-mb-m"
+            // Each id becomes the href of a link, so it needs the leading number sign. It points at the first
+            // Radio, whose id sits on the input element, so following it moves focus to an answerable control –
+            // though, unlike GOV.UK’s error summary, nothing scrolls the legend and error message into view first.
             errors={[{ id: '#passport-id-driving-license', label: 'Geef aan waar u voor wilt langskomen.' }]}
+            // The legend of the field set below is the page’s h1, so this heading is a level 2.
             headingLevel={2}
           />
           {/*
-           * A header labelled by an aria-hidden heading gives screen readers a labelled section without adding
-           * an extra entry to the heading hierarchy – and it stays clearly labelled if CSS fails to load.
+           * The aria-hidden heading stays out of the heading hierarchy, and aria-labelledby re-exposes its text as
+           * the header’s accessible name. That is not a labelled section, though: a header inside main is no landmark
+           * – Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is
+           * prohibited and dropped. Label a landmark instead when a named section is what you need.
            */}
           <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
             <Heading aria-hidden id="form-header" level={2} size="level-4">
@@ -660,31 +812,39 @@ export const WithValidationError: StoryObj = {
             </Heading>
             {/*
              * First test the form without a progress indicator to see whether it is simple enough to go without
-             * one. If not, use a plain one like this.
+             * one, and try improving the order, type or number of questions first. Only if people still have
+             * difficulty, add a plain indicator like this, and state a total only if you can do so reliably.
              * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
              */}
             <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
           </header>
           {/*
-           * Do not rely on HTML5 form validation: it is inconsistent across browsers and devices and often tells
-           * the user too little. Validate on the server and return the result, or use client-side validation.
+           * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
+           * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
+           * (WCAG 3.3.1 Error Identification, level A). Validate on the server and return the result, and add
+           * client-side validation on top of that when there is time to do it well.
            * See https://nldesignsystem.nl/richtlijnen/formulieren/foutmeldingen/html-formuliervalidatie/#gebruik-geen-html-formuliervalidatie
            */}
+          {/* The onSubmit handler only keeps this example from navigating; a real form submits. */}
           <form noValidate onSubmit={(e) => e.preventDefault()}>
-            {/* See the docs on each form component on https://designsystem.amsterdam for how to use them. */}
             <FieldSet
-              // Only link the error message to the field set while the message is in the DOM. Referencing a
-              // non-existent element can trip up accessibility evaluation tools.
+              // Only link the error message to the field set while the message is in the DOM. Browsers ignore
+              // a reference to a missing element, but some evaluation tools flag it for review.
               aria-describedby="error"
+              // Mark the group required with ARIA. The native required attribute is left off so that nothing here
+              // depends on HTML5 validation.
               aria-required="true"
               className="ams-mb-xl"
               invalid
               legend="Kies waar u voor wilt langskomen op het Stadsloket"
               // When a page is a single question, treat its legend as the main page heading (h1).
               legendIsPageHeading
+              // Every Radio already carries the ARIA radio role, which is what conveys that only one can be chosen.
+              // This role has the field set announced as a radio group, and it permits the aria-required above.
               role="radiogroup"
             >
               <ErrorMessage id="error">Geef aan waar u voor wilt langskomen.</ErrorMessage>
+              {/* All Radios turn red: it is the group that lacks an answer, not the option the alert links to. */}
               <Column gap="x-small">
                 <Radio
                   aria-required="true"

--- a/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.stories.tsx
@@ -19,6 +19,9 @@ const meta = {
   title: 'Pages/Public/Handbook Page',
   parameters: {
     ...commonMeta.parameters,
+    // Of the templates that use the shared public Page Layout, this is the only one that overrides its single
+    // Skip Link: a reader may want to reach either the Table of Contents or the content. Each targetId matches
+    // an id in the story below.
     skipLinks: [
       { label: 'Direct naar de inhoudsopgave', targetId: 'inhoudsopgave' },
       { label: 'Direct naar de inhoud', targetId: 'inhoud' },
@@ -51,6 +54,10 @@ type RenderTocOptions = {
 const renderTocList = (list: Array<HandbookPage>, options: RenderTocOptions) => (
   <TableOfContents.List>
     {list.map((page) => (
+      /*
+       * aria-current="page" marks the entry for the page on screen. Everything else gets undefined, which
+       * drops the attribute; 'false' would be valid ARIA but leaves an explicit negative on every other link.
+       */
       <TableOfContents.Link
         aria-current={page.slug === options.currentSlug ? 'page' : undefined}
         expanded={options.expandedSlugs.has(page.slug)}
@@ -70,13 +77,23 @@ export const Default: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // A `render` without arguments prints the story’s own source, including its state and handlers.
-        // Provide the source by hand so the panel shows the markup to compose, without that scaffolding.
-        code: `// handleSelect sets the current page; handleToggle opens and closes a branch. Both keep the Table of Contents controlled.
+        // Because this story’s `render` takes no argument, the Code Panel prints its source as written, state and
+        // handlers and all. Provide the source by hand so the panel shows the markup to compose, without that
+        // scaffolding.
+        code: `// A snapshot of one moment: expanded and aria-current are written out here, but a real page binds them
+// to state. Both handlers need the link’s own slug, so bind it per link: onClick={(event) => handleSelect(event, slug)}
+// and onToggle={(expanded) => handleToggle(slug, expanded)} — onToggle receives only the new expanded state.
 
 // One Grid for the whole page combines both rules: a paddingTop of large and a paddingBottom of 2x-large.
 <Grid paddingBottom="2x-large" paddingTop="large">
   <Grid.Cell span={{ narrow: 4, medium: 3, wide: 4 }}>
+    {/*
+     * Controlled Table of Contents: collapsible is the capability, expanded and onToggle the state, so the
+     * branch of the current page stays open as the reader moves through the document. Focus stays on the
+     * activated link, though not because of preventDefault: these hrefs point at ids that exist nowhere on
+     * the page, so the browser finds no fragment target and leaves focus where it is.
+     */}
+    {/* The two Skip Links this page declares in its meta target this id and the one on <main> below. */}
     <TableOfContents collapsible heading="Inhoudsopgave" id="inhoudsopgave">
       <TableOfContents.List>
         <TableOfContents.Link href="#s1" label="Inleiding" onClick={handleSelect} />
@@ -97,6 +114,11 @@ export const Default: StoryObj = {
               onToggle={handleToggle}
             >
               <TableOfContents.List>
+                {/*
+                 * aria-current="page" marks the entry for the page on screen. Everything else gets undefined,
+                 * which drops the attribute; 'false' would be valid ARIA but leaves an explicit negative on
+                 * every other link.
+                 */}
                 <TableOfContents.Link aria-current="page" href="#s2-2-1" label="Methode" onClick={handleSelect} />
                 <TableOfContents.Link href="#s2-2-2" label="Procedure" onClick={handleSelect} />
                 {/* … a Bezwaar page … */}
@@ -131,6 +153,14 @@ export const Default: StoryObj = {
     const [expandedSlugs, setExpandedSlugs] = useState(() => branchFor(initialSlug))
 
     const handleSelect = (event: MouseEvent<HTMLAnchorElement>, slug: string) => {
+      // preventDefault is here because the story has no router: the handler swaps the page in local state
+      // instead of letting the browser act on the href, and the hrefs (#s1, #s2-2-1) point at ids that exist
+      // nowhere on this page. In a real page, keep preventDefault only if you pair it with client-side routing
+      // (a history push, or a router component passed via linkComponent), and drop it if the hrefs are real
+      // URLs. Copied as is, the handler does break the links: the content swaps, but the URL, the back button
+      // and deep links do not follow, and because preventDefault runs unconditionally, cmd, ctrl and
+      // shift-click no longer open a section in a new tab. The internal Table Page guards for those before
+      // preventing the default.
       event.preventDefault()
       setCurrentSlug(slug)
       setExpandedSlugs((slugs) => new Set([...slugs, ...branchFor(slug)]))
@@ -156,6 +186,13 @@ export const Default: StoryObj = {
       /* One Grid for the whole page combines both rules: a paddingTop of large and a paddingBottom of 2x-large. */
       <Grid paddingBottom="2x-large" paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 3, wide: 4 }}>
+          {/*
+           * Controlled Table of Contents: collapsible is the capability, expanded and onToggle the state, so the
+           * branch of the current page stays open as the reader moves through the document. Focus stays on the
+           * activated link, though not because of preventDefault: these hrefs point at ids that exist nowhere on
+           * the page, so the browser finds no fragment target and leaves focus where it is.
+           */}
+          {/* The two Skip Links this page declares in its meta target this id and the one on <main> below. */}
           <TableOfContents collapsible heading="Inhoudsopgave" id="inhoudsopgave">
             {renderTocList(pages, { currentSlug, expandedSlugs, onSelect: handleSelect, onToggle: handleToggle })}
           </TableOfContents>

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -16,6 +16,7 @@ const meta = {
   title: 'Pages/Public/Home Page',
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args: unknown) => (
+    // The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content.
     <main id="inhoud">
       {/*
        * The homepage’s visible headings start at the section level, so give the page one visually hidden
@@ -23,6 +24,10 @@ const meta = {
        */}
       <h1 className="ams-visually-hidden">Homepage van de gemeente Amsterdam</h1>
       {/* A hero that overlaps a full-width image with the block beneath it – see the Overlap component. */}
+      {/*
+       * The hero content comes from the Overlap component’s own story: reading its args.children breaks
+       * silently if that story ever switches to a render function, leaving this hero empty.
+       */}
       <Overlap>{OverlapStory.args?.children}</Overlap>
       <Grid paddingVertical="x-large">
         <Grid.Cell span="all">
@@ -31,6 +36,13 @@ const meta = {
             {topTaskSection.title}
           </Heading>
         </Grid.Cell>
+        {/*
+         * Cells flow from the left in source order, so no section here needs a start. On the wide grid the top
+         * tasks fit four to a row at {{ narrow: 4, medium: 4, wide: 3 }} and three preview cards at span={4}
+         * fill the row exactly; on the medium grid both drop to two per row, and on the narrow grid every cell
+         * is full width. The two Spotlight blocks at {{ narrow: 4, medium: 4, wide: 6 }} sit side by side on
+         * both the wide and medium grids, and stack on the narrow one.
+         */}
         {topTaskSection.tasks.map(({ title, description }) => (
           <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
             <Card>
@@ -43,12 +55,14 @@ const meta = {
           </Grid.Cell>
         ))}
       </Grid>
-      {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
+      {/*
+       * These highlights are part of the homepage’s own content, so the Spotlight stays a plain band inside <main>.
+       * On the Article Page the same band sits outside <main> as an as="aside" landmark beside the article.
+       */}
       <Spotlight>
         <Grid paddingVertical="x-large">
           {spotlightSections.map(({ title, description, link }) => (
             <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 6 }}>
-              {/* On the dark Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
               <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
                 {title}
               </Heading>
@@ -72,6 +86,7 @@ const meta = {
         {newsSection.items.map(({ title, description, image }) => (
           <Grid.Cell key={title} span={4}>
             <Card>
+              {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
               <Card.Image alt="" src={image} />
               {/* Card.HeadingGroup adds a short tagline above the Card’s heading. */}
               <Card.HeadingGroup tagline="Nieuws">
@@ -94,10 +109,11 @@ export const Default: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments and expands each `map`. Provide the source by hand so the guidance below stays
-        // visible in the panel.
-        code: `<main id="inhoud">
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear and every `map` is expanded. Provide the source by hand so the page reads the way a
+        // developer would write it.
+        code: `// The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content.
+<main id="inhoud">
   {/*
    * The homepage’s visible headings start at the section level, so give the page one visually hidden
    * h1. Screen readers still announce a page title and the heading outline keeps a single top level.
@@ -110,6 +126,13 @@ export const Default: StoryObj = {
       {/* Second level in the outline (the hidden h1 is first), shown at the largest size. */}
       <Heading level={2} size="level-1">{topTaskSection.title}</Heading>
     </Grid.Cell>
+    {/*
+     * Cells flow from the left in source order, so no section here needs a start. On the wide grid the top
+     * tasks fit four to a row at {{ narrow: 4, medium: 4, wide: 3 }} and three preview cards at span={4}
+     * fill the row exactly; on the medium grid both drop to two per row, and on the narrow grid every cell
+     * is full width. The two Spotlight blocks at {{ narrow: 4, medium: 4, wide: 6 }} sit side by side on
+     * both the wide and medium grids, and stack on the narrow one.
+     */}
     {topTaskSection.tasks.map(({ title, description }) => (
       <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
         <Card>
@@ -122,12 +145,14 @@ export const Default: StoryObj = {
       </Grid.Cell>
     ))}
   </Grid>
-  {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
+  {/*
+   * These highlights are part of the homepage’s own content, so the Spotlight stays a plain band inside <main>.
+   * On the Article Page the same band sits outside <main> as an as="aside" landmark beside the article.
+   */}
   <Spotlight>
     <Grid paddingVertical="x-large">
       {spotlightSections.map(({ title, description, link }) => (
         <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 6 }}>
-          {/* On the dark Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
           <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">{title}</Heading>
           <Paragraph className="ams-mb-m" color="inverse">{description}</Paragraph>
           <StandaloneLink color="inverse" href="#">{link}</StandaloneLink>
@@ -143,6 +168,7 @@ export const Default: StoryObj = {
     {newsSection.items.map(({ title, description, image }) => (
       <Grid.Cell key={title} span={4}>
         <Card>
+          {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
           <Card.Image alt="" src={image} />
           {/* Card.HeadingGroup adds a short tagline above the Card’s heading. */}
           <Card.HeadingGroup tagline="Nieuws">

--- a/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
+++ b/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
@@ -50,6 +50,7 @@ type Phase = 'idle' | 'loaded' | 'loading'
 
 type LoadingPageArgs = { readonly initialPhase: Phase }
 
+// The Skeletons and the Cards share one span, so the placeholders cannot drift from the cells they stand in for.
 const cellSpan = { narrow: 4, medium: 4, wide: 4 } as const
 
 const meta = {
@@ -98,12 +99,21 @@ const meta = {
           : ''
 
     return (
+      // The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content.
+      // This page has two Grids in one landmark, so a plain <main> wraps them both. A page that is a single
+      // section can put as="main" on the Grid itself instead.
       <main id="inhoud">
         {/* The first Grid holds the search field instead of a breadcrumb, so it still takes the large top padding. */}
         <Grid paddingTop="large">
+          {/* Search is not a content page, so the title spans the full width, not the documented header cell. */}
           <Grid.Cell span="all">
             <Heading level={1}>Zoeken op amsterdam.nl</Heading>
           </Grid.Cell>
+          {/*
+           * The search field spans half the grid on wide screens rather than the documented header cell width, so
+           * the input does not stretch to an unusable length. It takes three quarters of the grid at medium and
+           * the full width at narrow.
+           */}
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }}>
             <SearchField onSubmit={search}>
               <SearchField.Input defaultValue={initialQuery} label="Zoek op de website" name="search" />
@@ -115,16 +125,21 @@ const meta = {
         {/*
          * Mark the whole results region busy while it loads and let it announce once, rather than once per
          * Skeleton – which would repeat the message for every card. The Skeletons are hidden from assistive
-         * technologies, so this region is all a screen reader hears.
+         * technologies, so this region is all a screen reader hears. Be aware that aria-busy="true" also
+         * permits assistive technology to hold back updates from the live region below and deliver them as
+         * one atomic update once it turns false. The ARIA spec allows this rather than requiring it, so not
+         * every screen reader does.
          */}
         {/* The search field is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
         {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
         <Grid aria-busy={phase === 'loading'} paddingBottom="2x-large" paddingTop="x-large">
           <Grid.Cell span="all">
             {/*
-             * Keep one status message in the DOM at all times and only change its text – from a loading
-             * message to the result count – so screen readers reliably announce the update. A Loading Region
-             * component to wrap this pattern is planned; until then it is plain HTML.
+             * Keep one status message in the DOM at all times and only change its text – from a loading message
+             * to the result count. A live region inserted together with its text is announced inconsistently
+             * across screen readers and browsers, so an always-present region is the more robust pattern. No
+             * component wraps this pattern yet, so the Grid carries the busy state and the message is a visually
+             * hidden <p>.
              */}
             <p className="ams-visually-hidden" role="status">
               {status}
@@ -138,7 +153,10 @@ const meta = {
           {/*
            * Compose each Skeleton from the same parts, in the same Grid cell, as the Card that will replace
            * it: an image of the same aspect ratio, a heading, and two paragraph lines for the description.
-           * Mirroring the shape keeps the layout from shifting when the real content arrives.
+           * Mirroring the shape keeps the layout shift small, but does not remove it: Skeleton.Heading is
+           * fixed to the Heading 2 size while this Card’s heading is level-3, the Skeleton spaces all its
+           * parts alike where the Card sets a smaller margin below its heading, and real headings and
+           * descriptions wrap onto more lines in these narrow cells than the placeholders show.
            */}
           {phase === 'loading' &&
             results.map((_, index) => (
@@ -155,6 +173,7 @@ const meta = {
             results.map((result) => (
               <Grid.Cell key={result.heading} span={cellSpan}>
                 <Card>
+                  {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
                   <Card.Image alt="" aspectRatio="16:9" src={result.imageSrc} />
                   <Card.Heading level={3}>
                     <Card.Link href="#">{result.heading}</Card.Link>
@@ -180,12 +199,24 @@ type PageSourceOptions = {
   statusCell?: string
 }
 
-const pageShell = ({ busy, extraCells = '', status, statusCell = '' }: PageSourceOptions) => `<main id="inhoud">
+const pageShell = ({ busy, extraCells = '', status, statusCell = '' }: PageSourceOptions) =>
+  `{/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
+{/*
+ * This page has two Grids in one landmark, so a plain <main> wraps them both. A page that is a single
+ * section can put as="main" on the Grid itself instead.
+ */}
+<main id="inhoud">
   {/* The first Grid holds the search field instead of a breadcrumb, so it still takes the large top padding. */}
   <Grid paddingTop="large">
+    {/* Search is not a content page, so the title spans the full width, not the documented header cell. */}
     <Grid.Cell span="all">
       <Heading level={1}>Zoeken op amsterdam.nl</Heading>
     </Grid.Cell>
+    {/*
+     * The search field spans half the grid on wide screens rather than the documented header cell width, so
+     * the input does not stretch to an unusable length. It takes three quarters of the grid at medium and
+     * the full width at narrow.
+     */}
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 6 }}>
       <SearchField onSubmit={search}>
         <SearchField.Input defaultValue="woningbouw" label="Zoek op de website" name="search" />
@@ -197,24 +228,30 @@ const pageShell = ({ busy, extraCells = '', status, statusCell = '' }: PageSourc
   {/*
    * Mark the whole results region busy while it loads and let it announce once, rather than once per
    * Skeleton – which would repeat the message for every card. The Skeletons are hidden from assistive
-   * technologies, so this region is all a screen reader hears.
+   * technologies, so this region is all a screen reader hears. Be aware that aria-busy="true" also
+   * permits assistive technology to hold back updates from the live region below and deliver them as
+   * one atomic update once it turns false. The ARIA spec allows this rather than requiring it, so not
+   * every screen reader does.
    */}
   {/* The search field is not a Breadcrumb, so this Grid keeps the regular x-large top padding. */}
   {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
   <Grid aria-busy={${busy}} paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span="all">
       {/*
-       * Keep one status message in the DOM at all times and only change its text – from a loading
-       * message to the result count – so screen readers reliably announce the update. A Loading Region
-       * component to wrap this pattern is planned; until then it is plain HTML.
+       * Keep one status message in the DOM at all times and only change its text – from a loading message
+       * to the result count. A live region inserted together with its text is announced inconsistently
+       * across screen readers and browsers, so an always-present region is the more robust pattern. No
+       * component wraps this pattern yet, so the Grid carries the busy state and the message is a visually
+       * hidden <p>.
        */}
       <p className="ams-visually-hidden" role="status">${status}</p>${statusCell}
     </Grid.Cell>${extraCells}
   </Grid>
 </main>`
 
-// The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-// comments. Provide the source by hand so the guidance above the results region stays visible.
+// Because these stories’ `render` takes an argument, the Code Panel rebuilds their source from the rendered tree:
+// JSX comments disappear and every `map` is expanded. Provide the source by hand so each story shows its own phase as
+// plain markup, without the state that switches between them.
 const idleSource = pageShell({
   busy: 'false',
   status: '',
@@ -229,7 +266,10 @@ const loadingSource = pageShell({
     {/*
      * Compose each Skeleton from the same parts, in the same Grid cell, as the Card that will replace
      * it: an image of the same aspect ratio, a heading, and two paragraph lines for the description.
-     * Mirroring the shape keeps the layout from shifting when the real content arrives.
+     * Mirroring the shape keeps the layout shift small, but does not remove it: Skeleton.Heading is
+     * fixed to the Heading 2 size while this Card’s heading is level-3, the Skeleton spaces all its
+     * parts alike where the Card sets a smaller margin below its heading, and real headings and
+     * descriptions wrap onto more lines in these narrow cells than the placeholders show.
      */}
     <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
       <Skeleton>
@@ -248,6 +288,7 @@ const loadedSource = pageShell({
 
     <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
       <Card>
+        {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
         <Card.Image alt="" aspectRatio="16:9" src="https://picsum.photos/id/1015/640/360" />
         <Card.Heading level={3}>
           <Card.Link href="#">Nederlands eerste houten woonwijk komt in Zuidoost</Card.Link>

--- a/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
+++ b/storybook/src/pages/public/LoadingPage/LoadingPage.stories.tsx
@@ -200,11 +200,9 @@ type PageSourceOptions = {
 }
 
 const pageShell = ({ busy, extraCells = '', status, statusCell = '' }: PageSourceOptions) =>
-  `{/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
-{/*
- * This page has two Grids in one landmark, so a plain <main> wraps them both. A page that is a single
- * section can put as="main" on the Grid itself instead.
- */}
+  `// The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content.
+// This page has two Grids in one landmark, so a plain <main> wraps them both. A page that is a single
+// section can put as="main" on the Grid itself instead.
 <main id="inhoud">
   {/* The first Grid holds the search field instead of a breadcrumb, so it still takes the large top padding. */}
   <Grid paddingTop="large">

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -3,7 +3,6 @@
  * Copyright Gemeente Amsterdam
  */
 
-import type { GridColumnNumbers } from '@amsterdam/design-system-react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import {
@@ -55,12 +54,13 @@ export const Default: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear and every `map` is expanded. Provide the source by hand so the `map` and `getLinks`
+        // patterns read the way a developer would write them.
         code: `// getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
 
 <>
-  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  {/* Public page templates keep the Breadcrumb in its own Grid above <main>, so its nav sits outside it. */}
   <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Breadcrumb>
@@ -70,6 +70,12 @@ export const Default: StoryObj = {
   </Grid>
   {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
   {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+  {/*
+   * The main region here is a single section, so the Grid itself is that region. When the landmark has
+   * to hold several sections — more Grids, a Spotlight, a full-bleed image — wrap them in a plain
+   * <main> instead. Beside a sidebar, <main> goes in its own Grid Cell.
+   */}
+  {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
   <Grid as="main" id="inhoud" paddingBottom="2x-large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Heading className="ams-mb-m" level={1}>Burgerzaken</Heading>
@@ -99,7 +105,7 @@ export const Default: StoryObj = {
   render: (args) => (
     // getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
     <>
-      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+      {/* Public page templates keep the Breadcrumb in its own Grid above <main>, so its nav sits outside it. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -109,6 +115,12 @@ export const Default: StoryObj = {
       </Grid>
       {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
       {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+      {/*
+       * The main region here is a single section, so the Grid itself is that region. When the landmark has
+       * to hold several sections — more Grids, a Spotlight, a full-bleed image — wrap them in a plain
+       * <main> instead. Beside a sidebar, <main> goes in its own Grid Cell.
+       */}
+      {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
       <Grid as="main" id="inhoud" paddingBottom="2x-large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-m" level={1}>
@@ -141,12 +153,13 @@ export const WithTopTasks: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear and every `map` is expanded. Provide the source by hand so the `map` and `getLinks`
+        // patterns read the way a developer would write them.
         code: `// getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
 
 <>
-  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  {/* Public page templates keep the Breadcrumb in its own Grid above <main>, so its nav sits outside it. */}
   <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Breadcrumb>
@@ -156,6 +169,7 @@ export const WithTopTasks: StoryObj = {
   </Grid>
   {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
   {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+  {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
   <Grid as="main" id="inhoud" paddingBottom="2x-large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Heading className="ams-mb-m" level={1}>Leefomgeving</Heading>
@@ -201,7 +215,7 @@ export const WithTopTasks: StoryObj = {
   render: (args) => (
     // getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
     <>
-      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+      {/* Public page templates keep the Breadcrumb in its own Grid above <main>, so its nav sits outside it. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -211,6 +225,7 @@ export const WithTopTasks: StoryObj = {
       </Grid>
       {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
       {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+      {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
       <Grid as="main" id="inhoud" paddingBottom="2x-large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-m" level={1}>
@@ -259,12 +274,13 @@ export const WithInteractiveElement: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear and every `map` is expanded. Provide the source by hand so the `map` and `getLinks`
+        // patterns read the way a developer would write them.
         code: `// getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
 
 <>
-  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  {/* Public page templates keep the Breadcrumb in its own Grid above <main>, so its nav sits outside it. */}
   <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Breadcrumb>
@@ -273,6 +289,11 @@ export const WithInteractiveElement: StoryObj = {
     </Grid.Cell>
   </Grid>
   {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+  {/*
+   * Spotlights and full-bleed images sit between the Grids, so a plain <main> wraps them all. A page that
+   * is a single section can put as="main" on the Grid itself instead.
+   */}
+  {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
   <main id="inhoud">
     <Grid paddingBottom="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -293,14 +314,22 @@ export const WithInteractiveElement: StoryObj = {
         </Grid.Cell>
       ))}
     </Grid>
-    {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
+    {/*
+     * These bands sit inside <main>, so they stay plain <div>s; the Article Page marks its comparable
+     * pull-outs as labelled asides because those sit outside its <main>, where as="aside" makes them
+     * complementary landmarks.
+     */}
     <Spotlight>
       <Grid paddingVertical="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          {/* On the dark Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
           <Heading className="ams-mb-m" color="inverse" level={2} size="level-3">Parkeertarieven</Heading>
           {/* An interactive element in the page: a search field. */}
           <SearchField className="ams-mb-m">
+            {/*
+             * SearchField renders the label visually hidden and offers no way to show it, so the placeholder is the
+             * only visible text this field can carry. It disappears on the first keystroke, so the field is then
+             * unlabelled on screen. The design system advises against placeholders; this one is a compromise.
+             */}
             <SearchField.Input label="Zoek op adres" placeholder="Zoek op adres" />
             <SearchField.Button />
           </SearchField>
@@ -312,6 +341,11 @@ export const WithInteractiveElement: StoryObj = {
       </Grid>
     </Spotlight>
     {/* A last section that is not a Grid takes ams-mb-2xl instead of a Grid’s paddingBottom. */}
+    {/*
+     * Image always reserves its box: .ams-image sets inline-size: 100% and an aspect ratio, so the
+     * layout does not shift while the file loads.
+     */}
+    {/* This image carries no information the text does not, so it takes an empty alt. */}
     <Image alt="" aspectRatio="16:9" className="ams-mb-2xl" src="https://picsum.photos/id/133/1440/810" />
   </main>
 </>`,
@@ -323,7 +357,7 @@ export const WithInteractiveElement: StoryObj = {
   render: (args) => (
     // getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
     <>
-      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+      {/* Public page templates keep the Breadcrumb in its own Grid above <main>, so its nav sits outside it. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -332,6 +366,11 @@ export const WithInteractiveElement: StoryObj = {
         </Grid.Cell>
       </Grid>
       {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+      {/*
+       * Spotlights and full-bleed images sit between the Grids, so a plain <main> wraps them all. A page that
+       * is a single section can put as="main" on the Grid itself instead.
+       */}
+      {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
       <main id="inhoud">
         <Grid paddingBottom="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -356,16 +395,24 @@ export const WithInteractiveElement: StoryObj = {
             </Grid.Cell>
           ))}
         </Grid>
-        {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
+        {/*
+         * These bands sit inside <main>, so they stay plain <div>s; the Article Page marks its comparable
+         * pull-outs as labelled asides because those sit outside its <main>, where as="aside" makes them
+         * complementary landmarks.
+         */}
         <Spotlight>
           <Grid paddingVertical="x-large">
             <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-              {/* On the dark Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
               <Heading className="ams-mb-m" color="inverse" level={2} size="level-3">
                 Parkeertarieven
               </Heading>
               {/* An interactive element in the page: a search field. */}
               <SearchField className="ams-mb-m">
+                {/*
+                 * SearchField renders the label visually hidden and offers no way to show it, so the placeholder is the
+                 * only visible text this field can carry. It disappears on the first keystroke, so the field is then
+                 * unlabelled on screen. The design system advises against placeholders; this one is a compromise.
+                 */}
                 <SearchField.Input label="Zoek op adres" placeholder="Zoek op adres" />
                 <SearchField.Button />
               </SearchField>
@@ -381,6 +428,11 @@ export const WithInteractiveElement: StoryObj = {
           </Grid>
         </Spotlight>
         {/* A last section that is not a Grid takes ams-mb-2xl instead of a Grid’s paddingBottom. */}
+        {/*
+         * Image always reserves its box: .ams-image sets inline-size: 100% and an aspect ratio, so the
+         * layout does not shift while the file loads.
+         */}
+        {/* This image carries no information the text does not, so it takes an empty alt. */}
         <Image alt="" aspectRatio="16:9" className="ams-mb-2xl" src="https://picsum.photos/id/133/1440/810" />
       </main>
     </>
@@ -391,10 +443,11 @@ export const WithImageGallery: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear and every `map` is expanded. Provide the source by hand so the `map` and `getLinks`
+        // patterns read the way a developer would write them.
         code: `<>
-  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  {/* Public page templates keep the Breadcrumb in its own Grid above <main>, so its nav sits outside it. */}
   <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Breadcrumb>
@@ -404,6 +457,7 @@ export const WithImageGallery: StoryObj = {
     </Grid.Cell>
   </Grid>
   {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+  {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
   <main id="inhoud">
     <Grid paddingBottom="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -414,7 +468,9 @@ export const WithImageGallery: StoryObj = {
         </Paragraph>
       </Grid.Cell>
     </Grid>
-    {/* A full-width banner image sits outside the Grid and runs full-bleed; aspectRatio keeps it from shifting the layout. */}
+    {/* Outside the Grid, the image spans the full Page width: up to 90rem, centred — not the full window. */}
+    {/* Image always reserves its box; aspectRatio only changes it from the default 16:9 to a banner’s 16:5. */}
+    {/* This image carries no information the text does not, so it takes an empty alt. */}
     <Image alt="" aspectRatio="16:5" src="https://picsum.photos/1440/450" />
     <Grid paddingVertical="x-large">
       {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
@@ -428,17 +484,21 @@ export const WithImageGallery: StoryObj = {
       {/*
        * The image gallery. Each card spans 4 columns; the computed start lays them out two per row on
        * medium ([1, 5]) and three per row on wide ([1, 5, 9]) screens.
+       * Indexing a plain array produces a number, which is wider than the union Grid.Cell accepts, so each
+       * array is marked as const to keep its elements narrow.
        */}
-      {persons.map(({ imageSource, name, role }, index) => (
+      {persons.map(({ imageSource, name, role, suffix }, index) => (
         <Grid.Cell
           key={name}
           span={4}
-          start={{ narrow: 1, medium: [1, 5][index % 2], wide: [1, 5, 9][index % 3] }}
+          start={{ narrow: 1, medium: ([1, 5] as const)[index % 2], wide: ([1, 5, 9] as const)[index % 3] }}
         >
           <Card>
+            {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
             <Card.Image alt="" src={imageSource} />
+            {/* Level 3 keeps the card under the level-2 section heading; Card.Heading supplies its own size. */}
             <Card.Heading level={3}>
-              <Card.Link href="#">{role} {name}</Card.Link>
+              <Card.Link href="#">{\`\${role} \${name}\${suffix ? \` (\${suffix})\` : ''}\`}</Card.Link>
             </Card.Heading>
           </Card>
         </Grid.Cell>
@@ -458,11 +518,9 @@ export const WithImageGallery: StoryObj = {
         <StandaloneLink href="#">Coalitieakkoord en Uitvoeringsagenda</StandaloneLink>
       </Grid.Cell>
     </Grid>
-    {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
     <Spotlight>
       <Grid paddingVertical="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          {/* On the dark Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
           <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Persberichten en nieuws</Heading>
           <LinkList className="ams-mb-m">
             <LinkList.Link color="inverse" href="#">
@@ -510,6 +568,10 @@ export const WithImageGallery: StoryObj = {
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
         <Heading className="ams-mb-s" level={2} size="level-3">Rechtenvrije foto’s</Heading>
+        {/*
+         * Image always crops to an aspect ratio: omitting aspectRatio falls back to the 16:9 default,
+         * not to the file’s own ratio. This 640x360 source is already 16:9, so nothing is cropped.
+         */}
         <Image alt="" src="https://picsum.photos/640/360" />
       </Grid.Cell>
     </Grid>
@@ -522,7 +584,7 @@ export const WithImageGallery: StoryObj = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
-      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+      {/* Public page templates keep the Breadcrumb in its own Grid above <main>, so its nav sits outside it. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -532,6 +594,7 @@ export const WithImageGallery: StoryObj = {
         </Grid.Cell>
       </Grid>
       {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+      {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
       <main id="inhoud">
         <Grid paddingBottom="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -544,7 +607,9 @@ export const WithImageGallery: StoryObj = {
             </Paragraph>
           </Grid.Cell>
         </Grid>
-        {/* A full-width banner image sits outside the Grid and runs full-bleed; aspectRatio keeps it from shifting the layout. */}
+        {/* Outside the Grid, the image spans the full Page width: up to 90rem, centred — not the full window. */}
+        {/* Image always reserves its box; aspectRatio only changes it from the default 16:9 to a banner’s 16:5. */}
+        {/* This image carries no information the text does not, so it takes an empty alt. */}
         <Image alt="" aspectRatio="16:5" src={exampleImageSource(1440, 450, 11)} />
         <Grid paddingVertical="x-large">
           {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
@@ -560,15 +625,19 @@ export const WithImageGallery: StoryObj = {
           {/*
            * The image gallery. Each card spans 4 columns; the computed start lays them out two per row on
            * medium ([1, 5]) and three per row on wide ([1, 5, 9]) screens.
+           * Indexing a plain array produces a number, which is wider than the union Grid.Cell accepts, so each
+           * array is marked as const to keep its elements narrow.
            */}
           {persons.map(({ imageSource, name, role, suffix }, index) => (
             <Grid.Cell
               key={name}
               span={4}
-              start={{ narrow: 1, medium: [1, 5][index % 2], wide: [1, 5, 9][index % 3] } as GridColumnNumbers}
+              start={{ narrow: 1, medium: ([1, 5] as const)[index % 2], wide: ([1, 5, 9] as const)[index % 3] }}
             >
               <Card>
+                {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
                 <Card.Image alt="" src={imageSource} />
+                {/* Level 3 keeps the card under the level-2 section heading; Card.Heading supplies its own size. */}
                 <Card.Heading level={3}>
                   <Card.Link href="#">{`${role} ${name}${suffix ? ` (${suffix})` : ''}`}</Card.Link>
                 </Card.Heading>
@@ -594,11 +663,9 @@ export const WithImageGallery: StoryObj = {
             <StandaloneLink href="#">Coalitieakkoord en Uitvoeringsagenda</StandaloneLink>
           </Grid.Cell>
         </Grid>
-        {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
         <Spotlight>
           <Grid paddingVertical="x-large">
             <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-              {/* On the dark Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
               <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
                 Persberichten en nieuws
               </Heading>
@@ -678,6 +745,10 @@ export const WithImageGallery: StoryObj = {
             <Heading className="ams-mb-s" level={2} size="level-3">
               Rechtenvrije foto’s
             </Heading>
+            {/*
+             * Image always crops to an aspect ratio: omitting aspectRatio falls back to the 16:9 default,
+             * not to the file’s own ratio. This 640x360 source is already 16:9, so nothing is cropped.
+             */}
             <Image alt="" src={exampleImageSource(640, 360, 12)} />
           </Grid.Cell>
         </Grid>
@@ -690,12 +761,13 @@ export const SubnavigationPage: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear and every `map` is expanded. Provide the source by hand so the `map` and `getLinks`
+        // patterns read the way a developer would write them.
         code: `// getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
 
 <>
-  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  {/* Public page templates keep the Breadcrumb in its own Grid above <main>, so its nav sits outside it. */}
   <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Breadcrumb>
@@ -705,6 +777,7 @@ export const SubnavigationPage: StoryObj = {
     </Grid.Cell>
   </Grid>
   {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+  {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
   <main id="inhoud">
     <Grid paddingBottom="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -715,10 +788,19 @@ export const SubnavigationPage: StoryObj = {
         </Paragraph>
       </Grid.Cell>
     </Grid>
+    {/* Outside the Grid, the image spans the full Page width: up to 90rem, centred — not the full window. */}
+    {/* Image always reserves its box; aspectRatio only changes it from the default 16:9 to a banner’s 16:5. */}
+    {/* This image carries no information the text does not, so it takes an empty alt. */}
     <Image alt="" aspectRatio="16:5" src="https://picsum.photos/1440/450" />
     <Grid paddingVertical="x-large">
       {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        {/*
+         * This page nests one level deeper than the other navigation pages: level-2 section titles with
+         * level-3 groups under them. Those headings each want the size of their own level, so they set
+         * no size. The Spotlight headings below are the exception: they stay level={2} in the outline
+         * but take size="level-3", as Link Sections do.
+         */}
         <Heading className="ams-mb-s" level={2}>L2 Paragraaf titel</Heading>
         <Paragraph>Voorbeeldtekst bij dit onderwerp.</Paragraph>
       </Grid.Cell>
@@ -754,11 +836,9 @@ export const SubnavigationPage: StoryObj = {
         <StandaloneLink href="#">Lees meer</StandaloneLink>
       </Grid.Cell>
     </Grid>
-    {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
     <Spotlight color="magenta">
       <Grid paddingVertical="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          {/* On the magenta Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
           <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Titel</Heading>
           <Paragraph color="inverse">Voorbeeldtekst bij dit onderwerp.</Paragraph>
         </Grid.Cell>
@@ -770,7 +850,6 @@ export const SubnavigationPage: StoryObj = {
     </Spotlight>
     {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
     <Grid paddingBottom="2x-large" paddingTop="x-large">
-      {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading className="ams-mb-s" level={2}>L2 Paragraaf titel</Heading>
         <Paragraph>Voorbeeldtekst bij dit onderwerp.</Paragraph>
@@ -797,7 +876,7 @@ export const SubnavigationPage: StoryObj = {
   render: (args) => (
     // getLinks shows a single StandaloneLink when a group has one link, or a LinkList when it has several.
     <>
-      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+      {/* Public page templates keep the Breadcrumb in its own Grid above <main>, so its nav sits outside it. */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -807,6 +886,7 @@ export const SubnavigationPage: StoryObj = {
         </Grid.Cell>
       </Grid>
       {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+      {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
       <main id="inhoud">
         <Grid paddingBottom="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
@@ -819,10 +899,19 @@ export const SubnavigationPage: StoryObj = {
             </Paragraph>
           </Grid.Cell>
         </Grid>
+        {/* Outside the Grid, the image spans the full Page width: up to 90rem, centred — not the full window. */}
+        {/* Image always reserves its box; aspectRatio only changes it from the default 16:9 to a banner’s 16:5. */}
+        {/* This image carries no information the text does not, so it takes an empty alt. */}
         <Image alt="" aspectRatio="16:5" src={exampleImageSource(1440, 450)} />
         <Grid paddingVertical="x-large">
           {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            {/*
+             * This page nests one level deeper than the other navigation pages: level-2 section titles with
+             * level-3 groups under them. Those headings each want the size of their own level, so they set
+             * no size. The Spotlight headings below are the exception: they stay level={2} in the outline
+             * but take size="level-3", as Link Sections do.
+             */}
             <Heading className="ams-mb-s" level={2}>
               L2 Paragraaf titel
             </Heading>
@@ -870,11 +959,9 @@ export const SubnavigationPage: StoryObj = {
             <StandaloneLink href="#">{exampleStandaloneLink()}</StandaloneLink>
           </Grid.Cell>
         </Grid>
-        {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
         <Spotlight color="magenta">
           <Grid paddingVertical="x-large">
             <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-              {/* On the magenta Spotlight, color="inverse" switches the heading, text, and links to their light variant. */}
               <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
                 {exampleHeading()}
               </Heading>
@@ -890,7 +977,6 @@ export const SubnavigationPage: StoryObj = {
         </Spotlight>
         {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
         <Grid paddingBottom="2x-large" paddingTop="x-large">
-          {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
             <Heading className="ams-mb-s" level={2}>
               L2 Paragraaf titel

--- a/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
+++ b/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
@@ -40,7 +40,7 @@ const meta = {
         {/* The title and lead span the wide intro column. */}
         {/* This cell is not ams-prose, so every element but the last sets its own bottom margin. */}
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading className="ams-mb-xl" level={1}>
+          <Heading className="ams-mb-m" level={1}>
             Gratis laptop of tablet voor de basisschool aanvragen
           </Heading>
           <Paragraph size="large">
@@ -191,7 +191,7 @@ export const Default: StoryObj = {
     {/* The title and lead span the wide intro column. */}
     {/* This cell is not ams-prose, so every element but the last sets its own bottom margin. */}
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-      <Heading className="ams-mb-xl" level={1}>Gratis laptop of tablet voor de basisschool aanvragen</Heading>
+      <Heading className="ams-mb-m" level={1}>Gratis laptop of tablet voor de basisschool aanvragen</Heading>
       <Paragraph size="large">
         U krijgt per huishouden 1 keer per 5 schooljaren een gratis laptop of tablet op de basisschool.
       </Paragraph>

--- a/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
+++ b/storybook/src/pages/public/ProductPage/ProductPage.stories.tsx
@@ -35,8 +35,10 @@ const meta = {
       </Grid>
       {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
       {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+      {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
       <Grid as="main" id="inhoud" paddingBottom="2x-large">
         {/* The title and lead span the wide intro column. */}
+        {/* This cell is not ams-prose, so every element but the last sets its own bottom margin. */}
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-xl" level={1}>
             Gratis laptop of tablet voor de basisschool aanvragen
@@ -94,7 +96,10 @@ const meta = {
               Ga naar <Link href="#">www.digid.nl</Link> en vraag uw DigiD aan.
             </UnorderedList.Item>
             <UnorderedList.Item>
-              {/* download hints the browser to save the PDF rather than open it in a new tab. */}
+              {/*
+               * download asks the browser to save the linked file instead of navigating to it. It only applies
+               * to same-origin URLs.
+               */}
               Lees eerst{' '}
               <Link download href="#">
                 Toelichting Gratis laptop of tablet basisschool Schooljaar 2024-2025.pdf
@@ -166,8 +171,9 @@ export const Default: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear. Provide the source by hand so the panel shows the whole
+        // page, with the notes on its layout and links kept.
         code: `<>
   {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
   <Grid paddingTop="large">
@@ -180,8 +186,10 @@ export const Default: StoryObj = {
   </Grid>
   {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
   {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+  {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
   <Grid as="main" id="inhoud" paddingBottom="2x-large">
     {/* The title and lead span the wide intro column. */}
+    {/* This cell is not ams-prose, so every element but the last sets its own bottom margin. */}
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Heading className="ams-mb-xl" level={1}>Gratis laptop of tablet voor de basisschool aanvragen</Heading>
       <Paragraph size="large">
@@ -222,7 +230,10 @@ export const Default: StoryObj = {
       <UnorderedList className="ams-mb-xl">
         <UnorderedList.Item>Ga naar <Link href="#">www.digid.nl</Link> en vraag uw DigiD aan.</UnorderedList.Item>
         <UnorderedList.Item>
-          {/* download hints the browser to save the PDF rather than open it in a new tab. */}
+          {/*
+           * download asks the browser to save the linked file instead of navigating to it. It only applies
+           * to same-origin URLs.
+           */}
           Lees eerst{' '}
           <Link download href="#">Toelichting Gratis laptop of tablet basisschool Schooljaar 2024-2025.pdf</Link>{' '}
           en{' '}

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -35,7 +35,10 @@ const meta = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <>
-      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+      {/*
+       * Padding is a prop of the Grid, not of the Grid Cell, so the breadcrumb needs its own Grid for
+       * the paddingTop of large that opens every page.
+       */}
       <Grid paddingTop="large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Breadcrumb>
@@ -45,14 +48,23 @@ const meta = {
         </Grid.Cell>
       </Grid>
       {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+      {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
       <Grid as="main" id="inhoud" paddingBottom="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading level={1}>Centrumeiland: hét zelfbouweiland van Amsterdam</Heading>
         </Grid.Cell>
+        {/* The slider spans the full grid width, where the title above it keeps to the narrower header cell. */}
         <Grid.Cell span="all">
-          {/* ImageSlider takes an array of images; each entry has an alt text, an aspectRatio, and a src. */}
+          {/*
+           * ImageSlider takes an array of images. Each entry accepts the props of an Image plus an
+           * optional caption; only alt is required.
+           */}
           <ImageSlider images={images} />
         </Grid.Cell>
+        {/*
+         * This cell is not ams-prose, and components never set outer margins, so every element that is
+         * followed by another sets its own bottom margin.
+         */}
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           <Heading className="ams-mb-s" level={2}>
             Wat
@@ -98,8 +110,12 @@ const meta = {
             alle woningen en voorzieningen klaar zijn in 2028. Het laatste woonblok wordt opgeleverd in 2029.
           </Paragraph>
           {/*
-           * A ProgressList shows a timeline. status="completed" marks a finished step, status="current" the one
-           * in progress, and a step with no status is still to come. hasSubsteps nests a ProgressList.Substeps.
+           * A ProgressList shows a timeline. status="completed" marks a finished step, status="current"
+           * the one in progress, and a step with no status is still to come. Substeps are nested by hand
+           * in a ProgressList.Substeps; hasSubsteps only tells the CSS about them, so that it draws the
+           * connecting lines correctly. collapsible gives every step its own fold button and decides what
+           * opens first: completed steps start collapsed, all others expanded, so the finished years here
+           * arrive folded. headingLevel is 3 because the list sits under the ‘Wanneer’ heading of level 2.
            */}
           <ProgressList collapsible headingLevel={3}>
             <ProgressList.Step hasSubsteps heading="2021" status="completed">
@@ -187,7 +203,10 @@ const meta = {
             </ProgressList.Step>
           </ProgressList>
         </Grid.Cell>
-        {/* Two link lists side by side, each start-aligned to its own half of the grid. */}
+        {/*
+         * Two link lists: the full-width narrow span stacks them, and from medium up the start values
+         * put them side by side – halves of the medium grid, inset 5-column blocks on the wide one.
+         */}
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-s" level={2} size="level-3">
             Nieuws
@@ -207,7 +226,6 @@ const meta = {
           </LinkList>
         </Grid.Cell>
       </Grid>
-      {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
       <Spotlight color="azure">
         <Grid paddingVertical="x-large">
           <Grid.Cell span="all">
@@ -215,10 +233,7 @@ const meta = {
               Zelfbouw
             </Heading>
           </Grid.Cell>
-          {/*
-           * The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens.
-           * On the azure Spotlight, color="inverse" switches the heading, text, and links to their light variant.
-           */}
+          {/* The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens. */}
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
             <Paragraph className="ams-mb-s" color="inverse">
               Meer over de verschillende vormen van zelfbouw vindt u op:
@@ -254,6 +269,7 @@ const meta = {
         </Grid>
       </Spotlight>
       <Grid paddingVertical="x-large">
+        {/* These four cells alternate between the same start positions, so they too read as two columns. */}
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading className="ams-mb-s" level={2} size="level-3">
             Meer informatie
@@ -275,6 +291,7 @@ const meta = {
           <Heading className="ams-mb-m" level={2} size="level-3">
             Ontwikkeling Centrumeiland, herfst 2025
           </Heading>
+          {/* This image only contributes to the visual atmosphere of the page, so it takes an empty alt. */}
           <Image alt="" className="ams-mb-m" src="https://picsum.photos/id/385/640/360" />
           <StandaloneLink href="#">Meer video’s</StandaloneLink>
         </Grid.Cell>
@@ -298,7 +315,10 @@ const meta = {
           </LinkList>
         </Grid.Cell>
       </Grid>
-      {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
+      {/*
+       * The highlight colours have no prescribed meaning, so this second band takes the default purple
+       * rather than repeating the azure of the first.
+       */}
       <Spotlight>
         <Grid paddingVertical="x-large">
           <Grid.Cell span="all">
@@ -318,7 +338,7 @@ const meta = {
             </Paragraph>
           </Grid.Cell>
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-            {/* <br /> holds a contact block’s lines together inside one Paragraph. */}
+            {/* These lines are kept in one Paragraph so they read as a single contact block, not as running text. */}
             <Paragraph color="inverse">
               Maud van Esch
               <br />
@@ -353,11 +373,14 @@ export const Default: StoryObj = {
   parameters: {
     docs: {
       source: {
-        // The Code Panel regenerates a `render` story’s source from the rendered tree, which drops JSX
-        // comments. Provide the source by hand so the guidance below stays visible in the panel. Repetitive
-        // sections are shortened with `{/* … */}` markers.
+        // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
+        // JSX comments disappear and every `map` is expanded. Provide the source by hand so repetitive sections can
+        // be shortened with `{/* … */}` markers, keeping the timeline and grid patterns readable.
         code: `<>
-  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  {/*
+   * Padding is a prop of the Grid, not of the Grid Cell, so the breadcrumb needs its own Grid for
+   * the paddingTop of large that opens every page.
+   */}
   <Grid paddingTop="large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Breadcrumb>
@@ -367,14 +390,23 @@ export const Default: StoryObj = {
     </Grid.Cell>
   </Grid>
   {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+  {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
   <Grid as="main" id="inhoud" paddingBottom="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Heading level={1}>Centrumeiland: hét zelfbouweiland van Amsterdam</Heading>
     </Grid.Cell>
+    {/* The slider spans the full grid width, where the title above it keeps to the narrower header cell. */}
     <Grid.Cell span="all">
-      {/* ImageSlider takes an array of images; each entry has an alt text, an aspectRatio, and a src. */}
+      {/*
+       * ImageSlider takes an array of images. Each entry accepts the props of an Image plus an
+       * optional caption; only alt is required.
+       */}
       <ImageSlider images={images} />
     </Grid.Cell>
+    {/*
+     * This cell is not ams-prose, and components never set outer margins, so every element that is
+     * followed by another sets its own bottom margin.
+     */}
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       <Heading className="ams-mb-s" level={2}>Wat</Heading>
       <Paragraph className="ams-mb-m">
@@ -393,8 +425,12 @@ export const Default: StoryObj = {
         voorzieningen klaar zijn in 2028.
       </Paragraph>
       {/*
-       * A ProgressList shows a timeline. status="completed" marks a finished step, status="current" the one
-       * in progress, and a step with no status is still to come. hasSubsteps nests a ProgressList.Substeps.
+       * A ProgressList shows a timeline. status="completed" marks a finished step, status="current"
+       * the one in progress, and a step with no status is still to come. Substeps are nested by hand
+       * in a ProgressList.Substeps; hasSubsteps only tells the CSS about them, so that it draws the
+       * connecting lines correctly. collapsible gives every step its own fold button and decides what
+       * opens first: completed steps start collapsed, all others expanded, so the finished years here
+       * arrive folded. headingLevel is 3 because the list sits under the ‘Wanneer’ heading of level 2.
        */}
       <ProgressList collapsible headingLevel={3}>
         <ProgressList.Step hasSubsteps heading="2021" status="completed">
@@ -421,7 +457,10 @@ export const Default: StoryObj = {
         </ProgressList.Step>
       </ProgressList>
     </Grid.Cell>
-    {/* Two link lists side by side, each start-aligned to its own half of the grid. */}
+    {/*
+     * Two link lists: the full-width narrow span stacks them, and from medium up the start values
+     * put them side by side – halves of the medium grid, inset 5-column blocks on the wide one.
+     */}
     <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Heading className="ams-mb-s" level={2} size="level-3">Nieuws</Heading>
       <LinkList>
@@ -437,16 +476,12 @@ export const Default: StoryObj = {
       </LinkList>
     </Grid.Cell>
   </Grid>
-  {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
   <Spotlight color="azure">
     <Grid paddingVertical="x-large">
       <Grid.Cell span="all">
         <Heading color="inverse" level={2}>Zelfbouw</Heading>
       </Grid.Cell>
-      {/*
-       * The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens.
-       * On the azure Spotlight, color="inverse" switches the heading, text, and links to their light variant.
-       */}
+      {/* The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens. */}
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
         <Paragraph className="ams-mb-s" color="inverse">
           Meer over de verschillende vormen van zelfbouw vindt u op:
@@ -457,6 +492,7 @@ export const Default: StoryObj = {
     </Grid>
   </Spotlight>
   <Grid paddingVertical="x-large">
+    {/* These four cells alternate between the same start positions, so they too read as two columns. */}
     <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
       <Heading className="ams-mb-s" level={2} size="level-3">Meer informatie</Heading>
       <LinkList>
@@ -467,6 +503,7 @@ export const Default: StoryObj = {
     </Grid.Cell>
     <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
       <Heading className="ams-mb-m" level={2} size="level-3">Ontwikkeling Centrumeiland, herfst 2025</Heading>
+      {/* This image only contributes to the visual atmosphere of the page, so it takes an empty alt. */}
       <Image alt="" className="ams-mb-m" src="https://picsum.photos/id/385/640/360" />
       <StandaloneLink href="#">Meer video’s</StandaloneLink>
     </Grid.Cell>
@@ -479,7 +516,10 @@ export const Default: StoryObj = {
       </LinkList>
     </Grid.Cell>
   </Grid>
-  {/* The paddings either side of the Spotlight add up on purpose: the coloured band separates them. */}
+  {/*
+   * The highlight colours have no prescribed meaning, so this second band takes the default purple
+   * rather than repeating the azure of the first.
+   */}
   <Spotlight>
     <Grid paddingVertical="x-large">
       <Grid.Cell span="all">
@@ -492,7 +532,7 @@ export const Default: StoryObj = {
         </Paragraph>
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-        {/* <br /> holds a contact block’s lines together inside one Paragraph. */}
+        {/* These lines are kept in one Paragraph so they read as a single contact block, not as running text. */}
         <Paragraph color="inverse">
           Maud van Esch
           <br />


### PR DESCRIPTION
## Links

- Preview deploy: https://designsystem.amsterdam/ (live once the deploy finishes)

## What

The page templates demonstrate a lot of decisions they never explain: why a field set takes a radio group role, why an image carries an empty alt, why a heading sets `size` alongside `level`. This adds those explanations as comments, in the eleven public and internal templates, and carries the ones that are true of a component in general into that component's own documentation page.

Seventeen component pages gain a paragraph or two, mostly under **How to use** or **Accessibility**.

## Why

Someone building a city service reads a page template to see how the parts fit together, then copies it. Until now the template showed the result without the reasoning, so the decisions behind it were invisible and easy to drop.

Several of those decisions turned out to be documented nowhere at all. An Image always crops to an aspect ratio, and leaving the prop off falls back to 16:9 rather than keeping the file's own proportions. A Heading's `level` sets its appearance too, unless `size` overrides it. A Search Field renders its label visually hidden with no way to show it. An Invalid Form Alert error `id` becomes the `href` of a link, so it needs a leading `#` despite the prop name. A Skip Link moves the sequential focus starting point rather than focusing its target. Each of those is the kind of thing you learn by reading the source, which is exactly what a documentation page is for.

## How

Every claim was checked against the component source, the CSS, the tokens, or the guidance it cites, rather than written from memory. That mattered: a first pass produced a good number of confident, plausible and wrong explanations, and they were corrected before this branch took shape. Two claims that could not be settled from the source are deliberately absent rather than hedged.

The comments live twice in most templates — once in the `render` and once in the hand-written `parameters.docs.source.code` — and both copies carry the same wording. The comment above each of those sources now says why it is hand-written, which depends on the story: a `render` that declares a parameter is rebuilt from the rendered tree, a `render` on the shared meta leaves the story with nothing but its parameters, and a `render` without a parameter is printed as written.

Two small fixes came out of the same reading and are kept in their own commits, because they change what renders:

- The Article Page lazy-loaded its hero image, which sits in the first screenful.
- The Product Page separated its level 1 heading from the lead with an x-large margin where the vertical space guide prescribes medium — and a comment had been written to justify it.

The Navigation Page also drops an `as GridColumnNumbers` assertion. It was there to widen a computed column number, but it silently switched off checking for `medium` and `wide`; marking the arrays `as const` keeps the values narrow and restores the error. Verified by putting an out-of-range column in and watching `tsc` reject it.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Only the two fix commits change rendered output, and neither is a layout change: one removes a `loading` attribute, the other shrinks one heading's bottom margin. Everything else is comments and documentation prose, so Chromatic should show the Product Page heading gap and nothing more.

The Field Set and Label pages both scoped `legendIsPageHeading` / `isPageHeading` to "the only content on the page". That is narrower than the Form Flow uses it, where a back link, a step indicator and a submit button are also present, so both now say "the only question on the page".

Two things are deliberately left alone for a maintainer to decide:

- `Radio.docs.mdx` instructs setting `aria-required` on individual Radios as well as the group, and `FieldSet.docs.mdx` says the same for all its form elements. MDN states it is not expected on individual radio buttons and belongs on the radio group, while axe-core does permit it. Settling this needs screen reader testing rather than a spec citation, so nothing was changed.
- `brand/design-tokens/colour.docs.mdx` calls azure a dark background that takes white text. Under WCAG 2 that pairing is 3.01:1. This is a known, deliberate deviation — white reads better than black there and APCA agrees — so the Spotlight page now points at that guidance rather than restating ratios beside it.
