### PR TITLE
chore(tokens): Note which tokens have to hold a single value

### DIFF
--- a/packages-proprietary/tokens/src/brand/ams/border.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/border.tokens.json
@@ -25,6 +25,7 @@
           },
           "$description": "2px equivalent. The default border width for inputs and containers.",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.type": "borderWidth"
           }
         },

--- a/packages-proprietary/tokens/src/brand/ams/focus.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/focus.tokens.json
@@ -9,6 +9,7 @@
         "$type": "dimension",
         "$description": "The distance between a focused element and its outline. Provides breathing room so the outline doesn't touch the element.",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "space"
         }
       }

--- a/packages-proprietary/tokens/src/brand/ams/space.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/space.tokens.json
@@ -6,6 +6,7 @@
         "$value": "clamp(0.25rem, 0.2143rem + 0.1786vw, 0.375rem)",
         "$description": "Scales from 4px to 6px.",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
           "nl.amsterdam.type": "dimension",
           "nl.amsterdam.subtype": "space"
         }
@@ -14,6 +15,7 @@
         "$value": "clamp(0.5rem, 0.4286rem + 0.3571vw, 0.75rem)",
         "$description": "Scales from 8px to 12px.",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
           "nl.amsterdam.type": "dimension",
           "nl.amsterdam.subtype": "space"
         }
@@ -22,6 +24,7 @@
         "$value": "clamp(1rem, 0.8571rem + 0.7143vw, 1.5rem)",
         "$description": "Scales from 16px to 24px.",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
           "nl.amsterdam.type": "dimension",
           "nl.amsterdam.subtype": "space"
         }
@@ -30,6 +33,7 @@
         "$value": "clamp(1.5rem, 1.2857rem + 1.0714vw, 2.25rem)",
         "$description": "Scales from 24px to 36px.",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.type": "dimension",
           "nl.amsterdam.subtype": "space"
         }
@@ -38,6 +42,7 @@
         "$value": "clamp(2.25rem, 1.8214rem + 2.1429vw, 3.75rem)",
         "$description": "Scales from 36px to 60px.",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.type": "dimension",
           "nl.amsterdam.subtype": "space"
         }
@@ -46,6 +51,7 @@
         "$value": "clamp(3rem, 2.25rem + 3.75vw, 5.625rem)",
         "$description": "Scales from 48px to 90px.",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.type": "dimension",
           "nl.amsterdam.subtype": "space"
         }

--- a/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
+++ b/packages-proprietary/tokens/src/brand/ams/typography.tokens.json
@@ -27,6 +27,7 @@
           "$value": "clamp(1.125rem, 1.0893rem + 0.1786vw, 1.25rem)",
           "$description": "Scales from 18px to 20px.",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.type": "fontSize"
           }
         },
@@ -37,6 +38,7 @@
         "line-height": {
           "$value": 1.6,
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "lineHeight"
           },
           "$type": "number"
@@ -151,12 +153,14 @@
           "font-size": {
             "$value": "{ams.typography.body-text.x-large.font-size}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
               "nl.amsterdam.type": "fontSize"
             }
           },
           "line-height": {
             "$value": 1.3,
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
               "nl.amsterdam.subtype": "lineHeight"
             },
             "$type": "number"
@@ -166,12 +170,14 @@
           "font-size": {
             "$value": "{ams.typography.body-text.large.font-size}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
               "nl.amsterdam.type": "fontSize"
             }
           },
           "line-height": {
             "$value": 1.3,
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
               "nl.amsterdam.subtype": "lineHeight"
             },
             "$type": "number"
@@ -181,12 +187,14 @@
           "font-size": {
             "$value": "{ams.typography.body-text.font-size}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
               "nl.amsterdam.type": "fontSize"
             }
           },
           "line-height": {
             "$value": 1.4,
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
               "nl.amsterdam.subtype": "lineHeight"
             },
             "$type": "number"

