### PR TITLE
fix(Breakout): Cancel the row gap that each vertical gap size actually sets

### DIFF
--- a/packages/css/src/components/breakout/breakout.scss
+++ b/packages/css/src/components/breakout/breakout.scss
@@ -129,11 +129,15 @@ $ams-breakout-row-span-max: 4;
     );
   }
 
-  .ams-breakout--gap-vertical--small > & {
-    margin-block: calc(var(--ams-space-l) * -1);
+  .ams-breakout--gap-vertical--none > & {
+    margin-block: 0;
   }
 
   .ams-breakout--gap-vertical--large > & {
+    margin-block: calc(var(--ams-space-l) * -1);
+  }
+
+  .ams-breakout--gap-vertical--2x-large > & {
     margin-block: calc(var(--ams-space-2xl) * -1);
   }
 }

--- a/packages/css/src/components/breakout/breakout.scss
+++ b/packages/css/src/components/breakout/breakout.scss
@@ -114,7 +114,7 @@ $ams-breakout-row-span-max: 4;
 
 .ams-breakout__cell--has-spotlight {
   display: grid; /* Stretches the empty Spotlight vertically. */
-  margin-block: calc(var(--ams-space-xl) * -1);
+  margin-block: calc(var(--ams-grid-row-gap-xl) * -1);
   margin-inline: calc(var(--ams-grid-padding-inline) * -1);
 
   @media (min-width: $ams-breakpoint-medium) {
@@ -134,11 +134,11 @@ $ams-breakout-row-span-max: 4;
   }
 
   .ams-breakout--gap-vertical--large > & {
-    margin-block: calc(var(--ams-space-l) * -1);
+    margin-block: calc(var(--ams-grid-row-gap-l) * -1);
   }
 
   .ams-breakout--gap-vertical--2x-large > & {
-    margin-block: calc(var(--ams-space-2xl) * -1);
+    margin-block: calc(var(--ams-grid-row-gap-2xl) * -1);
   }
 }
 

--- a/storybook/src/components/Breakout/Breakout.docs.mdx
+++ b/storybook/src/components/Breakout/Breakout.docs.mdx
@@ -59,7 +59,7 @@ Additionally, Breakout allows cells to span multiple rows.
 
 The break-out effect is a Cell pulled outward by exactly the space the Grid holds it in: the horizontal padding at the current breakpoint, and the vertical gap above and below.
 The Spotlight inside it therefore reaches both edges of the window while every other Cell keeps its columns.
-Those offsets are restated at each breakpoint and for each vertical gap, because the space being cancelled is different in every one of those cases.
+The horizontal offsets are restated at each breakpoint and the vertical ones for each gap size, because the space being cancelled is different in every one of those cases.
 
 Row spans and row starts are generated up to four.
 A higher number produces no rule at all rather than an error, so a Cell asking for five rows quietly spans one.

--- a/storybook/src/components/Breakout/Breakout.test.stories.tsx
+++ b/storybook/src/components/Breakout/Breakout.test.stories.tsx
@@ -5,8 +5,9 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { Spotlight } from '@amsterdam/design-system-react'
+import { Paragraph, Spotlight } from '@amsterdam/design-system-react'
 import { Breakout } from '@amsterdam/design-system-react/src'
+import { gridGaps } from '@amsterdam/design-system-react/src/Grid/Grid'
 
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
@@ -20,6 +21,9 @@ const meta = {
 export default meta
 
 type Story = StoryObj<typeof meta>
+
+/** Mirrors gridGaps in packages/react/src/Grid/Grid.tsx, preceded by the default. Each gap is cancelled by its own offset. */
+const gaps = [undefined, ...gridGaps] as const
 
 export const Test: Story = {
   args: {
@@ -46,6 +50,27 @@ export const Test: Story = {
       </Breakout.Cell>,
     ],
   },
-  render: (args, context) => renderComponentVariants(Breakout, { args }, context),
+  render: (args, context) => (
+    <>
+      {renderComponentVariants(Breakout, { args }, context)}
+      <div className="_ams-tests-stack">
+        {gaps.map((gap) => (
+          // The vertical padding is the largest one, so each Spotlight escapes into its own Breakout
+          // instead of into the one above or below it.
+          <Breakout gapVertical={gap} key={gap ?? 'default'} paddingVertical="2x-large">
+            <Breakout.Cell colSpan="all" has="spotlight" rowSpan={2} rowStart={1}>
+              <Spotlight color="green" />
+            </Breakout.Cell>
+            <Breakout.Cell colSpan="all" rowStart={1}>
+              <Paragraph color="inverse">{`gapVertical: ${gap ?? 'x-large (default)'}`}</Paragraph>
+            </Breakout.Cell>
+            <Breakout.Cell colSpan="all" rowStart={2}>
+              <Paragraph color="inverse">De Spotlight reikt precies tot de gap boven en onder deze tekst.</Paragraph>
+            </Breakout.Cell>
+          </Breakout>
+        ))}
+      </div>
+    </>
+  ),
   tags: ['!dev', '!autodocs'],
 }

--- a/storybook/src/components/Breakout/Breakout.test.stories.tsx
+++ b/storybook/src/components/Breakout/Breakout.test.stories.tsx
@@ -5,7 +5,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { Paragraph, Spotlight } from '@amsterdam/design-system-react'
+import { Spotlight } from '@amsterdam/design-system-react'
 import { Breakout } from '@amsterdam/design-system-react/src'
 import { gridGaps } from '@amsterdam/design-system-react/src/Grid/Grid'
 
@@ -62,10 +62,10 @@ export const Test: Story = {
               <Spotlight color="green" />
             </Breakout.Cell>
             <Breakout.Cell colSpan="all" rowStart={1}>
-              <Paragraph color="inverse">{`gapVertical: ${gap ?? 'x-large (default)'}`}</Paragraph>
+              <p style={{ color: 'white' }}>{`gapVertical: ${gap ?? 'x-large (default)'}`}</p>
             </Breakout.Cell>
             <Breakout.Cell colSpan="all" rowStart={2}>
-              <Paragraph color="inverse">De Spotlight reikt precies tot de gap boven en onder deze tekst.</Paragraph>
+              <p style={{ color: 'white' }}>De Spotlight reikt precies tot de gap boven en onder deze tekst.</p>
             </Breakout.Cell>
           </Breakout>
         ))}


