### PR TITLE
feat(Storybook): Add a News Overview Page template

### DIFF
--- a/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.docs.mdx
+++ b/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.docs.mdx
@@ -1,0 +1,59 @@
+{/* @license CC0-1.0 */}
+
+import { Meta } from "@storybook/addon-docs/blocks";
+
+import * as NewsOverviewStories from "./NewsOverviewPage.stories.tsx";
+
+<Meta of={NewsOverviewStories} />
+
+# News overview page
+
+An index of content items that a visitor narrows down: news, blogs, vacancies, activities, or search results.
+The page is a filter column beside a list of results, and the same layout serves all of those content types.
+Use a [Home Page](/docs/pages-public-home-page--docs) section instead when a handful of items is enough and nobody needs to filter them.
+
+## Structure
+
+The breadcrumb sits in its own Grid above `main`, as on every public page.
+The Grid below it carries the page title and the search field, and the Grid below that carries the filter column and the results.
+
+Write the filter column first.
+It then precedes the results in the reading and the tab order, which is the order someone filtering wants, and no `start` value has to move it back.
+Give it `as="aside"` and name it with a Heading that `aria-labelledby` points at, so it is reachable as a landmark.
+
+Put the results in a [Grid Subgrid](/docs/components-layout-grid--docs) rather than a Cell.
+A Subgrid hands the columns it spans to its own children, so the Cells inside it sit on the columns of the page.
+Without it the results have no columns of their own, and nothing in them can line up with the rest of the page.
+
+Announce the number of results in a `role="status"` paragraph, and name the filters that produced it.
+A visitor using a screen reader otherwise has no way to tell that ticking a checkbox changed anything.
+
+Compose that sentence with `Intl.ListFormat` rather than joining the values with a hard-coded `en`.
+It applies the punctuation and the conjunction of the language itself, so the sentence survives translation: Dutch writes ‘a, b en c’ where English writes ‘a, b, and c’.
+
+Close the list with [Pagination](/docs/components-navigation-pagination--docs) in a Cell spanning all the columns of the Subgrid.
+Leave it out when everything fits on one page.
+
+## Headings
+
+The page title is the only Heading 1.
+The filter column and the list of results each take a Heading 2, and the title of every result is a Heading 3.
+
+Neither Heading 2 has a place in the design, so both are visually hidden.
+They are still worth having: they name the two halves of the page in the heading outline, which is how a screen reader user skips the filters and reaches the results.
+The heading of the filter column is hidden visually but not from assistive technology, so it still names the landmark that `aria-labelledby` points at.
+
+## Layout and spacing
+
+The filter column takes 3 of the 12 columns on the wide grid and 3 of the 8 on the medium grid.
+The results take the remaining 9 and 5.
+On the narrow grid neither fits beside the other, so both span the full 4 columns and the filter column lands above the results.
+
+A [Card](/docs/components-navigation-card--docs) that pairs an image with a Card Content lays out horizontally once its container is wide enough, which it is at every width where the filter column sits beside the results.
+Its image measures 4 of the 9 columns the Card spans on the wide grid.
+Give a vertical Card beside it a span of 4 and its image is exactly that width too, so the two line up rather than disagreeing about where the images start and end.
+
+The medium grid leaves the results 5 columns, which is not enough for a row.
+Give each Card 4 of those 5 there and leave the last column empty: that is below the width at which a Card with an image goes horizontal, so the Cards turn into a single column of vertical ones and the image spans the full width of each.
+
+Two adjacent Grids add their touching paddings together, so the Grid holding the filter column and the results leaves its `paddingTop` off.