--- a/packages-proprietary/tokens/src/common/ams/inputs.tokens.json
+++ b/packages-proprietary/tokens/src/common/ams/inputs.tokens.json
@@ -80,6 +80,7 @@
       "padding-inline": {
         "$value": "{ams.space.m}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }

--- a/packages-proprietary/tokens/src/components/ams/avatar.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/avatar.tokens.json
@@ -46,6 +46,7 @@
       "font-size": {
         "$value": "{ams.typography.body-text.small.font-size}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.type": "fontSize"
         }
       },
@@ -58,6 +59,7 @@
       "line-height": {
         "$value": "{ams.typography.body-text.small.line-height}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "lineHeight",
           "nl.amsterdam.type": "number"
         }
@@ -72,6 +74,7 @@
       "padding-inline": {
         "$value": "{ams.space.xs}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }

--- a/packages-proprietary/tokens/src/components/ams/card.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/card.tokens.json
@@ -5,6 +5,7 @@
         "margin-block-end": {
           "$value": "{ams.space.xs}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -21,6 +22,7 @@
         "margin-block-end": {
           "$value": "{ams.space.xs}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -30,6 +32,7 @@
         "margin-block-end": {
           "$value": "{ams.space.s}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/checkbox.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/checkbox.tokens.json
@@ -22,6 +22,7 @@
       "font-size": {
         "$value": "{ams.typography.body-text.font-size}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.type": "fontSize"
         }
       },
@@ -41,6 +42,7 @@
       "line-height": {
         "$value": "{ams.typography.body-text.line-height}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "lineHeight",
           "nl.amsterdam.type": "number"
         }

--- a/packages-proprietary/tokens/src/components/ams/date-input.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/date-input.tokens.json
@@ -46,6 +46,7 @@
       "font-size": {
         "$value": "{ams.inputs.font-size}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.type": "fontSize"
         }
       },
@@ -58,6 +59,7 @@
       "line-height": {
         "$value": "{ams.inputs.line-height}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "lineHeight",
           "nl.amsterdam.type": "number"
         }
@@ -72,6 +74,7 @@
       "padding-block": {
         "$value": "{ams.inputs.padding-block}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }
@@ -79,6 +82,7 @@
       "padding-inline": {
         "$value": "{ams.inputs.padding-inline}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }

--- a/packages-proprietary/tokens/src/components/ams/description-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/description-list.tokens.json
@@ -24,14 +24,14 @@
       "font-size": {
         "$value": "{ams.typography.body-text.font-size}",
         "$extensions": {
-          "nl.amsterdam.hint": "Applies to descriptions only; terms set their own font size.",
+          "nl.amsterdam.hint": "Applies to descriptions only; terms set their own font size. Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.type": "fontSize"
         }
       },
       "line-height": {
         "$value": "{ams.typography.body-text.line-height}",
         "$extensions": {
-          "nl.amsterdam.hint": "Applies to descriptions only; terms set their own line height.",
+          "nl.amsterdam.hint": "Applies to descriptions only; terms set their own line height. Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "lineHeight",
           "nl.amsterdam.type": "number"
         }
@@ -56,6 +56,7 @@
         "font-size": {
           "$value": "{ams.typography.heading.4.font-size}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.type": "fontSize"
           }
         },
@@ -68,6 +69,7 @@
         "line-height": {
           "$value": "{ams.typography.heading.4.line-height}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "lineHeight",
             "nl.amsterdam.type": "number"
           }
@@ -75,6 +77,7 @@
         "margin-block-end": {
           "$value": "{ams.space.xs}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -89,7 +92,7 @@
           "margin-block-end": {
             "$value": "{ams.description-list.description.margin-block-end}",
             "$extensions": {
-              "nl.amsterdam.hint": "Should equal the bottom margin of descriptions.",
+              "nl.amsterdam.hint": "Should equal the bottom margin of descriptions. Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }
@@ -106,6 +109,7 @@
         "margin-block-end": {
           "$value": "{ams.space.m}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -114,6 +118,7 @@
           "$value": "0",
           "$type": "dimension",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space"
           }
         }
@@ -122,6 +127,7 @@
         "margin-block-end": {
           "$value": "{ams.space.m}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/dialog.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/dialog.tokens.json
@@ -28,6 +28,7 @@
       "border-width": {
         "$value": "{ams.border.width.m}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.type": "borderWidth"
         }
       },

--- a/packages-proprietary/tokens/src/components/ams/field-set.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/field-set.tokens.json
@@ -5,6 +5,7 @@
         "margin-block-end": {
           "$value": "{ams.space.xs}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -13,6 +14,7 @@
           "margin-block-end": {
             "$value": "{ams.space.s}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }
@@ -22,6 +24,7 @@
           "margin-block-end": {
             "$value": "{ams.space.m}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }
@@ -31,6 +34,7 @@
           "margin-block-end": {
             "$value": "{ams.space.l}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }
@@ -47,6 +51,7 @@
         "padding-inline-start": {
           "$value": "{ams.space.m}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/field.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/field.tokens.json
@@ -13,6 +13,7 @@
         "margin-block-end": {
           "$value": "{ams.space.xs}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -21,6 +22,7 @@
           "margin-block-end": {
             "$value": "{ams.space.s}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }
@@ -37,6 +39,7 @@
         "padding-inline-start": {
           "$value": "{ams.space.m}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/file-input.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/file-input.tokens.json
@@ -150,6 +150,7 @@
         "margin-inline-end": {
           "$value": "{ams.space.m}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/grid.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/grid.tokens.json
@@ -16,6 +16,7 @@
         "l": {
           "$value": "{ams.space.l}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -23,6 +24,7 @@
         "xl": {
           "$value": "{ams.space.xl}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -30,6 +32,7 @@
         "2xl": {
           "$value": "{ams.space.2xl}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -38,6 +41,7 @@
       "padding-inline": {
         "$value": "{ams.space.l}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }
@@ -46,6 +50,7 @@
         "l": {
           "$value": "{ams.space.l}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -53,6 +58,7 @@
         "xl": {
           "$value": "{ams.space.xl}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -60,6 +66,7 @@
         "2xl": {
           "$value": "{ams.space.2xl}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -103,6 +110,7 @@
         "padding-inline": {
           "$value": "{ams.space.xl}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -116,6 +124,7 @@
         "padding-inline": {
           "$value": "{ams.space.2xl}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/image-slider.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/image-slider.tokens.json
@@ -84,6 +84,7 @@
         "margin-block-end": {
           "$value": "{ams.space.m}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/logo.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/logo.tokens.json
@@ -4,6 +4,7 @@
       "block-size": {
         "$value": "{ams.space.xl}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.type": "dimension"
         }
       },

--- a/packages-proprietary/tokens/src/components/ams/menu.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/menu.tokens.json
@@ -116,6 +116,7 @@
         "padding-inline": {
           "$value": "{ams.space.s}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/ordered-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/ordered-list.tokens.json
@@ -75,7 +75,7 @@
             "unit": "rem"
           },
           "$extensions": {
-            "nl.amsterdam.hint": "Divide your total indentation width over margin and padding to position the marker.",
+            "nl.amsterdam.hint": "Divide your total indentation width over margin and padding to position the marker. Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space"
           }
         },
@@ -85,7 +85,7 @@
             "unit": "rem"
           },
           "$extensions": {
-            "nl.amsterdam.hint": "The total level 1 indentation for Amsterdam is 40 pixels, or 2.5rem.",
+            "nl.amsterdam.hint": "The total level 1 indentation for Amsterdam is 40 pixels, or 2.5rem. Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space"
           }
         },
@@ -108,6 +108,7 @@
         "padding-block-end": {
           "$value": "{ams.space.s}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -115,6 +116,7 @@
         "padding-block-start": {
           "$value": "{ams.space.s}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -126,7 +128,7 @@
               "unit": "rem"
             },
             "$extensions": {
-              "nl.amsterdam.hint": "Indent less than the parent to start-align the child’s marker with the parent text.",
+              "nl.amsterdam.hint": "Indent less than the parent to start-align the child’s marker with the parent text. Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space"
             }
           },
@@ -136,7 +138,7 @@
               "unit": "rem"
             },
             "$extensions": {
-              "nl.amsterdam.hint": "The total level >=2 indentation for Amsterdam is 28 pixels, or 1.75rem.",
+              "nl.amsterdam.hint": "The total level >=2 indentation for Amsterdam is 28 pixels, or 1.75rem. Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space"
             }
           },

--- a/packages-proprietary/tokens/src/components/ams/page-footer.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/page-footer.tokens.json
@@ -18,6 +18,7 @@
         "padding-block": {
           "$value": "{ams.space.l}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -25,6 +26,7 @@
         "padding-inline": {
           "$value": "{ams.grid.padding-inline}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -60,6 +62,7 @@
           "padding-inline": {
             "$value": "{ams.grid.vi-medium.padding-inline}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }
@@ -69,6 +72,7 @@
           "padding-inline": {
             "$value": "{ams.grid.vi-wide.padding-inline}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }

--- a/packages-proprietary/tokens/src/components/ams/page-header.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/page-header.tokens.json
@@ -16,6 +16,7 @@
       "padding-block": {
         "$value": "{ams.space.l}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }
@@ -23,7 +24,7 @@
       "padding-inline": {
         "$value": "{ams.grid.padding-inline}",
         "$extensions": {
-          "nl.amsterdam.hint": "Must be the Grid inline padding, to make sure Header and Grid line up.",
+          "nl.amsterdam.hint": "Must be the Grid inline padding, to make sure Header and Grid line up. Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }
@@ -52,6 +53,7 @@
         "padding-inline": {
           "$value": "{ams.grid.vi-medium.padding-inline}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -61,6 +63,7 @@
         "padding-inline": {
           "$value": "{ams.grid.vi-wide.padding-inline}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/page.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/page.tokens.json
@@ -32,7 +32,7 @@
           "margin-inline-end": {
             "$value": "{ams.grid.padding-inline}",
             "$extensions": {
-              "nl.amsterdam.hint": "Must be the Grid inline padding, to make sure Skip Link and Grid line up.",
+              "nl.amsterdam.hint": "Must be the Grid inline padding, to make sure Skip Link and Grid line up. Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.type": "dimension",
               "nl.amsterdam.subtype": "space"
             }

--- a/packages-proprietary/tokens/src/components/ams/progress-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/progress-list.tokens.json
@@ -13,6 +13,7 @@
             "margin-block-start": {
               "$value": "calc(({ams.typography.heading.2.line-height} * {ams.typography.heading.2.font-size}) / 2)",
               "$extensions": {
+                "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
                 "nl.amsterdam.type": "dimension"
               }
             }
@@ -31,6 +32,7 @@
             "margin-block-start": {
               "$value": "calc(({ams.typography.heading.3.line-height} * {ams.typography.heading.3.font-size}) / 2)",
               "$extensions": {
+                "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
                 "nl.amsterdam.type": "dimension"
               }
             }
@@ -49,6 +51,7 @@
             "margin-block-start": {
               "$value": "calc(({ams.typography.heading.4.line-height} * {ams.typography.heading.4.font-size}) / 2)",
               "$extensions": {
+                "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
                 "nl.amsterdam.type": "dimension"
               }
             }
@@ -121,6 +124,7 @@
         "gap": {
           "$value": "{ams.space.m}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -139,6 +143,7 @@
           "gap": {
             "$value": "{ams.space.l}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }
@@ -151,7 +156,10 @@
                 "value": 1.5,
                 "unit": "rem"
               },
-              "$type": "dimension"
+              "$type": "dimension",
+              "$extensions": {
+                "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate."
+              }
             },
             "background-color": {
               "$value": "{ams.color.background.default}",
@@ -222,6 +230,7 @@
           "margin-block-end": {
             "$value": "{ams.space.s}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }
@@ -231,6 +240,7 @@
           "margin-block-end": {
             "$value": "{ams.space.l}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }
@@ -299,6 +309,7 @@
         "padding-block-start": {
           "$value": "{ams.space.m}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -308,6 +319,7 @@
             "margin-inline-end": {
               "$value": "{ams.space.m}",
               "$extensions": {
+                "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
                 "nl.amsterdam.subtype": "space",
                 "nl.amsterdam.type": "dimension"
               }
@@ -425,6 +437,7 @@
             "margin-block-start": {
               "$value": "calc({ams.typography.body-text.font-size} * {ams.typography.body-text.line-height} / 2)",
               "$extensions": {
+                "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
                 "nl.amsterdam.type": "dimension"
               }
             },
@@ -441,6 +454,7 @@
             "margin-block-end": {
               "$value": "{ams.space.m}",
               "$extensions": {
+                "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
                 "nl.amsterdam.subtype": "space",
                 "nl.amsterdam.type": "dimension"
               }
@@ -502,6 +516,7 @@
             "margin-block-end": {
               "$value": "{ams.space.l}",
               "$extensions": {
+                "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
                 "nl.amsterdam.subtype": "space",
                 "nl.amsterdam.type": "dimension"
               }

--- a/packages-proprietary/tokens/src/components/ams/radio.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/radio.tokens.json
@@ -22,6 +22,7 @@
       "font-size": {
         "$value": "{ams.typography.body-text.font-size}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.type": "fontSize"
         }
       },
@@ -41,6 +42,7 @@
       "line-height": {
         "$value": "{ams.typography.body-text.line-height}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "lineHeight",
           "nl.amsterdam.type": "number"
         }

--- a/packages-proprietary/tokens/src/components/ams/skeleton.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/skeleton.tokens.json
@@ -135,7 +135,7 @@
           "padding-inline-start": {
             "$value": "{ams.unordered-list.item.margin-inline-start}",
             "$extensions": {
-              "nl.amsterdam.hint": "Starts the marker where the marker of Unordered List renders.",
+              "nl.amsterdam.hint": "Starts the marker where the marker of Unordered List renders. Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }

--- a/packages-proprietary/tokens/src/components/ams/switch.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/switch.tokens.json
@@ -29,6 +29,7 @@
         "border-width": {
           "$value": "{ams.border.width.m}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.type": "borderWidth"
           }
         }
@@ -52,7 +53,10 @@
             "value": 1.75,
             "unit": "rem"
           },
-          "$type": "dimension"
+          "$type": "dimension",
+          "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate."
+          }
         },
         "hover": {
           "box-shadow": {

--- a/packages-proprietary/tokens/src/components/ams/table-of-contents.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/table-of-contents.tokens.json
@@ -29,6 +29,7 @@
       "line-height": {
         "$value": "{ams.typography.body-text.line-height}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "lineHeight",
           "nl.amsterdam.type": "number"
         }
@@ -45,6 +46,7 @@
           "padding-block-start": {
             "$value": "{ams.space.xs}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }
@@ -52,6 +54,7 @@
           "padding-inline-start": {
             "$value": "{ams.space.m}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }

--- a/packages-proprietary/tokens/src/components/ams/table.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/table.tokens.json
@@ -48,6 +48,7 @@
           "$value": "{ams.space.s}",
           "$type": "dimension",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space"
           }
         }

--- a/packages-proprietary/tokens/src/components/ams/text-area.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/text-area.tokens.json
@@ -79,6 +79,7 @@
       "padding-block": {
         "$value": "{ams.inputs.padding-block}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }

--- a/packages-proprietary/tokens/src/components/ams/time-input.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/time-input.tokens.json
@@ -46,6 +46,7 @@
       "font-size": {
         "$value": "{ams.inputs.font-size}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.type": "fontSize"
         }
       },
@@ -58,6 +59,7 @@
       "line-height": {
         "$value": "{ams.inputs.line-height}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "lineHeight",
           "nl.amsterdam.type": "number"
         }
@@ -72,6 +74,7 @@
       "padding-block": {
         "$value": "{ams.inputs.padding-block}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }
@@ -79,6 +82,7 @@
       "padding-inline": {
         "$value": "{ams.inputs.padding-inline}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }

--- a/packages-proprietary/tokens/src/components/ams/unordered-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/unordered-list.tokens.json
@@ -75,7 +75,7 @@
             "unit": "rem"
           },
           "$extensions": {
-            "nl.amsterdam.hint": "Divide your total indentation width over margin and padding to position the marker.",
+            "nl.amsterdam.hint": "Divide your total indentation width over margin and padding to position the marker. Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space"
           }
         },
@@ -85,7 +85,7 @@
             "unit": "rem"
           },
           "$extensions": {
-            "nl.amsterdam.hint": "The total level 1 indentation for Amsterdam is 40 pixels, or 2.5rem.",
+            "nl.amsterdam.hint": "The total level 1 indentation for Amsterdam is 40 pixels, or 2.5rem. Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space"
           }
         },
@@ -108,6 +108,7 @@
         "padding-block-end": {
           "$value": "{ams.space.s}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -115,6 +116,7 @@
         "padding-block-start": {
           "$value": "{ams.space.s}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -126,7 +128,7 @@
               "unit": "rem"
             },
             "$extensions": {
-              "nl.amsterdam.hint": "Indent less than the parent to start-align the child’s marker with the parent text.",
+              "nl.amsterdam.hint": "Indent less than the parent to start-align the child’s marker with the parent text. Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space"
             }
           },
@@ -136,7 +138,7 @@
               "unit": "rem"
             },
             "$extensions": {
-              "nl.amsterdam.hint": "The total level >=2 indentation for Amsterdam is 28 pixels, or 1.75rem.",
+              "nl.amsterdam.hint": "The total level >=2 indentation for Amsterdam is 28 pixels, or 1.75rem. Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space"
             }
           },


### PR DESCRIPTION
# Describe the pull request

## Links

- Stacked on #2855. Review and merge that one first; this branch is a single commit on top of it.

## What

Adds a `nl.amsterdam.hint` to every token that has to resolve to a single value, saying so.

A token read through `calc()`, `max()`, `min()` or `clamp()`, or assigned to a longhand such as `padding-inline-start`, cannot hold two values. Given two, the declaration is invalid at computed-value time and the property falls back to its initial value rather than to the token, so the spacing disappears rather than degrading.

91 tokens gain a hint and 14 have it appended to one they already carried. Deprecated aliases are skipped, since they forward to the token that now carries the note.

## Why

Nothing enforces this, and the two kinds of token look identical in the source. The design system ships six two-value spacing tokens of its own — Dialog's header and footer block padding, Menu's wide block padding, Select's inline padding — so writing one is established practice rather than an obvious mistake.

Seventeen of the annotated tokens are in scope for a reason that is easy to miss: they are referenced inside another token's own `calc()`, not from any stylesheet. The typography sizes behind the Progress List step markers, the logo block size behind Menu's wide padding, and the inputs inline padding behind Select's are all in that group.

## How

The hint is the only place this distinction can live today, so that is where it goes. It is a stopgap: the tokens that legitimately hold two values should be split in two, and the rule should be enforced by the token build and by Stylelint rather than by a sentence someone has to read. That has its own ticket.

The generated stylesheets are byte for byte identical — hints do not reach the output — so there is nothing to see in the deploy.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- The wording splits by reason, `it is used in a calculation` against `it sets a longhand property`, because those are different constraints and whoever edits a token should know which applies.
- This does not protect consumers. An application overriding a custom property with two values still fails silently; the hint only reaches people editing the tokens here.
