### PR TITLE
fix(Storybook): Write the Information Page table sources as one caption sentence

### DIFF
--- a/storybook/src/pages/public/InformationPage/InformationPage.docs.mdx
+++ b/storybook/src/pages/public/InformationPage/InformationPage.docs.mdx
@@ -63,6 +63,6 @@ A [Figure](/docs/components-media-figure--docs) groups the table with the source
 Keep the table’s own Caption as its name, and use the Figure’s Caption for the sources: the two describe different things, and a table that loses its Caption loses its accessible name.
 The Figure supplies the space between them, so the table needs no margin of its own.
 
-A Figure Caption takes any content, not only a sentence.
-Here it holds a level 3 Heading and a [Link List](/docs/components-navigation-link-list--docs), which keeps the sources scannable and lets each one be its own link.
+Write any sources as one sentence, with a [Link](/docs/components-navigation-link--docs) for each of them.
+The Figure Caption then presents them in the small caption text it is meant for.
 Note that the whole caption becomes the accessible name of the Figure, so keep it short.

--- a/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
+++ b/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
@@ -12,7 +12,7 @@ import {
   Grid,
   Heading,
   Image,
-  LinkList,
+  Link,
   Paragraph,
   Table,
 } from '@amsterdam/design-system-react'
@@ -410,12 +410,10 @@ export const WithTable: StoryObj = {
               </Table.Row>
             </Table.Body>
           </Table>
+          {/* Write any sources as one sentence, so the Figure Caption presents them in its small caption text. */}
           <Figure.Caption>
-            <Heading className="ams-mb-xs" level={3}>Bron</Heading>
-            <LinkList>
-              <LinkList.Link href="#">Catalogus Basisregistratie WOZ</LinkList.Link>
-              <LinkList.Link href="#">Gegevenswoordenboek WOZ</LinkList.Link>
-            </LinkList>
+            Bronnen: <Link href="#">Catalogus Basisregistratie WOZ</Link> en{' '}
+            <Link href="#">Gegevenswoordenboek WOZ</Link>.
           </Figure.Caption>
         </Figure>
       </Grid.Cell>
@@ -544,14 +542,10 @@ export const WithTable: StoryObj = {
                   </Table.Row>
                 </Table.Body>
               </Table>
+              {/* Write any sources as one sentence, so the Figure Caption presents them in its small caption text. */}
               <Figure.Caption>
-                <Heading className="ams-mb-xs" level={3}>
-                  Bron
-                </Heading>
-                <LinkList>
-                  <LinkList.Link href="#">Catalogus Basisregistratie WOZ</LinkList.Link>
-                  <LinkList.Link href="#">Gegevenswoordenboek WOZ</LinkList.Link>
-                </LinkList>
+                Bronnen: <Link href="#">Catalogus Basisregistratie WOZ</Link> en{' '}
+                <Link href="#">Gegevenswoordenboek WOZ</Link>.
               </Figure.Caption>
             </Figure>
           </Grid.Cell>


### PR DESCRIPTION
## Links

- (Deploy links follow once the preview is up.)

## What

The With table story of the Information Page template lists the sources of the table in its Figure Caption. That list was a level 3 Heading followed by a Link List. This PR writes those sources as a single sentence instead: “Bronnen: … en ….”, with a Link for each source. The documentation page describes the sentence as the approach to take.

## Why

A Figure Caption has its own text style: small, in the caption colour. A Heading and a Link List bring their own font size and spacing, so they overrode that style and the sources came out looking like a section of the page rather than a caption. Two sources also hardly need the scannability of a list. As one sentence, they get the caption text the component is meant to give them, and the caption stays short — which matters, since the whole caption becomes the accessible name of the Figure.

## How

The story renders the sentence with a Link per source, and the hand-written Code Panel source mirrors it. The documentation page now states the preferred approach without describing the alternatives.

## Checklist

- [ ] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [ ] Add or update exports in index.\* files
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
