### PR TITLE
chore(Storybook): Explain the internal page template decisions and document them per component

### DIFF
--- a/storybook/src/components/Menu/Menu.docs.mdx
+++ b/storybook/src/components/Menu/Menu.docs.mdx
@@ -75,6 +75,14 @@ In a wide window, the menu has a maximum width of 8rem.
 It adds whitespace at the top to align with the baseline of Page Header.
 The icon is larger and positioned above the label.
 
+## Accessibility
+
+Without `inWideWindow` the Menu renders a `div`, because it then sits inside the `nav` element of the [Page Header](/docs/components-containers-page-header--docs).
+With the prop it renders a `nav` of its own, named by a visually hidden heading that `accessibleName` fills.
+
+That name defaults to ‘Hoofdmenu’, and so does the `navigationLabel` of the Page Header.
+A wide window shows both navigations, so give one of the two another name.
+
 ## See also
 
 - [Page Header](/docs/components-containers-page-header--docs) – contains one instance of the Menu.

--- a/storybook/src/components/Page/Page.docs.mdx
+++ b/storybook/src/components/Page/Page.docs.mdx
@@ -26,21 +26,35 @@ As a root layout component, it must be used for all websites for the City of Ams
 
 ### How to use
 
+#### Public websites
+
+Use the Page as it is.
+Its children – a [Skip Link](/docs/components-navigation-skip-link--docs), the Page Header, the sections of the page, and the Page Footer – follow one another in document order.
+See the [introduction to the public templates](/docs/pages-public-introduction--docs) for the structure of a page.
+
+#### Internal websites
+
 Set `withMenu` to lay the Page out as a grid, with a column for the [Menu](/docs/components-navigation-menu--docs) beside the header, the body, and the footer.
-Every child then needs the class name of the area it belongs in: `ams-page__area--skip-link`, `--header`, `--menu`, `--body`, or `--footer`.
+Every child then needs the class name of the area it belongs in, such as `ams-page__area--header`.
+The description of `withMenu` in the table above names all five.
+
 Those rules apply to direct children of the Page only, so none of these elements may be wrapped in another one.
+See the [introduction to the internal templates](/docs/pages-internal-introduction--docs) for the structure of a page.
 
 ## Examples
 
-See the [Home Page](/story/pages-public-home-page--default) template for public websites for a full-page example.
+### Public websites
 
-### With menu
+Navigation sits in the Page Header, so no Menu is involved.
+See the [Home Page](/story/pages-public-home-page--default) template for a full-page example.
+
+### Internal websites
 
 Internal websites can add a [Menu](/docs/components-navigation-menu--docs) for navigating between its modules and pages.
 This is an alternative to the approach using Link Lists, which is appropriate for public, content-oriented websites.
 
 We can’t display the example here, as it requires Compact Mode to be enabled, which affects the example for the public Home Page template.
-Open the [full example page](/story/components-containers-page--with-menu) or see the [Home Page](/story/pages-internal-home-page--default) template for internal websites.
+Open the [full example page](/story/components-containers-page--with-menu) or see the [Home Page](/story/pages-internal-home-page--default) template.
 
 ## Features
 

--- a/storybook/src/components/Page/Page.docs.mdx
+++ b/storybook/src/components/Page/Page.docs.mdx
@@ -24,6 +24,12 @@ import * as PageStories from "./Page.stories.tsx";
 The Page component wraps the [Page Header](/docs/components-containers-page-header--docs), [Page Footer](/docs/components-containers-page-footer--docs), and the main content in between.
 As a root layout component, it must be used for all websites for the City of Amsterdam.
 
+### How to use
+
+Set `withMenu` to lay the Page out as a grid, with a column for the [Menu](/docs/components-navigation-menu--docs) beside the header, the body, and the footer.
+Every child then needs the class name of the area it belongs in: `ams-page__area--skip-link`, `--header`, `--menu`, `--body`, or `--footer`.
+Those rules apply to direct children of the Page only, so none of these elements may be wrapped in another one.
+
 ## Examples
 
 See the [Home Page](/story/pages-public-home-page--default) template for public websites for a full-page example.

