### PR TITLE
feat(Storybook): Add Information Page templates

### DIFF
--- a/storybook/src/pages/public/InformationPage/InformationPage.docs.mdx
+++ b/storybook/src/pages/public/InformationPage/InformationPage.docs.mdx
@@ -1,0 +1,42 @@
+{/* @license CC0-1.0 */}
+
+import { Meta } from "@storybook/addon-docs/blocks";
+
+import * as InformationStories from "./InformationPage.stories.tsx";
+
+<Meta of={InformationStories} />
+
+# Information page
+
+Explains a subject that is neither a product nor a news article: background, rules, and what they mean for the reader.
+Use it when the reader wants to understand something, rather than arrange something.
+For a task that ends in a form or an application, use the [Product page](/docs/pages-public-product-page--docs) instead.
+
+## Structure
+
+- The [Breadcrumb](/docs/components-navigation-breadcrumb--docs) has its own [Grid](/docs/components-layout-grid--docs) to separate its `nav` element from the `main` wrapping the page content.
+- The page header contains the title and the taxonomy tags that classify the page.
+  The tags are a plain [Paragraph](/docs/components-text-paragraph--docs) of comma-separated terms, not links.
+- The lead paragraph and an introductory [Image](/docs/components-media-image--docs) sit side by side below the header.
+- The body holds several sections, each opening with a level 2 Heading.
+- An [Accordion](/docs/components-containers-accordion--docs) groups detail questions that not every reader needs.
+  Keep the answers short enough to read without scrolling back to the question.
+- Images within the body are as wide as the text column.
+
+## Headings
+
+- Use a level 1 Heading for the title of the page.
+- Use level 2 Headings for the section titles, and level 3 for subsections.
+- Set the Accordion’s `headingLevel` one level below the section heading it follows.
+  In this example that is level 3.
+
+## Layout and spacing
+
+- The Grids use the [recommended Cell sizes](/docs/pages-public-introduction--docs#how-to-size-the-grid-cells).
+- The lead paragraph and the introductory image each span half the content width, and stack on the narrow grid.
+- All body sections share a single Grid Cell, indented one column on wider screens for a comfortable reading measure.
+- An Image always reserves its box, so the layout does not shift while it loads.
+  Use `aspectRatio` to change the ratio it crops to; leaving it off keeps the default of 16:9.
+  Do not lazy-load an image in the first screenful, where it would only delay the largest image in the viewport.
+- For the spacing between components, refer to [vertical space](/docs/docs-designer-guide-vertical-space--docs).
+  An Accordion starts with a Heading, so it takes the spacing that its heading level calls for.

--- a/storybook/src/pages/public/InformationPage/InformationPage.docs.mdx
+++ b/storybook/src/pages/public/InformationPage/InformationPage.docs.mdx
@@ -18,7 +18,9 @@ For a task that ends in a form or an application, use the [Product page](/docs/p
 - The page header contains the title and the metadata that classifies the page: taxonomy tags, optionally preceded by a date.
   The tags are a plain [Paragraph](/docs/components-text-paragraph--docs) of comma-separated terms, not links.
 - The body holds several sections, each opening with a level 2 Heading.
-- Everything below the header sits in its own Grid, so that each block is set apart by the padding between them rather than by a row gap.
+- The header Grid holds the title and the metadata in one Cell.
+  Where an introductory Image sits beside the lead paragraph, each of the two takes its own Cell in that same Grid; without one, the lead stays in the header Cell.
+- Each section below the header sits in its own Grid, so the padding between those Grids sets them apart rather than a row gap.
 
 ## Headings
 
@@ -30,7 +32,10 @@ For a task that ends in a form or an application, use the [Product page](/docs/p
 ## Layout and spacing
 
 - The Grids use the [recommended Cell sizes](/docs/pages-public-introduction--docs#how-to-size-the-grid-cells).
+  The Cells for the lead paragraph and the Image take the sizes for side-by-side blocks, which reach one column further than the header Cell above them.
 - All body sections share a single Grid Cell, indented one column on wider screens for a comfortable reading measure.
+- Where the lead paragraph takes a Cell of its own, the Grid’s row gap sets the space between it and the title above.
+  That gap stays at the default of `x-large`: [vertical space](/docs/docs-designer-guide-vertical-space--docs) asks for medium here, which `gapVertical` does not offer.
 - An [Image](/docs/components-media-image--docs) always reserves its box, so the layout does not shift while it loads.
   Use `aspectRatio` to change the ratio it crops to; leaving it off keeps the default of 16:9.
   Do not lazy-load an image in the first screenful, where it would only delay the largest image in the viewport.
@@ -39,7 +44,7 @@ For a task that ends in a form or an application, use the [Product page](/docs/p
 
 ## Default
 
-The lead paragraph and an introductory Image sit side by side below the header, each spanning half the content width, and stack on the narrow grid.
+The lead paragraph and an introductory Image sit side by side below the header, and stack on the narrow grid.
 
 An [Accordion](/docs/components-containers-accordion--docs) groups detail questions that not every reader needs.
 Keep the answers short enough to read without scrolling back to the question.

--- a/storybook/src/pages/public/InformationPage/InformationPage.docs.mdx
+++ b/storybook/src/pages/public/InformationPage/InformationPage.docs.mdx
@@ -15,28 +15,49 @@ For a task that ends in a form or an application, use the [Product page](/docs/p
 ## Structure
 
 - The [Breadcrumb](/docs/components-navigation-breadcrumb--docs) has its own [Grid](/docs/components-layout-grid--docs) to separate its `nav` element from the `main` wrapping the page content.
-- The page header contains the title and the taxonomy tags that classify the page.
+- The page header contains the title and the metadata that classifies the page: taxonomy tags, optionally preceded by a date.
   The tags are a plain [Paragraph](/docs/components-text-paragraph--docs) of comma-separated terms, not links.
-- The lead paragraph and an introductory [Image](/docs/components-media-image--docs) sit side by side below the header.
 - The body holds several sections, each opening with a level 2 Heading.
-- An [Accordion](/docs/components-containers-accordion--docs) groups detail questions that not every reader needs.
-  Keep the answers short enough to read without scrolling back to the question.
-- Images within the body are as wide as the text column.
+- Everything below the header sits in its own Grid, so that each block is set apart by the padding between them rather than by a row gap.
 
 ## Headings
 
 - Use a level 1 Heading for the title of the page.
 - Use level 2 Headings for the section titles, and level 3 for subsections.
 - Set the Accordion’s `headingLevel` one level below the section heading it follows.
-  In this example that is level 3.
+  In the first example that is level 3.
 
 ## Layout and spacing
 
 - The Grids use the [recommended Cell sizes](/docs/pages-public-introduction--docs#how-to-size-the-grid-cells).
-- The lead paragraph and the introductory image each span half the content width, and stack on the narrow grid.
 - All body sections share a single Grid Cell, indented one column on wider screens for a comfortable reading measure.
-- An Image always reserves its box, so the layout does not shift while it loads.
+- An [Image](/docs/components-media-image--docs) always reserves its box, so the layout does not shift while it loads.
   Use `aspectRatio` to change the ratio it crops to; leaving it off keeps the default of 16:9.
   Do not lazy-load an image in the first screenful, where it would only delay the largest image in the viewport.
 - For the spacing between components, refer to [vertical space](/docs/docs-designer-guide-vertical-space--docs).
   An Accordion starts with a Heading, so it takes the spacing that its heading level calls for.
+
+## Default
+
+The lead paragraph and an introductory Image sit side by side below the header, each spanning half the content width, and stack on the narrow grid.
+
+An [Accordion](/docs/components-containers-accordion--docs) groups detail questions that not every reader needs.
+Keep the answers short enough to read without scrolling back to the question.
+
+Images within the body are as wide as the text column.
+
+## With Table
+
+Without an image beside it, the lead paragraph stays in the header cell with the title and metadata.
+
+A [Table](/docs/components-containers-table--docs) presents reference data that would be unreadable as prose.
+It sizes to its content and scrolls horizontally once it outgrows its Grid Cell, so give it a cell wider than the reading column.
+Put the title of the table in its Caption rather than in a separate Heading above it, and mark the first cell of each row as a header cell with `scope="row"` so that screen readers announce it with every cell that follows.
+
+A [Figure](/docs/components-media-figure--docs) groups the table with the sources the data comes from.
+Keep the table’s own Caption as its name, and use the Figure’s Caption for the sources: the two describe different things, and a table that loses its Caption loses its accessible name.
+The Figure supplies the space between them, so the table needs no margin of its own.
+
+A Figure Caption takes any content, not only a sentence.
+Here it holds a level 3 Heading and a [Link List](/docs/components-navigation-link-list--docs), which keeps the sources scannable and lets each one be its own link.
+Note that the whole caption becomes the accessible name of the Figure, so keep it short.

--- a/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
+++ b/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
@@ -1,0 +1,147 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Accordion, Breadcrumb, Grid, Heading, Image, Paragraph } from '@amsterdam/design-system-react'
+
+import { commonMeta } from '../common/commonMeta'
+
+const meta = {
+  ...commonMeta,
+  title: 'Pages/Public/Information Page',
+} satisfies Meta
+
+export default meta
+
+export const Default: StoryObj = {
+  render: () => (
+    <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+      <Grid paddingTop="large">
+        <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+          <Breadcrumb>
+            <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+            <Breadcrumb.Link href="#">Parken en groen</Breadcrumb.Link>
+            <Breadcrumb.Link href="#">Evenementen in parken</Breadcrumb.Link>
+          </Breadcrumb>
+        </Grid.Cell>
+      </Grid>
+      {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+      {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
+      <main id="inhoud">
+        <Grid paddingBottom="x-large">
+          {/* The title spans the wide intro column. The taxonomy tags below it are a metadata Paragraph. */}
+          <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading className="ams-mb-xs" level={1}>
+              Natuurbescherming bij evenementen in parken en groengebieden
+            </Heading>
+            <Paragraph>Evenementen, Natuur en groen, Vergunningen</Paragraph>
+          </Grid.Cell>
+          {/* The lead paragraph and the introductory image each span half the content width, and stack on the narrow grid. */}
+          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Paragraph size="large">
+              De Wet Natuurbescherming verbiedt festivals in het broedseizoen niet. Festivalorganisatoren moeten wel
+              extra maatregelen nemen om de planten en dieren in het park te beschermen. Volgens een natuurtoets door
+              een adviesbureau voldoet de festivalorganisator aan de eisen van de natuurbeschermingswet. Het stadsdeel
+              verleent de vergunning.
+            </Paragraph>
+          </Grid.Cell>
+          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
+            {/*
+             * Image always reserves its box; aspectRatio only changes it from the default 16:9 to 4:3. This one
+             * sits in the first screenful, so it is not lazy-loaded: that would delay the largest image in the
+             * viewport.
+             */}
+            {/* This image carries no information the text does not, so it takes an empty alt. */}
+            <Image alt="" aspectRatio="4:3" src="https://picsum.photos/id/1015/640/480" />
+          </Grid.Cell>
+        </Grid>
+        {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+        <Grid paddingBottom="2x-large">
+          {/* The body sits in a narrower cell, indented one column on wider screens, for a comfortable reading measure. */}
+          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+            <Heading className="ams-mb-s" level={2}>
+              Regels tijdens het broedseizoen
+            </Heading>
+            <Paragraph className="ams-mb-l">
+              Van half maart tot half juli broeden veel vogels in de parken. In die periode gelden extra regels voor
+              geluid, verlichting en de opbouw van podia.
+            </Paragraph>
+            {/* The Accordion’s headings sit one level below the section heading above it, so headingLevel is 3 here. */}
+            <Accordion className="ams-mb-xl" headingLevel={3}>
+              <Accordion.Section label="Wanneer is het broedseizoen?">
+                <Paragraph>
+                  Het broedseizoen loopt globaal van 15 maart tot 15 juli. De precieze periode verschilt per vogelsoort
+                  en per jaar. Een ecoloog bepaalt bij elk evenement of er op dat moment nesten in gebruik zijn.
+                </Paragraph>
+              </Accordion.Section>
+              <Accordion.Section label="Welke maatregelen neemt een organisator?">
+                <Paragraph>
+                  Denk aan het weren van geluid richting bosschages, het uitschakelen van schijnwerpers na
+                  zonsondergang, en het vrijhouden van een zone rond nestbomen. De maatregelen staan in het ecologisch
+                  werkprotocol bij de vergunning.
+                </Paragraph>
+              </Accordion.Section>
+              <Accordion.Section label="Wat staat er in een natuurtoets?">
+                <Paragraph>
+                  Een adviesbureau onderzoekt welke beschermde planten en dieren in het gebied voorkomen. De natuurtoets
+                  beschrijft de verwachte effecten van het evenement en de maatregelen die nodig zijn om schade te
+                  voorkomen.
+                </Paragraph>
+              </Accordion.Section>
+              <Accordion.Section label="Wie controleert de afspraken?">
+                <Paragraph>
+                  Toezichthouders van de gemeente controleren voor, tijdens en na het evenement. Bij overtredingen kan
+                  het stadsdeel het evenement stilleggen of de vergunning voor een volgend jaar weigeren.
+                </Paragraph>
+              </Accordion.Section>
+              <Accordion.Section label="Waar meldt u schade aan groen?">
+                <Paragraph>
+                  Ziet u schade aan bomen, struiken of oevers? Meld dit via het formulier Melding openbare ruimte.
+                  Vermeld de locatie en voeg zo mogelijk een foto toe.
+                </Paragraph>
+              </Accordion.Section>
+            </Accordion>
+
+            <Heading className="ams-mb-s" level={2}>
+              Onderzoek naar planten en dieren
+            </Heading>
+            <Paragraph className="ams-mb-l">
+              Voor elk groot evenement in een park laat de organisator een natuurtoets uitvoeren. Het onderzoek brengt
+              in kaart welke soorten er leven en hoe kwetsbaar zij zijn. De uitkomsten bepalen waar podia, hekken en
+              horeca mogen staan.
+            </Paragraph>
+            {/* An image within the body column is as wide as the text above it. */}
+            <Image alt="" className="ams-mb-xl" loading="lazy" src="https://picsum.photos/id/1016/1280/720" />
+
+            <Heading className="ams-mb-s" level={2}>
+              Bezwaar maken tegen een vergunning
+            </Heading>
+            <Paragraph className="ams-mb-m">
+              Bent u het niet eens met een verleende vergunning? Dan kunt u binnen 6 weken na de bekendmaking bezwaar
+              maken. De termijn begint op de dag na de publicatie in het Gemeenteblad.
+            </Paragraph>
+            <Paragraph className="ams-mb-l">
+              Een bezwaar schorst de vergunning niet. Wilt u dat het evenement voorlopig niet doorgaat, dan vraagt u de
+              rechtbank daarnaast om een voorlopige voorziening.
+            </Paragraph>
+            <Heading className="ams-mb-xs" level={3}>
+              Wat zet u in uw bezwaarschrift?
+            </Heading>
+            <Paragraph className="ams-mb-m">
+              Beschrijf om welke vergunning het gaat, waarom u het er niet mee eens bent, en wat u anders zou willen
+              zien. Vermeld ook uw naam, adres en de datum.
+            </Paragraph>
+            <Paragraph>
+              U ontvangt een bevestiging van ontvangst. Daarna nodigt de bezwaarcommissie u uit voor een hoorzitting.
+              Binnen 12 weken volgt een beslissing op uw bezwaar.
+            </Paragraph>
+          </Grid.Cell>
+        </Grid>
+      </main>
+    </>
+  ),
+}

--- a/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
+++ b/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
@@ -5,7 +5,17 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { Accordion, Breadcrumb, Grid, Heading, Image, Paragraph } from '@amsterdam/design-system-react'
+import {
+  Accordion,
+  Breadcrumb,
+  Figure,
+  Grid,
+  Heading,
+  Image,
+  LinkList,
+  Paragraph,
+  Table,
+} from '@amsterdam/design-system-react'
 
 import { commonMeta } from '../common/commonMeta'
 
@@ -139,6 +149,142 @@ export const Default: StoryObj = {
               U ontvangt een bevestiging van ontvangst. Daarna nodigt de bezwaarcommissie u uit voor een hoorzitting.
               Binnen 12 weken volgt een beslissing op uw bezwaar.
             </Paragraph>
+          </Grid.Cell>
+        </Grid>
+      </main>
+    </>
+  ),
+}
+
+export const WithTable: StoryObj = {
+  render: () => (
+    <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+      <Grid paddingTop="large">
+        <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+          <Breadcrumb>
+            <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+            <Breadcrumb.Link href="#">Belastingen</Breadcrumb.Link>
+            <Breadcrumb.Link href="#">WOZ-waarde</Breadcrumb.Link>
+          </Breadcrumb>
+        </Grid.Cell>
+      </Grid>
+      {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+      {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
+      <main id="inhoud">
+        <Grid paddingBottom="x-large">
+          {/* Without an image beside it, the lead paragraph stays in the header cell with the title and metadata. */}
+          <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading className="ams-mb-xs" level={1}>
+              Landelijk vastgestelde gegevens voor de WOZ-waarde van uw woning
+            </Heading>
+            <Paragraph className="ams-mb-xl">
+              {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
+              <time dateTime="2026-01-01">1 januari 2026</time> – Belastingen, Wonen, WOZ
+            </Paragraph>
+            <Paragraph size="large">
+              De gemeente stelt elk jaar de WOZ-waarde van uw woning vast. Welke gegevens daarbij horen en hoe zij
+              worden vastgelegd, is landelijk bepaald. Zo betekent een gegeven in Amsterdam hetzelfde als in elke andere
+              gemeente.
+            </Paragraph>
+          </Grid.Cell>
+        </Grid>
+        <Grid paddingBottom="x-large">
+          {/* The body sits in a narrower cell, indented one column on wider screens, for a comfortable reading measure. */}
+          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+            <Heading className="ams-mb-s" level={2}>
+              Hoe de WOZ-waarde tot stand komt
+            </Heading>
+            <Paragraph className="ams-mb-m">
+              De WOZ-waarde is de waarde die uw woning op de peildatum zou opbrengen bij verkoop. De peildatum ligt
+              altijd een jaar voor het belastingjaar, zodat de gemeente verkoopcijfers van een heel jaar kan gebruiken.
+            </Paragraph>
+            <Paragraph className="ams-mb-l">
+              Voor de vergelijking gebruikt de gemeente woningen die in dezelfde periode zijn verkocht en die op uw
+              woning lijken in type, grootte, bouwjaar en ligging. Verschillen tussen die woningen en de uwe worden
+              verrekend.
+            </Paragraph>
+            <Heading className="ams-mb-xs" level={3}>
+              Niet eens met de waarde
+            </Heading>
+            <Paragraph className="ams-mb-m">
+              Bekijk eerst het taxatieverslag. Daarin staat welke woningen zijn vergeleken en welke kenmerken zijn
+              gebruikt. Klopt een kenmerk niet, geef dat dan aan ons door.
+            </Paragraph>
+            <Paragraph>
+              Bent u het daarna nog niet eens met de waarde? Maak dan binnen 6 weken na de dagtekening van de aanslag
+              bezwaar. U hoeft daar geen bureau voor in te schakelen.
+            </Paragraph>
+          </Grid.Cell>
+        </Grid>
+        {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+        <Grid paddingBottom="2x-large">
+          {/* A Table sizes to its content and scrolls once it outgrows its cell, so give it a wider cell than the reading column. */}
+          <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            {/* A Figure groups the table with the sources it came from. The Figure supplies the space between them. */}
+            <Figure>
+              <Table>
+                <Table.Caption>
+                  <Heading level={2}>Landelijk vastgestelde gegevens WOZ</Heading>
+                </Table.Caption>
+                <Table.Header>
+                  <Table.Row>
+                    <Table.HeaderCell>Gegeven</Table.HeaderCell>
+                    <Table.HeaderCell>Omschrijving</Table.HeaderCell>
+                    <Table.HeaderCell>Eenheid</Table.HeaderCell>
+                    <Table.HeaderCell>Verplicht</Table.HeaderCell>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  <Table.Row>
+                    {/* A row header names the row, so screen readers announce it with each cell that follows. */}
+                    <Table.HeaderCell scope="row">WOZ-waarde</Table.HeaderCell>
+                    <Table.Cell>Vastgestelde waarde van de woning</Table.Cell>
+                    <Table.Cell>Euro</Table.Cell>
+                    <Table.Cell>Ja</Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <Table.HeaderCell scope="row">Objectnummer</Table.HeaderCell>
+                    <Table.Cell>Uniek nummer van het WOZ-object</Table.Cell>
+                    <Table.Cell>Tekst</Table.Cell>
+                    <Table.Cell>Ja</Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <Table.HeaderCell scope="row">Grondoppervlakte</Table.HeaderCell>
+                    <Table.Cell>Oppervlakte van het perceel</Table.Cell>
+                    <Table.Cell>m²</Table.Cell>
+                    <Table.Cell>Ja</Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <Table.HeaderCell scope="row">Woonoppervlakte</Table.HeaderCell>
+                    <Table.Cell>Gebruiksoppervlakte volgens de BAG</Table.Cell>
+                    <Table.Cell>m²</Table.Cell>
+                    <Table.Cell>Nee</Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <Table.HeaderCell scope="row">Bouwjaar</Table.HeaderCell>
+                    <Table.Cell>Jaar waarin het object is gebouwd</Table.Cell>
+                    <Table.Cell>Jaartal</Table.Cell>
+                    <Table.Cell>Nee</Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <Table.HeaderCell scope="row">Gebruiksdoel</Table.HeaderCell>
+                    <Table.Cell>Functie van het object volgens de BAG</Table.Cell>
+                    <Table.Cell>Tekst</Table.Cell>
+                    <Table.Cell>Ja</Table.Cell>
+                  </Table.Row>
+                </Table.Body>
+              </Table>
+              <Figure.Caption>
+                <Heading className="ams-mb-xs" level={3}>
+                  Bron
+                </Heading>
+                <LinkList>
+                  <LinkList.Link href="#">Catalogus Basisregistratie WOZ</LinkList.Link>
+                  <LinkList.Link href="#">Gegevenswoordenboek WOZ</LinkList.Link>
+                </LinkList>
+              </Figure.Caption>
+            </Figure>
           </Grid.Cell>
         </Grid>
       </main>

--- a/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
+++ b/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
@@ -54,7 +54,8 @@ export const Default: StoryObj = {
         <Paragraph>Evenementen, Natuur en groen, Vergunningen</Paragraph>
       </Grid.Cell>
       {/*
-       * The lead paragraph and the introductory image each span half the content width, and stack on the narrow grid.
+       * The lead paragraph and the introductory image take the side-by-side Cell sizes, so the pair reaches a
+       * column further than the header Cell above it. Both stack on the narrow grid.
        */}
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Paragraph size="large">
@@ -176,7 +177,10 @@ export const Default: StoryObj = {
             </Heading>
             <Paragraph>Evenementen, Natuur en groen, Vergunningen</Paragraph>
           </Grid.Cell>
-          {/* The lead paragraph and the introductory image each span half the content width, and stack on the narrow grid. */}
+          {/*
+           * The lead paragraph and the introductory image take the side-by-side Cell sizes, so the pair reaches a
+           * column further than the header Cell above it. Both stack on the narrow grid.
+           */}
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
             <Paragraph size="large">
               De Wet Natuurbescherming verbiedt festivals in het broedseizoen niet. Festivalorganisatoren moeten wel

--- a/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
+++ b/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
@@ -27,6 +27,132 @@ const meta = {
 export default meta
 
 export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // Because this story’s `render` takes no argument, the Code Panel prints its source as written, the story
+        // wrapper and its types included. Provide the source by hand so the panel shows the markup to compose,
+        // without that scaffolding.
+        code: `<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+        <Breadcrumb.Link href="#">Parken en groen</Breadcrumb.Link>
+        <Breadcrumb.Link href="#">Evenementen in parken</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+  {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
+  <main id="inhoud">
+    <Grid paddingBottom="x-large">
+      {/* The title spans the wide intro column. The taxonomy tags below it are a metadata Paragraph. */}
+      <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-xs" level={1}>Natuurbescherming bij evenementen in parken en groengebieden</Heading>
+        <Paragraph>Evenementen, Natuur en groen, Vergunningen</Paragraph>
+      </Grid.Cell>
+      {/*
+       * The lead paragraph and the introductory image each span half the content width, and stack on the narrow grid.
+       */}
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Paragraph size="large">
+          De Wet Natuurbescherming verbiedt festivals in het broedseizoen niet. Festivalorganisatoren moeten wel
+          extra maatregelen nemen om de planten en dieren in het park te beschermen. Volgens een natuurtoets door
+          een adviesbureau voldoet de festivalorganisator aan de eisen van de natuurbeschermingswet. Het stadsdeel
+          verleent de vergunning.
+        </Paragraph>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
+        {/*
+         * Image always reserves its box; aspectRatio only changes it from the default 16:9 to 4:3. This one
+         * sits in the first screenful, so it is not lazy-loaded: that would delay the largest image in the
+         * viewport.
+         */}
+        {/* This image carries no information the text does not, so it takes an empty alt. */}
+        <Image alt="" aspectRatio="4:3" src="https://picsum.photos/id/1015/640/480" />
+      </Grid.Cell>
+    </Grid>
+    {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+    <Grid paddingBottom="2x-large">
+      {/* The body sits in a narrower cell, indented one column on wider screens, for a comfortable reading measure. */}
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+        <Heading className="ams-mb-s" level={2}>Regels tijdens het broedseizoen</Heading>
+        <Paragraph className="ams-mb-l">
+          Van half maart tot half juli broeden veel vogels in de parken. In die periode gelden extra regels voor
+          geluid, verlichting en de opbouw van podia.
+        </Paragraph>
+        {/* The Accordion’s headings sit one level below the section heading above it, so headingLevel is 3 here. */}
+        <Accordion className="ams-mb-xl" headingLevel={3}>
+          <Accordion.Section label="Wanneer is het broedseizoen?">
+            <Paragraph>
+              Het broedseizoen loopt globaal van 15 maart tot 15 juli. De precieze periode verschilt per vogelsoort
+              en per jaar. Een ecoloog bepaalt bij elk evenement of er op dat moment nesten in gebruik zijn.
+            </Paragraph>
+          </Accordion.Section>
+          <Accordion.Section label="Welke maatregelen neemt een organisator?">
+            <Paragraph>
+              Denk aan het weren van geluid richting bosschages, het uitschakelen van schijnwerpers na
+              zonsondergang, en het vrijhouden van een zone rond nestbomen. De maatregelen staan in het ecologisch
+              werkprotocol bij de vergunning.
+            </Paragraph>
+          </Accordion.Section>
+          <Accordion.Section label="Wat staat er in een natuurtoets?">
+            <Paragraph>
+              Een adviesbureau onderzoekt welke beschermde planten en dieren in het gebied voorkomen. De natuurtoets
+              beschrijft de verwachte effecten van het evenement en de maatregelen die nodig zijn om schade te
+              voorkomen.
+            </Paragraph>
+          </Accordion.Section>
+          <Accordion.Section label="Wie controleert de afspraken?">
+            <Paragraph>
+              Toezichthouders van de gemeente controleren voor, tijdens en na het evenement. Bij overtredingen kan
+              het stadsdeel het evenement stilleggen of de vergunning voor een volgend jaar weigeren.
+            </Paragraph>
+          </Accordion.Section>
+          <Accordion.Section label="Waar meldt u schade aan groen?">
+            <Paragraph>
+              Ziet u schade aan bomen, struiken of oevers? Meld dit via het formulier Melding openbare ruimte.
+              Vermeld de locatie en voeg zo mogelijk een foto toe.
+            </Paragraph>
+          </Accordion.Section>
+        </Accordion>
+
+        <Heading className="ams-mb-s" level={2}>Onderzoek naar planten en dieren</Heading>
+        <Paragraph className="ams-mb-l">
+          Voor elk groot evenement in een park laat de organisator een natuurtoets uitvoeren. Het onderzoek brengt
+          in kaart welke soorten er leven en hoe kwetsbaar zij zijn. De uitkomsten bepalen waar podia, hekken en
+          horeca mogen staan.
+        </Paragraph>
+        {/* An image within the body column is as wide as the text above it. */}
+        <Image alt="" className="ams-mb-xl" loading="lazy" src="https://picsum.photos/id/1016/1280/720" />
+
+        <Heading className="ams-mb-s" level={2}>Bezwaar maken tegen een vergunning</Heading>
+        <Paragraph className="ams-mb-m">
+          Bent u het niet eens met een verleende vergunning? Dan kunt u binnen 6 weken na de bekendmaking bezwaar
+          maken. De termijn begint op de dag na de publicatie in het Gemeenteblad.
+        </Paragraph>
+        <Paragraph className="ams-mb-l">
+          Een bezwaar schorst de vergunning niet. Wilt u dat het evenement voorlopig niet doorgaat, dan vraagt u de
+          rechtbank daarnaast om een voorlopige voorziening.
+        </Paragraph>
+        <Heading className="ams-mb-xs" level={3}>Wat zet u in uw bezwaarschrift?</Heading>
+        <Paragraph className="ams-mb-m">
+          Beschrijf om welke vergunning het gaat, waarom u het er niet mee eens bent, en wat u anders zou willen
+          zien. Vermeld ook uw naam, adres en de datum.
+        </Paragraph>
+        <Paragraph>
+          U ontvangt een bevestiging van ontvangst. Daarna nodigt de bezwaarcommissie u uit voor een hoorzitting.
+          Binnen 12 weken volgt een beslissing op uw bezwaar.
+        </Paragraph>
+      </Grid.Cell>
+    </Grid>
+  </main>
+</>`,
+      },
+    },
+  },
   render: () => (
     <>
       {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
@@ -157,6 +283,143 @@ export const Default: StoryObj = {
 }
 
 export const WithTable: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // Because this story’s `render` takes no argument, the Code Panel prints its source as written, the story
+        // wrapper and its types included. Provide the source by hand so the panel shows the markup to compose,
+        // without that scaffolding.
+        code: `<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+        <Breadcrumb.Link href="#">Belastingen</Breadcrumb.Link>
+        <Breadcrumb.Link href="#">WOZ-waarde</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+  {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
+  <main id="inhoud">
+    <Grid paddingBottom="x-large">
+      {/* Without an image beside it, the lead paragraph stays in the header cell with the title and metadata. */}
+      <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-xs" level={1}>
+          Landelijk vastgestelde gegevens voor de WOZ-waarde van uw woning
+        </Heading>
+        <Paragraph className="ams-mb-xl">
+          {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
+          <time dateTime="2026-01-01">1 januari 2026</time> – Belastingen, Wonen, WOZ
+        </Paragraph>
+        <Paragraph size="large">
+          De gemeente stelt elk jaar de WOZ-waarde van uw woning vast. Welke gegevens daarbij horen en hoe zij
+          worden vastgelegd, is landelijk bepaald. Zo betekent een gegeven in Amsterdam hetzelfde als in elke andere
+          gemeente.
+        </Paragraph>
+      </Grid.Cell>
+    </Grid>
+    <Grid paddingBottom="x-large">
+      {/* The body sits in a narrower cell, indented one column on wider screens, for a comfortable reading measure. */}
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+        <Heading className="ams-mb-s" level={2}>Hoe de WOZ-waarde tot stand komt</Heading>
+        <Paragraph className="ams-mb-m">
+          De WOZ-waarde is de waarde die uw woning op de peildatum zou opbrengen bij verkoop. De peildatum ligt
+          altijd een jaar voor het belastingjaar, zodat de gemeente verkoopcijfers van een heel jaar kan gebruiken.
+        </Paragraph>
+        <Paragraph className="ams-mb-l">
+          Voor de vergelijking gebruikt de gemeente woningen die in dezelfde periode zijn verkocht en die op uw
+          woning lijken in type, grootte, bouwjaar en ligging. Verschillen tussen die woningen en de uwe worden
+          verrekend.
+        </Paragraph>
+        <Heading className="ams-mb-xs" level={3}>Niet eens met de waarde</Heading>
+        <Paragraph className="ams-mb-m">
+          Bekijk eerst het taxatieverslag. Daarin staat welke woningen zijn vergeleken en welke kenmerken zijn
+          gebruikt. Klopt een kenmerk niet, geef dat dan aan ons door.
+        </Paragraph>
+        <Paragraph>
+          Bent u het daarna nog niet eens met de waarde? Maak dan binnen 6 weken na de dagtekening van de aanslag
+          bezwaar. U hoeft daar geen bureau voor in te schakelen.
+        </Paragraph>
+      </Grid.Cell>
+    </Grid>
+    {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+    <Grid paddingBottom="2x-large">
+      {/*
+       * A Table sizes to its content and scrolls once it outgrows its cell, so give it a wider cell than the reading
+       * column.
+       */}
+      <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        {/* A Figure groups the table with the sources it came from. The Figure supplies the space between them. */}
+        <Figure>
+          <Table>
+            <Table.Caption>
+              <Heading level={2}>Landelijk vastgestelde gegevens WOZ</Heading>
+            </Table.Caption>
+            <Table.Header>
+              <Table.Row>
+                <Table.HeaderCell>Gegeven</Table.HeaderCell>
+                <Table.HeaderCell>Omschrijving</Table.HeaderCell>
+                <Table.HeaderCell>Eenheid</Table.HeaderCell>
+                <Table.HeaderCell>Verplicht</Table.HeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              <Table.Row>
+                {/* A row header names the row, so screen readers announce it with each cell that follows. */}
+                <Table.HeaderCell scope="row">WOZ-waarde</Table.HeaderCell>
+                <Table.Cell>Vastgestelde waarde van de woning</Table.Cell>
+                <Table.Cell>Euro</Table.Cell>
+                <Table.Cell>Ja</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.HeaderCell scope="row">Objectnummer</Table.HeaderCell>
+                <Table.Cell>Uniek nummer van het WOZ-object</Table.Cell>
+                <Table.Cell>Tekst</Table.Cell>
+                <Table.Cell>Ja</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.HeaderCell scope="row">Grondoppervlakte</Table.HeaderCell>
+                <Table.Cell>Oppervlakte van het perceel</Table.Cell>
+                <Table.Cell>m²</Table.Cell>
+                <Table.Cell>Ja</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.HeaderCell scope="row">Woonoppervlakte</Table.HeaderCell>
+                <Table.Cell>Gebruiksoppervlakte volgens de BAG</Table.Cell>
+                <Table.Cell>m²</Table.Cell>
+                <Table.Cell>Nee</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.HeaderCell scope="row">Bouwjaar</Table.HeaderCell>
+                <Table.Cell>Jaar waarin het object is gebouwd</Table.Cell>
+                <Table.Cell>Jaartal</Table.Cell>
+                <Table.Cell>Nee</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.HeaderCell scope="row">Gebruiksdoel</Table.HeaderCell>
+                <Table.Cell>Functie van het object volgens de BAG</Table.Cell>
+                <Table.Cell>Tekst</Table.Cell>
+                <Table.Cell>Ja</Table.Cell>
+              </Table.Row>
+            </Table.Body>
+          </Table>
+          <Figure.Caption>
+            <Heading className="ams-mb-xs" level={3}>Bron</Heading>
+            <LinkList>
+              <LinkList.Link href="#">Catalogus Basisregistratie WOZ</LinkList.Link>
+              <LinkList.Link href="#">Gegevenswoordenboek WOZ</LinkList.Link>
+            </LinkList>
+          </Figure.Caption>
+        </Figure>
+      </Grid.Cell>
+    </Grid>
+  </main>
+</>`,
+      },
+    },
+  },
   render: () => (
     <>
       {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}

--- a/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
+++ b/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
@@ -151,6 +151,7 @@ export const Default: StoryObj = {
     </Grid>
   </main>
 </>`,
+        language: 'tsx',
       },
     },
   },
@@ -421,6 +422,7 @@ export const WithTable: StoryObj = {
     </Grid>
   </main>
 </>`,
+        language: 'tsx',
       },
     },
   },


### PR DESCRIPTION
# Add the Information Page template

## Links

- [Storybook on main](https://designsystem.amsterdam/) — the whole preview deploy
- [Pages/Public/Information Page](https://designsystem.amsterdam/?path=/docs/pages-public-information-page--docs) — the documentation page
- [Default](https://designsystem.amsterdam/?path=/story/pages-public-information-page--default) — lead paragraph beside an image, with an Accordion
- [With Table](https://designsystem.amsterdam/?path=/story/pages-public-information-page--with-table) — reference data in a Figure with its sources

## What

A new public page template for a subject that is neither a product nor a news article: background, rules, and what they mean for the reader. It comes with two stories and a documentation page.

`Default` pairs a lead paragraph with an introductory image below the header, and groups the detail questions not every reader needs into an Accordion. `With Table` keeps the lead in the header cell and ends on reference data, presented as a Figure that pairs a captioned Table with the sources it came from.

## Why

The public set covers products, articles, navigation, projects, forms, the home page, the handbook and search, but nothing for a page whose job is simply to explain. Teams building one have been borrowing the Product Page and stripping its call to action, which loses the structure that actually distinguishes an explanatory page: a header that classifies the subject with taxonomy tags, and a body that can carry an Accordion, an image at text width, or a table of reference data.

## How

The structure follows the Grid Cell sizes and the Grid padding rules from the Pages/Public introduction, and the component spacing from the vertical space guide. Both stories carry a hand-written `parameters.docs.source.code`, like the rest of the templates, so the Code Panel shows the markup to copy rather than the story scaffolding around it.

Two layout decisions are worth calling out, because both look like mistakes until you know why. The `Default` story splits the content header across Grid Cells so the lead can sit beside an image; that pair takes the documented side-by-side Cell sizes, which reach one column further than the header Cell above them. And the row gap between the title block and the lead stays at the Grid's default of `x-large` even though the vertical space matrix asks for medium — `gapVertical` offers `none`, `large` and `2x-large`, so medium is not a value it can take. Both are written into the documentation page rather than left as an unexplained mismatch.

In `With Table`, the name of the table lives in the table's own Caption and the sources live in the Figure's Caption. The two describe different things on purpose: a table that loses its Caption loses its accessible name, and the whole Figure Caption becomes the accessible name of the Figure. The Figure supplies the space between the two, so the table needs no margin of its own.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

Two new Chromatic snapshots, since `Pages/**` is part of `onlyStoryNames`. There is no test story: page templates deliberately have none, because every story under `Pages/` is snapshotted directly.

One thing is deliberately left open. The separator in the metadata line of `With Table` — `1 januari 2026 – Belastingen, Wonen, WOZ` — is still an en dash, and we will revisit what it should be. Worth knowing while looking at it: the line can wrap between the date and the separator on a narrow grid.

