### PR TITLE
chore(css): Remove the redundant transition: none from the reduced-motion guards

### DIFF
--- a/packages/css/src/components/accordion/accordion.scss
+++ b/packages/css/src/components/accordion/accordion.scss
@@ -44,7 +44,6 @@
 
 .ams-accordion__icon svg {
   rotate: 0deg;
-  transition: none;
 
   [aria-expanded="true"] & {
     rotate: -180deg;

--- a/packages/css/src/components/progress-list/progress-list.scss
+++ b/packages/css/src/components/progress-list/progress-list.scss
@@ -198,7 +198,6 @@
 
 .ams-progress-list__icon svg {
   rotate: 0deg;
-  transition: none;
 
   [aria-expanded="true"] & {
     rotate: -180deg;

--- a/packages/css/src/components/table-of-contents/table-of-contents.scss
+++ b/packages/css/src/components/table-of-contents/table-of-contents.scss
@@ -72,8 +72,6 @@
 }
 
 .ams-table-of-contents__button svg {
-  transition: none;
-
   @media (prefers-reduced-motion: no-preference) {
     transition: rotate var(--ams-table-of-contents-button-icon-transition-duration)
       var(--ams-table-of-contents-button-icon-transition-timing-function);


### PR DESCRIPTION
## Links

- Feature branch deploy links to follow once the first preview build is live.

## What

Removes the redundant `transition: none` from the base rule of Accordion, Progress List, and Table of Contents.
Their chevron rotation was already guarded behind `@media (prefers-reduced-motion: no-preference)`; the base `transition: none` only wrote out the property's default value.

## Why

These three were the last animated components still using that older form.
Page Header, Image Slider, Skeleton — and now Switch (#2847) — declare their motion only inside the guard, with no redundant base declaration.
This lands every animated component on one pattern.

## How

Deleted the `transition: none` line from each component's icon rule.
`transition: none` is the initial value of the `transition` property, so removing it changes nothing: the transition is still defined only inside the reduced-motion guard, and someone who asked for reduced motion still gets no animation.
No behaviour, visual, or token change.

## Checklist

- [x] Add or update unit tests — not necessary; CSS-only, no scripted behaviour
- [x] Add or update documentation — not necessary; no visual or behavioural change
- [x] Add or update stories — not necessary
- [x] Add or update exports in index.\* files — not necessary
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- Pure refactor: because `transition: none` is the CSS default, the rendered result is identical, so Chromatic should show no differences.
- Completes the guard-only consistency established by #2847 (Switch).
