### PR TITLE
fix(Table): Make the horizontal scroll container keyboard accessible

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/table.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/table.tokens.json
@@ -32,6 +32,13 @@
           "nl.amsterdam.type": "number"
         }
       },
+      "outline-offset": {
+        "$value": "{ams.focus.outline-offset}",
+        "$extensions": {
+          "nl.amsterdam.subtype": "space",
+          "nl.amsterdam.type": "dimension"
+        }
+      },
       "caption": {
         "font-weight": {
           "$value": "{ams.typography.body-text.bold.font-weight}",

--- a/packages/css/src/components/table/table.scss
+++ b/packages/css/src/components/table/table.scss
@@ -4,6 +4,7 @@
  */
 
 .ams-table {
+  outline-offset: var(--ams-table-outline-offset);
   /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- This scrolls horizontally only. */
   overflow-x: auto;
   overflow-y: hidden;

--- a/packages/react/src/Table/Table.test.tsx
+++ b/packages/react/src/Table/Table.test.tsx
@@ -54,4 +54,14 @@ describe('Table', () => {
     expect(component).toHaveAttribute('id', 'id')
     expect(component).toHaveAttribute('data-test', 'data-test')
   })
+
+  it('wraps the table in a keyboard-focusable group so it can be scrolled horizontally', () => {
+    render(<Table />)
+
+    const group = screen.getByRole('group')
+
+    expect(group).toHaveClass('ams-table')
+    expect(group).toHaveAttribute('tabindex', '0')
+    expect(group).toContainElement(screen.getByRole('table'))
+  })
 })

--- a/packages/react/src/Table/Table.tsx
+++ b/packages/react/src/Table/Table.tsx
@@ -20,7 +20,6 @@ export type TableProps = PropsWithChildren<TableHTMLAttributes<HTMLTableElement>
 
 const TableRoot = forwardRef(
   ({ children, className, ...restProps }: TableProps, ref: ForwardedRef<HTMLTableElement>) => (
-    // tabIndex makes this scroll container keyboard-focusable so its overflow can be scrolled without a pointer; role="group" identifies it without adding a landmark.
     <div className="ams-table" role="group" tabIndex={0}>
       <table {...restProps} className={clsx('ams-table__table', className)} ref={ref}>
         {children}

--- a/packages/react/src/Table/Table.tsx
+++ b/packages/react/src/Table/Table.tsx
@@ -20,7 +20,8 @@ export type TableProps = PropsWithChildren<TableHTMLAttributes<HTMLTableElement>
 
 const TableRoot = forwardRef(
   ({ children, className, ...restProps }: TableProps, ref: ForwardedRef<HTMLTableElement>) => (
-    <div className="ams-table">
+    // tabIndex makes this scroll container keyboard-focusable so its overflow can be scrolled without a pointer; role="group" identifies it without adding a landmark.
+    <div className="ams-table" role="group" tabIndex={0}>
       <table {...restProps} className={clsx('ams-table__table', className)} ref={ref}>
         {children}
       </table>

--- a/storybook/src/components/Table/Table.docs.mdx
+++ b/storybook/src/components/Table/Table.docs.mdx
@@ -81,10 +81,13 @@ In this case, use a [Figure](/docs/components-media-figure--docs) and let the Ta
 ## Features
 
 A Table wider than the space it sits in scrolls horizontally within its own container, rather than widening the page around it.
+That container takes keyboard focus, so someone can scroll it with the arrow keys, not only with a pointer or touch.
 
 ## Accessibility
 
 A Table caption creates the accessible name for the Table, announced by screen readers on every encounter.
+
+The container that scrolls is a focusable group, which keeps the columns past its right edge reachable without a pointing device, as [WCAG 2.1.1](https://www.w3.org/TR/WCAG22/#keyboard) requires.
 
 ## See also
 


### PR DESCRIPTION
## Links

- [Storybook preview](https://designsystem.amsterdam/) on main.
- [Table documentation in the preview](https://designsystem.amsterdam/?path=/docs/components-containers-table--docs) — with the updated Features and Accessibility sections.

## What

The wrapper around a Table that scrolls horizontally, when the table is wider than the space it sits in, is now keyboard-focusable. Someone using a keyboard can move focus to that wrapper and scroll it with the arrow keys, so the columns past the right edge stay reachable without a pointing device.

## Why

A Table of plain values contains nothing focusable to tab to. When such a table overflowed its container, a keyboard-only user had no way to scroll it, leaving the off-screen columns unreachable. This is the well-known "scrollable region must be keyboard accessible" case (WCAG 2.1.1).

## How

The `.ams-table` wrapper now carries `role="group"` and `tabIndex={0}`, matching the approach the Image Slider already uses for its scroller. `group` is deliberately lighter than `region`: it is valid without an accessible name, so a Table without a caption degrades gracefully, and it avoids adding a landmark for every Table on a page. The table's own semantics are untouched — the group wraps the table rather than re-roling any of its elements.

A new `--ams-table-outline-offset` token, aliasing the shared focus offset, keeps the focus ring consistent with the rest of the system. The Features and Accessibility sections of the documentation now describe the behaviour, and there is a unit test for the focusable group.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

