### PR TITLE
fix(Switch): Guard its transitions behind prefers-reduced-motion

### DIFF
--- a/packages/css/src/components/switch/switch.scss
+++ b/packages/css/src/components/switch/switch.scss
@@ -27,12 +27,15 @@
   display: inline-block;
   inline-size: var(--ams-switch-inline-size);
   outline-offset: var(--ams-switch-outline-offset);
-  transition: background-color 0.2s ease-in-out;
   vertical-align: middle;
 
   // Keep at least 1px so a token set to 0 can’t hide the border.
   @media (forced-colors: active) {
     --_ams-switch-label-border-width: max(1px, var(--ams-switch-label-border-width));
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: background-color 0.2s ease-in-out;
   }
 }
 
@@ -43,12 +46,15 @@
   content: "";
   display: block;
   inline-size: var(--ams-switch-thumb-inline-size);
-  transition-duration: 0.1s;
-  transition-property: box-shadow, transform;
-  transition-timing-function: ease-in-out;
 
   @media (forced-colors: active) {
     background-color: FieldText;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition-duration: 0.1s;
+    transition-property: box-shadow, transform;
+    transition-timing-function: ease-in-out;
   }
 }
 


### PR DESCRIPTION
## Links

- [Switch documentation](https://designsystem.amsterdam/?path=/docs/components-forms-switch--docs)
- Feature branch deploy links to follow once the first preview build is live.

## What

The Switch's transitions now run only when the user has not asked for reduced motion.
The track's background-colour change and the thumb's slide and hover shadow are moved behind a `@media (prefers-reduced-motion: no-preference)` guard.

## Why

The Switch was the only animated component in the library whose transitions ran unconditionally.
Every other animated component — Accordion, Progress List, Table of Contents, Page Header, Image Slider and Skeleton — already guards its motion this way.
Someone who has set a reduced-motion preference should not see the thumb slide across or the background fade.

## How

The transition declarations are placed inside the `@media (prefers-reduced-motion: no-preference)` block rather than on the base rule, so no motion is defined outside the guard.
This matches Page Header, Image Slider and Skeleton, which declare their motion only inside the guard rather than resetting it with a redundant `transition: none`.
For everyone without a reduced-motion preference the animation is unchanged, so there is no visual regression.

## Checklist

- [x] Add or update unit tests — not necessary; this is a CSS media-query guard with no scripted behaviour
- [ ] Add or update documentation — the reduced-motion note lives on the design-and-accessibility docs branch, where the Switch Design section exists (develop's Switch page has no Design section yet)
- [x] Add or update stories — not necessary
- [x] Add or update exports in index.\* files — not necessary
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- CSS-only; the rendered animation is identical for users without a reduced-motion preference.
- A follow-up branch standardises the three components still using the older `transition: none` form (Accordion, Progress List, Table of Contents) on this same guard-only pattern.
