### PR TITLE
fix(Storybook): Space Heading 3 by its visual size in the page templates

### DIFF
--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -139,7 +139,7 @@ const meta = {
       <Spotlight aria-labelledby="blijf-op-de-hoogte" as="aside" color="green">
         <Grid paddingVertical="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-            <Heading className="ams-mb-s" color="inverse" id="blijf-op-de-hoogte" level={2} size="level-3">
+            <Heading className="ams-mb-xs" color="inverse" id="blijf-op-de-hoogte" level={2} size="level-3">
               Blijf op de hoogte!
             </Heading>
             <Paragraph className="ams-mb-m" color="inverse">
@@ -310,7 +310,7 @@ export const Default: StoryObj = {
   <Spotlight aria-labelledby="blijf-op-de-hoogte" as="aside" color="green">
     <Grid paddingVertical="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-        <Heading className="ams-mb-s" color="inverse" id="blijf-op-de-hoogte" level={2} size="level-3">
+        <Heading className="ams-mb-xs" color="inverse" id="blijf-op-de-hoogte" level={2} size="level-3">
           Blijf op de hoogte!
         </Heading>
         <Paragraph className="ams-mb-m" color="inverse">

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -63,7 +63,7 @@ const meta = {
         <Grid paddingVertical="x-large">
           {spotlightSections.map(({ title, description, link }) => (
             <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 6 }}>
-              <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
+              <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">
                 {title}
               </Heading>
               <Paragraph className="ams-mb-m" color="inverse">
@@ -153,7 +153,7 @@ export const Default: StoryObj = {
     <Grid paddingVertical="x-large">
       {spotlightSections.map(({ title, description, link }) => (
         <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 6 }}>
-          <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">{title}</Heading>
+          <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">{title}</Heading>
           <Paragraph className="ams-mb-m" color="inverse">{description}</Paragraph>
           <StandaloneLink color="inverse" href="#">{link}</StandaloneLink>
         </Grid.Cell>

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -504,14 +504,14 @@ export const WithImageGallery: StoryObj = {
         </Grid.Cell>
       ))}
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading className="ams-mb-s" level={2} size="level-3">Portefeuilleverdeling</Heading>
+        <Heading className="ams-mb-xs" level={2} size="level-3">Portefeuilleverdeling</Heading>
         <Paragraph className="ams-mb-s">
           Een alfabetisch overzicht van de portefeuilles van burgemeester en wethouders.
         </Paragraph>
         <StandaloneLink href="#">Portefeuilleverdeling</StandaloneLink>
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
-        <Heading className="ams-mb-s" level={2} size="level-3">Coalitieakkoord</Heading>
+        <Heading className="ams-mb-xs" level={2} size="level-3">Coalitieakkoord</Heading>
         <Paragraph className="ams-mb-s">
           In dit akkoord staan de plannen en visie van de coalitie PvdA, GroenLinks en D66 voor 2022-2026.
         </Paragraph>
@@ -521,7 +521,7 @@ export const WithImageGallery: StoryObj = {
     <Spotlight>
       <Grid paddingVertical="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Persberichten en nieuws</Heading>
+          <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">Persberichten en nieuws</Heading>
           <LinkList className="ams-mb-m">
             <LinkList.Link color="inverse" href="#">
               Proef elektrische fietsen voor sociale huurders op Strandeiland en Centrumeiland
@@ -531,7 +531,7 @@ export const WithImageGallery: StoryObj = {
           </LinkList>
         </Grid.Cell>
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
-          <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Besluiten B en W</Heading>
+          <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">Besluiten B en W</Heading>
           <LinkList className="ams-mb-m">
             <LinkList.Link color="inverse" href="#">Nieuws uit B en W 9 juli 2025</LinkList.Link>
             <LinkList.Link color="inverse" href="#">Nieuws uit B en W 2 juli 2025</LinkList.Link>
@@ -544,12 +544,12 @@ export const WithImageGallery: StoryObj = {
     {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
     <Grid paddingBottom="2x-large" paddingTop="x-large">
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading className="ams-mb-s" level={2} size="level-3">Pers en woordvoering</Heading>
+        <Heading className="ams-mb-xs" level={2} size="level-3">Pers en woordvoering</Heading>
         <Paragraph className="ams-mb-s">Voor vragen van journalisten aan de afdeling Bestuursvoorlichting.</Paragraph>
         <StandaloneLink href="#">Pers en woordvoering</StandaloneLink>
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
-        <Heading className="ams-mb-s" level={2} size="level-3">Meer over het college</Heading>
+        <Heading className="ams-mb-xs" level={2} size="level-3">Meer over het college</Heading>
         <LinkList className="ams-mb-m">
           <LinkList.Link href="#">Vervangingsregeling en locoburgemeesters</LinkList.Link>
           <LinkList.Link href="#">Gedragscode</LinkList.Link>
@@ -558,7 +558,7 @@ export const WithImageGallery: StoryObj = {
         </LinkList>
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading className="ams-mb-s" level={2} size="level-3">Contact</Heading>
+        <Heading className="ams-mb-xs" level={2} size="level-3">Contact</Heading>
         <Paragraph className="ams-mb-s">Een bericht voor het college van burgemeester en wethouders kunt u:</Paragraph>
         <UnorderedList>
           <UnorderedList.Item>sturen naar Postbus 202, 1000 AE Amsterdam</UnorderedList.Item>
@@ -645,7 +645,7 @@ export const WithImageGallery: StoryObj = {
             </Grid.Cell>
           ))}
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-            <Heading className="ams-mb-s" level={2} size="level-3">
+            <Heading className="ams-mb-xs" level={2} size="level-3">
               Portefeuilleverdeling
             </Heading>
             <Paragraph className="ams-mb-s">
@@ -654,7 +654,7 @@ export const WithImageGallery: StoryObj = {
             <StandaloneLink href="#">Portefeuilleverdeling</StandaloneLink>
           </Grid.Cell>
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
-            <Heading className="ams-mb-s" level={2} size="level-3">
+            <Heading className="ams-mb-xs" level={2} size="level-3">
               Coalitieakkoord
             </Heading>
             <Paragraph className="ams-mb-s">
@@ -666,7 +666,7 @@ export const WithImageGallery: StoryObj = {
         <Spotlight>
           <Grid paddingVertical="x-large">
             <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-              <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
+              <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">
                 Persberichten en nieuws
               </Heading>
               <LinkList className="ams-mb-m">
@@ -682,7 +682,7 @@ export const WithImageGallery: StoryObj = {
               </LinkList>
             </Grid.Cell>
             <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
-              <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
+              <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">
                 Besluiten B en W
               </Heading>
               <LinkList className="ams-mb-m">
@@ -705,7 +705,7 @@ export const WithImageGallery: StoryObj = {
         {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
         <Grid paddingBottom="2x-large" paddingTop="x-large">
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-            <Heading className="ams-mb-s" level={2} size="level-3">
+            <Heading className="ams-mb-xs" level={2} size="level-3">
               Pers en woordvoering
             </Heading>
             <Paragraph className="ams-mb-s">
@@ -714,7 +714,7 @@ export const WithImageGallery: StoryObj = {
             <StandaloneLink href="#">Pers en woordvoering</StandaloneLink>
           </Grid.Cell>
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
-            <Heading className="ams-mb-s" level={2} size="level-3">
+            <Heading className="ams-mb-xs" level={2} size="level-3">
               Meer over het college
             </Heading>
             <LinkList className="ams-mb-m">
@@ -725,7 +725,7 @@ export const WithImageGallery: StoryObj = {
             </LinkList>
           </Grid.Cell>
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-            <Heading className="ams-mb-s" level={2} size="level-3">
+            <Heading className="ams-mb-xs" level={2} size="level-3">
               Contact
             </Heading>
             <Paragraph className="ams-mb-s">
@@ -816,22 +816,22 @@ export const SubnavigationPage: StoryObj = {
         </Grid.Cell>
       ))}
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading className="ams-mb-s" level={3}>Titel</Heading>
+        <Heading className="ams-mb-xs" level={3}>Titel</Heading>
         <Paragraph className="ams-mb-m">Voorbeeldtekst bij dit onderwerp.</Paragraph>
         <StandaloneLink href="#">Lees meer</StandaloneLink>
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
-        <Heading className="ams-mb-s" level={3}>Titel</Heading>
+        <Heading className="ams-mb-xs" level={3}>Titel</Heading>
         <Paragraph className="ams-mb-m">Voorbeeldtekst bij dit onderwerp.</Paragraph>
         <StandaloneLink href="#">Lees meer</StandaloneLink>
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading className="ams-mb-s" level={3}>Titel</Heading>
+        <Heading className="ams-mb-xs" level={3}>Titel</Heading>
         <Paragraph className="ams-mb-m">Voorbeeldtekst bij dit onderwerp.</Paragraph>
         <StandaloneLink href="#">Lees meer</StandaloneLink>
       </Grid.Cell>
       <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
-        <Heading className="ams-mb-s" level={3}>Titel</Heading>
+        <Heading className="ams-mb-xs" level={3}>Titel</Heading>
         <Paragraph className="ams-mb-m">Voorbeeldtekst bij dit onderwerp.</Paragraph>
         <StandaloneLink href="#">Lees meer</StandaloneLink>
       </Grid.Cell>
@@ -839,11 +839,11 @@ export const SubnavigationPage: StoryObj = {
     <Spotlight color="magenta">
       <Grid paddingVertical="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Titel</Heading>
+          <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">Titel</Heading>
           <Paragraph color="inverse">Voorbeeldtekst bij dit onderwerp.</Paragraph>
         </Grid.Cell>
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
-          <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">Titel</Heading>
+          <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">Titel</Heading>
           <Paragraph color="inverse">Voorbeeldtekst bij dit onderwerp.</Paragraph>
         </Grid.Cell>
       </Grid>
@@ -931,28 +931,28 @@ export const SubnavigationPage: StoryObj = {
             </Grid.Cell>
           ))}
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-            <Heading className="ams-mb-s" level={3}>
+            <Heading className="ams-mb-xs" level={3}>
               {exampleHeading()}
             </Heading>
             <Paragraph className="ams-mb-m">{exampleParagraph()}</Paragraph>
             <StandaloneLink href="#">{exampleStandaloneLink()}</StandaloneLink>
           </Grid.Cell>
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
-            <Heading className="ams-mb-s" level={3}>
+            <Heading className="ams-mb-xs" level={3}>
               {exampleHeading()}
             </Heading>
             <Paragraph className="ams-mb-m">{exampleParagraph()}</Paragraph>
             <StandaloneLink href="#">{exampleStandaloneLink()}</StandaloneLink>
           </Grid.Cell>
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-            <Heading className="ams-mb-s" level={3}>
+            <Heading className="ams-mb-xs" level={3}>
               {exampleHeading()}
             </Heading>
             <Paragraph className="ams-mb-m">{exampleParagraph()}</Paragraph>
             <StandaloneLink href="#">{exampleStandaloneLink()}</StandaloneLink>
           </Grid.Cell>
           <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
-            <Heading className="ams-mb-s" level={3}>
+            <Heading className="ams-mb-xs" level={3}>
               {exampleHeading()}
             </Heading>
             <Paragraph className="ams-mb-m">{exampleParagraph()}</Paragraph>
@@ -962,13 +962,13 @@ export const SubnavigationPage: StoryObj = {
         <Spotlight color="magenta">
           <Grid paddingVertical="x-large">
             <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-              <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
+              <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">
                 {exampleHeading()}
               </Heading>
               <Paragraph color="inverse">{exampleParagraph()}</Paragraph>
             </Grid.Cell>
             <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
-              <Heading className="ams-mb-s" color="inverse" level={2} size="level-3">
+              <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">
                 {exampleHeading()}
               </Heading>
               <Paragraph color="inverse">{exampleParagraph()}</Paragraph>

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -91,7 +91,7 @@ export const Default: StoryObj = {
         span={{ narrow: 4, medium: 4, wide: 5 }}
         start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
       >
-        <Heading className="ams-mb-s" level={2} size="level-3">{heading}</Heading>
+        <Heading className="ams-mb-xs" level={2} size="level-3">{heading}</Heading>
         {getLinks(links)}
       </Grid.Cell>
     ))}
@@ -138,7 +138,7 @@ export const Default: StoryObj = {
             span={{ narrow: 4, medium: 4, wide: 5 }}
             start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
           >
-            <Heading className="ams-mb-s" level={2} size="level-3">
+            <Heading className="ams-mb-xs" level={2} size="level-3">
               {heading}
             </Heading>
             {getLinks(links)}
@@ -201,7 +201,7 @@ export const WithTopTasks: StoryObj = {
         span={{ narrow: 4, medium: 4, wide: 5 }}
         start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
       >
-        <Heading className="ams-mb-s" level={2} size="level-3">{heading}</Heading>
+        <Heading className="ams-mb-xs" level={2} size="level-3">{heading}</Heading>
         {getLinks(links)}
       </Grid.Cell>
     ))}
@@ -259,7 +259,7 @@ export const WithTopTasks: StoryObj = {
             span={{ narrow: 4, medium: 4, wide: 5 }}
             start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
           >
-            <Heading className="ams-mb-s" level={2} size="level-3">
+            <Heading className="ams-mb-xs" level={2} size="level-3">
               {heading}
             </Heading>
             {getLinks(links)}
@@ -309,7 +309,7 @@ export const WithInteractiveElement: StoryObj = {
           span={{ narrow: 4, medium: 4, wide: 5 }}
           start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
         >
-          <Heading className="ams-mb-s" level={2} size="level-3">{heading}</Heading>
+          <Heading className="ams-mb-xs" level={2} size="level-3">{heading}</Heading>
           {getLinks(links)}
         </Grid.Cell>
       ))}
@@ -388,7 +388,7 @@ export const WithInteractiveElement: StoryObj = {
               span={{ narrow: 4, medium: 4, wide: 5 }}
               start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
             >
-              <Heading className="ams-mb-s" level={2} size="level-3">
+              <Heading className="ams-mb-xs" level={2} size="level-3">
                 {heading}
               </Heading>
               {getLinks(links)}
@@ -811,7 +811,7 @@ export const SubnavigationPage: StoryObj = {
           span={{ narrow: 4, medium: 4, wide: 5 }}
           start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
         >
-          <Heading className="ams-mb-s" level={3}>{heading}</Heading>
+          <Heading className="ams-mb-xs" level={3}>{heading}</Heading>
           {getLinks(links)}
         </Grid.Cell>
       ))}
@@ -861,7 +861,7 @@ export const SubnavigationPage: StoryObj = {
           span={{ narrow: 4, medium: 4, wide: 5 }}
           start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
         >
-          <Heading className="ams-mb-s" level={3}>{heading}</Heading>
+          <Heading className="ams-mb-xs" level={3}>{heading}</Heading>
           {getLinks(links)}
         </Grid.Cell>
       ))}
@@ -924,7 +924,7 @@ export const SubnavigationPage: StoryObj = {
               span={{ narrow: 4, medium: 4, wide: 5 }}
               start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
             >
-              <Heading className="ams-mb-s" level={3}>
+              <Heading className="ams-mb-xs" level={3}>
                 {heading}
               </Heading>
               {getLinks(links)}
@@ -990,7 +990,7 @@ export const SubnavigationPage: StoryObj = {
               span={{ narrow: 4, medium: 4, wide: 5 }}
               start={index % 2 ? undefined : { narrow: 1, medium: 1, wide: 2 }}
             >
-              <Heading className="ams-mb-s" level={3}>
+              <Heading className="ams-mb-xs" level={3}>
                 {heading}
               </Heading>
               {getLinks(links)}

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -208,7 +208,7 @@ const meta = {
          * put them side by side – halves of the medium grid, inset 5-column blocks on the wide one.
          */}
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading className="ams-mb-s" level={2} size="level-3">
+          <Heading className="ams-mb-xs" level={2} size="level-3">
             Nieuws
           </Heading>
           <LinkList>
@@ -217,7 +217,7 @@ const meta = {
           </LinkList>
         </Grid.Cell>
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
-          <Heading className="ams-mb-s" level={2} size="level-3">
+          <Heading className="ams-mb-xs" level={2} size="level-3">
             Werk aan de weg
           </Heading>
           <LinkList>
@@ -271,7 +271,7 @@ const meta = {
       <Grid paddingVertical="x-large">
         {/* These four cells alternate between the same start positions, so they too read as two columns. */}
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading className="ams-mb-s" level={2} size="level-3">
+          <Heading className="ams-mb-xs" level={2} size="level-3">
             Meer informatie
           </Heading>
           <LinkList>
@@ -296,7 +296,7 @@ const meta = {
           <StandaloneLink href="#">Meer video’s</StandaloneLink>
         </Grid.Cell>
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading className="ams-mb-s" level={2} size="level-3">
+          <Heading className="ams-mb-xs" level={2} size="level-3">
             Plannen en publicaties
           </Heading>
           <LinkList>
@@ -304,7 +304,7 @@ const meta = {
           </LinkList>
         </Grid.Cell>
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
-          <Heading className="ams-mb-s" level={2} size="level-3">
+          <Heading className="ams-mb-xs" level={2} size="level-3">
             Blijf op de hoogte
           </Heading>
           <LinkList>
@@ -462,14 +462,14 @@ export const Default: StoryObj = {
      * put them side by side – halves of the medium grid, inset 5-column blocks on the wide one.
      */}
     <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-      <Heading className="ams-mb-s" level={2} size="level-3">Nieuws</Heading>
+      <Heading className="ams-mb-xs" level={2} size="level-3">Nieuws</Heading>
       <LinkList>
         <LinkList.Link href="#">Werkzaamheden Bert Haanstrakade en Pampuslaan (27 november 2025)</LinkList.Link>
         <LinkList.Link href="#">17 november: bijeenkomst over Strandeiland (11 november 2025)</LinkList.Link>
       </LinkList>
     </Grid.Cell>
     <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
-      <Heading className="ams-mb-s" level={2} size="level-3">Werk aan de weg</Heading>
+      <Heading className="ams-mb-xs" level={2} size="level-3">Werk aan de weg</Heading>
       <LinkList>
         <LinkList.Link href="#">Bert Haanstrakade, omleiding</LinkList.Link>
         <LinkList.Link href="#">Straten Centrumeiland, afsluitingen</LinkList.Link>
@@ -494,7 +494,7 @@ export const Default: StoryObj = {
   <Grid paddingVertical="x-large">
     {/* These four cells alternate between the same start positions, so they too read as two columns. */}
     <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-      <Heading className="ams-mb-s" level={2} size="level-3">Meer informatie</Heading>
+      <Heading className="ams-mb-xs" level={2} size="level-3">Meer informatie</Heading>
       <LinkList>
         <LinkList.Link href="#">Blok 16: Amsterdams nabuurschap, een nieuwe vorm van zelfbouw</LinkList.Link>
         <LinkList.Link href="#">Woningaanbod Centrumeiland</LinkList.Link>
@@ -509,7 +509,7 @@ export const Default: StoryObj = {
     </Grid.Cell>
     {/* … a Plannen en publicaties cell, start-aligned to the left like Meer informatie … */}
     <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
-      <Heading className="ams-mb-s" level={2} size="level-3">Blijf op de hoogte</Heading>
+      <Heading className="ams-mb-xs" level={2} size="level-3">Blijf op de hoogte</Heading>
       <LinkList>
         <LinkList.Link href="#">Nieuwsbrief ontwikkeling IJburg</LinkList.Link>
         <LinkList.Link href="#">Hallo Centrumeiland: praat mee</LinkList.Link>


### PR DESCRIPTION
## Links

- [Vertical space](https://designsystem.amsterdam/?path=/docs/docs-guidelines-vertical-space--docs), the guide these values come from.
- [Storybook on main](https://designsystem.amsterdam/).

The eight affected stories, in the main deploy:

- [Article Page](https://designsystem.amsterdam/?path=/story/pages-public-article-page--default)
- [Home Page](https://designsystem.amsterdam/?path=/story/pages-public-home-page--default)
- [Navigation Page, Default](https://designsystem.amsterdam/?path=/story/pages-public-navigation-page--default)
- [Navigation Page, With Top Tasks](https://designsystem.amsterdam/?path=/story/pages-public-navigation-page--with-top-tasks)
- [Navigation Page, With Interactive Element](https://designsystem.amsterdam/?path=/story/pages-public-navigation-page--with-interactive-element)
- [Navigation Page, With Image Gallery](https://designsystem.amsterdam/?path=/story/pages-public-navigation-page--with-image-gallery)
- [Navigation Page, Subnavigation Page](https://designsystem.amsterdam/?path=/story/pages-public-navigation-page--subnavigation-page)
- [Project Page](https://designsystem.amsterdam/?path=/story/pages-public-project-page--default)

## What

Four public page templates space a Heading 3 by the size it is shown at instead of by its level. On the Article, Home, Navigation and Project pages, a Paragraph or a List that sits directly below a heading rendered at Heading 3 size moves from `ams-mb-s` to `ams-mb-xs`. That is 49 headings in total.

## Why

The vertical space guide says to look a heading up by the size it is shown at, not by its level. So a `<Heading level={2} size="level-3" />` takes the Heading 3 column of the tables, where a Paragraph, a List and a Table each want x-small. The templates were using small throughout, which is the Heading 2 value. The rendered pages therefore showed more space under these headings than the guide recommends.

## How

Only the combinations the guide actually documents for a Heading 3 change. An Image below such a heading keeps the value it had, because Image has no row in the “Space below headings” table — and the guide states that a missing component means it advises against that combination, so there is no value to pick.

The Navigation Page needed a second pass. Ten of its headings sit inside a `.map()` above `{getLinks(links)}` rather than above literal markup, so reading the file for `<Heading>` followed by a component misses them. `getLinks` renders a Link List for a group of several links, which is the documented x-small case.

One group per array holds a single link, where `getLinks` renders a Standalone Link instead. That pair has no row in the table either, so no documented value exists for it, and a mapped heading has a single `className` serving every group — so the List value the other groups need wins.

Every page carries the markup twice: the render and the hand-written Code Panel source. Both copies change, so what a reader copies from the Code Panel matches what they see on screen.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

The Profile Page needed the same correction, but that template only exists on #2830, so it is fixed there instead.

Expect Chromatic to flag every affected story. Both tokens are fluid, so the deliberate reduction under each of these headings is 4px on a narrow viewport and 6px on a wide one.