--- a/storybook/src/components/Page/Page.docs.mdx
+++ b/storybook/src/components/Page/Page.docs.mdx
@@ -70,7 +70,9 @@ An element placed directly in the Page, outside a [Grid](/docs/components-layout
 
 ## See also
 
+- [Skip Link](/docs/components-navigation-skip-link--docs) – the first element in the Page, above the Page Header.
 - [Page Header](/docs/components-containers-page-header--docs) – sits at the top of the Page.
+- [Menu](/docs/components-navigation-menu--docs) – fills the menu column that `withMenu` adds, on an internal website.
 - [Page Footer](/docs/components-containers-page-footer--docs) – sits at the bottom of the Page.
 
 ## Design tokens

--- a/storybook/src/components/Pagination/Pagination.docs.mdx
+++ b/storybook/src/components/Pagination/Pagination.docs.mdx
@@ -66,6 +66,8 @@ return <Pagination linkComponent={LinkComponent} />
 
 ## Features
 
+Pagination renders nothing when `totalPages` is 1 or less, so a set that fits on a single page needs no condition around it.
+
 Start a page with an overview list at the top after changing the page.
 Redirect users to the first page if they enter a URL with a page number that doesn’t exist.
 

--- a/storybook/src/components/Pagination/Pagination.docs.mdx
+++ b/storybook/src/components/Pagination/Pagination.docs.mdx
@@ -34,6 +34,9 @@ Pagination should not be displayed if there is only one page.
 
 Make sure that the visible and accessible labels for the 'previous' and 'next' buttons convey the same meaning at all times – e.g. don't update one and forget the other.
 
+Start a page with an overview list at the top after changing the page.
+Redirect users to the first page if they enter a URL with a page number that doesn’t exist.
+
 ## Examples
 
 ### Specifying a link template
@@ -67,9 +70,6 @@ return <Pagination linkComponent={LinkComponent} />
 ## Features
 
 Pagination renders nothing when `totalPages` is 1 or less, so a set that fits on a single page needs no condition around it.
-
-Start a page with an overview list at the top after changing the page.
-Redirect users to the first page if they enter a URL with a page number that doesn’t exist.
 
 ## Design tokens
 

--- a/storybook/src/components/TabNavigation/TabNavigation.docs.mdx
+++ b/storybook/src/components/TabNavigation/TabNavigation.docs.mdx
@@ -48,6 +48,9 @@ Use [Tabs](/docs/components-containers-tabs--docs) instead to switch between sma
 
 Add `aria-current="page"` to the link pointing to the current page.
 
+Give each Tab Navigation an `accessibleName`.
+The name defaults to ‘Navigatie’, so a page with two of them would otherwise hold two navigations named the same.
+
 ## Examples
 
 ### Vertical

--- a/storybook/src/components/Table/Table.docs.mdx
+++ b/storybook/src/components/Table/Table.docs.mdx
@@ -78,6 +78,10 @@ In this case, use a [Figure](/docs/components-media-figure--docs) and let the Ta
 
 <Canvas of={TableStories.InFigure} />
 
+## Features
+
+A Table wider than the space it sits in scrolls horizontally within its own container, rather than widening the page around it.
+
 ## Accessibility
 
 A Table caption creates the accessible name for the Table, announced by screen readers on every encounter.

--- a/storybook/src/pages/internal/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/internal/HomePage/HomePage.stories.tsx
@@ -20,9 +20,19 @@ const meta = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
     <Grid paddingBottom="x-large" paddingTop="large">
+      {/*
+       * appearance="transparent" removes the cell’s background and padding, so the page title sits directly
+       * on the page instead of looking like one of the content blocks the other cells form.
+       */}
       <Grid.Cell appearance="transparent" span="all">
         <Heading level={1}>Titel van de pagina</Heading>
       </Grid.Cell>
+      {/*
+       * This is a layout demo: the empty cells stand in for content blocks. Their blockSize only gives them
+       * a height to show here – on a real page the content sets the height. What matters is the responsive
+       * span: how many of the grid’s columns a cell fills at narrow, medium, and wide widths. That is what
+       * makes the cells reflow into different rows as the window changes.
+       */}
       <Grid.Cell span={{ narrow: 4, medium: 5, wide: 8 }} style={{ blockSize: '12rem' }} />
       <Grid.Cell span={{ narrow: 1, medium: 3, wide: 4 }} style={{ blockSize: '10rem' }} />
       <Grid.Cell span={{ narrow: 3, medium: 3, wide: 3 }}>

--- a/storybook/src/pages/internal/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/internal/HomePage/HomePage.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
   title: 'Pages/Internal/Home Page',
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: (args) => (
-    <Grid paddingBottom="x-large" paddingTop="large">
+    <Grid paddingVertical="x-large">
       {/*
        * appearance="transparent" removes the cell’s background and padding, so the page title sits directly
        * on the page instead of looking like one of the content blocks the other cells form.
@@ -59,7 +59,7 @@ export const Default: StoryObj = {
         // Because this story’s `render` takes an argument, the Code Panel rebuilds its source from the rendered tree:
         // JSX comments disappear. Provide the source by hand so the panel shows a trimmed,
         // annotated version of the page.
-        code: `<Grid paddingBottom="x-large" paddingTop="large">
+        code: `<Grid paddingVertical="x-large">
   {/*
    * appearance="transparent" removes the cell’s background and padding, so the page title sits directly
    * on the page instead of looking like one of the content blocks the other cells form.

--- a/storybook/src/pages/internal/Introduction.docs.mdx
+++ b/storybook/src/pages/internal/Introduction.docs.mdx
@@ -59,6 +59,16 @@ The component must be rendered twice.
 
 Make sure that both menus have the same items.
 
+## Vertical space
+
+Between the Page Header and the Page Footer, an internal page holds one or more Grids.
+Give each of them a `paddingVertical` of `x-large`.
+The public templates vary this padding along the page; internal pages use the same value everywhere.
+
+Leave `gapVertical` at its default of `x-large` as well, so the space between the rows matches the space above and below them.
+
+Use the [Margin](/docs/utilities-css-margin--docs) utility classes for the space between the elements within a Grid Cell, in the amounts of the [vertical space](/docs/docs-designer-guide-vertical-space--docs) guide.
+
 ## See also
 
 - [Breadcrumb](/docs/components-navigation-breadcrumb--docs)

--- a/storybook/src/pages/internal/Introduction.docs.mdx
+++ b/storybook/src/pages/internal/Introduction.docs.mdx
@@ -52,7 +52,7 @@ The component must be rendered twice.
 
 1. One instance, for narrow and medium windows, sits in the Page Header.
    The user can access it through the menu button.
-   Hide the menu button on wide windows.
+   Hide the menu button on wide windows: this instance hides itself there, so the button would open an empty menu.
 2. A second Menu goes between the Page Header and the main content.
    This is for wide windows, where the menu is positioned to the side.
    The `inWideWindow` prop ensures that only one of both components is present at all times.

--- a/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
@@ -101,7 +101,7 @@ const meta = {
           start={{ narrow: 1, medium: 3, wide: 3 }}
           style={{ blockSize: `${currentSubMenu.cellHeights[0]}vb` }}
         >
-          <Heading className="ams-mb-s" level={2}>
+          <Heading className="ams-mb-m" level={2}>
             {currentMenu.label}
           </Heading>
           <Heading className="ams-mb-m" level={3}>
@@ -179,7 +179,7 @@ export const Default: StoryObj = {
   </Grid.Cell>
   {/* The content area, start-aligned next to the vertical navigation. Its cells stand in for content. */}
   <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 3, wide: 3 }}>
