### PR TITLE
chore(Storybook): Document how to group dependency updates

### DIFF
--- a/storybook/src/docs/developer-guide/release-policy.docs.mdx
+++ b/storybook/src/docs/developer-guide/release-policy.docs.mdx
@@ -39,8 +39,46 @@ The React package relies on the CSS package, while the CSS package depends on th
 Upgrading one of these packages likely means you will also need to upgrade the others to satisfy the peer dependency version requirements.
 
 Without additional configuration, tools like **Dependabot by GitHub** might create separate pull requests for each package, which could fail due to unmet peer dependency constraints.
-Grouping the design system packages into a single update can prevent this issue.
-[Their documentation](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#grouping-related-dependencies-together) provides details on this.
+Grouping the design system packages into a single update prevents this issue.
+
+## Grouping dependency updates
+
+Two rules keep our packages together in one pull request.
+
+1. Put every package whose name starts with `@amsterdam/design-system-` in **one group**, and let that group accept major updates next to minor and patch ones.
+   Our major releases tend to move several packages at once, which is precisely when grouping matters most.
+2. **Exclude that same pattern** from any catch-all group you already have.
+   A dependency ends up in the first group it matches, so without this exclusion the order of your groups decides where our packages land.
+
+In Dependabot, both rules fit in the `groups` option in `.github/dependabot.yml`:
+
+```yaml
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      amsterdam-design-system:
+        patterns:
+          - "@amsterdam/design-system-*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+      patch-and-minor-dependencies:
+        exclude-patterns:
+          - "@amsterdam/design-system-*"
+        update-types:
+          - "patch"
+          - "minor"
+```
+
+Dependencies that match no group still get their own pull request, so nothing goes unnoticed.
+[Dependabot’s documentation](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#grouping-related-dependencies-together) describes the available options.
+Other update tools offer comparable grouping, and the two rules above apply there as well.
 
 ## Release cadence
 


### PR DESCRIPTION
## Links

- [Release policy](https://designsystem.amsterdam/?path=/docs/docs-developer-guide-release-policy--docs) (deploy links to follow once the feature branch deploy is ready)
- [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)

## What

Adds a "Grouping dependency updates" section to the Release policy page in the developer guide, with a worked `.github/dependabot.yml` example that keeps all five design system packages in a single pull request.

The Peer dependencies section already told consumers that grouping "can prevent this issue" and linked to GitHub's documentation, but left them to work out the configuration themselves. That section now states the recommendation plainly and hands off to the new one.

## Why

Our packages are connected through peer dependencies, so an ungrouped update tool proposes five pull requests that each fail their peer dependency constraints. Consumers have to solve this themselves, and at least one team already has: the configuration in this PR is a generalisation of one that is running in production in another Amsterdam front-end.

Two details in that configuration are easy to miss and are the reason a link to GitHub's documentation was not enough on its own. The design system group has to accept `major` updates, not just minor and patch, because our major releases are exactly the ones that move several packages at once. And the same pattern has to be excluded from the consumer's existing catch-all group, because a dependency ends up in the first group it matches — without the exclusion, the order in which the groups happen to be written decides whether our packages stay together.

## How

The new section leads with those two rules as prose, then shows a minimal `dependabot.yml` that applies both. The example is deliberately stripped back to what is relevant to us: no cooldown, versioning strategy, PR limits or project-specific exclusions, so readers can lift the `groups` block into a configuration they already have.

Both behavioural claims were checked against GitHub's options reference rather than assumed: first-match-wins group assignment, and the fact that dependencies matching no group still get individual pull requests. That last point is worth stating in the docs, since the exclusion in rule 2 otherwise looks as though it might drop updates.

Renovate is deliberately not given example syntax. The equivalent configuration is not a straight translation — `separateMajorMinor` defaults to splitting majors back out, which would undo rule 1 — and that could not be confirmed against current documentation, so the page says other tools offer comparable grouping without naming options that may be wrong or deprecated. Worth a follow-up for anyone who uses Renovate.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Prose-only change to one MDX page, so there are no stories, exports or unit tests to touch and no snapshot to affect.
