### PR TITLE
fix(Storybook): Put the Skip Links in a navigation landmark

### DIFF
--- a/storybook/src/components/Page/Page.docs.mdx
+++ b/storybook/src/components/Page/Page.docs.mdx
@@ -29,7 +29,7 @@ As a root layout component, it must be used for all websites for the City of Ams
 #### Public websites
 
 Use the Page as it is.
-Its children – a [Skip Link](/docs/components-navigation-skip-link--docs), the Page Header, the sections of the page, and the Page Footer – follow one another in document order.
+Its children – a `nav` holding the [Skip Links](/docs/components-navigation-skip-link--docs), the Page Header, the sections of the page, and the Page Footer – follow one another in document order.
 See the [introduction to the public templates](/docs/pages-public-introduction--docs) for the structure of a page.
 
 #### Internal websites
@@ -70,7 +70,7 @@ An element placed directly in the Page, outside a [Grid](/docs/components-layout
 
 ## See also
 
-- [Skip Link](/docs/components-navigation-skip-link--docs) – the first element in the Page, above the Page Header.
+- [Skip Link](/docs/components-navigation-skip-link--docs) – sits in the first element of the Page, above the Page Header.
 - [Page Header](/docs/components-containers-page-header--docs) – sits at the top of the Page.
 - [Menu](/docs/components-navigation-menu--docs) – fills the menu column that `withMenu` adds, on an internal website.
 - [Page Footer](/docs/components-containers-page-footer--docs) – sits at the bottom of the Page.

--- a/storybook/src/components/Page/Page.stories.tsx
+++ b/storybook/src/components/Page/Page.stories.tsx
@@ -69,9 +69,9 @@ export const WithMenu: Story = {
   },
   render: ({ children, ...args }) => (
     <Page {...args}>
-      <SkipLink className="ams-page__area--skip-link" href="#inhoud">
-        Direct naar inhoud
-      </SkipLink>
+      <nav aria-label="Snelkoppelingen" className="ams-page__area--skip-link">
+        <SkipLink href="#inhoud">Direct naar inhoud</SkipLink>
+      </nav>
       <PageHeader brandName="Page Header" className="ams-page__area--header" noMenuButtonOnWideWindow>
         <Menu>
           <Menu.Link href="#" icon={<SettingsFillIcon />}>

--- a/storybook/src/components/SkipLink/SkipLink.docs.mdx
+++ b/storybook/src/components/SkipLink/SkipLink.docs.mdx
@@ -21,7 +21,7 @@ import * as SkipLinkStories from "./SkipLink.stories.tsx";
 
 ### When to use
 
-Place the Skip Link as the first element in the [Page](/docs/components-containers-page--docs) container.
+Place the Skip Link in a `nav` that is the first element in the [Page](/docs/components-containers-page--docs) container.
 
 Direct the Skip Link to the main content area on the Page.
 Typically, this is the `main` HTML element.
@@ -63,9 +63,20 @@ After appearing, it pushes the rest of the page down.
 Following a Skip Link moves the starting point for sequential focus navigation to the target, so the next ‘Tab’ press continues from there.
 The target itself does not receive focus, and it does not need to: an `id` is enough, so leave `tabindex` off.
 
+A Skip Link comes before the Page Header, which puts it ahead of every landmark on the page.
+Wrap it in a `nav` so that it sits in one like the rest of the page, and give that `nav` an accessible name to tell it apart from the other navigation landmarks:
+
+```tsx
+<nav aria-label="Snelkoppelingen">
+  <SkipLink href="#inhoud">Direct naar inhoud</SkipLink>
+</nav>
+```
+
+Put every Skip Link of a page in that same `nav`, rather than giving each one its own.
+
 ## See also
 
-- [Page](/docs/components-containers-page--docs) – contains the Skip Link as its first element.
+- [Page](/docs/components-containers-page--docs) – contains the Skip Link in its first element.
 
 ## Design tokens
 

--- a/storybook/src/pages/internal/Introduction.docs.mdx
+++ b/storybook/src/pages/internal/Introduction.docs.mdx
@@ -25,9 +25,9 @@ The general structure for a page is:
 
 ```tsx
 <Page withMenu>
-  <SkipLink className="ams-page__area--skip-link" href="#inhoud">
-    Direct naar inhoud
-  </SkipLink>
+  <nav aria-label="Snelkoppelingen" className="ams-page__area--skip-link">
+    <SkipLink href="#inhoud">Direct naar inhoud</SkipLink>
+  </nav>
   <PageHeader className="ams-page__area--header" noMenuButtonOnWideWindow>
     <Menu />
   </PageHeader>

--- a/storybook/src/pages/internal/common/PageLayout.tsx
+++ b/storybook/src/pages/internal/common/PageLayout.tsx
@@ -15,12 +15,16 @@ type PageLayoutProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>
 export const PageLayout = ({ children, ...restProps }: PageLayoutProps) => (
   // withMenu lays the Page out as a grid with a column for the Menu beside the header, the body and the footer.
   // The rules for those areas select direct children of the Page only, so each child below needs its own
-  // ams-page__area class and none of them may be wrapped in another element.
+  // ams-page__area class. Wrapping one is fine as long as the wrapper carries the class instead, as the nav does.
   <Page {...restProps} withMenu>
-    {/* Targets the id on the main element below, so the next Tab press continues past the header and the menu. */}
-    <SkipLink className="ams-page__area--skip-link" href="#inhoud">
-      Direct naar inhoud
-    </SkipLink>
+    {/*
+     * The Skip Link comes before the Page Header, which leaves it outside every landmark unless a nav holds
+     * it. Its accessible name sets it apart from the other navigation landmarks on the page.
+     */}
+    <nav aria-label="Snelkoppelingen" className="ams-page__area--skip-link">
+      {/* Targets the id on the main element below, so the next Tab press continues past the header and the menu. */}
+      <SkipLink href="#inhoud">Direct naar inhoud</SkipLink>
+    </nav>
     <PageHeader
       // An internal application is not the City’s main website, so the header names it beside the logo.
       // That name also completes the hidden text of the logo link: ‘Ga naar de homepage van …’.

--- a/storybook/src/pages/public/HomePage/HomePage.docs.mdx
+++ b/storybook/src/pages/public/HomePage/HomePage.docs.mdx
@@ -16,7 +16,9 @@ A typical layout for a homepage:
 
 ```tsx
 <Page>
-  <SkipLink href="#inhoud">Direct naar inhoud</SkipLink>
+  <nav aria-label="Snelkoppelingen">
+    <SkipLink href="#inhoud">Direct naar inhoud</SkipLink>
+  </nav>
   <PageHeader />
   <main id="inhoud">
     <Overlap>

--- a/storybook/src/pages/public/Introduction.docs.mdx
+++ b/storybook/src/pages/public/Introduction.docs.mdx
@@ -22,7 +22,9 @@ The general structure for a page is:
 
 ```tsx
 <Page>
-  <SkipLink href="#inhoud">Direct naar inhoud</SkipLink>
+  <nav aria-label="Snelkoppelingen">
+    <SkipLink href="#inhoud">Direct naar inhoud</SkipLink>
+  </nav>
   <PageHeader>
     <Grid />
   </PageHeader>

--- a/storybook/src/pages/public/common/PageLayout.tsx
+++ b/storybook/src/pages/public/common/PageLayout.tsx
@@ -27,11 +27,18 @@ export const PageLayout = ({
   ...restProps
 }: PageLayoutProps) => (
   <Page {...restProps}>
-    {skipLinks.map(({ label, targetId }) => (
-      <SkipLink href={`#${targetId}`} key={targetId}>
-        {label}
-      </SkipLink>
-    ))}
+    {/*
+     * The Skip Links come before the Page Header, which leaves them outside every landmark unless a nav
+     * holds them. Its accessible name sets it apart from the other navigation landmarks on the page:
+     * Hoofdmenu, Kruimelpad, and a Table of Contents where a page has one.
+     */}
+    <nav aria-label="Snelkoppelingen">
+      {skipLinks.map(({ label, targetId }) => (
+        <SkipLink href={`#${targetId}`} key={targetId}>
+          {label}
+        </SkipLink>
+      ))}
+    </nav>
     <PageHeader
       menuItems={pageHeaderMenuLinks.map(({ fixed, href, icon, label, lang }) => (
         <PageHeader.MenuLink


### PR DESCRIPTION
## Links

- [Skip Link](https://designsystem.amsterdam/?path=/docs/components-navigation-skip-link--docs)
- [Page](https://designsystem.amsterdam/?path=/docs/components-containers-page--docs)
- Deploy links follow once the preview is up.

## What

A Skip Link now sits in a `nav` with an accessible name, instead of loose in the Page container:

```tsx
<nav aria-label="Snelkoppelingen">
  <SkipLink href="#inhoud">Direct naar inhoud</SkipLink>
</nav>
```

This changes the two Page Layout decorators behind the public and internal templates, the `WithMenu` story of Page, and the snippets in both introductions, on the Page and Skip Link pages, and in the Home Page layout sketch. No component in `packages` changes, so nothing here needs a release.

## Why

A Skip Link comes before the Page Header, which put it ahead of every landmark on the page. axe reported `region` — "All page content should be contained by landmarks" — on every page template because of it. That rule is tagged best-practice rather than WCAG, so this was never a conformance failure, but it was the only finding on our page templates, and it also maps to RGAA 9.2.1, which an auditor working from a checklist may well raise.

Wrapping the link is enough to resolve it, and it gives the group a name of its own alongside the Hoofdmenu, the Kruimelpad and a page's own Table of Contents.

## How

All of a page's Skip Links share one `nav`, rather than each getting its own — the Handbook Page declares two, and two landmarks for two hidden links would be noise.

On the internal layout the `nav` carries `ams-page__area--skip-link`. The grid that `withMenu` sets up selects direct children of the Page, so the class has to move to whichever element is that child. The comment in the decorator said that none of those children may be wrapped; it now says wrapping is fine as long as the wrapper takes the class.

The Skip Link stories are unchanged. They render the component on its own, with no Page around it, so a `nav` there would be scaffolding that demonstrates nothing.

Verified with axe-core against three public and three internal page stories: every one of them reported `region` before and none of them reports anything now. The only remaining `incomplete` result is `color-contrast` on the Page Header's `aria-hidden` brand name, which is unrelated and untouched. I also forced focus on the Skip Link in both layouts and compared the rendering, since the focused state is the only thing that could regress — the band still spans the full Page width and pushes the page down, including on the internal grid where the area class moved.

## Checklist

- [ ] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [ ] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Skip Links are hidden until focused, so I do not expect visual regressions, but every story under `Pages/**` is snapshotted and the internal templates changed a grid area, so the Chromatic run is worth a look rather than a wave-through.

The naming is the one thing worth a second opinion: `aria-label="Snelkoppelingen"` was chosen to sit alongside Hoofdmenu and Kruimelpad as a plain noun. It is one string in three places if you would rather have something else.