-    <Heading className="ams-mb-s" level={2}>{currentMenu.label}</Heading>
+    <Heading className="ams-mb-m" level={2}>{currentMenu.label}</Heading>
     <Heading className="ams-mb-m" level={3}>{currentSubMenu.label}</Heading>
   </Grid.Cell>
   <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }} start={{ narrow: 1, medium: 3, wide: 10 }} />

--- a/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
@@ -104,9 +104,7 @@ const meta = {
           <Heading className="ams-mb-m" level={2}>
             {currentMenu.label}
           </Heading>
-          <Heading className="ams-mb-m" level={3}>
-            {currentSubMenu.label}
-          </Heading>
+          <Heading level={3}>{currentSubMenu.label}</Heading>
         </Grid.Cell>
         <Grid.Cell
           span={{ narrow: 4, medium: 4, wide: 3 }}
@@ -180,7 +178,7 @@ export const Default: StoryObj = {
   {/* The content area, start-aligned next to the vertical navigation. Its cells stand in for content. */}
   <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 3, wide: 3 }}>
     <Heading className="ams-mb-m" level={2}>{currentMenu.label}</Heading>
-    <Heading className="ams-mb-m" level={3}>{currentSubMenu.label}</Heading>
+    <Heading level={3}>{currentSubMenu.label}</Heading>
   </Grid.Cell>
   <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }} start={{ narrow: 1, medium: 3, wide: 10 }} />
 </Grid>`,

--- a/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/internal/NavigationPage/NavigationPage.stories.tsx
@@ -49,6 +49,11 @@ const meta = {
           </Breadcrumb>
           <Heading level={1}>Naam van het project</Heading>
         </Grid.Cell>
+        {/*
+         * The main project navigation. rowSpan={2} lets this one cell sit beside both the subnavigation and
+         * the content below it; appearance="flush" drops the cell padding so the tabs align with the grid.
+         * accessibleName labels the nav for screen readers, and aria-current="page" marks the active link.
+         */}
         <Grid.Cell appearance="flush" rowSpan={2} span={{ narrow: 4, medium: 2, wide: 2 }}>
           <TabNavigation accessibleName="Navigatie voor dit project" orientation="vertical">
             <TabNavigation.List>
@@ -66,6 +71,10 @@ const meta = {
             </TabNavigation.List>
           </TabNavigation>
         </Grid.Cell>
+        {/*
+         * The subnavigation scrolls sideways when it overflows. Keep a ref to its list so selecting another
+         * main menu item can reset the scroll back to the start (see handleMenuItemClick).
+         */}
         <Grid.Cell
           appearance="flush"
           span={{ narrow: 4, medium: 6, wide: 10 }}
@@ -86,6 +95,7 @@ const meta = {
             </TabNavigation.List>
           </TabNavigation>
         </Grid.Cell>
+        {/* The content area, start-aligned next to the vertical navigation. Its cells stand in for content. */}
         <Grid.Cell
           span={{ narrow: 4, medium: 6, wide: 7 }}
           start={{ narrow: 1, medium: 3, wide: 3 }}

--- a/storybook/src/pages/internal/TablePage/TablePage.stories.tsx
+++ b/storybook/src/pages/internal/TablePage/TablePage.stories.tsx
@@ -108,6 +108,7 @@ export const SortingWithSelect: StoryObj = {
             <form onSubmit={handleSortSubmit}>
               <Row alignVertical="center" wrap>
                 <Label htmlFor="sort">Sorteren op</Label>
+                {/* Submitting the form on change avoids a separate submit button (see handleSortChange). */}
                 <Select defaultValue={sortOrder} id="sort" name="sort" onChange={handleSortChange}>
                   {sortSelectOptions}
                 </Select>
@@ -130,6 +131,8 @@ export const SortingWithSelect: StoryObj = {
 
 // With Pagination
 
+// 50 rows at 5 per page make 10 pages: more than the seven page links Pagination shows at once, so this
+// example includes an ellipsis.
 const paginationOptions = {
   addresses: bagAddresses.slice(0, 50),
   pageSize: 5,
@@ -216,6 +219,11 @@ export const WithPagination = () => {
           <AddressTableBody addresses={paginatedAddresses} firstRow={firstRow} />
         </Table>
         <Row align="center">
+          {/*
+           * Pagination renders links, so pages stay shareable and open in a new tab. linkTemplate builds each
+           * href; linkComponent lets you pass your router’s link. Here a small wrapper keeps navigation inside
+           * Storybook rather than reloading the iframe – see PaginationLink and handlePaginationClick.
+           */}
           <Pagination
             linkComponent={PaginationLink}
             linkTemplate={paginationLinkTemplate}

--- a/storybook/src/pages/internal/TablePage/TablePage.stories.tsx
+++ b/storybook/src/pages/internal/TablePage/TablePage.stories.tsx
@@ -210,7 +210,7 @@ export const WithPagination = () => {
       <Grid.Cell span="all">
         <Table className="ams-mb-l">
           {/* If nothing sits between the Heading and the Table, wrap the Heading in the Caption. */}
-          <Table.Caption className="ams-mb-m">
+          <Table.Caption>
             <Heading level={2}>Gegevens per adres</Heading>
           </Table.Caption>
           <Table.Header>
@@ -249,7 +249,7 @@ WithPagination.parameters = {
   <Grid.Cell span="all">
     <Table className="ams-mb-l">
       {/* If nothing sits between the Heading and the Table, wrap the Heading in the Caption. */}
-      <Table.Caption className="ams-mb-m">
+      <Table.Caption>
         <Heading level={2}>Gegevens per adres</Heading>
       </Table.Caption>
       <Table.Header>

--- a/storybook/src/pages/internal/TablePage/TablePage.stories.tsx
+++ b/storybook/src/pages/internal/TablePage/TablePage.stories.tsx
@@ -56,7 +56,7 @@ export const SortingWithSelect: StoryObj = {
         // Because this story’s `render` takes no argument, the Code Panel prints its source as written, sorting
         // scaffolding and all. Provide the source by hand so the panel shows the table markup on its own, with the
         // guidance kept short.
-        code: `<Grid paddingBottom="x-large" paddingTop="large">
+        code: `<Grid paddingVertical="x-large">
   <Grid.Cell appearance="transparent" span="all">
     <Heading level={1}>Vergunninghouders 2026/2027</Heading>
   </Grid.Cell>
@@ -96,7 +96,7 @@ export const SortingWithSelect: StoryObj = {
     const addresses = sortAddresses(bagAddresses.slice(0, 30), sortOrder)
 
     return (
-      <Grid paddingBottom="x-large" paddingTop="large">
+      <Grid paddingVertical="x-large">
         <Grid.Cell appearance="transparent" span="all">
           <Heading level={1}>Vergunninghouders 2026/2027</Heading>
         </Grid.Cell>
@@ -203,7 +203,7 @@ export const WithPagination = () => {
   }, [])
 
   return (
-    <Grid paddingBottom="x-large" paddingTop="large">
+    <Grid paddingVertical="x-large">
       <Grid.Cell appearance="transparent" span="all">
         <Heading level={1}>Vergunninghouders 2026/2027</Heading>
       </Grid.Cell>
@@ -242,7 +242,7 @@ WithPagination.parameters = {
       // Because this story’s `render` takes no argument, the Code Panel prints its source as written, pagination
       // scaffolding and all. Provide the source by hand so the panel shows the table markup on its own, with the
       // guidance kept short.
-      code: `<Grid paddingBottom="x-large" paddingTop="large">
+      code: `<Grid paddingVertical="x-large">
   <Grid.Cell appearance="transparent" span="all">
     <Heading level={1}>Vergunninghouders 2026/2027</Heading>
   </Grid.Cell>

--- a/storybook/src/pages/internal/TablePage/common/AddressTableBody.tsx
+++ b/storybook/src/pages/internal/TablePage/common/AddressTableBody.tsx
@@ -33,6 +33,10 @@ export const AddressTableBody = ({ addresses, firstRow = 1 }: AddressTableBodyPr
           index,
         ) => (
           <Table.Row key={id}>
+            {/*
+             * scope="row" makes the number the header of its row, so assistive technology can announce which
+             * row a cell belongs to. firstRow continues the numbering across pages instead of restarting at 1.
+             */}
             <Table.HeaderCell scope="row">{firstRow + index}</Table.HeaderCell>
             <Table.Cell>{straat}</Table.Cell>
             <Table.Cell align="end">{huisnummer}</Table.Cell>
@@ -49,6 +53,10 @@ export const AddressTableBody = ({ addresses, firstRow = 1 }: AddressTableBodyPr
       )
     ) : (
       <Table.Row>
+        {/*
+         * The empty state spans all eleven columns of AddressTableHeaderRow, so its message is not squeezed
+         * into the first one.
+         */}
         <Table.Cell colSpan={11}>Geen resultaten</Table.Cell>
       </Table.Row>
     )}

--- a/storybook/src/pages/internal/TablePage/common/AddressTableHeaderRow.tsx
+++ b/storybook/src/pages/internal/TablePage/common/AddressTableHeaderRow.tsx
@@ -5,6 +5,8 @@
 
 import { Table } from '@amsterdam/design-system-react'
 
+// scope="col" tells assistive technology that these cells label the columns below them.
+// Every align value matches the cells of its column: numbers line up on their last digit when end-aligned.
 export const AddressTableHeaderRow = () => (
   <Table.Row>
     <Table.HeaderCell scope="col">#</Table.HeaderCell>

--- a/storybook/src/pages/internal/common/MenuWithItems.tsx
+++ b/storybook/src/pages/internal/common/MenuWithItems.tsx
@@ -20,6 +20,7 @@ type MenuItem = {
   text: string
 }
 
+// Menu links take the filled variant of an icon.
 const menuItems: MenuItem[] = [
   {
     href: '#',
@@ -48,6 +49,7 @@ const menuItems: MenuItem[] = [
   },
 ]
 
+// Both Menus of a page must offer the same links, so one component renders the list for either position.
 export const MenuWithItems = (props: MenuProps) => (
   <Menu {...props}>
     {menuItems.map(({ href, icon, text }) => (

--- a/storybook/src/pages/internal/common/PageLayout.tsx
+++ b/storybook/src/pages/internal/common/PageLayout.tsx
@@ -22,10 +22,10 @@ export const PageLayout = ({ children, ...restProps }: PageLayoutProps) => (
       Direct naar inhoud
     </SkipLink>
     <PageHeader
+      // An internal application is not the City’s main website, so the header names it beside the logo.
+      // That name also completes the hidden text of the logo link: ‘Ga naar de homepage van …’.
+      brandName="Naam van de applicatie"
       className="ams-page__area--header"
-      logoLink="/"
-      // Without a brandName the hidden text of the logo link reads ‘Ga naar de homepage’. Name the application instead.
-      logoLinkTitle="Naar de homepage van Applicatie"
       menuItems={
         // fixed keeps this link next to the menu button below the wide breakpoint, where menu items otherwise hide.
         <PageHeader.MenuLink fixed href="#" icon={UserAccountIcon}>

--- a/storybook/src/pages/internal/common/PageLayout.tsx
+++ b/storybook/src/pages/internal/common/PageLayout.tsx
@@ -25,6 +25,8 @@ export const PageLayout = ({ children, ...restProps }: PageLayoutProps) => (
       // An internal application is not the City’s main website, so the header names it beside the logo.
       // That name also completes the hidden text of the logo link: ‘Ga naar de homepage van …’.
       brandName="Naam van de applicatie"
+      // Below the wide breakpoint the short form replaces the full name.
+      brandNameShort="NvdA"
       className="ams-page__area--header"
       menuItems={
         // fixed keeps this link next to the menu button below the wide breakpoint, where menu items otherwise hide.

--- a/storybook/src/pages/internal/common/PageLayout.tsx
+++ b/storybook/src/pages/internal/common/PageLayout.tsx
@@ -13,25 +13,37 @@ import { MenuWithItems } from './MenuWithItems'
 type PageLayoutProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 
 export const PageLayout = ({ children, ...restProps }: PageLayoutProps) => (
+  // withMenu lays the Page out as a grid with a column for the Menu beside the header, the body and the footer.
+  // The rules for those areas select direct children of the Page only, so each child below needs its own
+  // ams-page__area class and none of them may be wrapped in another element.
   <Page {...restProps} withMenu>
+    {/* Targets the id on the main element below, so the next Tab press continues past the header and the menu. */}
     <SkipLink className="ams-page__area--skip-link" href="#inhoud">
       Direct naar inhoud
     </SkipLink>
     <PageHeader
       className="ams-page__area--header"
       logoLink="/"
+      // Without a brandName the hidden text of the logo link reads ‘Ga naar de homepage’. Name the application instead.
       logoLinkTitle="Naar de homepage van Applicatie"
       menuItems={
+        // fixed keeps this link next to the menu button below the wide breakpoint, where menu items otherwise hide.
         <PageHeader.MenuLink fixed href="#" icon={UserAccountIcon}>
           Inloggen
         </PageHeader.MenuLink>
       }
+      // This navigation and the Menu below both default to the accessible name ‘Hoofdmenu’, and a wide window
+      // shows both of them. Give one of the two another name.
       navigationLabel="Menu"
+      // On a wide window the Menu in this header hides itself, so the button would open an empty menu there.
       noMenuButtonOnWideWindow
     >
+      {/* The Menu for narrow and medium windows, inside the collapsible menu of the Page Header. */}
       <MenuWithItems />
     </PageHeader>
+    {/* The same Menu for wide windows, in the menu column of the Page. inWideWindow shows one of the two. */}
     <MenuWithItems className="ams-page__area--menu" inWideWindow />
+    {/* The main element lives here rather than in the templates: an area class only works on a direct child. */}
     <main className="ams-page__area--body" id="inhoud">
       {children}
     </main>

--- a/storybook/src/pages/internal/common/commonMeta.tsx
+++ b/storybook/src/pages/internal/common/commonMeta.tsx
@@ -9,6 +9,7 @@ import { PageLayout } from './PageLayout'
 
 export const commonMeta = {
   decorators: [
+    // Every internal template renders inside the same Page Layout, so each story supplies the page body only.
     (Story) => (
       <PageLayout>
         <Story />
@@ -20,6 +21,8 @@ export const commonMeta = {
     // instead of Chromatic’s 1200px default, so the visual test covers the widest layout we design for.
     chromatic: { modes: { '1920px': { viewport: 1920 } } },
     layout: 'fullscreen',
+    // Internal websites use Compact Mode, and the Menu may only be used with it. The override applies it to
+    // every story here, whichever mode the toolbar selects.
     themes: { themeOverride: 'Compact' },
   },
 } satisfies Meta


### PR DESCRIPTION
## Links

- Preview deploy: https://designsystem.amsterdam/
- [Home Page](https://designsystem.amsterdam/?path=/story/pages-internal-home-page--default), [Navigation Page](https://designsystem.amsterdam/?path=/story/pages-internal-navigation-page--default), [Table Page](https://designsystem.amsterdam/?path=/story/pages-internal-table-page--sorting-with-select)
- [Page documentation](https://designsystem.amsterdam/?path=/docs/components-containers-page--docs), which now separates public from internal guidance
- Follows #2826, which did the same for the public templates

## What

This explains the decisions the three internal page templates demonstrate, in comments, and carries the ones that hold for a component in general into that component’s own documentation page.

Internal templates are not public pages with a different skin. `Page` takes `withMenu`, which lays it out as a grid with a column for the Menu; the children carry `ams-page__area--*` classes to land in their area; one Menu is rendered twice, once inside the Page Header and once beside it; and the meta forces Compact Mode. None of that machinery was explained where a reader would copy it from, and the shared layout modules carried no comments at all. Every comment the Code Panel already showed now sits in the JSX as well, so the explanation is there whether you read the page in Storybook or the file in your editor.

Five component pages gain a paragraph or two, and reading the templates this closely turned up six things worth correcting.

## Why

Someone building an internal application reads a template to see how the parts fit together, then copies it. The public run made that argument already; it holds at least as strongly here, because the internal machinery is less familiar and easier to get subtly wrong. Leaving out one `ams-page__area--*` class, or wrapping a child in a `div`, quietly breaks the layout — those rules are direct-child selectors, which was documented nowhere.

Several other decisions turned out to be undocumented too. A Menu renders a `div` without `inWideWindow` because it then sits inside the Page Header’s own `nav`, and a `nav` of its own with it. That `nav` defaults to the accessible name ‘Hoofdmenu’, and so does the Page Header’s navigation, so a wide window would otherwise hold two navigations named the same — which is exactly why the template passes `navigationLabel`. Two Tab Navigations have the same problem with their own default of ‘Navigatie’. A Table scrolls horizontally inside its own container rather than widening the page. Pagination renders nothing at all when there is only one page, so no consumer needs a condition around it.

The Page documentation had a related gap: its ‘How to use’ described only the `withMenu` layout, so a public website had nothing to read there. That section and ‘Examples’ now each split into a public and an internal part, public first, and the Skip Link and the Menu join the companions in ‘See also’ — both already pointed back at the Page from their own pages.

## How

Every claim was checked against the component source, the SCSS, the tokens, or the guidance it cites, rather than written from memory. That is the lesson of the public run, where a first pass produced a good number of confident, plausible and wrong explanations. One of them turned up again here and was caught before it landed: `accessibleNameId` on Tab Navigation sets the id of the component’s *own* heading, it does not point at an external element, so it is absent from the documentation rather than described.

The comments live twice in each template, once in the `render` and once in the hand-written `parameters.docs.source.code`, and both copies carry the same wording. The wording the Code Panel already had was reused verbatim rather than rewritten. A small script extracted the comments from both copies of each story and diffed them, to prove nothing was left stranded in one of the two.

The comment commits change no rendered output at all: all eight touched `.tsx` files compile to byte-identical JavaScript before and after.

Six fixes came out of the same reading and are kept in their own commits:

- The Page Header showed no brand name, although its own documentation asks every website other than the City’s to name the brand or service beside the logo. Only screen reader users learned which application they were looking at, through the hidden text of the logo link. That text is now generated from the brand name, which makes `logoLinkTitle` unnecessary, and `logoLink` repeated the component default. A `brandNameShort` covers the windows below the wide breakpoint.
- The Navigation Page put `small` between a level 2 and a level 3 heading, where the vertical space guide prescribes `medium`. The level 3 heading also carried a bottom margin with nothing below it to offset against, which is gone.
- Two templates opened with `large` padding and closed with `x-large`, one used `x-large` throughout, and no rule said which was right. They now all use `x-large`, and the Introduction states that as the rule — the internal Introduction had no vertical space section, unlike the public one.
- The Table caption carried a `medium` bottom margin over the `small` one the Table already applies, without a documented reason to deviate.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11)

## Additional notes

**On the Chromatic diff.** Build 1477 reports forty changes, and none of them come from this branch.

Chromatic’s ancestor is build 1458, which predates #2815 and #2816 — the two pull requests that added `Pages/**` and `Utilities/**/**/Test` to the snapshot glob. Twenty-nine of the forty are therefore listed as *new stories*: all twenty-two page templates and all seven CSS utility tests, none of which have a baseline yet. The remaining eleven are genuine diffs on component tests — Icon Button, Search Field, Select, Switch, Calendar, Tab Navigation, and the date, time, text, text area and password inputs — and they trace to #2807, #2809, #2810 and #2814, all of which are already on develop. This branch touches none of those files.

That has a practical consequence: Chromatic cannot show a before and after for the four internal templates, because they are new baselines with nothing to diff against. The six fixes are best checked on the preview deploy instead. It may also be worth letting develop accept its own baselines first, so this pull request does not end up owning eleven unrelated component changes.

The brand name does not change the height of the header: in Compact Mode its line box tops out around 1.87rem against the logo’s 2.5rem minimum, so the Menu beside it still lines up.

Two things are noted and deliberately not changed here:

- The Breadcrumb on the Navigation Page sits inside `main`, where every public template keeps it outside. `SkipLink.docs.mdx` says repeated navigation blocks do not belong in the main content area, so this looks wrong — but moving it means changing the layout containers, since the body area has to be a direct child of `Page` and the shared layout owns the `main` element.
- `AddressTableBody` hardcodes `colSpan={11}` against the eleven columns of `AddressTableHeaderRow`, so adding a column silently breaks the empty state. The comment there names the coupling.
