### PR TITLE
chore(ci): Give Chromatic a baseline build on the integration branch

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -103,7 +103,8 @@ The supporting scripts live in [`.github/scripts`](../scripts).
   Publish always executes from `develop`, then checks out `main` itself; this is intentional and noted inline in the file.
 - **Required status checks follow job names, not workflow names.**
   Branch protection and rulesets refer to a check by its job's `name:` (or its id, if the job has no `name:`) — never the workflow's name or file. If you rename a job that's a required check, update the required status checks in the repository settings in the same change, or the check gets stuck on “Expected — waiting for status” forever.
-- **Chromatic only snapshots the story named “Test”.**
+- **Chromatic snapshots a subset of the stories.**
+  `onlyStoryNames` in [`storybook/chromatic.config.json`](../../storybook/chromatic.config.json) limits it to the story named “Test” for each component and CSS utility, plus every story under `Pages`.
   That is a Storybook convention unrelated to any workflow name; see the [testing documentation](../../documentation/tests.md).
 - **A pull request's Chromatic baseline does not come from its own history.**
   Because pull requests are squash-merged, no build runs on a commit that `develop` keeps, so Chromatic relies on the merge association from its GitHub App to carry baselines across.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 # GitHub Actions workflows
 
 This folder holds every continuous integration and delivery workflow for the design system.
-There are fourteen of them, but they only do four kinds of work, and the file name now starts with the verb for that kind.
+There are fifteen of them, but they only do four kinds of work, and the file name now starts with the verb for that kind.
 Job ids and step names follow the same rule — a verb first, and a name that matches what actually happens — so keep new ones consistent with their neighbours rather than inventing a new style.
 Reading them by responsibility is the quickest way to understand the whole picture.
 
@@ -25,6 +25,7 @@ Changes reach `main` through a release pull request, which is what triggers the 
 | Check bundle size             | Every pull request                                             | Report the compressed size change of the published bundles.                                                                                |
 | Check PR title                | Pull request opened, edited, or synchronized                   | Enforce a Conventional Commit title (`feat`, `fix`, `chore`) so release-please can read it.                                                |
 | Check workflows               | Every pull request                                             | Lint the Actions workflow files themselves with actionlint, including shellcheck on their `run:` scripts.                                  |
+| Deploy acceptance Chromatic   | Push to `develop`                                              | Publish Storybook to Chromatic and accept the snapshots, keeping the baseline on the integration branch current.                           |
 | Deploy acceptance Storybook   | Push to any branch except `main`; pull request reopened        | Build Storybook and publish a per-branch preview to `gh-pages` under `demo-<branch>`. Records a GitHub Deployment and Environment.         |
 | Deploy production Storybook   | Push to `main`                                                 | Build Storybook and publish the live documentation site to the `gh-pages` root.                                                            |
 | Deploy production Chromatic   | Push to `main`                                                 | Publish Storybook to Chromatic and auto-accept the snapshots as the new baseline, keeping the public permalink and its MCP server in sync. |
@@ -44,6 +45,12 @@ The **Check** workflows run together and gate the merge.
 **Check workflows** lints the Actions workflow files themselves.
 
 At the same time, **Deploy acceptance Storybook** publishes a live Storybook preview for the branch at `demo-<branch>` on GitHub Pages.
+
+### Merging to `develop`
+
+**Deploy acceptance Chromatic** publishes Storybook to Chromatic and accepts the snapshots, so a build exists on the integration branch itself.
+Pull requests are squash-merged, so no build ever runs on a commit that stays in the history of `develop`.
+Chromatic carries baselines across that gap through the merge association from its GitHub App, and normally resolves a current one; a build on `develop` means resolution no longer rests on that indirection alone.
 
 ### Merging to `main`
 
@@ -98,3 +105,7 @@ The supporting scripts live in [`.github/scripts`](../scripts).
   Branch protection and rulesets refer to a check by its job's `name:` (or its id, if the job has no `name:`) — never the workflow's name or file. If you rename a job that's a required check, update the required status checks in the repository settings in the same change, or the check gets stuck on “Expected — waiting for status” forever.
 - **Chromatic only snapshots the story named “Test”.**
   That is a Storybook convention unrelated to any workflow name; see the [testing documentation](../../documentation/tests.md).
+- **A pull request's Chromatic baseline does not come from its own history.**
+  Because pull requests are squash-merged, no build runs on a commit that `develop` keeps, so Chromatic relies on the merge association from its GitHub App to carry baselines across.
+  **Deploy acceptance Chromatic** puts a build on `develop` itself, so resolution has something on the integration branch to land on.
+  If a pull request ever reports far more changes than it made, suspect the baseline before the diff: re-running Chromatic is the quickest way to tell the two apart, and the required ‘UI Tests’ check makes it a merge blocker until it is settled.

--- a/.github/workflows/deploy-acceptance-chromatic.yml
+++ b/.github/workflows/deploy-acceptance-chromatic.yml
@@ -1,0 +1,62 @@
+name: Deploy acceptance Chromatic
+
+# Publishes Storybook to Chromatic on every push to develop and accepts the
+# snapshots, so a build exists on the integration branch itself.
+#
+# Pull requests are squash-merged, so no build ever runs on a commit that stays
+# in develop's history. Chromatic carries baselines across that gap through the
+# merge association from its GitHub App, and normally resolves a current one.
+# A build on develop means resolution no longer rests on that indirection
+# alone, and that the oldest build it can fall back to is develop's own rather
+# than the last release on main.
+
+on:
+  push:
+    branches: [develop]
+
+permissions:
+  contents: read
+
+# A newer push to develop supersedes the one in flight: the later commit
+# contains the earlier one, so cancelling saves snapshots without losing a
+# baseline.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  run-chromatic:
+    name: Run Chromatic
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Chromatic walks the commit history to find the build to compare against.
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node.js version
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          cache: pnpm
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm --filter=!storybook -r run build
+
+      - name: Run Chromatic
+        uses: chromaui/action@94713c544284a14195de3b50ef24301579f1877e # v18.0.1
+        with:
+          # Every change reaching develop was reviewed on its pull request, so accept
+          # it as the new baseline rather than leaving the build unreviewed.
+          autoAcceptChanges: "develop"
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: storybook

