### PR TITLE
chore: Declare the dependency that the defensive CSS Stylelint plugin misplaces

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,8 @@ overrides:
   sigstore@<4.1.1: ^4.1.1
   tar: ^7.5.19
 
+packageExtensionsChecksum: sha256-M0OA4c/8RneRmye72JnuYDFacaS6F+DBhvG/ABGnAjM=
+
 importers:
 
   .:
@@ -11599,6 +11601,7 @@ snapshots:
 
   stylelint-plugin-defensive-css@2.9.4(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3)):
     dependencies:
+      postcss-selector-parser: 7.1.4
       stylelint: 17.14.1(supports-color@10.2.2)(typescript@6.0.3)
 
   stylelint-plugin-use-baseline@1.4.4(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3)):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,14 @@ overrides:
   "js-yaml@<4.3.0": "^4.3.0"
   "sigstore@<4.1.1": "^4.1.1"
   tar: "^7.5.19"
+# stylelint-plugin-defensive-css imports postcss-selector-parser at runtime but lists it under
+# devDependencies, which consumers never receive. Without this, the plugin resolves that import
+# only by chance, through whichever packages pnpm happens to have hoisted into the virtual store,
+# which is not guaranteed to include it. The range matches the one the plugin declares itself.
+packageExtensions:
+  stylelint-plugin-defensive-css:
+    dependencies:
+      postcss-selector-parser: "^7.1.1"
 engineStrict: true
 savePrefix: ""
 # Explicitly mark these dependencies' install scripts as ignored.


### PR DESCRIPTION
# Describe the pull request

## Links

- [`stylelint-plugin-defensive-css` package manifest at 2.9.4](https://github.com/yuschick/stylelint-plugin-defensive-css/blob/ea97b7c4d9f3adf74041f909b271de07ad2d407d/package.json#L54), where `postcss-selector-parser` sits under `devDependencies`.
- [pnpm `packageExtensions` documentation](https://pnpm.io/settings#packageextensions).

There is nothing to see in the deploy: this changes tooling only, and no component, story or stylesheet is touched.

## What

This adds a `packageExtensions` entry to `pnpm-workspace.yaml` that gives `stylelint-plugin-defensive-css` the runtime dependency on `postcss-selector-parser` that its own manifest omits. The lockfile gains three lines: the package extensions checksum, and the dependency in the plugin's snapshot.

## Why

`stylelint-plugin-defensive-css` imports `postcss-selector-parser` at runtime from `dist/index.mjs`, but its manifest lists that package under `devDependencies` and declares no runtime dependencies at all. A dependency's devDependencies are never installed for consumers, so under pnpm's strict layout the plugin has no copy of its own to resolve. It currently works only because pnpm hoists the whole graph into `node_modules/.pnpm/node_modules/` as a best-effort safety net, and Stylelint happens to pull `postcss-selector-parser` in.

That safety net is not a guarantee. A working copy whose store had drifted was missing exactly that hoisted entry, and `pnpm run lint:css` there failed before linting a single file, with `Cannot find package 'postcss-selector-parser'`. Continuous integration never saw it, because a clean install always hoists the full graph. Recovering the affected working copy needed `rm -rf node_modules` followed by a fresh install: plain `pnpm install`, `pnpm install --force`, and removing pnpm's install state files all reported "Already up to date" and re-materialised nothing.

Version 2.9.4 is the most recent release, so there is no upgrade that fixes the packaging. The problem will be reported upstream, where the fix is a one-line move of that entry into `dependencies`.

## How

The package extension is the accurate model of the fault, in that it repairs the manifest rather than working around it. pnpm then links `postcss-selector-parser` into the plugin's own directory, which makes resolution independent of hoisting. The alternative, adding the package to the root `devDependencies`, would also unblock resolution, but it would claim a direct dependency this repository does not have.

The declared range, `^7.1.1`, is the one the plugin declares for itself, so this states the plugin's own intent rather than guessing at a compatible range. It resolves to 7.1.4, the copy Stylelint already uses, so no additional version is installed.

Verified by deleting the hoisted copy from the virtual store and confirming `pnpm run lint:css` still passes, then deleting the plugin's own copy as well and confirming the original error returns. `pnpm install --frozen-lockfile` and `pnpm ls --recursive` both pass, so the lockfile is consistent with the workspace settings.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).
