### PR TITLE
fix(Storybook): Wrap the whole Project Page in its main element

### DIFF
--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -49,320 +49,327 @@ const meta = {
       </Grid>
       {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
       {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
-      <Grid as="main" id="inhoud" paddingBottom="x-large">
-        <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading level={1}>Centrumeiland: hét zelfbouweiland van Amsterdam</Heading>
-        </Grid.Cell>
-        {/* The slider spans the full grid width, where the title above it keeps to the narrower header cell. */}
-        <Grid.Cell span="all">
-          {/*
-           * ImageSlider takes an array of images. Each entry accepts the props of an Image plus an
-           * optional caption; only alt is required.
-           */}
-          <ImageSlider images={images} />
-        </Grid.Cell>
-        {/*
-         * This cell is not ams-prose, and components never set outer margins, so every element that is
-         * followed by another sets its own bottom margin.
-         */}
-        <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-          <Heading className="ams-mb-s" level={2}>
-            Wat
-          </Heading>
-          <Paragraph className="ams-mb-m">
-            Centrumeiland is hét zelfbouweiland van de stad en maakt deel uit van <Link href="#">IJburg</Link>. Er komen
-            zo’n 1.500 tot 1.700 woningen, waarvan 60 tot 70 procent zelfbouw.
-          </Paragraph>
-          <Paragraph className="ams-mb-m">
-            Op verschillende zelfbouwkavels laten bewoners hun eigen droomwoning bouwen. Ook komen er sociale en
-            middeldure huurwoningen. In totaal is de verdeling van huurwoningen straks 60 procent vrije sector en 40
-            procent sociale en middeldure huur.
-          </Paragraph>
-          <Paragraph className="ams-mb-m">
-            Verder komen er verschillende voorzieningen zoals een basisschool, kinderdagverblijf,
-            jongerentalentencentrum, horeca, broedplaats, verpleeghuis en passantenpension. Er komt een mix aan kleine
-            winkels, bedrijven en kantoren. Het eiland is ongeveer 15 hectare groot. Dat komt overeen met ongeveer 23
-            voetbalvelden. Dat is in oppervlakte vergelijkbaar met Steigereiland Zuid.
-          </Paragraph>
-          <StandaloneLink className="ams-mb-xl" href="#">
-            Lees meer over Centrumeiland
-          </StandaloneLink>
-          <Heading className="ams-mb-s" level={2}>
-            Waar
-          </Heading>
-          <Paragraph className="ams-mb-m">
-            Centrumeiland ligt op IJburg aan de oostkant van Amsterdam, in het IJmeer. Het is het vierde eiland van
-            IJburg en ligt tussen Haveneiland en Strandeiland. Het stadsstrand van IJburg en natuurgebied Diemer
-            Vijfhoek liggen om de hoek.
-          </Paragraph>
-          <Paragraph className="ams-mb-xl">
-            De wijk is goed bereikbaar met het openbaar vervoer, de fiets of de auto. De stad is niet ver weg: tram 26
-            rijdt naar station Amsterdam Centraal en bus 66 gaat naar station Bijlmer Arena. Wie toch liever de auto
-            pakt, is binnen enkele minuten op de A1 of A10.
-          </Paragraph>
-          <Heading className="ams-mb-s" level={2}>
-            Wanneer
-          </Heading>
-          <Paragraph className="ams-mb-l">
-            De bouwwerkzaamheden op Centrumeiland zijn in volle gang. Veel zelfbouwers zijn bezig met de bouw van hun
-            eigen huis. De eerste bewoners zijn in 2020 naar het eiland verhuisd. De komende jaren starten verschillende
-            ontwikkelaars, bouwgroepen en zelfbouwers ook met de bouw van hun nieuwe woningen. We verwachten dat bijna
-            alle woningen en voorzieningen klaar zijn in 2028. Het laatste woonblok wordt opgeleverd in 2029.
-          </Paragraph>
-          {/*
-           * A ProgressList shows a timeline. status="completed" marks a finished step, status="current"
-           * the one in progress, and a step with no status is still to come. Substeps are nested by hand
-           * in a ProgressList.Substeps; hasSubsteps only tells the CSS about them, so that it draws the
-           * connecting lines correctly. collapsible gives every step its own fold button and decides what
-           * opens first: completed steps start collapsed, all others expanded, so the finished years here
-           * arrive folded. headingLevel is 3 because the list sits under the ‘Wanneer’ heading of level 2.
-           */}
-          <ProgressList collapsible headingLevel={3}>
-            <ProgressList.Step hasSubsteps heading="2021" status="completed">
-              <ProgressList.Substeps>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>Landmaken voor de Noordoever en Noordpunt, start oktober.</Paragraph>
-                </ProgressList.Substep>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>Start bouw brug tussen Centrumeiland en Strandeiland in oktober (brug 2125).</Paragraph>
-                </ProgressList.Substep>
-              </ProgressList.Substeps>
-            </ProgressList.Step>
-            <ProgressList.Step hasSubsteps heading="2022" status="completed">
-              <ProgressList.Substeps>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>Inrichting zuidelijke natuuroever, begin 2022.</Paragraph>
-                </ProgressList.Substep>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>Start bouw basisschool en kinderdagverblijf, begin 2022.</Paragraph>
-                </ProgressList.Substep>
-              </ProgressList.Substeps>
-            </ProgressList.Step>
-            <ProgressList.Step hasSubsteps heading="2023" status="completed">
-              <ProgressList.Substeps>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>
-                    Opening <Link href="#">basisschool en kinderdagverblijf</Link>, zomer 2023.
-                  </Paragraph>
-                </ProgressList.Substep>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>Strandeilandlaan krijgt definitieve inrichting.</Paragraph>
-                </ProgressList.Substep>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>
-                    Start bouw <Link href="#">Annemie Wolffbrug</Link> tussen Haveneiland met Centrumeiland.
-                  </Paragraph>
-                </ProgressList.Substep>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>
-                    Voorbereiding en start bouw <Link href="#">Lee Millerbrug</Link> met brugpaviljoens tussen
-                    Centrumeiland en Strandeiland.
-                  </Paragraph>
-                </ProgressList.Substep>
-              </ProgressList.Substeps>
-            </ProgressList.Step>
-            <ProgressList.Step hasSubsteps heading="2024" status="completed">
-              <ProgressList.Substeps>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>Start bouw brug tussen Centrumeiland en Strandeiland (brug 2080 bij strand).</Paragraph>
-                </ProgressList.Substep>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>Opening Jongerentalentencentrum.</Paragraph>
-                </ProgressList.Substep>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>Definitieve inrichting eerste straten en wadi’s.</Paragraph>
-                </ProgressList.Substep>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>Oplevering sociale woonblokken Ymere en de Alliantie.</Paragraph>
-                </ProgressList.Substep>
-              </ProgressList.Substeps>
-            </ProgressList.Step>
-            <ProgressList.Step hasSubsteps heading="2025" status="completed">
-              <ProgressList.Substeps>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>Halte IJtram 26 op Centrumeiland eind 2025.</Paragraph>
-                </ProgressList.Substep>
-                <ProgressList.Substep status="completed">
-                  <Paragraph>Start bouw Robin Wood.</Paragraph>
-                </ProgressList.Substep>
-              </ProgressList.Substeps>
-            </ProgressList.Step>
-            <ProgressList.Step hasSubsteps heading="2026" status="current">
-              <ProgressList.Substeps>
-                <ProgressList.Substep>
-                  <Paragraph>Oplevering Zuidoever (ecologische oever).</Paragraph>
-                </ProgressList.Substep>
-              </ProgressList.Substeps>
-            </ProgressList.Step>
-            <ProgressList.Step hasSubsteps heading="2029">
-              <ProgressList.Substeps>
-                <ProgressList.Substep>
-                  <Paragraph>Waarschijnlijk zijn bijna alle woningen en voorzieningen klaar.</Paragraph>
-                </ProgressList.Substep>
-              </ProgressList.Substeps>
-            </ProgressList.Step>
-          </ProgressList>
-        </Grid.Cell>
-        {/*
-         * Two link lists: the full-width narrow span stacks them, and from medium up the start values
-         * put them side by side – halves of the medium grid, inset 5-column blocks on the wide one.
-         */}
-        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading className="ams-mb-xs" level={2} size="level-3">
-            Nieuws
-          </Heading>
-          <LinkList>
-            <LinkList.Link href="#">Werkzaamheden Bert Haanstrakade en Pampuslaan (27 november 2025)</LinkList.Link>
-            <LinkList.Link href="#">17 november: bijeenkomst over Strandeiland (11 november 2025)</LinkList.Link>
-          </LinkList>
-        </Grid.Cell>
-        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
-          <Heading className="ams-mb-xs" level={2} size="level-3">
-            Werk aan de weg
-          </Heading>
-          <LinkList>
-            <LinkList.Link href="#">Bert Haanstrakade, omleiding</LinkList.Link>
-            <LinkList.Link href="#">Straten Centrumeiland, afsluitingen</LinkList.Link>
-          </LinkList>
-        </Grid.Cell>
-      </Grid>
-      <Spotlight color="azure">
-        <Grid paddingVertical="x-large">
-          <Grid.Cell span="all">
-            <Heading color="inverse" level={2}>
-              Zelfbouw
-            </Heading>
-          </Grid.Cell>
-          {/* The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens. */}
-          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
-            <Paragraph className="ams-mb-s" color="inverse">
-              Meer over de verschillende vormen van zelfbouw vindt u op:
-            </Paragraph>
-            <StandaloneLink color="inverse" href="#">
-              Zelfbouw
-            </StandaloneLink>
-          </Grid.Cell>
-          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
-            <Paragraph className="ams-mb-s" color="inverse">
-              Op de kavelkaart is te zien welke kavels in de toekomst op Centrumeiland vrij komen.
-            </Paragraph>
-            <StandaloneLink color="inverse" href="#">
-              Aanbod kavels
-            </StandaloneLink>
-          </Grid.Cell>
-          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
-            <Paragraph className="ams-mb-s" color="inverse">
-              Op zoek naar medebouwers of samen met anderen bouwen? Plaats een oproep.
-            </Paragraph>
-            <StandaloneLink color="inverse" href="#">
-              Prikbord
-            </StandaloneLink>
-          </Grid.Cell>
-          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
-            <Paragraph className="ams-mb-s" color="inverse">
-              Meld u aan en blijf op de hoogte over zelfbouw in Amsterdam.
-            </Paragraph>
-            <StandaloneLink color="inverse" href="#">
-              Nieuwsbrief zelfbouw
-            </StandaloneLink>
-          </Grid.Cell>
-        </Grid>
-      </Spotlight>
-      <Grid paddingVertical="x-large">
-        {/* These four cells alternate between the same start positions, so they too read as two columns. */}
-        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading className="ams-mb-xs" level={2} size="level-3">
-            Meer informatie
-          </Heading>
-          <LinkList>
-            <LinkList.Link href="#">Blok 16: Amsterdams nabuurschap, een nieuwe vorm van zelfbouw</LinkList.Link>
-            <LinkList.Link href="#">Strandlokaal IJburg</LinkList.Link>
-            <LinkList.Link href="#">Woningaanbod Centrumeiland</LinkList.Link>
-            <LinkList.Link href="#">Nieuwe bruggen op IJburg</LinkList.Link>
-            <LinkList.Link href="#">IJburg: nieuwe eilanden en woningbouw</LinkList.Link>
-            <LinkList.Link href="#">IJburg - stations Bijlmer Arena en Weesp: nieuwe busverbindingen</LinkList.Link>
-            <LinkList.Link className="ams-mb-m" href="#">
-              IJburg: verlengen IJtram
-            </LinkList.Link>
-            <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
-          </LinkList>
-        </Grid.Cell>
-        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
-          <Heading className="ams-mb-m" level={2} size="level-3">
-            Ontwikkeling Centrumeiland, herfst 2025
-          </Heading>
-          {/* This image only contributes to the visual atmosphere of the page, so it takes an empty alt. */}
-          <Image alt="" className="ams-mb-m" src="https://picsum.photos/id/385/640/360" />
-          <StandaloneLink href="#">Meer video’s</StandaloneLink>
-        </Grid.Cell>
-        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading className="ams-mb-xs" level={2} size="level-3">
-            Plannen en publicaties
-          </Heading>
-          <LinkList>
-            <LinkList.Link href="#">Plannen en publicaties Centrumeiland</LinkList.Link>
-          </LinkList>
-        </Grid.Cell>
-        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
-          <Heading className="ams-mb-xs" level={2} size="level-3">
-            Blijf op de hoogte
-          </Heading>
-          <LinkList>
-            <LinkList.Link href="#">Nieuwsbrief ontwikkeling IJburg</LinkList.Link>
-            <LinkList.Link href="#">Hallo Centrumeiland: praat mee</LinkList.Link>
-            <LinkList.Link href="#">Facebook: IJburg</LinkList.Link>
-            <LinkList.Link href="#">Instagram: Centrumeiland</LinkList.Link>
-          </LinkList>
-        </Grid.Cell>
-      </Grid>
       {/*
-       * The highlight colours have no prescribed meaning, so this second band takes the default purple
-       * rather than repeating the azure of the first.
+       * The Spotlight bands carry the project’s own content rather than supporting content,
+       * so <main> wraps several Grids here rather than being one itself.
        */}
-      <Spotlight>
-        <Grid paddingVertical="x-large">
+      <main id="inhoud">
+        <Grid paddingBottom="x-large">
+          <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading level={1}>Centrumeiland: hét zelfbouweiland van Amsterdam</Heading>
+          </Grid.Cell>
+          {/* The slider spans the full grid width, where the title above it keeps to the narrower header cell. */}
           <Grid.Cell span="all">
-            <Heading className="ams-mb-s" color="inverse" level={2}>
-              Contact
+            {/*
+             * ImageSlider takes an array of images. Each entry accepts the props of an Image plus an
+             * optional caption; only alt is required.
+             */}
+            <ImageSlider images={images} />
+          </Grid.Cell>
+          {/*
+           * This cell is not ams-prose, and components never set outer margins, so every element that is
+           * followed by another sets its own bottom margin.
+           */}
+          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+            <Heading className="ams-mb-s" level={2}>
+              Wat
             </Heading>
+            <Paragraph className="ams-mb-m">
+              Centrumeiland is hét zelfbouweiland van de stad en maakt deel uit van <Link href="#">IJburg</Link>. Er
+              komen zo’n 1.500 tot 1.700 woningen, waarvan 60 tot 70 procent zelfbouw.
+            </Paragraph>
+            <Paragraph className="ams-mb-m">
+              Op verschillende zelfbouwkavels laten bewoners hun eigen droomwoning bouwen. Ook komen er sociale en
+              middeldure huurwoningen. In totaal is de verdeling van huurwoningen straks 60 procent vrije sector en 40
+              procent sociale en middeldure huur.
+            </Paragraph>
+            <Paragraph className="ams-mb-m">
+              Verder komen er verschillende voorzieningen zoals een basisschool, kinderdagverblijf,
+              jongerentalentencentrum, horeca, broedplaats, verpleeghuis en passantenpension. Er komt een mix aan kleine
+              winkels, bedrijven en kantoren. Het eiland is ongeveer 15 hectare groot. Dat komt overeen met ongeveer 23
+              voetbalvelden. Dat is in oppervlakte vergelijkbaar met Steigereiland Zuid.
+            </Paragraph>
+            <StandaloneLink className="ams-mb-xl" href="#">
+              Lees meer over Centrumeiland
+            </StandaloneLink>
+            <Heading className="ams-mb-s" level={2}>
+              Waar
+            </Heading>
+            <Paragraph className="ams-mb-m">
+              Centrumeiland ligt op IJburg aan de oostkant van Amsterdam, in het IJmeer. Het is het vierde eiland van
+              IJburg en ligt tussen Haveneiland en Strandeiland. Het stadsstrand van IJburg en natuurgebied Diemer
+              Vijfhoek liggen om de hoek.
+            </Paragraph>
+            <Paragraph className="ams-mb-xl">
+              De wijk is goed bereikbaar met het openbaar vervoer, de fiets of de auto. De stad is niet ver weg: tram 26
+              rijdt naar station Amsterdam Centraal en bus 66 gaat naar station Bijlmer Arena. Wie toch liever de auto
+              pakt, is binnen enkele minuten op de A1 of A10.
+            </Paragraph>
+            <Heading className="ams-mb-s" level={2}>
+              Wanneer
+            </Heading>
+            <Paragraph className="ams-mb-l">
+              De bouwwerkzaamheden op Centrumeiland zijn in volle gang. Veel zelfbouwers zijn bezig met de bouw van hun
+              eigen huis. De eerste bewoners zijn in 2020 naar het eiland verhuisd. De komende jaren starten
+              verschillende ontwikkelaars, bouwgroepen en zelfbouwers ook met de bouw van hun nieuwe woningen. We
+              verwachten dat bijna alle woningen en voorzieningen klaar zijn in 2028. Het laatste woonblok wordt
+              opgeleverd in 2029.
+            </Paragraph>
+            {/*
+             * A ProgressList shows a timeline. status="completed" marks a finished step, status="current"
+             * the one in progress, and a step with no status is still to come. Substeps are nested by hand
+             * in a ProgressList.Substeps; hasSubsteps only tells the CSS about them, so that it draws the
+             * connecting lines correctly. collapsible gives every step its own fold button and decides what
+             * opens first: completed steps start collapsed, all others expanded, so the finished years here
+             * arrive folded. headingLevel is 3 because the list sits under the ‘Wanneer’ heading of level 2.
+             */}
+            <ProgressList collapsible headingLevel={3}>
+              <ProgressList.Step hasSubsteps heading="2021" status="completed">
+                <ProgressList.Substeps>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>Landmaken voor de Noordoever en Noordpunt, start oktober.</Paragraph>
+                  </ProgressList.Substep>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>Start bouw brug tussen Centrumeiland en Strandeiland in oktober (brug 2125).</Paragraph>
+                  </ProgressList.Substep>
+                </ProgressList.Substeps>
+              </ProgressList.Step>
+              <ProgressList.Step hasSubsteps heading="2022" status="completed">
+                <ProgressList.Substeps>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>Inrichting zuidelijke natuuroever, begin 2022.</Paragraph>
+                  </ProgressList.Substep>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>Start bouw basisschool en kinderdagverblijf, begin 2022.</Paragraph>
+                  </ProgressList.Substep>
+                </ProgressList.Substeps>
+              </ProgressList.Step>
+              <ProgressList.Step hasSubsteps heading="2023" status="completed">
+                <ProgressList.Substeps>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>
+                      Opening <Link href="#">basisschool en kinderdagverblijf</Link>, zomer 2023.
+                    </Paragraph>
+                  </ProgressList.Substep>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>Strandeilandlaan krijgt definitieve inrichting.</Paragraph>
+                  </ProgressList.Substep>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>
+                      Start bouw <Link href="#">Annemie Wolffbrug</Link> tussen Haveneiland met Centrumeiland.
+                    </Paragraph>
+                  </ProgressList.Substep>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>
+                      Voorbereiding en start bouw <Link href="#">Lee Millerbrug</Link> met brugpaviljoens tussen
+                      Centrumeiland en Strandeiland.
+                    </Paragraph>
+                  </ProgressList.Substep>
+                </ProgressList.Substeps>
+              </ProgressList.Step>
+              <ProgressList.Step hasSubsteps heading="2024" status="completed">
+                <ProgressList.Substeps>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>Start bouw brug tussen Centrumeiland en Strandeiland (brug 2080 bij strand).</Paragraph>
+                  </ProgressList.Substep>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>Opening Jongerentalentencentrum.</Paragraph>
+                  </ProgressList.Substep>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>Definitieve inrichting eerste straten en wadi’s.</Paragraph>
+                  </ProgressList.Substep>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>Oplevering sociale woonblokken Ymere en de Alliantie.</Paragraph>
+                  </ProgressList.Substep>
+                </ProgressList.Substeps>
+              </ProgressList.Step>
+              <ProgressList.Step hasSubsteps heading="2025" status="completed">
+                <ProgressList.Substeps>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>Halte IJtram 26 op Centrumeiland eind 2025.</Paragraph>
+                  </ProgressList.Substep>
+                  <ProgressList.Substep status="completed">
+                    <Paragraph>Start bouw Robin Wood.</Paragraph>
+                  </ProgressList.Substep>
+                </ProgressList.Substeps>
+              </ProgressList.Step>
+              <ProgressList.Step hasSubsteps heading="2026" status="current">
+                <ProgressList.Substeps>
+                  <ProgressList.Substep>
+                    <Paragraph>Oplevering Zuidoever (ecologische oever).</Paragraph>
+                  </ProgressList.Substep>
+                </ProgressList.Substeps>
+              </ProgressList.Step>
+              <ProgressList.Step hasSubsteps heading="2029">
+                <ProgressList.Substeps>
+                  <ProgressList.Substep>
+                    <Paragraph>Waarschijnlijk zijn bijna alle woningen en voorzieningen klaar.</Paragraph>
+                  </ProgressList.Substep>
+                </ProgressList.Substeps>
+              </ProgressList.Step>
+            </ProgressList>
           </Grid.Cell>
-          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-            <Paragraph className="ams-mb-m" color="inverse">
-              Vragen over zelfbouw op Centrumeiland:{' '}
-              <Link color="inverse" href="mailto:zelfbouwcentrumeiland@amsterdam.nl">
-                zelfbouwcentrumeiland@amsterdam.nl
-              </Link>
-            </Paragraph>
-            <Paragraph color="inverse">
-              Elke donderdag is er van 16.00 uur tot 17.00 uur een telefonisch spreekuur. Aanmelden via e-mail.
-            </Paragraph>
+          {/*
+           * Two link lists: the full-width narrow span stacks them, and from medium up the start values
+           * put them side by side – halves of the medium grid, inset 5-column blocks on the wide one.
+           */}
+          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading className="ams-mb-xs" level={2} size="level-3">
+              Nieuws
+            </Heading>
+            <LinkList>
+              <LinkList.Link href="#">Werkzaamheden Bert Haanstrakade en Pampuslaan (27 november 2025)</LinkList.Link>
+              <LinkList.Link href="#">17 november: bijeenkomst over Strandeiland (11 november 2025)</LinkList.Link>
+            </LinkList>
           </Grid.Cell>
-          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-            {/* These lines are kept in one Paragraph so they read as a single contact block, not as running text. */}
-            <Paragraph color="inverse">
-              Maud van Esch
-              <br />
-              Omgevingsmanager IJburg
-              <br />
-              <Link color="inverse" href="mailto:m.van.esch@amsterdam.nl">
-                m.van.esch@amsterdam.nl
-              </Link>
-              <br />
-              <Link color="inverse" href="tel:+316645899537">
-                06 4589 9537
-              </Link>
-              <br />
-              Voor vragen over werkzaamheden of bouwactiviteiten
-            </Paragraph>
+          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
+            <Heading className="ams-mb-xs" level={2} size="level-3">
+              Werk aan de weg
+            </Heading>
+            <LinkList>
+              <LinkList.Link href="#">Bert Haanstrakade, omleiding</LinkList.Link>
+              <LinkList.Link href="#">Straten Centrumeiland, afsluitingen</LinkList.Link>
+            </LinkList>
           </Grid.Cell>
         </Grid>
-      </Spotlight>
-      {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
-      <Grid paddingBottom="2x-large" paddingTop="x-large">
-        <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Image alt="" src={exampleImageSource(1280, 720)} />
-        </Grid.Cell>
-      </Grid>
+        <Spotlight color="azure">
+          <Grid paddingVertical="x-large">
+            <Grid.Cell span="all">
+              <Heading color="inverse" level={2}>
+                Zelfbouw
+              </Heading>
+            </Grid.Cell>
+            {/* The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens. */}
+            <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
+              <Paragraph className="ams-mb-s" color="inverse">
+                Meer over de verschillende vormen van zelfbouw vindt u op:
+              </Paragraph>
+              <StandaloneLink color="inverse" href="#">
+                Zelfbouw
+              </StandaloneLink>
+            </Grid.Cell>
+            <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
+              <Paragraph className="ams-mb-s" color="inverse">
+                Op de kavelkaart is te zien welke kavels in de toekomst op Centrumeiland vrij komen.
+              </Paragraph>
+              <StandaloneLink color="inverse" href="#">
+                Aanbod kavels
+              </StandaloneLink>
+            </Grid.Cell>
+            <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
+              <Paragraph className="ams-mb-s" color="inverse">
+                Op zoek naar medebouwers of samen met anderen bouwen? Plaats een oproep.
+              </Paragraph>
+              <StandaloneLink color="inverse" href="#">
+                Prikbord
+              </StandaloneLink>
+            </Grid.Cell>
+            <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
+              <Paragraph className="ams-mb-s" color="inverse">
+                Meld u aan en blijf op de hoogte over zelfbouw in Amsterdam.
+              </Paragraph>
+              <StandaloneLink color="inverse" href="#">
+                Nieuwsbrief zelfbouw
+              </StandaloneLink>
+            </Grid.Cell>
+          </Grid>
+        </Spotlight>
+        <Grid paddingVertical="x-large">
+          {/* These four cells alternate between the same start positions, so they too read as two columns. */}
+          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading className="ams-mb-xs" level={2} size="level-3">
+              Meer informatie
+            </Heading>
+            <LinkList>
+              <LinkList.Link href="#">Blok 16: Amsterdams nabuurschap, een nieuwe vorm van zelfbouw</LinkList.Link>
+              <LinkList.Link href="#">Strandlokaal IJburg</LinkList.Link>
+              <LinkList.Link href="#">Woningaanbod Centrumeiland</LinkList.Link>
+              <LinkList.Link href="#">Nieuwe bruggen op IJburg</LinkList.Link>
+              <LinkList.Link href="#">IJburg: nieuwe eilanden en woningbouw</LinkList.Link>
+              <LinkList.Link href="#">IJburg - stations Bijlmer Arena en Weesp: nieuwe busverbindingen</LinkList.Link>
+              <LinkList.Link className="ams-mb-m" href="#">
+                IJburg: verlengen IJtram
+              </LinkList.Link>
+              <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
+            </LinkList>
+          </Grid.Cell>
+          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
+            <Heading className="ams-mb-m" level={2} size="level-3">
+              Ontwikkeling Centrumeiland, herfst 2025
+            </Heading>
+            {/* This image only contributes to the visual atmosphere of the page, so it takes an empty alt. */}
+            <Image alt="" className="ams-mb-m" src="https://picsum.photos/id/385/640/360" />
+            <StandaloneLink href="#">Meer video’s</StandaloneLink>
+          </Grid.Cell>
+          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading className="ams-mb-xs" level={2} size="level-3">
+              Plannen en publicaties
+            </Heading>
+            <LinkList>
+              <LinkList.Link href="#">Plannen en publicaties Centrumeiland</LinkList.Link>
+            </LinkList>
+          </Grid.Cell>
+          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
+            <Heading className="ams-mb-xs" level={2} size="level-3">
+              Blijf op de hoogte
+            </Heading>
+            <LinkList>
+              <LinkList.Link href="#">Nieuwsbrief ontwikkeling IJburg</LinkList.Link>
+              <LinkList.Link href="#">Hallo Centrumeiland: praat mee</LinkList.Link>
+              <LinkList.Link href="#">Facebook: IJburg</LinkList.Link>
+              <LinkList.Link href="#">Instagram: Centrumeiland</LinkList.Link>
+            </LinkList>
+          </Grid.Cell>
+        </Grid>
+        {/*
+         * The highlight colours have no prescribed meaning, so this second band takes the default purple
+         * rather than repeating the azure of the first.
+         */}
+        <Spotlight>
+          <Grid paddingVertical="x-large">
+            <Grid.Cell span="all">
+              <Heading className="ams-mb-s" color="inverse" level={2}>
+                Contact
+              </Heading>
+            </Grid.Cell>
+            <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+              <Paragraph className="ams-mb-m" color="inverse">
+                Vragen over zelfbouw op Centrumeiland:{' '}
+                <Link color="inverse" href="mailto:zelfbouwcentrumeiland@amsterdam.nl">
+                  zelfbouwcentrumeiland@amsterdam.nl
+                </Link>
+              </Paragraph>
+              <Paragraph color="inverse">
+                Elke donderdag is er van 16.00 uur tot 17.00 uur een telefonisch spreekuur. Aanmelden via e-mail.
+              </Paragraph>
+            </Grid.Cell>
+            <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+              {/* These lines are kept in one Paragraph so they read as a single contact block, not as running text. */}
+              <Paragraph color="inverse">
+                Maud van Esch
+                <br />
+                Omgevingsmanager IJburg
+                <br />
+                <Link color="inverse" href="mailto:m.van.esch@amsterdam.nl">
+                  m.van.esch@amsterdam.nl
+                </Link>
+                <br />
+                <Link color="inverse" href="tel:+316645899537">
+                  06 4589 9537
+                </Link>
+                <br />
+                Voor vragen over werkzaamheden of bouwactiviteiten
+              </Paragraph>
+            </Grid.Cell>
+          </Grid>
+        </Spotlight>
+        {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+        <Grid paddingBottom="2x-large" paddingTop="x-large">
+          <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Image alt="" src={exampleImageSource(1280, 720)} />
+          </Grid.Cell>
+        </Grid>
+      </main>
     </>
   ),
 } satisfies Meta
@@ -391,164 +398,170 @@ export const Default: StoryObj = {
   </Grid>
   {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
   {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
-  <Grid as="main" id="inhoud" paddingBottom="x-large">
-    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-      <Heading level={1}>Centrumeiland: hét zelfbouweiland van Amsterdam</Heading>
-    </Grid.Cell>
-    {/* The slider spans the full grid width, where the title above it keeps to the narrower header cell. */}
-    <Grid.Cell span="all">
-      {/*
-       * ImageSlider takes an array of images. Each entry accepts the props of an Image plus an
-       * optional caption; only alt is required.
-       */}
-      <ImageSlider images={images} />
-    </Grid.Cell>
-    {/*
-     * This cell is not ams-prose, and components never set outer margins, so every element that is
-     * followed by another sets its own bottom margin.
-     */}
-    <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-      <Heading className="ams-mb-s" level={2}>Wat</Heading>
-      <Paragraph className="ams-mb-m">
-        Centrumeiland is hét zelfbouweiland van de stad en maakt deel uit van <Link href="#">IJburg</Link>.
-        Er komen zo’n 1.500 tot 1.700 woningen, waarvan 60 tot 70 procent zelfbouw.
-      </Paragraph>
-      <StandaloneLink className="ams-mb-xl" href="#">Lees meer over Centrumeiland</StandaloneLink>
-      <Heading className="ams-mb-s" level={2}>Waar</Heading>
-      <Paragraph className="ams-mb-xl">
-        Centrumeiland ligt op IJburg aan de oostkant van Amsterdam, in het IJmeer. Het is het vierde eiland
-        van IJburg en ligt tussen Haveneiland en Strandeiland.
-      </Paragraph>
-      <Heading className="ams-mb-s" level={2}>Wanneer</Heading>
-      <Paragraph className="ams-mb-l">
-        De bouwwerkzaamheden op Centrumeiland zijn in volle gang. We verwachten dat bijna alle woningen en
-        voorzieningen klaar zijn in 2028.
-      </Paragraph>
-      {/*
-       * A ProgressList shows a timeline. status="completed" marks a finished step, status="current"
-       * the one in progress, and a step with no status is still to come. Substeps are nested by hand
-       * in a ProgressList.Substeps; hasSubsteps only tells the CSS about them, so that it draws the
-       * connecting lines correctly. collapsible gives every step its own fold button and decides what
-       * opens first: completed steps start collapsed, all others expanded, so the finished years here
-       * arrive folded. headingLevel is 3 because the list sits under the ‘Wanneer’ heading of level 2.
-       */}
-      <ProgressList collapsible headingLevel={3}>
-        <ProgressList.Step hasSubsteps heading="2021" status="completed">
-          <ProgressList.Substeps>
-            <ProgressList.Substep status="completed">
-              <Paragraph>Landmaken voor de Noordoever en Noordpunt, start oktober.</Paragraph>
-            </ProgressList.Substep>
-          </ProgressList.Substeps>
-        </ProgressList.Step>
-        {/* … more completed years (2022–2025), each a Step with completed Substeps … */}
-        <ProgressList.Step hasSubsteps heading="2026" status="current">
-          <ProgressList.Substeps>
-            <ProgressList.Substep>
-              <Paragraph>Oplevering Zuidoever (ecologische oever).</Paragraph>
-            </ProgressList.Substep>
-          </ProgressList.Substeps>
-        </ProgressList.Step>
-        <ProgressList.Step hasSubsteps heading="2029">
-          <ProgressList.Substeps>
-            <ProgressList.Substep>
-              <Paragraph>Waarschijnlijk zijn bijna alle woningen en voorzieningen klaar.</Paragraph>
-            </ProgressList.Substep>
-          </ProgressList.Substeps>
-        </ProgressList.Step>
-      </ProgressList>
-    </Grid.Cell>
-    {/*
-     * Two link lists: the full-width narrow span stacks them, and from medium up the start values
-     * put them side by side – halves of the medium grid, inset 5-column blocks on the wide one.
-     */}
-    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-      <Heading className="ams-mb-xs" level={2} size="level-3">Nieuws</Heading>
-      <LinkList>
-        <LinkList.Link href="#">Werkzaamheden Bert Haanstrakade en Pampuslaan (27 november 2025)</LinkList.Link>
-        <LinkList.Link href="#">17 november: bijeenkomst over Strandeiland (11 november 2025)</LinkList.Link>
-      </LinkList>
-    </Grid.Cell>
-    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
-      <Heading className="ams-mb-xs" level={2} size="level-3">Werk aan de weg</Heading>
-      <LinkList>
-        <LinkList.Link href="#">Bert Haanstrakade, omleiding</LinkList.Link>
-        <LinkList.Link href="#">Straten Centrumeiland, afsluitingen</LinkList.Link>
-      </LinkList>
-    </Grid.Cell>
-  </Grid>
-  <Spotlight color="azure">
-    <Grid paddingVertical="x-large">
-      <Grid.Cell span="all">
-        <Heading color="inverse" level={2}>Zelfbouw</Heading>
-      </Grid.Cell>
-      {/* The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens. */}
-      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
-        <Paragraph className="ams-mb-s" color="inverse">
-          Meer over de verschillende vormen van zelfbouw vindt u op:
-        </Paragraph>
-        <StandaloneLink color="inverse" href="#">Zelfbouw</StandaloneLink>
-      </Grid.Cell>
-      {/* … three more columns (Aanbod kavels, Prikbord, Nieuwsbrief zelfbouw) … */}
-    </Grid>
-  </Spotlight>
-  <Grid paddingVertical="x-large">
-    {/* These four cells alternate between the same start positions, so they too read as two columns. */}
-    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-      <Heading className="ams-mb-xs" level={2} size="level-3">Meer informatie</Heading>
-      <LinkList>
-        <LinkList.Link href="#">Blok 16: Amsterdams nabuurschap, een nieuwe vorm van zelfbouw</LinkList.Link>
-        <LinkList.Link href="#">Woningaanbod Centrumeiland</LinkList.Link>
-        <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
-      </LinkList>
-    </Grid.Cell>
-    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
-      <Heading className="ams-mb-m" level={2} size="level-3">Ontwikkeling Centrumeiland, herfst 2025</Heading>
-      {/* This image only contributes to the visual atmosphere of the page, so it takes an empty alt. */}
-      <Image alt="" className="ams-mb-m" src="https://picsum.photos/id/385/640/360" />
-      <StandaloneLink href="#">Meer video’s</StandaloneLink>
-    </Grid.Cell>
-    {/* … a Plannen en publicaties cell, start-aligned to the left like Meer informatie … */}
-    <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
-      <Heading className="ams-mb-xs" level={2} size="level-3">Blijf op de hoogte</Heading>
-      <LinkList>
-        <LinkList.Link href="#">Nieuwsbrief ontwikkeling IJburg</LinkList.Link>
-        <LinkList.Link href="#">Hallo Centrumeiland: praat mee</LinkList.Link>
-      </LinkList>
-    </Grid.Cell>
-  </Grid>
   {/*
-   * The highlight colours have no prescribed meaning, so this second band takes the default purple
-   * rather than repeating the azure of the first.
+   * The Spotlight bands carry the project’s own content rather than supporting content,
+   * so <main> wraps several Grids here rather than being one itself.
    */}
-  <Spotlight>
-    <Grid paddingVertical="x-large">
+  <main id="inhoud">
+    <Grid paddingBottom="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading level={1}>Centrumeiland: hét zelfbouweiland van Amsterdam</Heading>
+      </Grid.Cell>
+      {/* The slider spans the full grid width, where the title above it keeps to the narrower header cell. */}
       <Grid.Cell span="all">
-        <Heading className="ams-mb-s" color="inverse" level={2}>Contact</Heading>
+        {/*
+         * ImageSlider takes an array of images. Each entry accepts the props of an Image plus an
+         * optional caption; only alt is required.
+         */}
+        <ImageSlider images={images} />
       </Grid.Cell>
-      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-        <Paragraph className="ams-mb-m" color="inverse">
-          Vragen over zelfbouw op Centrumeiland:{' '}
-          <Link color="inverse" href="mailto:zelfbouwcentrumeiland@amsterdam.nl">zelfbouwcentrumeiland@amsterdam.nl</Link>
+      {/*
+       * This cell is not ams-prose, and components never set outer margins, so every element that is
+       * followed by another sets its own bottom margin.
+       */}
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+        <Heading className="ams-mb-s" level={2}>Wat</Heading>
+        <Paragraph className="ams-mb-m">
+          Centrumeiland is hét zelfbouweiland van de stad en maakt deel uit van <Link href="#">IJburg</Link>.
+          Er komen zo’n 1.500 tot 1.700 woningen, waarvan 60 tot 70 procent zelfbouw.
         </Paragraph>
+        <StandaloneLink className="ams-mb-xl" href="#">Lees meer over Centrumeiland</StandaloneLink>
+        <Heading className="ams-mb-s" level={2}>Waar</Heading>
+        <Paragraph className="ams-mb-xl">
+          Centrumeiland ligt op IJburg aan de oostkant van Amsterdam, in het IJmeer. Het is het vierde eiland
+          van IJburg en ligt tussen Haveneiland en Strandeiland.
+        </Paragraph>
+        <Heading className="ams-mb-s" level={2}>Wanneer</Heading>
+        <Paragraph className="ams-mb-l">
+          De bouwwerkzaamheden op Centrumeiland zijn in volle gang. We verwachten dat bijna alle woningen en
+          voorzieningen klaar zijn in 2028.
+        </Paragraph>
+        {/*
+         * A ProgressList shows a timeline. status="completed" marks a finished step, status="current"
+         * the one in progress, and a step with no status is still to come. Substeps are nested by hand
+         * in a ProgressList.Substeps; hasSubsteps only tells the CSS about them, so that it draws the
+         * connecting lines correctly. collapsible gives every step its own fold button and decides what
+         * opens first: completed steps start collapsed, all others expanded, so the finished years here
+         * arrive folded. headingLevel is 3 because the list sits under the ‘Wanneer’ heading of level 2.
+         */}
+        <ProgressList collapsible headingLevel={3}>
+          <ProgressList.Step hasSubsteps heading="2021" status="completed">
+            <ProgressList.Substeps>
+              <ProgressList.Substep status="completed">
+                <Paragraph>Landmaken voor de Noordoever en Noordpunt, start oktober.</Paragraph>
+              </ProgressList.Substep>
+            </ProgressList.Substeps>
+          </ProgressList.Step>
+          {/* … more completed years (2022–2025), each a Step with completed Substeps … */}
+          <ProgressList.Step hasSubsteps heading="2026" status="current">
+            <ProgressList.Substeps>
+              <ProgressList.Substep>
+                <Paragraph>Oplevering Zuidoever (ecologische oever).</Paragraph>
+              </ProgressList.Substep>
+            </ProgressList.Substeps>
+          </ProgressList.Step>
+          <ProgressList.Step hasSubsteps heading="2029">
+            <ProgressList.Substeps>
+              <ProgressList.Substep>
+                <Paragraph>Waarschijnlijk zijn bijna alle woningen en voorzieningen klaar.</Paragraph>
+              </ProgressList.Substep>
+            </ProgressList.Substeps>
+          </ProgressList.Step>
+        </ProgressList>
       </Grid.Cell>
-      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-        {/* These lines are kept in one Paragraph so they read as a single contact block, not as running text. */}
-        <Paragraph color="inverse">
-          Maud van Esch
-          <br />
-          Omgevingsmanager IJburg
-          <br />
-          <Link color="inverse" href="mailto:m.van.esch@amsterdam.nl">m.van.esch@amsterdam.nl</Link>
-        </Paragraph>
+      {/*
+       * Two link lists: the full-width narrow span stacks them, and from medium up the start values
+       * put them side by side – halves of the medium grid, inset 5-column blocks on the wide one.
+       */}
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-xs" level={2} size="level-3">Nieuws</Heading>
+        <LinkList>
+          <LinkList.Link href="#">Werkzaamheden Bert Haanstrakade en Pampuslaan (27 november 2025)</LinkList.Link>
+          <LinkList.Link href="#">17 november: bijeenkomst over Strandeiland (11 november 2025)</LinkList.Link>
+        </LinkList>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
+        <Heading className="ams-mb-xs" level={2} size="level-3">Werk aan de weg</Heading>
+        <LinkList>
+          <LinkList.Link href="#">Bert Haanstrakade, omleiding</LinkList.Link>
+          <LinkList.Link href="#">Straten Centrumeiland, afsluitingen</LinkList.Link>
+        </LinkList>
       </Grid.Cell>
     </Grid>
-  </Spotlight>
-  {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
-  <Grid paddingBottom="2x-large" paddingTop="x-large">
-    <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-      <Image alt="" src="https://picsum.photos/1280/720" />
-    </Grid.Cell>
-  </Grid>
+    <Spotlight color="azure">
+      <Grid paddingVertical="x-large">
+        <Grid.Cell span="all">
+          <Heading color="inverse" level={2}>Zelfbouw</Heading>
+        </Grid.Cell>
+        {/* The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens. */}
+        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 3 }}>
+          <Paragraph className="ams-mb-s" color="inverse">
+            Meer over de verschillende vormen van zelfbouw vindt u op:
+          </Paragraph>
+          <StandaloneLink color="inverse" href="#">Zelfbouw</StandaloneLink>
+        </Grid.Cell>
+        {/* … three more columns (Aanbod kavels, Prikbord, Nieuwsbrief zelfbouw) … */}
+      </Grid>
+    </Spotlight>
+    <Grid paddingVertical="x-large">
+      {/* These four cells alternate between the same start positions, so they too read as two columns. */}
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-xs" level={2} size="level-3">Meer informatie</Heading>
+        <LinkList>
+          <LinkList.Link href="#">Blok 16: Amsterdams nabuurschap, een nieuwe vorm van zelfbouw</LinkList.Link>
+          <LinkList.Link href="#">Woningaanbod Centrumeiland</LinkList.Link>
+          <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
+        </LinkList>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
+        <Heading className="ams-mb-m" level={2} size="level-3">Ontwikkeling Centrumeiland, herfst 2025</Heading>
+        {/* This image only contributes to the visual atmosphere of the page, so it takes an empty alt. */}
+        <Image alt="" className="ams-mb-m" src="https://picsum.photos/id/385/640/360" />
+        <StandaloneLink href="#">Meer video’s</StandaloneLink>
+      </Grid.Cell>
+      {/* … a Plannen en publicaties cell, start-aligned to the left like Meer informatie … */}
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
+        <Heading className="ams-mb-xs" level={2} size="level-3">Blijf op de hoogte</Heading>
+        <LinkList>
+          <LinkList.Link href="#">Nieuwsbrief ontwikkeling IJburg</LinkList.Link>
+          <LinkList.Link href="#">Hallo Centrumeiland: praat mee</LinkList.Link>
+        </LinkList>
+      </Grid.Cell>
+    </Grid>
+    {/*
+     * The highlight colours have no prescribed meaning, so this second band takes the default purple
+     * rather than repeating the azure of the first.
+     */}
+    <Spotlight>
+      <Grid paddingVertical="x-large">
+        <Grid.Cell span="all">
+          <Heading className="ams-mb-s" color="inverse" level={2}>Contact</Heading>
+        </Grid.Cell>
+        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+          <Paragraph className="ams-mb-m" color="inverse">
+            Vragen over zelfbouw op Centrumeiland:{' '}
+            <Link color="inverse" href="mailto:zelfbouwcentrumeiland@amsterdam.nl">zelfbouwcentrumeiland@amsterdam.nl</Link>
+          </Paragraph>
+        </Grid.Cell>
+        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+          {/* These lines are kept in one Paragraph so they read as a single contact block, not as running text. */}
+          <Paragraph color="inverse">
+            Maud van Esch
+            <br />
+            Omgevingsmanager IJburg
+            <br />
+            <Link color="inverse" href="mailto:m.van.esch@amsterdam.nl">m.van.esch@amsterdam.nl</Link>
+          </Paragraph>
+        </Grid.Cell>
+      </Grid>
+    </Spotlight>
+    {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+    <Grid paddingBottom="2x-large" paddingTop="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Image alt="" src="https://picsum.photos/1280/720" />
+      </Grid.Cell>
+    </Grid>
+  </main>
 </>`,
         language: 'tsx',
       },


### PR DESCRIPTION
## Links

- [Project Page](https://designsystem.amsterdam/?path=/docs/pages-public-project-page--docs)
- [Page](https://designsystem.amsterdam/?path=/docs/components-containers-page--docs)
- Deploy links follow once the preview is up.

## What

The Project Page put `main` on its first Grid, so everything after that Grid — the Zelfbouw Spotlight, the four link sections, the Contact Spotlight and the closing image — sat outside it. `main` now wraps all of those together, the way the Information Page does:

```tsx
<main id="inhoud">
  <Grid paddingBottom="x-large">…</Grid>
  <Spotlight color="azure">…</Spotlight>
  <Grid paddingVertical="x-large">…</Grid>
  <Spotlight>…</Spotlight>
  <Grid paddingBottom="2x-large" paddingTop="x-large">…</Grid>
</main>
```

**The diff looks far bigger than the change.** Nineteen lines actually differ: the `main` element, the Grid that used to carry it, a comment, and two paragraphs that prettier re-wrapped because two spaces of extra indentation pushed them past 120 columns. Everything else in those 900 lines is the re-indent, in both the `render` and the hand-written Code Panel source.

## Why

Roughly a third of the page was in no landmark at all. Someone navigating by landmark, or jumping to the main content, reached the introduction and the timeline but not the highlights, the links, the contact details or the map — and nothing signalled where that content belonged.

axe reported `region` on each of those blocks. On the built story it now reports one node instead of four, and the remaining one is the Skip Link, which sits ahead of the landmarks deliberately and is documented as such since #2843.

## How

Both Spotlights stay plain bands inside `main` rather than becoming `aside` landmarks. That follows the rule the Home Page already states in its own comment:

> These highlights are part of the homepage's own content, so the Spotlight stays a plain band inside `<main>`. On the Article Page the same band sits outside `<main>` as an `as="aside"` landmark beside the article.

Zelfbouw is a candidate for `as="aside"`, being a set of links to city-wide self-build services. Against that: the page is titled "Centrumeiland: hét zelfbouweiland van Amsterdam", so those links are the page's own subject rather than an aside from it, and an `aside` nested in `main` is flagged by axe's `landmark-complementary-is-top-level` in the same way `region` flagged the old markup. Happy to revisit if you read the band differently — it is one prop, though it would be worth recording next to the Home Page comment so the two pages do not drift apart on the same question.

The `paddingBottom="x-large"` moves from the old `Grid as="main"` onto the plain Grid that replaces it, so the vertical rhythm is unchanged.

## Checklist

- [ ] Add or update unit tests
- [ ] Add or update documentation
- [x] Add or update stories
- [ ] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

No visual change is intended — this is landmark semantics and indentation — but the story is snapshotted, so the Chromatic run is worth a glance rather than a wave-through.

`color-contrast` still reports on the azure Spotlight. That is the deliberate APCA-backed deviation and is untouched here.