--- a/documentation/tests.md
+++ b/documentation/tests.md
@@ -71,6 +71,8 @@ Chromatic also uses a [GitHub App](https://github.com/apps/chromatic-com) to i
 
 On every pull request, the [workflow](https://github.com/Amsterdam/design-system/blob/develop/.github/workflows/check-visual-regressions.yml) builds Storybook and publishes it to Chromatic, where the tests are run. The test status is displayed in the pull request through the app integration.
 
+A separate [workflow](https://github.com/Amsterdam/design-system/blob/develop/.github/workflows/deploy-acceptance-chromatic.yml) does the same on every push to `develop` and accepts the snapshots, so a build exists on the integration branch itself. Pull requests are squash-merged, so no build ever runs on a commit that stays in the history of `develop`; Chromatic carries baselines across that gap through the merge association from its GitHub App. A build on `develop` means baseline resolution no longer rests on that indirection alone. If a pull request reports far more changes than it made, the baseline is the first thing to suspect — re-running Chromatic is the quickest way to tell a stale baseline from a real diff.
+
 #### How to get access
 
 Ask a team member to [add you to the Chromatic Team](https://www.chromatic.com/docs/collaborators/).


### PR DESCRIPTION
## Links

- [`storybook/chromatic.config.json`](https://github.com/Amsterdam/design-system/blob/develop/storybook/chromatic.config.json) — the snapshot glob
- #2815 and #2816 — the pull requests that added `Pages/**` and `Utilities/**/**/Test` to it
- #2827 — the pull request whose Chromatic build prompted this

## What

A new **Deploy acceptance Chromatic** workflow publishes Storybook to Chromatic on every push to `develop` and accepts the snapshots, mirroring what **Deploy production Chromatic** already does for `main`.

The workflows README gains a row, a ‘Merging to `develop`’ section and a gotcha, and the testing documentation gains a paragraph on where a baseline comes from. One existing note is corrected in its own commit: it still claimed Chromatic only snapshots the story named ‘Test’, which stopped being true when #2815 and #2816 added page templates and CSS utilities to the glob.

## Why

Pull requests are squash-merged, so no Chromatic build ever runs on a commit that stays in the history of `develop`. The build that ran on a branch is attached to commits the squash discards, and nothing builds `develop` itself: **Check visual regressions** triggers on `pull_request` and on a `/chromatic test` comment, never on a push, and **Deploy production Chromatic** only covers `main`.

Chromatic bridges that gap with the merge association from its GitHub App, and it normally works. The recent history shows it working: #2818 and #2820 through #2824 reported no changes, #2825 reported the sixteen public templates it actually changed, and #2826 reported the single heading margin it actually changed. This is not a claim that baselines are broken.

What this adds is that baseline resolution no longer rests on that indirection alone. A build on `develop` gives resolution something on the integration branch to land on, and bounds how far back it can reach when it degrades — `develop`'s last build rather than the last release on `main`. The gap between those two is not small: `main` moves only on a release, and today it sits twenty-four commits and four days behind.

The cost of getting it wrong is not just noise. The ruleset on the default branch requires the `UI Tests` check, so a pull request that inherits a stale baseline cannot merge until someone accepts a backlog of other people's changes under its name.

## How

The workflow is a copy of **Deploy production Chromatic** with the branch and the accepted branch changed, so the two stay easy to compare. `fetch-depth: 0` is kept — Chromatic walks the commit history to find the build to compare against — and the action digests are the ones already in use, so they pass the Actions allowlist unchanged.

Two things differ from the production workflow, both deliberate:

- A concurrency group with `cancel-in-progress`. Merges to `develop` arrive in bursts, and a later commit contains the earlier one, so cancelling the build in flight saves snapshots without losing a baseline. Drop it if you would rather have a build recorded per merge.
- A `timeout-minutes` of 30, matching **Check visual regressions**.

The job is named `Run Chromatic`, like the one in **Check visual regressions**. That name is not a required check anywhere — the ruleset requires `UI Tests`, which comes from the Chromatic app — and this workflow never runs on a pull request, so it cannot appear as a check on one.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11)

## Additional notes

**What this does not claim.** #2827 reported forty changes it did not make, and this workflow is not known to fix that. Its baseline resolved to a build from before 20 July, while this pull request — branched from the same commit, opened forty minutes later — reported no changes at all. Whatever made those two differ is unexplained, and Chromatic support is the shortest route to an answer if it recurs. This change makes the failure mode less costly rather than impossible.

**Cost.** One build per merge to `develop`, currently around 214 snapshots, minus whatever the concurrency group cancels.

**Effect.** Nothing here changes a component, so there is nothing for Chromatic to see on this pull request. The effect starts once it is merged: the first push to `develop` afterwards records the baseline.

**Related, and worth knowing while reviewing.** **Check visual regressions** does not trigger on `synchronize`, so pushing more commits to an open pull request does not re-run Chromatic. That saves snapshots, but it means the Chromatic result on a pull request can describe an older commit than the one you are looking at.
