### PR TITLE
chore: Raise the TypeScript lib to ES2023

### DIFF
--- a/packages-proprietary/react-icons/tsconfig.json
+++ b/packages-proprietary/react-icons/tsconfig.json
@@ -10,7 +10,7 @@
     "incremental": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "es2020"],
+    "lib": ["dom", "es2023"],
     "module": "es2020",
     "moduleResolution": "bundler",
     "noUnusedLocals": true,

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -10,7 +10,7 @@
     "incremental": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "es2020"],
+    "lib": ["dom", "es2023"],
     "module": "es2020",
     "moduleResolution": "bundler",
     "noUnusedLocals": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "jsx": "react-jsx",
-    "lib": ["es2020", "dom"],
+    "lib": ["dom", "es2023"],
     "module": "es2020",
     "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
# Describe the pull request

## Links

- [Browser support](https://github.com/Amsterdam/design-system/blob/develop/storybook/src/docs/developer-guide/browser-support.docs.mdx), the page stating the policy this aligns the compiler with.

## What

Raises the TypeScript `lib` from ES2020 to ES2023, in the root config and in the two package configs that do not extend it. `target` and `module` are untouched, so nothing about the emitted output moves.

## Why

Browser support is Baseline 'Widely available', and the developer guide says the linters enforce it. `baseline-js/use-baseline` does exactly that: per feature, by date, on the same policy the CSS follows through `plugin/use-baseline`.

The `lib` setting was a second and cruder gate. It is a year bucket: it admits everything up to its year and rejects everything after, however long a feature has actually been in all four browsers. The two gates disagreed in practice. `String.prototype.at` has been widely available for years and passes the linter, but the ES2020 lib rejected it outright, and the compiler suggested raising the lib as the fix. Deciding browser support twice, once well and once badly, means the bad answer wins.

This came up because a story needed `Intl.ListFormat` to build a sentence that survives translation, and the inherited ES2020 lib did not declare it. Raising the lib one year per feature that trips over it is not a policy, so this raises it to where the widely available set has reached and leaves the per-feature judgement to the linter that reasons about it correctly.

## How

Three one-line changes. `packages/react` and `packages-proprietary/react-icons` keep a `lib` of their own rather than inheriting the root value, because neither extends the root config: it sets `noEmit` along with a stricter set of checks that a publishable package cannot simply take on. Wiring them to it fails the build outright, since the declarations are never emitted and the rollup dts step has no entry module. Deleting their line instead would fall back to the default that `target` implies, which is the ES2020 they already had. `storybook/tsconfig.json` does extend the root, so it needs no change.

Raising the lib does not permit a feature. It only stops the compiler vetoing one the policy already allows, and leaves the veto to the linter. Building `packages/react` before and after produces a byte-identical `dist`, down to the checksum of every file; the build was confirmed deterministic first with an unchanged control rebuild. The React unit tests, both typechecks and the repository lint all pass.

Worth a second opinion: whether the same reasoning should eventually move `target`, which unlike `lib` does rewrite the published bundle. It is a genuine compatibility contract here, because the rollup pipeline runs `@babel/preset-react` without `preset-env`, so nothing downlevels after TypeScript. Building at ES2022 today changes exactly one line of output, a `??=` that no longer needs its downlevelled form, for 28 bytes on a 208 KB bundle. Not worth the churn now, but worth revisiting if the source ever leans on newer syntax.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

No documentation change was needed: the browser support page already describes the linters as the enforcement mechanism and never mentions the compiler, which is precisely the gap this closes.

One interaction to watch. `feat/DES-1950-news-overview-page` carries a commit that adds `"lib": ["es2021", "dom"]` to `storybook/tsconfig.json`, added before this branch existed. Once this merges that override becomes redundant, and worse, it would pull Storybook back below the root value. It should be dropped when that branch next rebases.
