### PR TITLE
fix(Alert): Generate a unique heading id by default

### DIFF
--- a/packages/react/src/Alert/Alert.test.tsx
+++ b/packages/react/src/Alert/Alert.test.tsx
@@ -106,6 +106,24 @@ describe('Alert', () => {
     expect(component).not.toHaveAttribute('aria-labelledby')
   })
 
+  it('generates a unique id to label each Alert by default', () => {
+    render(
+      <>
+        <Alert heading="First" headingLevel={2} />
+        <Alert heading="Second" headingLevel={2} />
+      </>,
+    )
+
+    const [first, second] = screen.getAllByRole('region')
+
+    const firstId = first.getAttribute('aria-labelledby')
+    const secondId = second.getAttribute('aria-labelledby')
+
+    expect(firstId).toBeTruthy()
+    expect(secondId).toBeTruthy()
+    expect(firstId).not.toEqual(secondId)
+  })
+
   it('passes additional props', () => {
     render(<Alert aria-hidden={false} data-test="data-test" heading="Let op!" headingLevel={2} id="id" />)
 

--- a/packages/react/src/Alert/Alert.test.tsx
+++ b/packages/react/src/Alert/Alert.test.tsx
@@ -124,6 +124,14 @@ describe('Alert', () => {
     expect(firstId).not.toEqual(secondId)
   })
 
+  it('falls back to a generated id when headingId is an empty string', () => {
+    render(<Alert heading="Let op!" headingId="" headingLevel={2} />)
+
+    const component = screen.getByRole('region', { name: 'Let op!' })
+
+    expect(component.getAttribute('aria-labelledby')).toBeTruthy()
+  })
+
   it('passes additional props', () => {
     render(<Alert aria-hidden={false} data-test="data-test" heading="Let op!" headingLevel={2} id="id" />)
 

--- a/packages/react/src/Alert/Alert.tsx
+++ b/packages/react/src/Alert/Alert.tsx
@@ -7,7 +7,7 @@ import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 
 import { ErrorFillIcon, InfoFillIcon, SuccessFillIcon, WarningFillIcon } from '@amsterdam/design-system-react-icons'
 import { clsx } from 'clsx'
-import { forwardRef } from 'react'
+import { forwardRef, useId } from 'react'
 
 import type { HeadingProps } from '../Heading'
 import type { IconProps } from '../Icon'
@@ -28,8 +28,9 @@ export type AlertProps = {
   readonly heading: string
   /**
    * The id of the Heading element, which is used to label the alert.
+   * Defaults to a generated unique id.
+   * Provide a custom value to reference the Heading elsewhere; it must then be unique for the page.
    * Can be set to `null` to explicitly remove the label.
-   * Note: must be unique for the page.
    */
   readonly headingId?: string | null
   /**
@@ -63,7 +64,7 @@ export const Alert = forwardRef(
       closeable,
       closeButtonLabel = 'Sluiten',
       heading,
-      headingId = 'ams-alert-heading',
+      headingId,
       headingLevel,
       onClose,
       severity,
@@ -71,12 +72,14 @@ export const Alert = forwardRef(
     }: AlertProps,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
+    const generatedId = useId()
+    const resolvedHeadingId = headingId === null ? undefined : (headingId ?? generatedId)
     const SeverityIcon = severity ? iconSvgBySeverity[severity] : InfoFillIcon
 
     return (
       <section
         {...restProps}
-        aria-labelledby={headingId || undefined} // NVDA on Chrome does not read the heading when it is not used as the label for the section.
+        aria-labelledby={resolvedHeadingId} // NVDA on Chrome does not read the heading when it is not used as the label for the section.
         className={clsx('ams-alert', severity && `ams-alert--${severity}`, className)}
         ref={ref}
       >
@@ -85,7 +88,7 @@ export const Alert = forwardRef(
         </div>
         <div className="ams-alert__content">
           <Row align="between" alignVertical="start">
-            <Heading id={headingId || undefined} level={headingLevel} size="level-3">
+            <Heading id={resolvedHeadingId} level={headingLevel} size="level-3">
               {heading}
             </Heading>
             {closeable && <IconButton label={closeButtonLabel} onClick={onClose} size="heading-3" />}

--- a/packages/react/src/Alert/Alert.tsx
+++ b/packages/react/src/Alert/Alert.tsx
@@ -73,7 +73,7 @@ export const Alert = forwardRef(
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
     const generatedId = useId()
-    const resolvedHeadingId = headingId === null ? undefined : (headingId ?? generatedId)
+    const resolvedHeadingId = headingId === null ? undefined : headingId || generatedId
     const SeverityIcon = severity ? iconSvgBySeverity[severity] : InfoFillIcon
 
     return (


### PR DESCRIPTION
## Links

- Documentation for this change: the “How to use” prose is reworded on the documentation-only PR #2841 (see the coordination note under Additional notes).
- Feature branch deploy links will follow once the first deploy is ready.

## What

Alert now generates a unique id for its heading with `useId()` when no `headingId` is passed, instead of falling back to the hardcoded `ams-alert-heading`. A string passed to `headingId` is still used verbatim, and `null` still removes both the label and the `region` landmark.

## Why

Alert was the only component in the library that hardcoded an id default rather than generating one. Rendering two Alerts without a `headingId` produced two elements sharing the id `ams-alert-heading`: a duplicate id on the page, and the second section’s `aria-labelledby` resolved to the first Alert’s heading. Generating the id brings Alert in line with the fourteen components that already rely on `useId()` for the same purpose.

## How

The literal default is dropped from the destructuring and `useId()` is called unconditionally, as the rules of hooks require. The heading id resolves to `undefined` when `headingId` is `null`, to the given value when it is a string, and to the generated id when it is omitted, so the opt-out and the custom-id override both keep working. The prop’s TSDoc now records that the id defaults to a generated unique value and that the “must be unique for the page” requirement applies only when you supply your own.

A unit test asserts that two default Alerts receive distinct ids. The existing tests for a custom id and for `headingId={null}` are unchanged, and no test asserted the old literal. `InvalidFormAlert` already passes `headingId={null}`, so it is unaffected.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

This component change is intentionally separate from the documentation-only PR #2841. The “How to use” guidance for Alert was reworded there to describe the generated id and to present the `headingId` override as optional rather than as a way to avoid a duplicate id. Because that prose describes behaviour that only becomes true once this fix merges, the two should land together, with this component fix first; #2841 should not merge on its own.

The feature branch deploy story link will be added once the first deploy is ready.