### PR DESCRIPTION
## Links

- [Storybook preview on main](https://designsystem.amsterdam/)
- [Breakout](https://designsystem.amsterdam/?path=/docs/components-layout-breakout--docs) — the corrected sentence is in the Design section. The gap sizes themselves are only visible in the Test story, which is hidden from the sidebar, so Chromatic is where the change shows.
- [Grid](https://designsystem.amsterdam/?path=/docs/components-layout-grid--docs) — the component whose row gaps are being cancelled.

## What

The Cell that holds a Spotlight escapes the Grid by cancelling the space around it with negative margins. Its vertical offsets were keyed to gap class names the component no longer renders, so they cancelled the wrong amounts. `gridGaps` emits `none`, `large` and `2x-large`, while `breakout.scss` keyed an offset to `--gap-vertical--small`, which is never rendered, and cancelled `--gap-vertical--large` with `space-2xl` where that class sets `row-gap-l`. One rule was therefore dead, one over-cancelled, and `2x-large` had no rule at all and fell back to the default `space-xl`. So did `none`, which sets no gap to cancel in the first place. The selectors look shifted by one, which fits a rename of the gap scale from small/large to large/2x-large that never reached these lines.

Each of the four values now cancels the row gap its own class sets: nothing for `none`, `space-l` for `large`, `space-2xl` for `2x-large`, and the unchanged `space-xl` for the default. The horizontal offsets are untouched.

**This changes what renders for three of the four gap sizes, so it needs design sign-off before merging.** A Breakout with `gapVertical="large"` no longer pulls its Spotlight further out than the gap it cancels, one with `2x-large` now pulls far enough, and one with `none` no longer pulls at all. Only the default gap is unaffected, which is why this went unnoticed: the Breakout stories and every page template use the default.

## Why

The offsets exist so the Spotlight lines up with the Cells beside it. At any gap other than the default it did not, by up to 53 pixels too far out at `large` and 29 pixels too far in at `2x-large` on a wide window.

## How

Measured rather than eyeballed, in a headless browser, comparing the computed `margin-block` of the Spotlight Cell against the parent's computed `row-gap` at 400, 800 and 1400 pixels. The table below is the 1400 pixel column.

| `gapVertical` | row gap | margin before | margin after |
| --- | --- | --- | --- |
| default | 59.14px | -59.14px | unchanged |
| `none` | 0px | -59.14px | 0px |
| `large` | 35.57px | -88.50px | -35.57px |
| `2x-large` | 88.50px | -59.14px | -88.50px |

All 24 Spotlight Cells in the built Test story now cancel exactly, at all three widths. The default gap is identical to before, so its snapshots should not move.

Two things worth flagging for review:

The Test story already covered these gaps. `renderComponentVariants` does not collapse for Breakout the way it does for DatePicker; it renders a 20 Breakout matrix, of which three carry a gap class. That coverage holds only while docgen keeps resolving Breakout's union props, and a shift of a few tens of pixels is easy to miss in the busy composition it uses, so the story now also sweeps the four gap sizes explicitly, labelled and on the block axis alone. Each Breakout in the sweep carries the largest vertical padding so its Spotlight escapes into its own Breakout rather than into the ones beside it. Chromatic will show diffs both for the three gap instances in the matrix and for the new sweep.

The Design section attributed both the horizontal and the vertical offsets to both breakpoints and gap sizes, which read as though the vertical offsets vary per breakpoint. Each axis now names the condition it actually varies with, and the claim about the vertical ones only became true with this fix.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

There is no ticket for this; the bug was found while reading the stylesheet.

The unit tests already assert the class names for every value of `gapVertical` and still pass unchanged. The behaviour that broke here lives in CSS, which no unit test reaches, so the Test story is the regression cover.

`feat/safe-area-insets` removed a sentence from this Design section for exactly this reason, that the offsets were not in fact written out per gap size. That sentence can go back once this lands. That branch also rewrote the horizontal offsets to follow the Grid's computed inline padding, which this PR deliberately leaves alone.
