### PR TITLE
chore(Storybook): Document the design and accessibility of the Text components

### DIFF
--- a/storybook/src/components/Blockquote/Blockquote.docs.mdx
+++ b/storybook/src/components/Blockquote/Blockquote.docs.mdx
@@ -29,6 +29,7 @@ Use [Margin](/docs/utilities-css-margin--docs) or [Prose](/docs/utilities-css-pr
 ### How to use
 
 If the citation is in a language other than that of the surrounding content, indicate so through the `lang` attribute.
+Assistive technology then switches pronunciation for that passage, which is what [WCAG 3.1.2](https://www.w3.org/TR/WCAG22/#language-of-parts) requires.
 
 ## Examples
 
@@ -58,6 +59,11 @@ Words that are too long for the line are hyphenated rather than left to overflow
 The browser decides where to split them, so the [language of the document](/docs/docs-developer-guide-localisation--docs#specify-the-language-for-the-entire-document) must be set correctly.
 
 In print, a Blockquote is never split across two pages.
+
+## Accessibility
+
+A Blockquote renders a `blockquote` element, which maps to the `blockquote` role.
+The passage is exposed as a quotation rather than as ordinary text, so the meaning does not depend on the quotation marks, which are decoration drawn by CSS.
 
 ## See also
 

--- a/storybook/src/components/Blockquote/Blockquote.docs.mdx
+++ b/storybook/src/components/Blockquote/Blockquote.docs.mdx
@@ -43,6 +43,22 @@ This ensures the colour of the text provides enough contrast.
 
 The component adds the correct quotation marks.
 
+## Design
+
+A Blockquote is set in bold text, one size larger than body text, with a tighter line height.
+This gives a quotation enough weight to stand apart from the running text around it, without needing a border, a background, or an indent.
+
+The quotation marks come from CSS rather than from the content.
+Authors cannot forget them or reach for the wrong pair, and the same curly double marks are used for every language.
+
+A Blockquote has no vertical margins of its own.
+This makes vertical rhythm a property of the layout rather than of the component, which is why [Margin](/docs/utilities-css-margin--docs) and [Prose](/docs/utilities-css-prose--docs) provide it.
+
+Words that are too long for the line are hyphenated rather than left to overflow.
+The browser decides where to split them, so the [language of the document](/docs/docs-developer-guide-localisation--docs#specify-the-language-for-the-entire-document) must be set correctly.
+
+In print, a Blockquote is never split across two pages.
+
 ## See also
 
 - [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.

--- a/storybook/src/components/DescriptionList/DescriptionList.docs.mdx
+++ b/storybook/src/components/DescriptionList/DescriptionList.docs.mdx
@@ -79,6 +79,15 @@ Side by side, a term therefore gets half of that difference as extra space above
 
 The term is set in bold text, and its line lengths are balanced so it does not end on a single short word.
 
+## Accessibility
+
+A Description List renders `dl`, `dt`, and `dd` elements.
+These tie each term to its descriptions in the markup instead of only through the layout, which is the kind of relationship [WCAG 1.3.1](https://www.w3.org/TR/WCAG22/#info-and-relationships) asks to be made available.
+A Section renders a `div` around one group, which HTML permits inside a `dl`.
+
+Screen readers expose description lists in noticeably different ways: the number of items they report, the context they give for a term or a description, and the commands available to move through the list all vary.
+The component leaves the native elements alone rather than adding `term` and `definition` roles, because overriding them changes how VoiceOver announces the list.
+
 ## See also
 
 - [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.

--- a/storybook/src/components/DescriptionList/DescriptionList.docs.mdx
+++ b/storybook/src/components/DescriptionList/DescriptionList.docs.mdx
@@ -72,9 +72,12 @@ The terms and descriptions stack vertically by default.
 They sit next to each other when their [query container](/docs/utilities-css-query-container--docs) is wide enough (at least `32rem`).
 
 The column for the terms is as wide as the longest term, without wrapping.
-Its width can be adjusted to ‘large’ (50%), ‘medium’ (33%), or ‘small’ (20%), which also allows the terms to wrap.
+Its width can be adjusted to ‘wide’ (50%), ‘medium’ (33%), or ‘narrow’ (20%), which also allows the terms to wrap.
 
-The term is set in bold text.
+Terms use heading typography and descriptions use body text, which gives the two different line heights.
+Side by side, a term therefore gets half of that difference as extra space above it, so its first line sits level with the first line of its description.
+
+The term is set in bold text, and its line lengths are balanced so it does not end on a single short word.
 
 ## See also
 

--- a/storybook/src/components/Heading/Heading.docs.mdx
+++ b/storybook/src/components/Heading/Heading.docs.mdx
@@ -89,6 +89,28 @@ Use a [Row](/docs/components-layout-row--docs) and the `size` prop of [Icon](/do
 
 <Canvas of={HeadingStories.WithIcon} />
 
+## Design
+
+Headings use the same font family as body text and are always bold.
+Their hierarchy comes from size and weight alone, not from a separate display typeface.
+
+Font sizes for levels 1 to 4 grow with the viewport; level 5 keeps a fixed size.
+Line heights tighten as the text grows, from 1.4 at the smallest sizes to 1.2 at level 1, where body text uses 1.6.
+Large text needs proportionally less space between its lines to stay legible.
+Mobile browsers are prevented from inflating heading text, so these sizes are the only ones that apply.
+[Read more in the typography documentation](/docs/brand-design-tokens-typography--docs#headings).
+
+A Heading that spans multiple lines has its line lengths balanced, so it never ends on a single short word.
+The large [Paragraph](/docs/components-text-paragraph--docs) that often follows a level 1 Heading does the same, which keeps the two visually consistent.
+
+Words that are too long for the line are hyphenated rather than left to overflow.
+The browser decides where to split them, so the [language of the document](/docs/docs-developer-guide-localisation--docs#specify-the-language-for-the-entire-document) must be set correctly.
+
+A Heading has no vertical margins of its own.
+This makes vertical rhythm a property of the layout rather than of the component, which is why [Margin](/docs/utilities-css-margin--docs) and [Prose](/docs/utilities-css-prose--docs) provide it.
+
+In print, a Heading stays with the content it introduces: it is never the last item on a page, and it is never split across two pages.
+
 ## Accessibility
 
 Screen reader users navigate by heading to understand page structure.

--- a/storybook/src/components/Heading/Heading.docs.mdx
+++ b/storybook/src/components/Heading/Heading.docs.mdx
@@ -42,6 +42,11 @@ Do not skip levels: a level 2 Heading must be followed by level 3, not level 4.
 - The same applies to large sections – e.g. Accordion, Alert, Dialog and the caption of a Table.
   Most of them can be given a different size if appropriate.
 
+### How to write
+
+Write a heading that describes the section it introduces.
+Users navigate by heading, so a vague one leaves them guessing what the section holds; [WCAG 2.4.6](https://www.w3.org/TR/WCAG22/#headings-and-labels) asks headings to describe their topic or purpose.
+
 ## Examples
 
 ### Levels
@@ -115,6 +120,9 @@ In print, a Heading stays with the content it introduces: it is never the last i
 
 Screen reader users navigate by heading to understand page structure.
 An incorrect hierarchy disrupts their mental model of the page.
+
+The `level` prop chooses the `h1` to `h4` element; the `size` prop changes the appearance and nothing else.
+A level 2 Heading shown at the size of a level 4 is still reported as level 2, so the outline assistive technology announces stays the one the content actually has.
 
 ## See also
 

--- a/storybook/src/components/Mark/Mark.docs.mdx
+++ b/storybook/src/components/Mark/Mark.docs.mdx
@@ -40,6 +40,17 @@ Ignore capitalization and include partial matches.
 
 <Canvas of={MarkStories.SearchResults} />
 
+## Design
+
+Only the background colour changes.
+The size, weight, and colour of the text stay as they are, so marked words remain part of the sentence instead of becoming a style of their own.
+
+The highlight is yellow, one of the [highlight colours](/docs/brand-design-tokens-colour--docs#highlight).
+Yellow is the lightest of them, so it keeps the most contrast with the text laid over it.
+
+The highlight has no padding and no rounded corners.
+It follows the shape of the text exactly and breaks across lines along with it.
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/Mark/Mark.docs.mdx
+++ b/storybook/src/components/Mark/Mark.docs.mdx
@@ -21,22 +21,37 @@ import * as MarkStories from "./Mark.stories.tsx";
 
 ### When to use
 
-Use a maximum of 1 Mark per page.
-Limit the marked text to 1 sentence.
+Highlight the words someone searched for in a list of results, so they can see at a glance why each result matched.
+
+Or draw attention to a single fragment of running text that a reader should not miss, such as the question a consultation puts to residents.
 
 ### When not to use
 
-Do not use Mark in titles and subtitles.
-Use a significant and engaging title if the entire paragraph is important.
+Do not reach for Mark to emphasise text in general.
+A passage that carries more weight than the rest usually belongs in a [Heading](/docs/components-text-heading--docs) or in the lead [Paragraph](/docs/components-text-paragraph--docs) of the page.
 
-Do not mark an entire paragraph.
+Do not use Mark to flag a warning, a deadline, or a change in service.
+An [Alert](/docs/components-feedback-alert--docs) carries that meaning and announces itself to assistive technology, which a highlight does not.
+
+### How to use
+
+Never let the highlight carry information by itself.
+The text around it has to make sense without it, so that what the highlight shows reaches everyone, as [WCAG 1.3.1](https://www.w3.org/TR/WCAG22/#info-and-relationships) requires.
+A list of search results already satisfies this: each result is meaningful on its own, and the highlight only speeds up scanning.
+
+Keep an editorial highlight to one fragment per page, and to at most one sentence.
+Marking a whole paragraph, or several passages at once, leaves nothing standing out.
+Rewrite a heading that needs emphasis rather than highlighting part of it.
+
+Highlighted search terms follow the search instead of an editorial choice, so those limits do not apply to them.
+Mark every match on the page, including matches inside the heading of a result.
+Ignore capitalisation and include partial matches.
 
 ## Examples
 
 ### Search results
 
-For a basic search, mark all appearances of every keyword.
-Ignore capitalization and include partial matches.
+Every match of every keyword is highlighted, in the heading of a result as well as in its summary.
 
 <Canvas of={MarkStories.SearchResults} />
 
@@ -55,10 +70,7 @@ It follows the shape of the text exactly and breaks across lines along with it.
 
 A Mark renders a `mark` element, but most screen readers do not announce highlighted text in their default configuration.
 Someone who does not see the page receives the sentence without learning which words were singled out.
-
-So never let the highlight carry information by itself.
-The text around it has to make sense without it, which keeps what the highlight shows available in the content as well, as [WCAG 1.3.1](https://www.w3.org/TR/WCAG22/#info-and-relationships) requires.
-In a list of search results this follows from the pattern: the result is meaningful as a result, and the highlight only speeds up scanning.
+The component cannot make up for that on its own, so what the highlight conveys has to be in the text as well, which ‘How to use’ covers.
 
 ## Design tokens
 

--- a/storybook/src/components/Mark/Mark.docs.mdx
+++ b/storybook/src/components/Mark/Mark.docs.mdx
@@ -51,6 +51,15 @@ Yellow is the lightest of them, so it keeps the most contrast with the text laid
 The highlight has no padding and no rounded corners.
 It follows the shape of the text exactly and breaks across lines along with it.
 
+## Accessibility
+
+A Mark renders a `mark` element, but most screen readers do not announce highlighted text in their default configuration.
+Someone who does not see the page receives the sentence without learning which words were singled out.
+
+So never let the highlight carry information by itself.
+The text around it has to make sense without it, which keeps what the highlight shows available in the content as well, as [WCAG 1.3.1](https://www.w3.org/TR/WCAG22/#info-and-relationships) requires.
+In a list of search results this follows from the pattern: the result is meaningful as a result, and the highlight only speeds up scanning.
+
 ## Design tokens
 
 <DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/OrderedList/OrderedList.docs.mdx
+++ b/storybook/src/components/OrderedList/OrderedList.docs.mdx
@@ -90,6 +90,14 @@ The second and following lines of an item line up with its first line instead of
 A nested list is indented less than the top level.
 Its numbers need less room because they are letters, and a smaller step keeps a two-level list from drifting far to the right.
 
+## Accessibility
+
+An Ordered List renders `ol` and `li` elements.
+Screen readers announce it as a list, report how many items it holds, and offer commands to move from one item to the next.
+
+Hiding the markers keeps those semantics intact, so screen readers still announce the items as a list and report how many there are.
+That is the point of the variant: the sequence still reaches assistive technology as [WCAG 1.3.1](https://www.w3.org/TR/WCAG22/#info-and-relationships) requires, while the numbers stay out of the way visually.
+
 ## See also
 
 - [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.

--- a/storybook/src/components/OrderedList/OrderedList.docs.mdx
+++ b/storybook/src/components/OrderedList/OrderedList.docs.mdx
@@ -84,6 +84,12 @@ When using a list in small text, set the prop for each item in the list.
 The list uses ascending numbers as markers, providing enough space for numbers up to 99.
 Extra white space between items enhances the distinction, mainly when they consist of multiple lines of text.
 
+Markers sit outside the text column.
+The second and following lines of an item line up with its first line instead of running back underneath the number, which keeps the left edge of the text straight.
+
+A nested list is indented less than the top level.
+Its numbers need less room because they are letters, and a smaller step keeps a two-level list from drifting far to the right.
+
 ## See also
 
 - [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.

--- a/storybook/src/components/Paragraph/Paragraph.docs.mdx
+++ b/storybook/src/components/Paragraph/Paragraph.docs.mdx
@@ -31,6 +31,9 @@ Start a new paragraph when the text shifts to a different topic or has its own p
 Consider whether a paragraph with more than 7 sentences or 140 words would be clearer if you divide the text into two paragraphs.
 Texts with not overly long paragraphs are easier to understand, and grouping makes information quicker to locate.
 
+The large and small sizes are a visual distinction only; nothing about them is announced.
+Say in the text itself whatever a size is meant to signal.
+
 ## Examples
 
 ### Large text
@@ -77,6 +80,13 @@ This makes vertical rhythm a property of the layout rather than of the component
 
 Words that are too long for the line are hyphenated rather than left to overflow.
 The browser decides where to split them, so the [language of the document](/docs/docs-developer-guide-localisation--docs#specify-the-language-for-the-entire-document) must be set correctly.
+
+## Accessibility
+
+A Paragraph renders a `p` element, so screen readers can move through running text one paragraph at a time.
+
+The `b` and `small` elements that the large and small sizes add carry no meaning of their own; both are generic in the accessibility tree.
+A lead paragraph and small print are therefore a visual distinction only, and neither is announced any differently from body text.
 
 ## See also
 

--- a/storybook/src/components/Paragraph/Paragraph.docs.mdx
+++ b/storybook/src/components/Paragraph/Paragraph.docs.mdx
@@ -63,6 +63,21 @@ Use a [Row](/docs/components-layout-row--docs) and the `size` prop of [Icon](/do
 
 <Canvas of={ParagraphStories.WithIcon} />
 
+## Design
+
+The large and small sizes wrap their text in a `b` and a `small` element.
+Browsers render those elements bold and smaller on their own, so a lead paragraph and small print keep an appearance of their own even if the stylesheet fails to load.
+Once it does load, their usual styling is switched off and the size prop alone sets the appearance, so the text does not turn bold or shrink a second time.
+
+Body text has the most generous line height of the three sizes, 1.6 against 1.5 for the large and small ones.
+Running text is read line after line and needs that space to stay easy to follow, while the shorter lines of a lead paragraph do not.
+
+A Paragraph has no vertical margins of its own.
+This makes vertical rhythm a property of the layout rather than of the component, which is why [Margin](/docs/utilities-css-margin--docs) and [Prose](/docs/utilities-css-prose--docs) provide it.
+
+Words that are too long for the line are hyphenated rather than left to overflow.
+The browser decides where to split them, so the [language of the document](/docs/docs-developer-guide-localisation--docs#specify-the-language-for-the-entire-document) must be set correctly.
+
 ## See also
 
 - [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.

--- a/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
+++ b/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
@@ -78,6 +78,14 @@ The second and following lines of an item line up with its first line instead of
 
 A nested list is indented less than the top level, which keeps a two-level list from drifting far to the right.
 
+## Accessibility
+
+An Unordered List renders `ul` and `li` elements.
+Screen readers announce it as a list, report how many items it holds, and offer commands to move from one item to the next.
+
+Hiding the markers keeps those semantics intact, so screen readers still announce the items as a list and report how many there are.
+That is the point of the variant: the grouping still reaches assistive technology as [WCAG 1.3.1](https://www.w3.org/TR/WCAG22/#info-and-relationships) requires, while the markers stay out of the way visually.
+
 ## See also
 
 - [Prose](/docs/utilities-css-prose--docs) – applies the recommended vertical spacing for editorial content.

--- a/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
+++ b/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
@@ -69,8 +69,14 @@ When using a list in small text, set the prop for each item in the list.
 ## Design
 
 Items of an unordered list have square markers.
+The marker is the bullet character, which Amsterdam Sans draws as a square.
 There is extra white space between the items.
 This provides better distinction between the items, especially when they consist of multiple lines of text.
+
+Markers sit outside the text column.
+The second and following lines of an item line up with its first line instead of running back underneath the marker, which keeps the left edge of the text straight.
+
+A nested list is indented less than the top level, which keeps a two-level list from drifting far to the right.
 
 ## See also
 


### PR DESCRIPTION
# Document the design and accessibility of the Text components

## Links

- [Documentation guidelines](https://github.com/Amsterdam/design-system/blob/develop/documentation/component-docs.md) — the content model these sections follow.

Deploy links to the seven documentation pages follow once the first preview build is ready.

## What

Every component under Components/Text now has both a Design and an Accessibility section: Blockquote, Description List, Heading, Mark, Ordered List, Paragraph and Unordered List. Design covers decisions that were previously visible only in the stylesheets. Accessibility covers the elements each component renders and what assistive technology makes of them.

Mark's usage guidelines are rewritten as well. One factual error is corrected along the way: Description List's Design section named the terms width values 'large', 'medium' and 'small', where the `termsWidth` prop actually takes `narrow`, `medium` and `wide`.

## Why

These pages explained what the components look like and how to use them, but not why they behave as they do. Several decisions were discoverable only by reading the SCSS — that headings balance their line lengths, that a Blockquote is never split across two printed pages, that Paragraph's large and small sizes wrap their text in `b` and `small` so the distinction survives when the stylesheet fails to load. None of it reached the reader.

The accessibility picture was thinner still. Only Heading had a section at all, and it described neither the markup these components render nor how screen readers treat it. That left out the case which matters most: `mark` is not announced by most screen readers in their default configuration, so a highlight must never be the only thing carrying a piece of information.

Mark's guidelines had also drifted from its own examples. They capped usage at one Mark per page and forbade marking titles, while the Search results story marks every match of every keyword, including inside the heading of each result. 'When to use' stated a limit rather than naming a scenario, so it never answered whether Mark was the right choice in the first place.

## How

The Design sections are written from the SCSS and the token files, with token references resolved to their real values rather than assumed. The Accessibility sections are written from the rendered HTML, with role mappings confirmed against the packages' own `getByRole` tests and the criteria checked against the WCAG 2.2 specification.

WCAG is cited inline and only where a criterion explains the behaviour, the way the Skeleton page does it, rather than as a per-page list like the developer guides use. That comes to six links across the seven pages.

The documentation guidelines separate what a component does by itself from what someone must do when composing it, and keep the latter in Usage guidelines where it is harder to miss. So Heading gained a 'How to write' about describing the section a heading introduces, Paragraph's says to signal a size in the text itself, and Mark's 'How to use' opens with the rule that a highlight must never carry information on its own.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

Documentation only — no component, CSS or token changes, so nothing should render differently and Chromatic should report no visual diffs.

Balanced line lengths and hyphenation have no story to point at, so those Design sections carry no Canvas. A story demonstrating both would make a reasonable follow-up.

Several Description List tokens are marked `@deprecated` in the SCSS: `row-gap`, `column-gap`, and the three `grid-template-columns`. They are untouched here, but may belong with the wider deprecation cleanup.
