### PR TITLE
chore(Storybook): Record why a Skip Link sits outside the landmarks

### DIFF
--- a/storybook/src/components/SkipLink/SkipLink.docs.mdx
+++ b/storybook/src/components/SkipLink/SkipLink.docs.mdx
@@ -63,6 +63,19 @@ After appearing, it pushes the rest of the page down.
 Following a Skip Link moves the starting point for sequential focus navigation to the target, so the next ‘Tab’ press continues from there.
 The target itself does not receive focus, and it does not need to: an `id` is enough, so leave `tabindex` off.
 
+### Placement outside the landmarks
+
+A Skip Link comes before the Page Header, which puts it ahead of every landmark on the page.
+Leave it there.
+NL Design System is explicit that this is [no violation of success criterion 2.4.1](https://www.nldesignsystem.nl/wcag/2.4.1/): a skip link at the top of the page, as the first focusable element and outside a landmark, meets it.
+
+Testing tools report the placement all the same.
+axe flags the link under its `region` rule, ‘All page content should be contained by landmarks’, which is one of its best practices rather than a success criterion.
+Treat that result as expected.
+
+Do not wrap the Skip Links in a `nav` to satisfy it.
+The [Utrecht design system](https://github.com/nl-design-system/utrecht/blob/main/components/skip-link/README.md) advises against exactly that, and a navigation landmark holding nothing but links that stay hidden until they are focused lengthens the landmark list without helping anyone find its contents.
+
 ## See also
 
 - [Page](/docs/components-containers-page--docs) – contains the Skip Link as its first element.


### PR DESCRIPTION
## Links

- [Skip Link](https://designsystem.amsterdam/?path=/docs/components-navigation-skip-link--docs)
- [WCAG 2.4.1 op nldesignsystem.nl](https://www.nldesignsystem.nl/wcag/2.4.1/)
- [Skip Link in het Utrecht design system](https://github.com/nl-design-system/utrecht/blob/main/components/skip-link/README.md)
- Replaces #2842, which took the wrong approach to the same finding.
- Deploy links follow once the preview is up.

## What

A subsection under Accessibility on the Skip Link page, recording that the Skip Link sits ahead of every landmark on purpose, that axe reports it, and that a `nav` wrapper is not the remedy. One file, thirteen lines.

## Why

A Skip Link comes before the Page Header, so it is outside every landmark, and axe reports `region` — "All page content should be contained by landmarks" — on every page template because of it. Nothing in the documentation said whether that was deliberate, so it reads like an oversight to anyone who runs an audit, and the obvious repair is to wrap the link in a `nav`.

That is what #2842 did, across both Page Layouts, both introductions and two component pages, before the sources were checked. They rule it out on both counts:

> Het plaatsen van een skiplink binnen de header-landmark is *best practice*. Maar, staat de skiplink bovenaan de pagina als eerste focusable element en buiten een landmark, dan is dit **geen** overtreding van dit WCAG-succescriterium.

> Niet: `<nav class="skip-links">…</nav>` Wel: `<div class="skip-links">…</div>`

The first is NL Design System on 2.4.1, the second the Utrecht README. Utrecht's own `SkipLink` renders a `<p>` around the link, with no ARIA and no landmark.

So there is nothing to fix in the markup, and the thing worth changing is that the reasoning was written down nowhere.

## How

The note says three things: the placement is deliberate and meets 2.4.1, axe flags it under a rule tagged best practice rather than a success criterion, and a `nav` is specifically not the answer. Both claims carry their source.

It sits under Accessibility as a `###` subsection, so it appears in the page's table of contents next to the note on focus behaviour.

## Checklist

- [ ] Add or update unit tests
- [x] Add or update documentation
- [ ] Add or update stories
- [ ] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Documentation only, no component or story changes, so no visual regressions are expected.

One thing deliberately left out: NL Design System calls placing the skip link inside the header landmark a best practice, which would clear the axe result without adding a landmark. That needs a slot on Page Header and a decision about the Skip Link's design, which is a full-width band above the header today rather than inside it. Worth its own ticket if we want to follow that guidance.
