### PR TITLE
feat(Card): Allow switching to horizontal layout if space permits

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/card.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/card.tokens.json
@@ -31,10 +31,16 @@
       "horizontal": {
         "column-gap": {
           "$value": "{ams.space.l}",
-          "$description": "The space between the image and the content of a horizontal Card. Independent of the column gap of the Grid, which the image is measured against so that it covers whole columns of the page.",
           "$extensions": {
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
+          }
+        },
+        "grid-template-columns": {
+          "$value": "calc((4 * 100% - 5 * {ams.grid.column-gap}) / 9) minmax(0, 1fr)",
+          "$description": "The image covers the first 4 columns if the Card spans exactly 9. That seems to be a common layout for horizontal Cards, and it allows them to visually align with vertical ones. In other contexts, the image scales proportionally.",
+          "$extensions": {
+            "nl.amsterdam.type": "gridTemplateColumns"
           }
         }
       },

--- a/packages-proprietary/tokens/src/components/ams/card.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/card.tokens.json
@@ -28,6 +28,16 @@
           }
         }
       },
+      "horizontal": {
+        "column-gap": {
+          "$value": "{ams.space.l}",
+          "$description": "The space between the image and the content of a horizontal Card. Independent of the column gap of the Grid, which the image is measured against so that it covers whole columns of the page.",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        }
+      },
       "image": {
         "margin-block-end": {
           "$value": "{ams.space.s}",

--- a/packages/css/src/components/card/card.scss
+++ b/packages/css/src/components/card/card.scss
@@ -3,6 +3,23 @@
  * Copyright Gemeente Amsterdam
  */
 
+/**
+ * CSS Custom properties cannot be used in container queries.
+ * We resort to Sass variables for our breakpoint values.
+ */
+
+/**
+ * The container width at which a Card with an image switches to a horizontal layout.
+ * Above the widest cell of the narrow Grid, so a Card that spans the full width of that Grid stays vertical.
+ */
+$ams-card-horizontal-breakpoint: 36rem;
+
+@mixin horizontal-layout {
+  @container ams-query-container-inline-size (inline-size > #{$ams-card-horizontal-breakpoint}) {
+    @content;
+  }
+}
+
 .ams-card {
   display: grid;
   outline-offset: var(--ams-card-outline-offset);
@@ -20,12 +37,63 @@
     outline-width: 0.0625rem;
   }
 
+  > .ams-card__image:not(:last-child) {
+    margin-block-end: var(--ams-card-image-margin-block-end);
+  }
+}
+
+// The heading takes the same space whether or not a Content wrapper groups it with the rest.
+.ams-card,
+.ams-card__content {
   > .ams-card__heading:not(:last-child) {
     margin-block-end: var(--ams-card-heading-margin-block-end);
   }
+}
 
-  > .ams-card__image:not(:last-child) {
-    margin-block-end: var(--ams-card-image-margin-block-end);
+@include horizontal-layout {
+  /*
+   * Only a Card that pairs an image with a Content switches to a horizontal layout: the image in the first
+   * column, the Content in the second. Every other Card is left unchanged, so a Card that is not built for
+   * this layout stays vertical rather than breaking. Content is what makes the layout possible: it occupies
+   * a single grid row beside the image, where several loose children would each start a row of their own.
+   * It is okay to use the :has() pseudo-class here, because the layout falls back to the vertical
+   * default in browsers that do not support it.
+   */
+  /* stylelint-disable-next-line plugin/use-baseline */
+  .ams-card:has(> .ams-card__image):has(> .ams-card__content) {
+    column-gap: var(--ams-card-horizontal-column-gap);
+
+    /*
+     * The image covers the first 4 of the 9 page columns the Card spans, so that it is exactly as wide as a
+     * Card that spans 4 columns and the images of horizontal and vertical Cards line up. It therefore
+     * measures 4 column widths plus the 3 gutters between them, and a column width is what is left of the
+     * Card once its own 8 gutters are taken off, divided by 9. That is the expression below, written the way
+     * it is counted rather than reduced, so that changing the 4 needs no algebra. Note this is not
+     * `1fr 2fr`, which accounts for one gutter where the columns need several.
+     *
+     * The gutters here are the ones of the Grid, not of the Card: they are the gaps between the page columns
+     * the image covers. The Card’s own column gap only sets the distance between the image and the content,
+     * which therefore starts wherever that leaves it rather than on a column of the page.
+     *
+     * 4 of 9 is the results region of an index page beside a 3-column filter column. A Card spanning a
+     * different number of columns keeps the same proportion, so its image stops landing on the page columns
+     * — the case on the medium Grid, where that region is 5 columns wide. That is accepted: one expression
+     * keeps the Card from having to know the layout of the page it sits on.
+     */
+    grid-template-columns:
+      calc(4 * (100% - 8 * var(--ams-grid-column-gap)) / 9 + 3 * var(--ams-grid-column-gap))
+      minmax(0, 1fr);
+
+    > .ams-card__image {
+      align-self: start; // Keep the aspect ratio of the image; the taller of the two columns sets the height.
+      grid-column-start: 1;
+      margin-block-end: 0; // The column gap handles the spacing in this layout.
+    }
+
+    // Anything that is not the image belongs in the second column, so a stray child never lands under it.
+    > :not(.ams-card__image) {
+      grid-column-start: 2;
+    }
   }
 }
 

--- a/packages/css/src/components/card/card.scss
+++ b/packages/css/src/components/card/card.scss
@@ -50,6 +50,7 @@ $ams-card-horizontal-breakpoint: 36rem;
   /* stylelint-disable-next-line plugin/use-baseline -- unsupporting browsers get vertical layout. */
   .ams-card:has(> .ams-card__image):has(> .ams-card__content) {
     column-gap: var(--ams-card-horizontal-column-gap);
+    grid-template-areas: "image content";
 
     /*
      * The interesting width aims to let the image cover the first 4 columns if the Card spans exactly 9.
@@ -59,13 +60,14 @@ $ams-card-horizontal-breakpoint: 36rem;
     grid-template-columns: calc((4 * 100% - 5 * var(--ams-grid-column-gap)) / 9) minmax(0, 1fr);
 
     > .ams-card__image {
-      grid-column-start: 1;
+      grid-column: image;
       margin-block-end: 0; // The column gap handles the spacing in this layout.
     }
 
     // Anything that is not the image belongs in the second column, so a stray child never lands under it.
+    // Naming the column and not the area leaves its row to auto-placement, so two children never overlap.
     > :not(.ams-card__image) {
-      grid-column-start: 2;
+      grid-column: content;
     }
   }
 }

--- a/packages/css/src/components/card/card.scss
+++ b/packages/css/src/components/card/card.scss
@@ -14,12 +14,6 @@
  */
 $ams-card-horizontal-breakpoint: 36rem;
 
-@mixin horizontal-layout {
-  @container ams-query-container-inline-size (inline-size > #{$ams-card-horizontal-breakpoint}) {
-    @content;
-  }
-}
-
 .ams-card {
   display: grid;
   outline-offset: var(--ams-card-outline-offset);
@@ -47,12 +41,11 @@ $ams-card-horizontal-breakpoint: 36rem;
   }
 }
 
-@include horizontal-layout {
+@container ams-query-container-inline-size (inline-size > #{$ams-card-horizontal-breakpoint}) {
   /*
-   * Only a Card that pairs an image with a Content switches to a horizontal layout: the image in the first
-   * column, the Content in the second. Every other Card is left unchanged, so a Card that is not built for
-   * this layout stays vertical rather than breaking. Content is what makes the layout possible: it occupies
-   * a single grid row beside the image, where several loose children would each start a row of their own.
+   * Only a Card with both an image and Content switches to a horizontal layout. Cards that are
+   * not built for this layout stay vertical rather than breaking. Content is what makes the
+   * layout possible by grouping all other content into a single area beside the image.
    */
   /* stylelint-disable-next-line plugin/use-baseline -- unsupporting browsers get vertical layout. */
   .ams-card:has(> .ams-card__image):has(> .ams-card__content) {

--- a/packages/css/src/components/card/card.scss
+++ b/packages/css/src/components/card/card.scss
@@ -26,11 +26,8 @@ $ams-card-horizontal-breakpoint: 36rem;
   position: relative; // Allows stretching the card link below.
   touch-action: manipulation;
 
-  /*
-   * Set native outline to Card if it has a visible focus inside.
-   * It is okay to use the :has() pseudo-class here, because we have a fallback for browsers that do not support it.
-   */
-  /* stylelint-disable-next-line plugin/use-baseline */
+  /* Set native outline to Card if it has a visible focus inside. */
+  /* stylelint-disable-next-line plugin/use-baseline -- we have a fallback for browsers that do not support it. */
   &:has(:focus-visible) {
     outline-color: -webkit-focus-ring-color;
     outline-style: auto;
@@ -56,33 +53,17 @@ $ams-card-horizontal-breakpoint: 36rem;
    * column, the Content in the second. Every other Card is left unchanged, so a Card that is not built for
    * this layout stays vertical rather than breaking. Content is what makes the layout possible: it occupies
    * a single grid row beside the image, where several loose children would each start a row of their own.
-   * It is okay to use the :has() pseudo-class here, because the layout falls back to the vertical
-   * default in browsers that do not support it.
    */
-  /* stylelint-disable-next-line plugin/use-baseline */
+  /* stylelint-disable-next-line plugin/use-baseline -- unsupporting browsers get vertical layout. */
   .ams-card:has(> .ams-card__image):has(> .ams-card__content) {
     column-gap: var(--ams-card-horizontal-column-gap);
 
     /*
-     * The image covers the first 4 of the 9 page columns the Card spans, so that it is exactly as wide as a
-     * Card that spans 4 columns and the images of horizontal and vertical Cards line up. It therefore
-     * measures 4 column widths plus the 3 gutters between them, and a column width is what is left of the
-     * Card once its own 8 gutters are taken off, divided by 9. That is the expression below, written the way
-     * it is counted rather than reduced, so that changing the 4 needs no algebra. Note this is not
-     * `1fr 2fr`, which accounts for one gutter where the columns need several.
-     *
-     * The gutters here are the ones of the Grid, not of the Card: they are the gaps between the page columns
-     * the image covers. The Card’s own column gap only sets the distance between the image and the content,
-     * which therefore starts wherever that leaves it rather than on a column of the page.
-     *
-     * 4 of 9 is the results region of an index page beside a 3-column filter column. A Card spanning a
-     * different number of columns keeps the same proportion, so its image stops landing on the page columns
-     * — the case on the medium Grid, where that region is 5 columns wide. That is accepted: one expression
-     * keeps the Card from having to know the layout of the page it sits on.
+     * The interesting width aims to let the image cover the first 4 columns if the Card spans exactly 9.
+     * That seems to be a common layout for horizontal Cards, and it allows them to visually align with
+     * vertical ones. In other contexts, the image scales proportionally.
      */
-    grid-template-columns:
-      calc(4 * (100% - 8 * var(--ams-grid-column-gap)) / 9 + 3 * var(--ams-grid-column-gap))
-      minmax(0, 1fr);
+    grid-template-columns: calc((4 * 100% - 5 * var(--ams-grid-column-gap)) / 9) minmax(0, 1fr);
 
     > .ams-card__image {
       grid-column-start: 1;

--- a/packages/css/src/components/card/card.scss
+++ b/packages/css/src/components/card/card.scss
@@ -51,13 +51,7 @@ $ams-card-horizontal-breakpoint: 36rem;
   .ams-card:has(> .ams-card__image):has(> .ams-card__content) {
     column-gap: var(--ams-card-horizontal-column-gap);
     grid-template-areas: "image content";
-
-    /*
-     * The interesting width aims to let the image cover the first 4 columns if the Card spans exactly 9.
-     * That seems to be a common layout for horizontal Cards, and it allows them to visually align with
-     * vertical ones. In other contexts, the image scales proportionally.
-     */
-    grid-template-columns: calc((4 * 100% - 5 * var(--ams-grid-column-gap)) / 9) minmax(0, 1fr);
+    grid-template-columns: var(--ams-card-horizontal-grid-template-columns);
 
     > .ams-card__image {
       grid-column: image;

--- a/packages/css/src/components/card/card.scss
+++ b/packages/css/src/components/card/card.scss
@@ -85,7 +85,6 @@ $ams-card-horizontal-breakpoint: 36rem;
       minmax(0, 1fr);
 
     > .ams-card__image {
-      align-self: start; // Keep the aspect ratio of the image; the taller of the two columns sets the height.
       grid-column-start: 1;
       margin-block-end: 0; // The column gap handles the spacing in this layout.
     }

--- a/packages/react/src/Card/Card.tsx
+++ b/packages/react/src/Card/Card.tsx
@@ -8,6 +8,7 @@ import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
 import { clsx } from 'clsx'
 import { forwardRef } from 'react'
 
+import { CardContent } from './CardContent'
 import { CardHeading } from './CardHeading'
 import { CardHeadingGroup } from './CardHeadingGroup'
 import { CardImage } from './CardImage'
@@ -29,6 +30,7 @@ CardRoot.displayName = 'Card'
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-navigation-card--docs Card docs at Amsterdam Design System}
  */
 export const Card = Object.assign(CardRoot, {
+  Content: CardContent,
   Heading: CardHeading,
   HeadingGroup: CardHeadingGroup,
   Image: CardImage,

--- a/packages/react/src/Card/CardContent.test.tsx
+++ b/packages/react/src/Card/CardContent.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { render } from '@testing-library/react'
+import { createRef } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { CardContent } from './CardContent'
+
+describe('CardContent', () => {
+  it('renders', () => {
+    const { container } = render(<CardContent />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toBeInTheDocument()
+    expect(component).toBeVisible()
+  })
+
+  it('renders a design system BEM class name', () => {
+    const { container } = render(<CardContent />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('ams-card__content')
+  })
+
+  it('renders an extra class name', () => {
+    const { container } = render(<CardContent className="extra" />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('ams-card__content extra')
+  })
+
+  it('renders its children', () => {
+    const { getByText } = render(<CardContent>content</CardContent>)
+
+    expect(getByText('content')).toBeInTheDocument()
+  })
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLDivElement>()
+
+    const { container } = render(<CardContent ref={ref} />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(ref.current).toBe(component)
+  })
+
+  it('passes additional props', () => {
+    const { container } = render(<CardContent aria-hidden={false} data-test="data-test" id="id" />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveAttribute('aria-hidden', 'false')
+    expect(component).toHaveAttribute('id', 'id')
+    expect(component).toHaveAttribute('data-test', 'data-test')
+  })
+})

--- a/packages/react/src/Card/CardContent.tsx
+++ b/packages/react/src/Card/CardContent.tsx
@@ -1,0 +1,26 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
+
+import { clsx } from 'clsx'
+import { forwardRef } from 'react'
+
+export type CardContentProps = Readonly<PropsWithChildren<HTMLAttributes<HTMLDivElement>>>
+
+/**
+ * Groups everything in a Card that is not its image, so the two sit side by side in the horizontal layout.
+ *
+ * @see {@link https://designsystem.amsterdam/?path=/docs/components-navigation-card--docs Card docs at Amsterdam Design System}
+ */
+export const CardContent = forwardRef(
+  ({ children, className, ...restProps }: CardContentProps, ref: ForwardedRef<HTMLDivElement>) => (
+    <div {...restProps} className={clsx('ams-card__content', className)} ref={ref}>
+      {children}
+    </div>
+  ),
+)
+
+CardContent.displayName = 'Card.Content'

--- a/packages/react/src/Card/index.ts
+++ b/packages/react/src/Card/index.ts
@@ -5,5 +5,6 @@
 
 export { Card } from './Card'
 export type { CardProps } from './Card'
+export type { CardContentProps } from './CardContent'
 export type { CardHeadingGroupProps } from './CardHeadingGroup'
 export type { CardLinkProps } from './CardLink'

--- a/storybook/src/components/Card/Card.docs.mdx
+++ b/storybook/src/components/Card/Card.docs.mdx
@@ -23,20 +23,26 @@ This component has no props to configure.
 
 ## Subcomponents
 
+### Image
+
+The image of the Card.
+It accepts all props of a regular [Image](/docs/components-media-image--docs), such as `aspectRatio` or a set of image sources.
+Only use decorative images with `alt=""` here.
+The heading provides screen reader users with enough context.
+
+<Canvas of={CardImageStories.Image} />
+
+<Controls of={CardImageStories.Image} />
+
 ### Heading
 
 Contains the name and link of the Card.
-Accepts all props of a regular Heading.
+Accepts all props of a regular [Heading](/docs/components-text-heading--docs).
 Set its `level` to fit the document outline.
 
 <Canvas of={CardHeadingStories.Heading} />
 
 <Controls of={CardHeadingStories.Heading} />
-
-### Content
-
-Groups everything in a Card that is not its image.
-Add it whenever a Card has an image: it is what allows the Card to switch to a [horizontal layout](#horizontal-layout).
 
 ### Heading Group
 
@@ -46,16 +52,10 @@ Displays a `tagline` above the heading.
 
 <Controls of={CardHeadingGroupStories.HeadingGroup} />
 
-### Image
+### Content
 
-The image of the Card.
-It accepts all props of a regular [Image](/docs/components-media-image--docs), such as `aspectRatio` or a set of image sources.
-Only use decorative images with `alt=""` here.
-Screen readers will not read the `alt` text of non-decorative images when navigating to a Card.
-
-<Canvas of={CardImageStories.Image} />
-
-<Controls of={CardImageStories.Image} />
+Groups everything in a Card that is not its image.
+Add it whenever you want to allow switching to a [horizontal layout](#horizontal-layout).
 
 ### Link
 
@@ -104,19 +104,20 @@ This ensures screen readers read out the heading before the metadata.
 
 ### Horizontal layout
 
-A Card that pairs an image with a Content places the image beside the content once there is room for it.
-This follows the width of the nearest [query container](/docs/utilities-css-query-container--docs) rather than the width of the viewport, so the same Card is horizontal in a wide Grid Cell and vertical in a narrow one, without any change to the markup.
-A Card that has an image but no Content stays vertical.
+A Card can place content beside the image once there is room for it.
+This follows the width of the nearest [query container](/docs/utilities-css-query-container--docs), so the same Card is horizontal in a wide Grid Cell and vertical in a narrow one, without any change to the markup.
+A Card that has an image but no Content subcomponent stays vertical.
 
-The image covers 4 of the 9 columns of the Grid Cell it sits in, which is the width of a Card spanning 4 columns.
-The images of horizontal and vertical Cards then line up on an index page that mixes the two.
-A Card that spans a different number of columns keeps the same proportion, so its image is no longer a whole number of columns wide and the two stop lining up.
+If the Card spans 9 columns of the Grid, the image covers 4 of them.
+In other contexts, the image scales proportionally.
+
+(Note that this example will appear vertically in a narrow window.)
 
 <Canvas of={CardStories.HorizontalLayout} />
 
 ### Top tasks
 
-A set of cards can be used to present links to frequently accessed interactions.
+A set of cards without images can present links to frequently accessed interactions.
 A short title and description are enough to guide the user to the page they need.
 Position 4 to 8 tasks on a [Grid](/docs/components-layout-grid--docs); left-align them and do not skip cells.
 For a group of links without a description, use a [Link List](/docs/components-navigation-link-list--docs) instead.
@@ -166,6 +167,7 @@ A description there would be read when browsing the page but skipped when moving
 ## See also
 
 - [Standalone Link](/docs/components-navigation-standalone-link--docs) – for a single link to a follow-up page when a Card is too much.
+- [Skeleton](/docs/components-feedback-skeleton--docs) – can increase the perceived performance of loading the Card’s content.
 - [Routing libraries](/docs/docs-developer-guide-routing-libraries--docs) – how to integrate links with external routing libraries.
 
 ## Design tokens

--- a/storybook/src/components/Card/Card.docs.mdx
+++ b/storybook/src/components/Card/Card.docs.mdx
@@ -114,8 +114,9 @@ A Card that pairs an image with a Content places the image beside the content on
 This follows the width of the nearest [query container](/docs/utilities-css-query-container--docs) rather than the width of the viewport, so the same Card is horizontal in a wide Grid Cell and vertical in a narrow one, without any change to the markup.
 A Card that has an image but no Content stays vertical.
 
-The image takes a third of the columns of the Grid Cell the Card sits in: 3 of 9, or 2 of 6.
-It is then exactly as wide as a Card that spans 3 columns, so the images of horizontal and vertical Cards line up on an index page that mixes the two.
+The image covers 4 of the 9 columns of the Grid Cell it sits in, which is the width of a Card spanning 4 columns.
+The images of horizontal and vertical Cards then line up on an index page that mixes the two.
+A Card that spans a different number of columns keeps the same proportion, so its image is no longer a whole number of columns wide and the two stop lining up.
 
 <Canvas of={CardStories.HorizontalLayout} />
 
@@ -133,6 +134,8 @@ For a group of links without a description, use a [Link List](/docs/components-n
 The mandatory title of a Card is a link within a Heading.
 The link is made active across the entire area of the Card.
 
+A Card that pairs an image with a Content lays out horizontally once its container is wide enough, and vertically below that.
+
 ## Design
 
 A Card has no border, no background, and no padding.
@@ -146,6 +149,13 @@ Browsers that cannot express that condition get neither rule, so they still show
 
 In a Heading Group the tagline is written after the heading and displayed above it.
 The reading order and the visual order differ on purpose, which is what lets the metadata sit on top while the heading is still what gets read first.
+
+Whether a Card is horizontal follows the width of its container rather than the width of the window.
+The same Card is one row in a list of results and one card in a row of three, and which of the two it should be depends on the space it is given, not on the size of the screen.
+
+The image of a horizontal Card measures 4 of the 9 columns it spans, which is the width of a vertical Card beside it, and it keeps its aspect ratio rather than stretching to the height of the text beside it.
+Both choices exist so that the image is the same size in either direction: an index page that opens with a row of vertical Cards above a list of horizontal ones then has one left edge and one image width running down it.
+Stretching the image instead would crop each one differently, according to how far its heading happened to wrap.
 
 ## Accessibility
 

--- a/storybook/src/components/Card/Card.docs.mdx
+++ b/storybook/src/components/Card/Card.docs.mdx
@@ -33,6 +33,11 @@ Set its `level` to fit the document outline.
 
 <Controls of={CardHeadingStories.Heading} />
 
+### Content
+
+Groups everything in a Card that is not its image.
+Add it whenever a Card has an image: it is what allows the Card to switch to a [horizontal layout](#horizontal-layout).
+
 ### Heading Group
 
 Displays a `tagline` above the heading.
@@ -102,6 +107,17 @@ The Card Image subcomponent renders an [Image](/docs/components-media-image--doc
 Only use decorative images with `alt=""` here. Screen readers will not read the `alt` text of non-decorative images when navigating to a Card.
 
 <Canvas of={CardStories.WithImage} />
+
+### Horizontal layout
+
+A Card that pairs an image with a Content places the image beside the content once there is room for it.
+This follows the width of the nearest [query container](/docs/utilities-css-query-container--docs) rather than the width of the viewport, so the same Card is horizontal in a wide Grid Cell and vertical in a narrow one, without any change to the markup.
+A Card that has an image but no Content stays vertical.
+
+The image takes a third of the columns of the Grid Cell the Card sits in: 3 of 9, or 2 of 6.
+It is then exactly as wide as a Card that spans 3 columns, so the images of horizontal and vertical Cards line up on an index page that mixes the two.
+
+<Canvas of={CardStories.HorizontalLayout} />
 
 ### Top tasks
 

--- a/storybook/src/components/Card/Card.docs.mdx
+++ b/storybook/src/components/Card/Card.docs.mdx
@@ -49,7 +49,9 @@ Displays a `tagline` above the heading.
 ### Image
 
 The image of the Card.
-It accepts all props of a regular Image, such as `aspectRatio`.
+It accepts all props of a regular [Image](/docs/components-media-image--docs), such as `aspectRatio` or a set of image sources.
+Only use decorative images with `alt=""` here.
+Screen readers will not read the `alt` text of non-decorative images when navigating to a Card.
 
 <Canvas of={CardImageStories.Image} />
 
@@ -99,14 +101,6 @@ Wrap the Heading in a Heading Group and set its `tagline` property.
 This ensures screen readers read out the heading before the metadata.
 
 <Canvas of={CardStories.WithTagline} />
-
-### With image
-
-A Card often displays the image of the article it links to.
-The Card Image subcomponent renders an [Image](/docs/components-media-image--docs) component and accepts its properties, e.g. to set an aspect ratio or provide a set of image sources.
-Only use decorative images with `alt=""` here. Screen readers will not read the `alt` text of non-decorative images when navigating to a Card.
-
-<Canvas of={CardStories.WithImage} />
 
 ### Horizontal layout
 
@@ -166,7 +160,7 @@ A screen reader reads the title first, then the rest of the content.
 The layer that makes the Card clickable is empty and carries no text, so it adds nothing to the name of the link and is not announced.
 The rest of the Card stays ordinary content: a paragraph inside it is read as a paragraph, not as part of the link.
 
-An image in a Card is decoration, which is why ‘With image’ asks for an empty `alt`.
+An image in a Card is decoration, which is why the examples pass an empty `alt`.
 A description there would be read when browsing the page but skipped when moving between links, so it would reach some readers and not others.
 
 ## See also

--- a/storybook/src/components/Card/Card.docs.mdx
+++ b/storybook/src/components/Card/Card.docs.mdx
@@ -111,7 +111,7 @@ A Card that has an image but no Content subcomponent stays vertical.
 If the Card spans 9 columns of the Grid, the image covers 4 of them.
 In other contexts, the image scales proportionally.
 
-(Note that this example will appear vertically in a narrow window.)
+The example below is vertical in a narrow window.
 
 <Canvas of={CardStories.HorizontalLayout} />
 

--- a/storybook/src/components/Card/Card.stories.tsx
+++ b/storybook/src/components/Card/Card.stories.tsx
@@ -35,7 +35,7 @@ type DefaultStory = StoryObj<DefaultProps>
 
 export const Default: DefaultStory = {
   args: {
-    aspectRatio: '4:3',
+    aspectRatio: '16:9',
     date: formatDate(Date.now()),
     heading: 'Nederlands eerste houten woonwijk komt in Zuidoost',
     imageSrc: 'https://picsum.photos/480/360',

--- a/storybook/src/components/Card/Card.stories.tsx
+++ b/storybook/src/components/Card/Card.stories.tsx
@@ -11,10 +11,7 @@ import { Card } from '@amsterdam/design-system-react/src'
 import { aspectRatioOptions } from '@amsterdam/design-system-react/src/common/types'
 
 import { maximiseInlineSize, wrapInInlineSizeQueryContainer } from '#storybook/_common/decorators'
-import { exampleTopTask } from '#storybook/_common/exampleContent'
 import { formatDate } from '#storybook/_common/formatDate'
-
-const topTask = exampleTopTask()
 
 const meta = {
   title: 'Components/Navigation/Card',
@@ -25,35 +22,7 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {
-  args: {
-    children: [
-      <Card.Heading key={1} level={2}>
-        <Card.Link href="/">{topTask.heading}</Card.Link>
-      </Card.Heading>,
-      <Paragraph key={2}>{topTask.description}</Paragraph>,
-    ],
-  },
-  decorators: [maximiseInlineSize('24rem')],
-}
-
-export const WithTagline: Story = {
-  args: {
-    children: [
-      <Card.HeadingGroup key={1} tagline="Dossier">
-        <Card.Heading level={2}>
-          <Card.Link href="/">Monitor Attracties MRA</Card.Link>
-        </Card.Heading>
-      </Card.HeadingGroup>,
-      <Paragraph key={2}>
-        Ontwikkeling van het aantal attracties en bezoekers in de metropoolregio Amsterdam.
-      </Paragraph>,
-    ],
-  },
-  decorators: [maximiseInlineSize('24rem')],
-}
-
-type WithImageProps = {
+type DefaultProps = {
   aspectRatio: (typeof aspectRatioOptions)[number]
   date: string
   heading: string
@@ -62,9 +31,9 @@ type WithImageProps = {
   text: string
 } & Readonly<ComponentProps<typeof Card>>
 
-type WithImageStory = StoryObj<WithImageProps>
+type DefaultStory = StoryObj<DefaultProps>
 
-export const WithImage: WithImageStory = {
+export const Default: DefaultStory = {
   args: {
     aspectRatio: '4:3',
     date: formatDate(Date.now()),
@@ -86,7 +55,7 @@ export const WithImage: WithImageStory = {
     text: { control: 'text' },
   },
   // The query container keeps this Card below the width at which it would switch to a horizontal layout.
-  decorators: [maximiseInlineSize('24rem'), wrapInInlineSizeQueryContainer()],
+  decorators: [wrapInInlineSizeQueryContainer(), maximiseInlineSize('24rem')],
   render: ({ aspectRatio, date, heading, imageSrc, tagline, text, ...args }) => (
     <Card {...args}>
       <Card.Image alt="" aspectRatio={aspectRatio} src={imageSrc} />
@@ -105,15 +74,31 @@ export const WithImage: WithImageStory = {
   ),
 }
 
+export const WithTagline: Story = {
+  args: {
+    children: [
+      <Card.HeadingGroup key={1} tagline="Dossier">
+        <Card.Heading level={2}>
+          <Card.Link href="/">Monitor Attracties MRA</Card.Link>
+        </Card.Heading>
+      </Card.HeadingGroup>,
+      <Paragraph key={2}>
+        Ontwikkeling van het aantal attracties en bezoekers in de metropoolregio Amsterdam.
+      </Paragraph>,
+    ],
+  },
+  decorators: [maximiseInlineSize('24rem')],
+}
+
 /**
  * A Card that pairs an image with a Card Content switches to a horizontal layout once its container is wider
  * than 36rem. Resize the container to see it change; the markup is the same in both layouts.
  */
-export const HorizontalLayout: WithImageStory = {
-  args: WithImage.args,
-  argTypes: WithImage.argTypes,
+export const HorizontalLayout: DefaultStory = {
+  args: Default.args,
+  argTypes: Default.argTypes,
   decorators: [wrapInInlineSizeQueryContainer(undefined, { inlineSize: '56rem', maxInlineSize: '100%' })],
-  render: WithImage.render,
+  render: Default.render,
 }
 
 export const TopTasks: Story = {

--- a/storybook/src/components/Card/Card.stories.tsx
+++ b/storybook/src/components/Card/Card.stories.tsx
@@ -10,7 +10,7 @@ import { Column, Grid, Paragraph } from '@amsterdam/design-system-react'
 import { Card } from '@amsterdam/design-system-react/src'
 import { aspectRatioOptions } from '@amsterdam/design-system-react/src/common/types'
 
-import { maximiseInlineSize } from '#storybook/_common/decorators'
+import { maximiseInlineSize, wrapInInlineSizeQueryContainer } from '#storybook/_common/decorators'
 import { exampleTopTask } from '#storybook/_common/exampleContent'
 import { formatDate } from '#storybook/_common/formatDate'
 
@@ -85,21 +85,35 @@ export const WithImage: WithImageStory = {
     tagline: { control: 'text' },
     text: { control: 'text' },
   },
-  decorators: [maximiseInlineSize('24rem')],
+  // The query container keeps this Card below the width at which it would switch to a horizontal layout.
+  decorators: [maximiseInlineSize('24rem'), wrapInInlineSizeQueryContainer()],
   render: ({ aspectRatio, date, heading, imageSrc, tagline, text, ...args }) => (
     <Card {...args}>
       <Card.Image alt="" aspectRatio={aspectRatio} src={imageSrc} />
-      <Card.HeadingGroup tagline={tagline}>
-        <Card.Heading level={3}>
-          <Card.Link href="/">{heading}</Card.Link>
-        </Card.Heading>
-      </Card.HeadingGroup>
-      <Column gap="small">
-        <Paragraph>{text}</Paragraph>
-        <Paragraph size="small">{date}</Paragraph>
-      </Column>
+      <Card.Content>
+        <Card.HeadingGroup tagline={tagline}>
+          <Card.Heading level={3}>
+            <Card.Link href="/">{heading}</Card.Link>
+          </Card.Heading>
+        </Card.HeadingGroup>
+        <Column gap="small">
+          <Paragraph>{text}</Paragraph>
+          <Paragraph size="small">{date}</Paragraph>
+        </Column>
+      </Card.Content>
     </Card>
   ),
+}
+
+/**
+ * A Card that pairs an image with a Card Content switches to a horizontal layout once its container is wider
+ * than 36rem. Resize the container to see it change; the markup is the same in both layouts.
+ */
+export const HorizontalLayout: WithImageStory = {
+  args: WithImage.args,
+  argTypes: WithImage.argTypes,
+  decorators: [wrapInInlineSizeQueryContainer(undefined, { inlineSize: '56rem', maxInlineSize: '100%' })],
+  render: WithImage.render,
 }
 
 export const TopTasks: Story = {

--- a/storybook/src/components/Card/Card.test.stories.tsx
+++ b/storybook/src/components/Card/Card.test.stories.tsx
@@ -43,7 +43,7 @@ const NewsCard = () => (
  */
 export const Test: Story = {
   render: () => (
-    <div style={{ display: 'grid', gap: '2rem' }}>
+    <div className="_ams-tests-stack">
       <div className="ams-query-container-inline-size" style={{ inlineSize: '24rem' }}>
         <NewsCard />
       </div>

--- a/storybook/src/components/Card/Card.test.stories.tsx
+++ b/storybook/src/components/Card/Card.test.stories.tsx
@@ -18,15 +18,10 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-export const Test: Story = {
-  render: (args) => (
-    <Card
-      {...args}
-      style={{
-        maxInlineSize: '24rem',
-      }}
-    >
-      <Card.Image alt="" aspectRatio="4:3" src="https://picsum.photos/id/122/1280/720" />
+const NewsCard = () => (
+  <Card>
+    <Card.Image alt="" aspectRatio="4:3" src="https://picsum.photos/id/122/1280/720" />
+    <Card.Content>
       <Card.HeadingGroup tagline="Nieuws">
         <Card.Heading level={3}>
           <Card.Link href="/">Nederlands eerste houten woonwijk komt in Zuidoost</Card.Link>
@@ -38,7 +33,27 @@ export const Test: Story = {
       <div>
         <p>We bouwen een levendige, groene en duurzame woonbuurt tussen de Gooiseweg en het Nelson Mandelapark.</p>
       </div>
-    </Card>
+    </Card.Content>
+  </Card>
+)
+
+/*
+ * Both sides of the 36rem container width at which a Card with an image and a Content switches to a
+ * horizontal layout. Each Card sits in its own query container, so one snapshot covers both layouts.
+ */
+export const Test: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: '2rem' }}>
+      <div className="ams-query-container-inline-size" style={{ inlineSize: '24rem' }}>
+        <NewsCard />
+      </div>
+      <div className="ams-query-container-inline-size" style={{ inlineSize: '35.9375rem' }}>
+        <NewsCard />
+      </div>
+      <div className="ams-query-container-inline-size" style={{ inlineSize: '48rem' }}>
+        <NewsCard />
+      </div>
+    </div>
   ),
   tags: ['!dev', '!autodocs'],
 }

--- a/storybook/src/components/Card/CardImage.stories.tsx
+++ b/storybook/src/components/Card/CardImage.stories.tsx
@@ -8,6 +8,8 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Card } from '@amsterdam/design-system-react/src'
 import { aspectRatioOptions } from '@amsterdam/design-system-react/src/common/types'
 
+import { maximiseInlineSize } from '#storybook/_common/decorators'
+
 const meta = {
   title: 'Components/Navigation/Card',
   component: Card.Image,
@@ -39,4 +41,10 @@ export const Image: Story = {
     aspectRatio: '16:9',
     src: 'https://picsum.photos/800/450',
   },
+  argTypes: {
+    alt: {
+      description: 'A textual description of the content of the image. Should be empty for `Card.Image`.',
+    },
+  },
+  decorators: [maximiseInlineSize('24rem')],
 }

--- a/storybook/src/components/Skeleton/Skeleton.docs.mdx
+++ b/storybook/src/components/Skeleton/Skeleton.docs.mdx
@@ -146,7 +146,7 @@ In forced colours mode, the blocks remain visible through the system colour for 
 
 ## See also
 
-- [Paragraph](/docs/components-text-paragraph--docs), [Heading](/docs/components-text-heading--docs), and [Table](/docs/components-containers-table--docs), the components a Skeleton stands in for.
+- [Card](/docs/components-navigation-card--docs), [Paragraph](/docs/components-text-paragraph--docs), [Heading](/docs/components-text-heading--docs), [Ordered List](/docs/components-text-ordered-list--docs), [Unordered List](/docs/components-text-unordered-list--docs), [Image](/docs/components-media-image--docs) and [Table](/docs/components-containers-table--docs) – the components a Skeleton can stand in for.
 
 ## Design tokens
 


### PR DESCRIPTION
# Add a horizontal layout and a Content subcomponent

## Links

- [Storybook of this branch](https://designsystem.amsterdam/)
- [Card documentation](https://designsystem.amsterdam/?path=/docs/components-navigation-card--docs)
- [Horizontal layout story](https://designsystem.amsterdam/?path=/story/components-navigation-card--horizontal-layout)

## What

A Card that pairs an image with the new Card Content subcomponent lays out horizontally once its container is wider than 36rem: the image in the first column, everything else beside it. Below that width, and for every Card that does not have both parts, nothing changes.

Card Content is a new subcomponent that groups everything in a Card that is not its image. The documentation page gains a Content section, a Horizontal layout example, and paragraphs under Features, Design and Accessibility that explain the choices. The primary example is now a news Card with an image, which is the Card most services build; a Card of only a heading and a paragraph is still shown under Top tasks.

## Why

Index pages need a row-shaped Card: a list of news items or search results reads better as one Card per row than as a grid of tiles. Whether a Card should be a row or a tile depends on the space it is given rather than on the size of the screen, so the same markup has to work in both places. This branch is the base for the Events Page and the news and search index templates, which all need it.

## How

The layout switches on a container query against the nearest inline-size query container, at a 36rem breakpoint held in a Sass variable because custom properties cannot be used in container queries. The rule applies only to a Card that has both an image and a Content child, so a Card that is not built for this layout stays vertical rather than breaking, and browsers without `:has()` get the vertical layout throughout.

The image covers 4 of the 9 page columns a Card spans, expressed as `calc((4 * 100% - 5 * var(--ams-grid-column-gap)) / 9)`, so that it is exactly as wide as a vertical Card next to it and the images of both line up on a page that mixes them. It keeps its aspect ratio rather than stretching to the height of the text, which needs no alignment declaration: a grid item that has an aspect ratio is start-aligned by default, so the row height comes from whichever column is taller. A new `ams.card.horizontal.column-gap` token sets the space between the image and the content, independent of the Grid gutter the image is measured against.

The test story renders the same Card in three query containers — 24rem, just below the breakpoint, and 48rem — so one snapshot covers both layouts and the switch between them.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

The Default story sits in a query container that keeps it below the breakpoint, so it stays vertical while the Horizontal layout story shows the other side of it.

