### PR TITLE
feat(Avatar): Make the accessible name configurable

### DIFF
--- a/packages/react/src/Avatar/Avatar.test.tsx
+++ b/packages/react/src/Avatar/Avatar.test.tsx
@@ -19,6 +19,13 @@ describe('Avatar', () => {
     expect(component).toBeVisible()
   })
 
+  it('accepts a custom accessible name for the initials', () => {
+    render(<Avatar initialsAccessibleName="User initials: NR" label="NR" />)
+
+    expect(screen.getByText('User initials: NR')).toBeInTheDocument()
+    expect(screen.queryByText('Initialen gebruiker: NR')).not.toBeInTheDocument()
+  })
+
   it('renders a design system BEM class name', () => {
     const { container } = render(<Avatar label="RS" />)
 
@@ -52,6 +59,13 @@ describe('Avatar', () => {
     expect(component).toBeVisible()
     expect(svg).toBeInTheDocument()
     expect(svg).not.toBeVisible() // The icon is hidden by default, and only shown when the CSS loads.
+  })
+
+  it('accepts a custom accessible name for the empty label', () => {
+    render(<Avatar label="" userAccessibleName="User" />)
+
+    expect(screen.getByText('User')).toBeInTheDocument()
+    expect(screen.queryByText('Gebruiker')).not.toBeInTheDocument()
   })
 
   it('renders with a profile picture', () => {

--- a/packages/react/src/Avatar/Avatar.tsx
+++ b/packages/react/src/Avatar/Avatar.tsx
@@ -36,8 +36,12 @@ export type AvatarProps = {
   readonly color?: AvatarColor
   /** The url for the user’s image. Its centre will be displayed. Should be square and scaled down. */
   readonly imageSrc?: string
+  /** The accessible name for the Avatar when the label provides initials. */
+  readonly initialsAccessibleName?: string
   /** The text content. Should be the user’s initials. The first two characters will be displayed. */
   readonly label: string
+  /** The accessible name for the Avatar when the label is empty. */
+  readonly userAccessibleName?: string
 } & Readonly<HTMLAttributes<HTMLSpanElement>>
 
 /**
@@ -46,10 +50,16 @@ export type AvatarProps = {
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-feedback-avatar--docs Avatar docs at Amsterdam Design System}
  */
 export const Avatar = forwardRef(
-  ({ className, color, imageSrc, label, ...restProps }: AvatarProps, ref: ForwardedRef<HTMLSpanElement>) => {
+  (
+    { className, color, imageSrc, initialsAccessibleName, label, userAccessibleName, ...restProps }: AvatarProps,
+    ref: ForwardedRef<HTMLSpanElement>,
+  ) => {
     const initials = label.slice(0, 2).toUpperCase()
 
-    const a11yLabel = initials.length === 0 ? 'Gebruiker' : `Initialen gebruiker: ${initials}`
+    const resolvedAccessibleName =
+      initials.length === 0
+        ? userAccessibleName || 'Gebruiker'
+        : initialsAccessibleName || `Initialen gebruiker: ${initials}`
 
     return (
       <span
@@ -57,7 +67,7 @@ export const Avatar = forwardRef(
         className={clsx('ams-avatar', color && `ams-avatar--${color}`, imageSrc && 'ams-avatar--has-image', className)}
         ref={ref}
       >
-        <span className="ams-visually-hidden">{a11yLabel}</span>
+        <span className="ams-visually-hidden">{resolvedAccessibleName}</span>
         <AvatarContent imageSrc={imageSrc} initials={initials} />
       </span>
     )


### PR DESCRIPTION
## Links

- [Avatar documentation (feature branch preview)](https://designsystem.amsterdam/?path=/docs/components-feedback-avatar--docs)
- [Storybook (feature branch preview)](https://designsystem.amsterdam/)

## What

Adds two optional props to `Avatar` that set its visually hidden accessible name:

- `initialsAccessibleName`, used when the label provides initials.
- `userAccessibleName`, used when the label is empty and the fallback icon shows.

Both fall back to the current Dutch wording (`Initialen gebruiker: …` and `Gebruiker`), so existing behaviour is unchanged.

## Why

The accessible name was hardcoded Dutch, so an Avatar on a page in another language was announced in Dutch with no way to change it. The rest of the library already exposes `…AccessibleName` props for exactly this.

## How

The props follow the accessible-name-props ADR and resolve to their Dutch defaults when omitted, matching the pattern used by Pagination. The hidden text keeps using the `ams-visually-hidden` helper rather than `aria-label`, which is not reliably auto-translated. Unit tests cover both custom-name cases.

The documentation for this change (the Avatar Accessibility section and a new How to use note) lives on the `chore/design-accessibility-components` branch and is merged separately. This PR should land first so the documented props exist.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation (on the `chore/design-accessibility-components` branch; merged separately)
- [x] Add or update stories (not needed: the accessible name is visually hidden, so there is no visual change)
- [x] Add or update exports in index.\* files (not needed: `Avatar` is already exported and the props are additive)
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- The accessible name is visually hidden, so there is no visual change and no new stories.
- Documentation is tracked on `chore/design-accessibility-components`; merge this PR first so the props it documents exist.
