### PR TITLE
chore(deps): Resolve the Dependabot security alerts via pnpm overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,12 @@ overrides:
   brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
   brace-expansion@>=3.0.0 <5.0.7: ^5.0.7
   esbuild@<0.28.1: ^0.28.1
+  fast-uri@<3.1.4: ^3.1.4
   js-yaml@<4.3.0: ^4.3.0
   sigstore@<4.1.1: ^4.1.1
+  svgo@>=3.0.0 <3.3.4: ^3.3.4
   tar: ^7.5.19
+  valibot@<1.4.2: ^1.4.2
 
 packageExtensionsChecksum: sha256-M0OA4c/8RneRmye72JnuYDFacaS6F+DBhvG/ABGnAjM=
 
@@ -1980,7 +1983,7 @@ packages:
     resolution: {integrity: sha512-drirZeNinhYLiRSMksN+m//u0ImFxtGRk1Vp425Xp/7CbBXFQdjAG+f7grssyHAukbVTGzmWsMMP6ejrGVErUA==}
     peerDependencies:
       tmcp: ^1.17.0
-      valibot: ^1.1.0
+      valibot: ^1.4.2
 
   '@tmcp/session-manager@0.2.2':
     resolution: {integrity: sha512-UrCRpTsxh5XnMbplspvftEYboiZWgAiXqqAUbyFTHoHMJ0LoNDy8bQd0+7qtxtT4S5Qsnv650gvs/Nbec5NTCQ==}
@@ -2335,7 +2338,7 @@ packages:
   '@valibot/to-json-schema@1.7.1':
     resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
     peerDependencies:
-      valibot: ^1.4.0
+      valibot: ^1.4.2
 
   '@vitejs/plugin-react@6.0.4':
     resolution: {integrity: sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==}
@@ -2607,11 +2610,6 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  baseline-browser-mapping@2.11.1:
-    resolution: {integrity: sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   baseline-browser-mapping@2.11.7:
     resolution: {integrity: sha512-APw5YuIQAg6L9w4sHDI6j26DGFJI6RpYOhnkMPdC9lWbkKvsyPHzDsve1yd73lk21yz7Y09Kci8B2Pp9FonzWA==}
@@ -3357,8 +3355,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -5466,8 +5464,8 @@ packages:
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
-  svgo@3.3.3:
-    resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
+  svgo@3.3.4:
+    resolution: {integrity: sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -5733,8 +5731,8 @@ packages:
     resolution: {integrity: sha512-fcRLaS4H/hrZk9hYwbdRM35D0U8IYMfEClhXxCivOojl+yTRAZH3Zy2sSy6qVCiGbV9YAtPssP6jaChqC9vPCg==}
     engines: {node: '>= 10.13.0'}
 
-  valibot@1.2.0:
-    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -5951,18 +5949,6 @@ packages:
   write-file-atomic@7.0.1:
     resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
     engines: {node: ^20.17.0 || >=22.9.0}
-
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   ws@8.21.1:
     resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
@@ -7236,12 +7222,12 @@ snapshots:
   '@storybook/addon-mcp@0.7.0(storybook@10.5.5(@types/react@18.3.31)(prettier@3.9.6)(react@18.3.1))(typescript@6.0.3)':
     dependencies:
       '@storybook/mcp': 0.8.0(typescript@6.0.3)
-      '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))
+      '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.2(typescript@6.0.3))
       '@tmcp/transport-http': 0.8.6(tmcp@1.19.4(typescript@6.0.3))
       picoquery: 2.5.0
       storybook: 10.5.5(@types/react@18.3.31)(prettier@3.9.6)(react@18.3.1)
       tmcp: 1.19.4(typescript@6.0.3)
-      valibot: 1.2.0(typescript@6.0.3)
+      valibot: 1.4.2(typescript@6.0.3)
     transitivePeerDependencies:
       - '@tmcp/auth'
       - typescript
@@ -7274,10 +7260,10 @@ snapshots:
 
   '@storybook/mcp@0.8.0(typescript@6.0.3)':
     dependencies:
-      '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))
+      '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.2(typescript@6.0.3))
       '@tmcp/transport-http': 0.8.6(tmcp@1.19.4(typescript@6.0.3))
       tmcp: 1.19.4(typescript@6.0.3)
-      valibot: 1.2.0(typescript@6.0.3)
+      valibot: 1.4.2(typescript@6.0.3)
     transitivePeerDependencies:
       - '@tmcp/auth'
       - typescript
@@ -7431,7 +7417,7 @@ snapshots:
       '@svgr/core': 8.1.0(supports-color@10.2.2)(typescript@6.0.3)
       cosmiconfig: 8.3.6(typescript@6.0.3)
       deepmerge: 4.3.1
-      svgo: 3.3.3
+      svgo: 3.3.4
     transitivePeerDependencies:
       - typescript
 
@@ -7479,12 +7465,12 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tmcp/adapter-valibot@0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))':
+  '@tmcp/adapter-valibot@0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.2(typescript@6.0.3))':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@valibot/to-json-schema': 1.7.1(valibot@1.2.0(typescript@6.0.3))
+      '@valibot/to-json-schema': 1.7.1(valibot@1.4.2(typescript@6.0.3))
       tmcp: 1.19.4(typescript@6.0.3)
-      valibot: 1.2.0(typescript@6.0.3)
+      valibot: 1.4.2(typescript@6.0.3)
 
   '@tmcp/session-manager@0.2.2(tmcp@1.19.4(typescript@6.0.3))':
     dependencies:
@@ -7835,9 +7821,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@valibot/to-json-schema@1.7.1(valibot@1.2.0(typescript@6.0.3))':
+  '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))':
     dependencies:
-      valibot: 1.2.0(typescript@6.0.3)
+      valibot: 1.4.2(typescript@6.0.3)
 
   '@vitejs/plugin-react@6.0.4(vite@8.1.5(@types/node@25.7.0)(esbuild@0.28.1)(sass@1.102.0)(terser@5.47.1)(yaml@2.9.0))':
     dependencies:
@@ -7974,7 +7960,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8140,8 +8126,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.11.1: {}
-
   baseline-browser-mapping@2.11.7: {}
 
   binary-extensions@2.3.0: {}
@@ -8181,7 +8165,7 @@ snapshots:
 
   browserslist@4.28.5:
     dependencies:
-      baseline-browser-mapping: 2.11.1
+      baseline-browser-mapping: 2.11.7
       caniuse-lite: 1.0.30001803
       electron-to-chromium: 1.5.389
       node-releases: 2.0.51
@@ -9004,7 +8988,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fastest-levenshtein@1.0.16: {}
 
@@ -9671,7 +9655,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.21.0
+      ws: 8.21.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -11647,7 +11631,7 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
-  svgo@3.3.3:
+  svgo@3.3.4:
     dependencies:
       commander: 7.2.0
       css-select: 5.2.2
@@ -11728,7 +11712,7 @@ snapshots:
       json-rpc-2.0: 1.7.1
       sqids: 0.3.0
       uri-template-matcher: 1.1.2
-      valibot: 1.2.0(typescript@6.0.3)
+      valibot: 1.4.2(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
@@ -11987,7 +11971,7 @@ snapshots:
 
   v8flags@4.0.1: {}
 
-  valibot@1.2.0(typescript@6.0.3):
+  valibot@1.4.2(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 
@@ -12035,7 +12019,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.23
+      postcss: 8.5.25
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -12195,8 +12179,6 @@ snapshots:
   write-file-atomic@7.0.1:
     dependencies:
       signal-exit: 4.1.0
-
-  ws@8.21.0: {}
 
   ws@8.21.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,9 +9,12 @@ overrides:
   "brace-expansion@>=2.0.0 <2.1.2": "^2.1.2"
   "brace-expansion@>=3.0.0 <5.0.7": "^5.0.7"
   "esbuild@<0.28.1": "^0.28.1"
+  "fast-uri@<3.1.4": "^3.1.4"
   "js-yaml@<4.3.0": "^4.3.0"
   "sigstore@<4.1.1": "^4.1.1"
+  "svgo@>=3.0.0 <3.3.4": "^3.3.4"
   tar: "^7.5.19"
+  "valibot@<1.4.2": "^1.4.2"
 # stylelint-plugin-defensive-css imports postcss-selector-parser at runtime but lists it under
 # devDependencies, which consumers never receive. Without this, the plugin resolves that import
 # only by chance, through whichever packages pnpm happens to have hoisted into the virtual store,


### PR DESCRIPTION
# Describe the pull request

## Links

- [Security › Dependabot](https://github.com/Amsterdam/design-system/security/dependabot), the four open alerts this closes.
- [#2706](https://github.com/Amsterdam/design-system/pull/2706), the previous round of overrides this follows.
- [This branch’s deploy](https://designsystem.amsterdam/).
- [Icons](https://designsystem.amsterdam/?path=/docs/brand-assets-icons--docs) and [Logo](https://designsystem.amsterdam/?path=/docs/components-media-logo--docs), the two sets SVGO regenerates, for checking that nothing about them moved.

## What

Resolves the four open Dependabot alerts by pinning three transitive dependencies to patched versions through `pnpm-workspace.yaml` overrides:

| Package | Was | Now | Advisory |
| --- | --- | --- | --- |
| `svgo` | 3.3.3 | **3.3.4** | [GHSA-2p49-hgcm-8545](https://github.com/advisories/GHSA-2p49-hgcm-8545) — high, `removeScripts` leaves some executable scripts intact |
| `fast-uri` | 3.1.2 | **3.1.4** | [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) and [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) — high, host confusion |
| `valibot` | 1.2.0 | **1.4.2** | [GHSA-5qjj-4xww-7phc](https://github.com/advisories/GHSA-5qjj-4xww-7phc) — moderate, `flatten()` throws on inherited `Object` property names |

## Why

All four alerts sit on the default branch, and all three packages arrive transitively, so none of them can be raised by editing a manifest. `svgo` comes in through `@svgr/plugin-svgo` in the SVGR chain that generates the icons and the Logo brands; `fast-uri` through `ajv` and `table` under Stylelint; `valibot` through the Storybook MCP addon.

`valibot` is the one that genuinely needs an override rather than a lockfile bump. Both `@storybook/addon-mcp` and `@storybook/mcp` depend on exactly `1.2.0`, and 0.7.0 is the latest release, so no upstream version lifts the pin. `svgo` and `fast-uri` would reach a patched version on a plain update, since their dependents accept `^3.0.2` and `^3.0.1`. They are pinned anyway so that each entry records which advisory it answers and a later resolution cannot slide back.

Worth noting for the risk assessment: none of these reach anyone installing the packages. No published package lists any of the three as a runtime dependency, so the "runtime" scope Dependabot reports for `svgo` and `valibot` reflects the lockfile importer rather than the actual dependency type. The `svgo` advisory is also narrower than it looks here, because `removeScripts` is not part of `preset-default`, which is all either SVGR config enables, so the affected plugin was never switched on.

Raising `valibot` settles a peer dependency that was already being violated as well: `@valibot/to-json-schema` asks for `^1.4.0` and was resolving against 1.2.0. `pnpm peers check` is now quiet about it.

## How

- Added `svgo@>=3.0.0 <3.3.4`, `fast-uri@<3.1.4` and `valibot@<1.4.2` overrides. The `svgo` range is bounded below so the 4.x copy that `@amsterdam/design-system-assets` uses, which is already patched, stays where it is.
- Regenerated the lockfile. All three now resolve to a single patched version each, and `svgo` 3.3.3, `fast-uri` 3.1.2 and `valibot` 1.2.0 are gone from it entirely.

`svgo` was the bump that needed proof rather than argument, since it rewrites committed source. Regenerating both `packages-proprietary/react-icons/src` and `packages/react/src/Logo/brands` on 3.3.4 produced byte-identical output, so no generated file moves in this PR.

Beyond that, the build, the linters and the full test suite (1,647 tests) pass, a `--frozen-lockfile` install from a pristine checkout resolves only the patched versions, and `flatten()` on the exact case from the `valibot` advisory now returns `{}` instead of throwing.

The lockfile diff is a net reduction, because re-resolving those subtrees also collapsed duplicate copies of `baseline-browser-mapping`, `ws` and `postcss` onto versions that were already in the tree. The three patched versions are the only entries this adds.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- No source or component changes, so no visual diffs are expected.
- The default branch is `develop`, so the alerts close on merge here rather than waiting for a release.
