### PR TITLE
fix(Dialog): Make the scrollable body keyboard accessible

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/dialog.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/dialog.tokens.json
@@ -159,6 +159,13 @@
         }
       },
       "body": {
+        "outline-offset": {
+          "$value": "{ams.focus.outline-offset}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        },
         "padding-block": {
           "$value": "0",
           "$type": "dimension",

--- a/packages/css/src/components/dialog/dialog.scss
+++ b/packages/css/src/components/dialog/dialog.scss
@@ -97,6 +97,7 @@ so do not apply these styles without an `open` attribute. */
 }
 
 .ams-dialog__body {
+  outline-offset: var(--ams-dialog-body-outline-offset);
   overflow-x: hidden;
   overflow-y: auto;
   /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */

--- a/packages/react/src/Dialog/Dialog.test.tsx
+++ b/packages/react/src/Dialog/Dialog.test.tsx
@@ -72,6 +72,20 @@ describe('Dialog', () => {
     expect(getByText('Test content')).toBeInTheDocument()
   })
 
+  it('wraps the body in a keyboard-focusable group so long content can be scrolled', () => {
+    render(
+      <Dialog heading="Test heading" open>
+        Long content
+      </Dialog>,
+    )
+
+    const group = screen.getByRole('group')
+
+    expect(group).toHaveClass('ams-dialog__body')
+    expect(group).toHaveAttribute('tabindex', '0')
+    expect(group).toHaveTextContent('Long content')
+  })
+
   it('renders footer when provided', () => {
     render(<Dialog footer={<button>Click Me</button>} heading="Test heading" open />)
 

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -35,7 +35,9 @@ const DialogRoot = forwardRef(
         </Heading>
         <IconButton label={closeButtonLabel} onClick={closeDialog} size="heading-3" type="button" />
       </header>
-      <div className="ams-dialog__body">{children}</div>
+      <div className="ams-dialog__body" role="group" tabIndex={0}>
+        {children}
+      </div>
       {footer && <footer className="ams-dialog__footer">{footer}</footer>}
     </dialog>
   ),

--- a/storybook/src/components/Dialog/Dialog.docs.mdx
+++ b/storybook/src/components/Dialog/Dialog.docs.mdx
@@ -74,6 +74,7 @@ The Dialog is a [query container](/docs/utilities-css-query-container--docs) for
 | :---------- | :--------------------------------------------------------------- |
 | Tab         | Moves focus to the next focusable element inside the Dialog.     |
 | Shift + Tab | Moves focus to the previous focusable element inside the Dialog. |
+| Arrow keys  | Scroll the body when it has focus and its content overflows.     |
 | Escape      | Closes the Dialog.                                               |
 
 ## See also


### PR DESCRIPTION
## Links

- [Storybook on main](https://designsystem.amsterdam/)
- [Dialog docs on main](https://designsystem.amsterdam/?path=/docs/components-containers-dialog--docs)
- Sibling of #2845, which closed the same gap horizontally for the Table.

## What

The Dialog’s scrollable body (`.ams-dialog__body`) is now a keyboard-focusable group: it gains `role="group"` and `tabIndex={0}`, and a new `outline-offset` token gives it a focus ring consistent with the rest of the system. A unit test and an ‘Arrow keys’ row in the keyboard-navigation table come with it.

## Why

The body scrolls when its content is taller than the space available, but nothing inside it is focusable and the only controls — the close button and the footer actions — sit outside the scroll region. Chromium and Firefox make an overflowing scroll container focusable on their own, so keyboard users there can already reach it; Safari does not, which left a keyboard-only user unable to scroll long, non-interactive content such as terms or a long message. This is the same gap #2845 closed for the Table, now closed vertically for the Dialog, as [WCAG 2.1.1](https://www.w3.org/TR/WCAG22/#keyboard) requires.

## How

The same approach as the Table: `role="group"` plus `tabIndex={0}` on the scroll container, kept as an unnamed group rather than a named region so it doesn’t add a landmark inside the dialog. The focus ring uses a new `ams.dialog.body.outline-offset` token aliasing `{ams.focus.outline-offset}`. The keyboard-navigation table gains an ‘Arrow keys’ row; the fuller Design and Accessibility prose for the Dialog is left to #2841, which introduces those sections, so this PR doesn’t pre-empt or duplicate them.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

The Modal Dialog already handles this itself (its body becomes focusable when it overflows), so it is intentionally not part of this PR.