--- a/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.stories.tsx
+++ b/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.stories.tsx
@@ -1,0 +1,319 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import {
+  Breadcrumb,
+  Button,
+  Card,
+  Checkbox,
+  Column,
+  Field,
+  FieldSet,
+  Grid,
+  Heading,
+  Label,
+  Pagination,
+  Paragraph,
+  SearchField,
+  Select,
+} from '@amsterdam/design-system-react'
+
+import { commonMeta } from '../common/commonMeta'
+import { newsArticles, newsCategories, newsDistricts } from './data'
+
+const searchTerm = 'tramspoor'
+const selectedCategories = ['Achtergrond']
+const selectedDistricts = ['Centrum', 'Noord', 'Oost']
+const totalResults = 12
+const totalPages = 2
+
+/**
+ * Intl.ListFormat joins the values with the punctuation and the conjunction of the language itself:
+ * ‘a, b en c’ in Dutch, ‘a, b, and c’ in English. Composing the sentence with it rather than with a
+ * hard-coded ‘en’ keeps it correct once the page is translated.
+ */
+const listFormatter = new Intl.ListFormat('nl', { style: 'long', type: 'conjunction' })
+
+/** Every chosen value is quoted, so it reads as a label rather than as part of the sentence around it. */
+const quotedList = (values: ReadonlyArray<string>) => listFormatter.format(values.map((value) => `‘${value}’`))
+
+/** Several districts are introduced by name of the filter; a single one needs no such introduction. */
+const districtPhrase =
+  selectedDistricts.length === 1 ? quotedList(selectedDistricts) : `de stadsdelen ${quotedList(selectedDistricts)}`
+
+const resultsMessage = `${totalResults} resultaten gevonden voor ‘${searchTerm}’ met soort nieuws ${quotedList(selectedCategories)} en ${districtPhrase}.`
+
+const meta = {
+  ...commonMeta,
+  title: 'Pages/Public/News Overview Page',
+} satisfies Meta
+
+export default meta
+
+export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // Because this story’s `render` takes no argument, the Code Panel prints its source as written, the story
+        // wrapper and its types included. Provide the source by hand so the panel shows the markup to compose,
+        // without that scaffolding.
+        code: `<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  <main id="inhoud">
+    {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+    <Grid paddingBottom="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-m" level={1}>
+          Nieuws uit Amsterdam
+        </Heading>
+        <SearchField>
+          <SearchField.Input defaultValue="tramspoor" label="Zoek in het nieuws" name="trefwoord" />
+          <SearchField.Button>Zoeken</SearchField.Button>
+        </SearchField>
+      </Grid.Cell>
+    </Grid>
+    {/*
+     * Two adjacent Grids add their touching paddings together, so this one leaves its paddingTop off.
+     * The last Grid before the Page Footer takes a paddingBottom of 2x-large.
+     */}
+    <Grid paddingBottom="2x-large">
+      {/*
+       * The filter column comes first in source, so it precedes the results in the reading and tab order.
+       * It only sits beside them from the medium grid up; on narrow screens it spans the full width above them.
+       */}
+      <Grid.Cell aria-labelledby="sorteren-en-filteren" as="aside" span={{ narrow: 4, medium: 3, wide: 3 }}>
+        <Heading className="ams-visually-hidden" id="sorteren-en-filteren" level={2}>
+          Sorteren en filteren
+        </Heading>
+        <form method="get">
+          <Field className="ams-mb-l">
+            <Label htmlFor="sorteren">Sorteren</Label>
+            <Select id="sorteren" name="sorteren">
+              <Select.Option value="nieuwste">Nieuwste eerst</Select.Option>
+              <Select.Option value="oudste">Oudste eerst</Select.Option>
+              <Select.Option value="relevantie">Op relevantie</Select.Option>
+            </Select>
+          </Field>
+          <FieldSet className="ams-mb-l" legend="Soort nieuws">
+            <Column gap="x-small">
+              <Checkbox name="soort" value="algemeen">
+                Algemeen
+              </Checkbox>
+              <Checkbox defaultChecked name="soort" value="achtergrond">
+                Achtergrond
+              </Checkbox>
+              <Checkbox name="soort" value="live blogs">
+                Live blogs
+              </Checkbox>
+            </Column>
+          </FieldSet>
+          <FieldSet className="ams-mb-l" legend="Stadsdelen">
+            <Column gap="x-small">
+              <Checkbox defaultChecked name="stadsdeel" value="centrum">
+                Centrum
+              </Checkbox>
+              {/* … one Checkbox per district … */}
+            </Column>
+          </FieldSet>
+          {/* The design filters as soon as a box is ticked; the button keeps the form usable without that script. */}
+          <Button type="submit">Resultaten tonen</Button>
+        </form>
+      </Grid.Cell>
+      {/*
+       * A Subgrid hands the columns it spans to its own children, so the Cells inside it are placed on the
+       * columns of the page rather than on columns of their own. That is what lines the Cards up with the rest.
+       */}
+      <Grid.Subgrid span={{ narrow: 4, medium: 5, wide: 9 }} start={{ narrow: 1, medium: 4, wide: 4 }}>
+        <Grid.Cell span="all">
+          <Heading className="ams-visually-hidden" level={2}>
+            Nieuwsberichten
+          </Heading>
+          {/* A polite live region, so a screen reader hears the new total when the filters change. */}
+          <Paragraph role="status">{resultsMessage}</Paragraph>
+        </Grid.Cell>
+        {/*
+         * On the medium Grid a Card takes 4 of the 5 columns of the results region, leaving the last one
+         * empty. That is below the width at which a Card with an image goes horizontal, so it stays vertical.
+         */}
+        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 9 }}>
+          <Card>
+            {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
+            <Card.Image alt="" loading="lazy" src="https://picsum.photos/id/122/640/360" />
+            {/* A Card that pairs an image with a Content lays out horizontally in a cell this wide. */}
+            <Card.Content>
+              <Card.HeadingGroup tagline="Algemeen, Centrum, Werkzaamheden">
+                <Card.Heading level={3}>
+                  <Card.Link href="#">Berlagebrug een aantal nachten dicht</Card.Link>
+                </Card.Heading>
+              </Card.HeadingGroup>
+              <Column gap="small">
+                <Paragraph>
+                  Tussen 3 juni en 21 juli leggen we het tramspoor op de Berlagebrug aan. De brug is ongeveer 12
+                  nachten dicht voor gemotoriseerd verkeer en in 3 nachten voor al het verkeer.
+                </Paragraph>
+                <Paragraph size="small">
+                  {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
+                  <time dateTime="2023-10-20">20 oktober 2023</time>
+                </Paragraph>
+              </Column>
+            </Card.Content>
+          </Card>
+        </Grid.Cell>
+        {/* … one Cell per article … */}
+        <Grid.Cell span="all">
+          <Pagination
+            accessibleNameId="paginering"
+            linkTemplate={(page) => \`?pagina=\${page}\`}
+            page={1}
+            totalPages={2}
+          />
+        </Grid.Cell>
+      </Grid.Subgrid>
+    </Grid>
+  </main>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
+  render: () => (
+    <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+      <Grid paddingTop="large">
+        <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+          <Breadcrumb>
+            <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+          </Breadcrumb>
+        </Grid.Cell>
+      </Grid>
+      <main id="inhoud">
+        {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+        <Grid paddingBottom="x-large">
+          <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading className="ams-mb-m" level={1}>
+              Nieuws uit Amsterdam
+            </Heading>
+            <SearchField>
+              <SearchField.Input defaultValue="tramspoor" label="Zoek in het nieuws" name="trefwoord" />
+              <SearchField.Button>Zoeken</SearchField.Button>
+            </SearchField>
+          </Grid.Cell>
+        </Grid>
+        {/*
+         * Two adjacent Grids add their touching paddings together, so this one leaves its paddingTop off.
+         * The last Grid before the Page Footer takes a paddingBottom of 2x-large.
+         */}
+        <Grid paddingBottom="2x-large">
+          {/*
+           * The filter column comes first in source, so it precedes the results in the reading and tab order.
+           * It only sits beside them from the medium grid up; on narrow screens it spans the full width above them.
+           */}
+          <Grid.Cell aria-labelledby="sorteren-en-filteren" as="aside" span={{ narrow: 4, medium: 3, wide: 3 }}>
+            <Heading className="ams-visually-hidden" id="sorteren-en-filteren" level={2}>
+              Sorteren en filteren
+            </Heading>
+            <form method="get">
+              <Field className="ams-mb-l">
+                <Label htmlFor="sorteren">Sorteren</Label>
+                <Select id="sorteren" name="sorteren">
+                  <Select.Option value="nieuwste">Nieuwste eerst</Select.Option>
+                  <Select.Option value="oudste">Oudste eerst</Select.Option>
+                  <Select.Option value="relevantie">Op relevantie</Select.Option>
+                </Select>
+              </Field>
+              <FieldSet className="ams-mb-l" legend="Soort nieuws">
+                <Column gap="x-small">
+                  {newsCategories.map((category) => (
+                    <Checkbox
+                      defaultChecked={selectedCategories.includes(category)}
+                      key={category}
+                      name="soort"
+                      value={category.toLowerCase()}
+                    >
+                      {category}
+                    </Checkbox>
+                  ))}
+                </Column>
+              </FieldSet>
+              <FieldSet className="ams-mb-l" legend="Stadsdelen">
+                <Column gap="x-small">
+                  {newsDistricts.map((district) => (
+                    <Checkbox
+                      defaultChecked={selectedDistricts.includes(district)}
+                      key={district}
+                      name="stadsdeel"
+                      value={district.toLowerCase()}
+                    >
+                      {district}
+                    </Checkbox>
+                  ))}
+                </Column>
+              </FieldSet>
+              {/* The design filters as soon as a box is ticked; the button keeps the form usable without that script. */}
+              <Button type="submit">Resultaten tonen</Button>
+            </form>
+          </Grid.Cell>
+          {/*
+           * A Subgrid hands the columns it spans to its own children, so the Cells inside it are placed on the
+           * columns of the page rather than on columns of their own. That is what lines the Cards up with the rest.
+           */}
+          <Grid.Subgrid span={{ narrow: 4, medium: 5, wide: 9 }} start={{ narrow: 1, medium: 4, wide: 4 }}>
+            <Grid.Cell span="all">
+              <Heading className="ams-visually-hidden" level={2}>
+                Nieuwsberichten
+              </Heading>
+              {/* A polite live region, so a screen reader hears the new total when the filters change. */}
+              <Paragraph role="status">{resultsMessage}</Paragraph>
+            </Grid.Cell>
+            {/*
+             * On the medium Grid a Card takes 4 of the 5 columns of the results region, leaving the last one
+             * empty. That is below the width at which a Card with an image goes horizontal, so it stays vertical.
+             */}
+            {newsArticles.map((article) => (
+              <Grid.Cell key={article.id} span={{ narrow: 4, medium: 4, wide: 9 }}>
+                <Card>
+                  {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
+                  <Card.Image alt="" loading="lazy" src={article.imageSource} />
+                  {/* A Card that pairs an image with a Content lays out horizontally in a cell this wide. */}
+                  <Card.Content>
+                    <Card.HeadingGroup tagline={article.category}>
+                      <Card.Heading level={3}>
+                        <Card.Link href="#">{article.title}</Card.Link>
+                      </Card.Heading>
+                    </Card.HeadingGroup>
+                    <Column gap="small">
+                      <Paragraph>{article.teaser}</Paragraph>
+                      <Paragraph size="small">
+                        {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
+                        <time dateTime={article.isoDate}>{article.date}</time>
+                      </Paragraph>
+                    </Column>
+                  </Card.Content>
+                </Card>
+              </Grid.Cell>
+            ))}
+            <Grid.Cell span="all">
+              <Pagination
+                accessibleNameId="paginering"
+                linkTemplate={(page) => `?pagina=${page}`}
+                page={1}
+                totalPages={totalPages}
+              />
+            </Grid.Cell>
+          </Grid.Subgrid>
+        </Grid>
+      </main>
+    </>
+  ),
+}

--- a/storybook/src/pages/public/NewsOverviewPage/data.ts
+++ b/storybook/src/pages/public/NewsOverviewPage/data.ts
@@ -1,0 +1,102 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { exampleImageSource } from '#storybook/_common/exampleContent'
+
+export type NewsArticle = {
+  readonly category: string
+  readonly date: string
+  readonly id: string
+  readonly imageSource: string
+  readonly isoDate: string
+  readonly teaser: string
+  readonly title: string
+}
+
+export const newsCategories: ReadonlyArray<string> = ['Algemeen', 'Achtergrond', 'Live blogs']
+
+export const newsDistricts: ReadonlyArray<string> = [
+  'Centrum',
+  'Noord',
+  'Oost',
+  'Zuid',
+  'Zuidoost',
+  'West',
+  'Nieuw-West',
+  'Weesp',
+]
+
+export const newsArticles: ReadonlyArray<NewsArticle> = [
+  {
+    title: 'Berlagebrug een aantal nachten dicht',
+    category: 'Algemeen, Centrum, Werkzaamheden',
+    date: '20 oktober 2023',
+    id: 'berlagebrug',
+    imageSource: exampleImageSource(640, 360, 0),
+    isoDate: '2023-10-20',
+    teaser:
+      'Tussen 3 juni en 21 juli leggen we het tramspoor op de Berlagebrug aan. De brug is ongeveer 12 nachten dicht voor gemotoriseerd verkeer en in 3 nachten voor al het verkeer.',
+  },
+  {
+    title: 'Het allereerste beroepsbrandweerkorps van Nederland bestaat 150 jaar',
+    category: 'Achtergrond',
+    date: '18 oktober 2023',
+    id: 'brandweerkorps',
+    imageSource: exampleImageSource(640, 360, 1),
+    isoDate: '2023-10-18',
+    teaser:
+      'In de zomer van 1874 werd het allereerste beroepsbrandweerkorps van Nederland opgericht: de huidige Brandweer Amsterdam-Amstelland.',
+  },
+  {
+    title: 'Noorderpark wordt groener en beter toegankelijk',
+    category: 'Algemeen, Noord',
+    date: '16 oktober 2023',
+    id: 'noorderpark',
+    imageSource: exampleImageSource(640, 360, 2),
+    isoDate: '2023-10-16',
+    teaser:
+      'Het Noorderpark krijgt meer schaduw, ruimere wandelpaden en een speelveld dat ook bij regen bruikbaar blijft. De werkzaamheden beginnen na de zomer.',
+  },
+  {
+    title: 'Zuidoost viert 750 jaar Amsterdam: vraag subsidie aan voor uw initiatief',
+    category: 'Algemeen, Zuidoost',
+    date: '13 oktober 2023',
+    id: 'zuidoost-subsidie',
+    imageSource: exampleImageSource(640, 360, 3),
+    isoDate: '2023-10-13',
+    teaser:
+      'Bewoners en organisaties in Zuidoost kunnen tot 1 december subsidie aanvragen voor een buurtinitiatief dat bijdraagt aan de viering van 750 jaar Amsterdam.',
+  },
+  {
+    title: 'Live blog: werkzaamheden aan kades en bruggen',
+    category: 'Live blogs',
+    date: '11 oktober 2023',
+    id: 'kades-bruggen',
+    imageSource: exampleImageSource(640, 360, 4),
+    isoDate: '2023-10-11',
+    teaser:
+      'We vernieuwen de komende jaren honderden kilometers kade en honderden bruggen. In dit live blog houden we bij welke werkzaamheden er deze week starten.',
+  },
+  {
+    title: 'Erfgoed van de week: het wonderkind van de Amsterdamse School',
+    category: 'Achtergrond, West',
+    date: '9 oktober 2023',
+    id: 'amsterdamse-school',
+    imageSource: exampleImageSource(640, 360, 5),
+    isoDate: '2023-10-09',
+    teaser:
+      'De woningblokken in de Spaarndammerbuurt gelden als het hoogtepunt van de Amsterdamse School. Honderd jaar later wonen er nog steeds Amsterdammers.',
+  },
+  {
+    title: 'Wat vindt u van de inzameling van grof afval in Amsterdam?',
+    category: 'Algemeen, Oost',
+    date: '6 oktober 2023',
+    id: 'grof-afval',
+    imageSource: exampleImageSource(640, 360, 6),
+    isoDate: '2023-10-06',
+    teaser:
+      'We willen weten hoe Amsterdammers de inzameling van grof afval ervaren. Vul de vragenlijst in en vertel wat er volgens u beter kan.',
+  },
+]


### PR DESCRIPTION
# Describe the pull request

## Links

- [Storybook of this branch](https://designsystem.amsterdam/)
- [The News Overview Page story](https://designsystem.amsterdam/?path=/story/pages-public-news-overview-page--default)
- [The News Overview Page documentation](https://designsystem.amsterdam/?path=/docs/pages-public-news-overview-page--docs)

## What

Adds a News Overview Page template under `Pages/Public`: an index page with a filter column beside a list of results, a search field above them and pagination below. One story, `Default`.

## Why

News, blogs, vacancies, activities and search results all share this layout, so one template serves all of them. Nothing in the system showed how to compose the parts: how the results line up with the columns of the page, where the filter column belongs in the source order, and how someone using a screen reader learns that ticking a checkbox changed the results.

## How

The results sit in a Grid Subgrid rather than a Cell, so the Cells inside them are placed on the columns of the page and the Cards line up with the search field and the breadcrumb above them.

The filter column is written first. It then precedes the results in the reading and the tab order, which is the order someone filtering wants, and no `start` value has to move it back. On the narrow grid it spans the full width above the results. It is an `aside` named by its Heading through `aria-labelledby`, so it is reachable as a landmark.

Neither Heading 2 has a place in the design, so both are visually hidden. They still name the two halves of the page in the heading outline, which is how a screen reader user skips the filters and reaches the results. Hiding the heading of the filter column visually leaves it in the accessibility tree, so it goes on naming the landmark.

The number of results is announced in a `role="status"` paragraph that also names the filters that produced it. That sentence is composed with `Intl.ListFormat` rather than a hard-coded `en`, so it takes the punctuation and the conjunction of the language the page is translated into.

A Card that pairs an image with a Card Content lays out horizontally at every width where the filter column sits beside the results. Its image measures 4 of the 9 columns the Card spans on the wide grid. The medium grid leaves the results 5 columns, which is not enough for a row, so each Card takes 4 of those 5 and the Cards turn into a single column of vertical ones.

The newsletter Spotlight that the design insets in the results column is left out. An inset Spotlight needs padding, and the system has margin and gap utilities but no padding utility yet.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11)

## Additional notes

The results sentence uses `Intl.ListFormat`, which the ES2020 lib does not declare. The branch takes the ES2023 raise from #2863 through a merge from `develop`, so it type-checks.
