### PR TITLE
feat(Storybook): Add a Search Results Page template

### DIFF
--- a/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.docs.mdx
+++ b/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.docs.mdx
@@ -49,6 +49,10 @@ The filter column takes 3 of the 12 columns on the wide grid and 3 of the 8 on t
 The results take the remaining 9 and 5.
 On the narrow grid neither fits beside the other, so both span the full 4 columns and the filter column lands above the results.
 
+The sentence that announces the total is running text, so give its Cell 7 of the 12 columns rather than the 9 the results span.
+That is the line length the body of a content page takes, and a sentence naming several filters is long enough to reach it.
+A Card spans all 9: its image takes 4 of them, so the text beside it stays well inside that maximum.
+
 A [Card](/docs/components-navigation-card--docs) that pairs an image with a Card Content lays out horizontally once its container is wide enough, which it is at every width where the filter column sits beside the results.
 Its image measures 4 of the 9 columns the Card spans on the wide grid.
 Give a vertical Card beside it a span of 4 and its image is exactly that width too, so the two line up rather than disagreeing about where the images start and end.

--- a/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.stories.tsx
+++ b/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.stories.tsx
@@ -135,7 +135,8 @@ export const Default: StoryObj = {
        * columns of the page rather than on columns of their own. That is what lines the Cards up with the rest.
        */}
       <Grid.Subgrid span={{ narrow: 4, medium: 5, wide: 9 }} start={{ narrow: 1, medium: 4, wide: 4 }}>
-        <Grid.Cell span="all">
+        {/* The sentence is running text, which takes at most 7 of the 12 columns, so it stops short of the Cards. */}
+        <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
           <Heading className="ams-visually-hidden" level={2}>
             Nieuwsberichten
           </Heading>
@@ -269,7 +270,8 @@ export const Default: StoryObj = {
            * columns of the page rather than on columns of their own. That is what lines the Cards up with the rest.
            */}
           <Grid.Subgrid span={{ narrow: 4, medium: 5, wide: 9 }} start={{ narrow: 1, medium: 4, wide: 4 }}>
-            <Grid.Cell span="all">
+            {/* The sentence is running text, which takes at most 7 of the 12 columns, so it stops short of the Cards. */}
+            <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
               <Heading className="ams-visually-hidden" level={2}>
                 Nieuwsberichten
               </Heading>

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.docs.mdx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.docs.mdx
@@ -1,0 +1,59 @@
+{/* @license CC0-1.0 */}
+
+import { Meta } from "@storybook/addon-docs/blocks";
+
+import * as SearchResultsStories from "./SearchResultsPage.stories.tsx";
+
+<Meta of={SearchResultsStories} />
+
+# Search results page
+
+What a visitor lands on after searching the site.
+It shares its layout with the [News Overview Page](/docs/pages-public-news-overview-page--docs): a filter column beside a list of results.
+The difference is the content, which comes from anywhere on the site and therefore has no image and no single content type.
+
+## Structure
+
+The breadcrumb sits in its own Grid above `main`, and the Grid below it carries the page title and the search field.
+
+Repeat the search field on the results page and fill it with the term that was searched for.
+Refining a search is the most common thing to do next, and a visitor who has to go back to find the field will type the whole query again.
+
+[Search Field](/docs/components-forms-search-field--docs) renders its own `form` with `role="search"`, so it needs no form around it.
+Keep it out of the filter form as well: nesting one `form` inside another is invalid HTML, and the two submit different things.
+
+Put the results in a [Grid Subgrid](/docs/components-layout-grid--docs) and announce the total in a `role="status"` paragraph, as on any index page.
+Name the term that was searched for in that sentence, so it is clear what produced the list.
+
+## Headings
+
+The page title is the only Heading 1, and it names the activity rather than the query.
+The filter column and the list of results each take a Heading 2, and the title of every result is a Heading 3.
+Neither Heading 2 has a place in the design, so both are visually hidden, as on the News Overview Page.
+The heading of the filter column is hidden visually but not from assistive technology, so it still names the landmark that `aria-labelledby` points at.
+
+A result title is the title of the page it links to.
+Do not shorten it to fit, and do not mark the matched words inside it: a highlight inside a link makes the link harder to read out.
+
+## Layout and spacing
+
+The filter column takes 3 of the 12 columns on the wide grid and 3 of the 8 on the medium grid, and the results take the remaining 9 and 5.
+On the narrow grid both span the full 4 columns and the filter column lands above the results.
+
+A search result has no image, so its [Card](/docs/components-navigation-card--docs) needs no Card Content and stays vertical at every width.
+Give its Cell 7 of the 12 columns on the wide grid: that is the line length the body of a content page takes, and running text is no easier to read here than there.
+The medium grid leaves the results 5 columns, which is under that maximum already, so a result takes the full width of the region there.
+The News Overview Page gives a Card 4 of those 5 to keep it below the width at which its image turns it horizontal, and a Card without an image needs no such room.
+
+Give the Pagination the width of the results above it rather than that of the region, so the column has one edge.
+Leave the row gap of the Subgrid at the vertical gap of the Grid.
+
+## Default
+
+A page of results with the term still in the search field.
+
+## No results
+
+An empty result set is a normal outcome, not an error, so the page says so plainly and offers a way on.
+The count is still announced, so a visitor using a screen reader hears that the search ran and returned nothing.
+Suggest what to change — a shorter term, a different word, or fewer filters — and give a way to clear the filters in one action.

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
@@ -1,0 +1,450 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import {
+  Alert,
+  Breadcrumb,
+  Button,
+  Card,
+  Checkbox,
+  Column,
+  Field,
+  FieldSet,
+  Grid,
+  Heading,
+  Label,
+  Pagination,
+  Paragraph,
+  SearchField,
+  Select,
+  StandaloneLink,
+} from '@amsterdam/design-system-react'
+
+import { commonMeta } from '../common/commonMeta'
+import { searchResults, searchTopics } from './data'
+
+const searchTerm = 'veiligheid'
+const totalResults = 62
+const totalPages = 8
+
+const meta = {
+  ...commonMeta,
+  title: 'Pages/Public/Search Results Page',
+} satisfies Meta
+
+export default meta
+
+export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // Because this story’s `render` takes no argument, the Code Panel prints its source as written, the story
+        // wrapper and its types included. Provide the source by hand so the panel shows the markup to compose,
+        // without that scaffolding.
+        code: `<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  <main id="inhoud">
+    {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+    <Grid paddingBottom="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-m" level={1}>
+          Zoeken
+        </Heading>
+        {/* Search Field renders its own form with role=search, so it needs no form around it. */}
+        <SearchField>
+          <SearchField.Input defaultValue="veiligheid" label="Zoek op amsterdam.nl" name="trefwoord" />
+          <SearchField.Button>Zoeken</SearchField.Button>
+        </SearchField>
+      </Grid.Cell>
+    </Grid>
+    {/*
+     * Two adjacent Grids add their touching paddings together, so this one leaves its paddingTop off.
+     * The last Grid before the Page Footer takes a paddingBottom of 2x-large.
+     */}
+    <Grid paddingBottom="2x-large">
+      {/*
+       * The filter column comes first in source, so it precedes the results in the reading and tab order.
+       * It only sits beside them from the medium grid up; on narrow screens it spans the full width above them.
+       */}
+      <Grid.Cell aria-labelledby="sorteren-en-filteren" as="aside" span={{ narrow: 4, medium: 3, wide: 3 }}>
+        <Heading className="ams-visually-hidden" id="sorteren-en-filteren" level={2}>
+          Sorteren en filteren
+        </Heading>
+        <form method="get">
+          <Field className="ams-mb-l">
+            <Label htmlFor="sorteren">Sorteren</Label>
+            <Select id="sorteren" name="sorteren">
+              <Select.Option value="relevantie">Op relevantie</Select.Option>
+              <Select.Option value="nieuwste">Nieuwste eerst</Select.Option>
+            </Select>
+          </Field>
+          <FieldSet className="ams-mb-l" legend="Soort artikel">
+            <Column gap="x-small">
+              <Checkbox name="soort" value="nieuwsbericht">
+                Nieuwsbericht
+              </Checkbox>
+              {/* … one Checkbox per topic … */}
+            </Column>
+          </FieldSet>
+          {/* The design filters as soon as a box is ticked; the button keeps the form usable without that script. */}
+          <Button type="submit">Resultaten tonen</Button>
+        </form>
+      </Grid.Cell>
+      {/*
+       * A Subgrid hands the columns it spans to its own children, so the Cells inside it are placed on the
+       * columns of the page rather than on columns of their own.
+       */}
+      <Grid.Subgrid span={{ narrow: 4, medium: 5, wide: 9 }} start={{ narrow: 1, medium: 4, wide: 4 }}>
+        {/* Prose takes at most 7 of the 12 columns, so on the wide grid these Cells stop short of the 9 beside the filters. */}
+        <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+          <Heading className="ams-visually-hidden" level={2}>
+            Zoekresultaten
+          </Heading>
+          {/* A polite live region, so a screen reader hears the new total when the search or the filters change. */}
+          <Paragraph role="status">62 resultaten gevonden voor ‘veiligheid’</Paragraph>
+        </Grid.Cell>
+        <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+          {/* A search result has no image, so this Card needs no Card Content and stays vertical at any width. */}
+          <Card>
+            <Card.HeadingGroup tagline="Actiecentrum Veiligheid en Zorg">
+              <Card.Heading level={3}>
+                <Card.Link href="#">Top 400/600</Card.Link>
+              </Card.Heading>
+            </Card.HeadingGroup>
+            <Column gap="small">
+              <Paragraph>
+                Om de stad veiliger te maken coördineert de gemeente, samen met haar maatschappelijke partners,
+                vanuit het Actiecentrum Veiligheid en Zorg verschillende aanpakken op het snijvlak van veiligheid,
+                zorg en het sociaal domein.
+              </Paragraph>
+              <Paragraph size="small">
+                {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
+                <time dateTime="2023-07-01">1 juli 2023</time>
+              </Paragraph>
+            </Column>
+          </Card>
+        </Grid.Cell>
+        {/* … one Cell per result … */}
+        {/* The Pagination takes the width of the results above it rather than that of the region. */}
+        <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+          <Pagination accessibleNameId="paginering" linkTemplate={(page) => \`?pagina=\${page}\`} page={1} totalPages={8} />
+        </Grid.Cell>
+      </Grid.Subgrid>
+    </Grid>
+  </main>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
+  render: () => (
+    <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+      <Grid paddingTop="large">
+        <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+          <Breadcrumb>
+            <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+          </Breadcrumb>
+        </Grid.Cell>
+      </Grid>
+      <main id="inhoud">
+        {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+        <Grid paddingBottom="x-large">
+          <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading className="ams-mb-m" level={1}>
+              Zoeken
+            </Heading>
+            {/* Search Field renders its own form with role=search, so it needs no form around it. */}
+            <SearchField>
+              <SearchField.Input defaultValue={searchTerm} label="Zoek op amsterdam.nl" name="trefwoord" />
+              <SearchField.Button>Zoeken</SearchField.Button>
+            </SearchField>
+          </Grid.Cell>
+        </Grid>
+        {/*
+         * Two adjacent Grids add their touching paddings together, so this one leaves its paddingTop off.
+         * The last Grid before the Page Footer takes a paddingBottom of 2x-large.
+         */}
+        <Grid paddingBottom="2x-large">
+          {/*
+           * The filter column comes first in source, so it precedes the results in the reading and tab order.
+           * It only sits beside them from the medium grid up; on narrow screens it spans the full width above them.
+           */}
+          <Grid.Cell aria-labelledby="sorteren-en-filteren" as="aside" span={{ narrow: 4, medium: 3, wide: 3 }}>
+            <Heading className="ams-visually-hidden" id="sorteren-en-filteren" level={2}>
+              Sorteren en filteren
+            </Heading>
+            <form method="get">
+              <Field className="ams-mb-l">
+                <Label htmlFor="sorteren">Sorteren</Label>
+                <Select id="sorteren" name="sorteren">
+                  <Select.Option value="relevantie">Op relevantie</Select.Option>
+                  <Select.Option value="nieuwste">Nieuwste eerst</Select.Option>
+                </Select>
+              </Field>
+              <FieldSet className="ams-mb-l" legend="Soort artikel">
+                <Column gap="x-small">
+                  {searchTopics.map((topic) => (
+                    <Checkbox key={topic} name="soort" value={topic.toLowerCase()}>
+                      {topic}
+                    </Checkbox>
+                  ))}
+                </Column>
+              </FieldSet>
+              {/* The design filters as soon as a box is ticked; the button keeps the form usable without that script. */}
+              <Button type="submit">Resultaten tonen</Button>
+            </form>
+          </Grid.Cell>
+          {/*
+           * A Subgrid hands the columns it spans to its own children, so the Cells inside it are placed on the
+           * columns of the page rather than on columns of their own.
+           */}
+          <Grid.Subgrid span={{ narrow: 4, medium: 5, wide: 9 }} start={{ narrow: 1, medium: 4, wide: 4 }}>
+            {/* Prose takes at most 7 of the 12 columns, so on the wide grid these Cells stop short of the 9 beside the filters. */}
+            <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+              <Heading className="ams-visually-hidden" level={2}>
+                Zoekresultaten
+              </Heading>
+              {/* A polite live region, so a screen reader hears the new total when the search or the filters change. */}
+              <Paragraph role="status">
+                {totalResults} resultaten gevonden voor ‘{searchTerm}’
+              </Paragraph>
+            </Grid.Cell>
+            {searchResults.map((result) => (
+              <Grid.Cell key={result.id} span={{ narrow: 4, medium: 5, wide: 7 }}>
+                {/* A search result has no image, so this Card needs no Card Content and stays vertical at any width. */}
+                <Card>
+                  <Card.HeadingGroup tagline={result.section}>
+                    <Card.Heading level={3}>
+                      <Card.Link href="#">{result.title}</Card.Link>
+                    </Card.Heading>
+                  </Card.HeadingGroup>
+                  <Column gap="small">
+                    <Paragraph>{result.teaser}</Paragraph>
+                    <Paragraph size="small">
+                      {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
+                      <time dateTime={result.isoDate}>{result.date}</time>
+                    </Paragraph>
+                  </Column>
+                </Card>
+              </Grid.Cell>
+            ))}
+            {/* The Pagination takes the width of the results above it rather than that of the region. */}
+            <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+              <Pagination
+                accessibleNameId="paginering"
+                linkTemplate={(page) => `?pagina=${page}`}
+                page={1}
+                totalPages={totalPages}
+              />
+            </Grid.Cell>
+          </Grid.Subgrid>
+        </Grid>
+      </main>
+    </>
+  ),
+}
+
+/**
+ * Nothing matched. The count is still announced, and an Alert offers a way on rather than leaving the visitor
+ * at a dead end.
+ */
+export const NoResults: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // Because this story’s `render` takes no argument, the Code Panel prints its source as written, the story
+        // wrapper and its types included. Provide the source by hand so the panel shows the markup to compose,
+        // without that scaffolding.
+        code: `<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  <main id="inhoud">
+    {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+    <Grid paddingBottom="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-m" level={1}>Zoeken</Heading>
+        {/* Search Field renders its own form with role=search, so it needs no form around it. */}
+        <SearchField>
+          <SearchField.Input
+            defaultValue="veiligheidsregio Amstelland"
+            label="Zoek op amsterdam.nl"
+            name="trefwoord"
+          />
+          <SearchField.Button>Zoeken</SearchField.Button>
+        </SearchField>
+      </Grid.Cell>
+    </Grid>
+    {/*
+     * Two adjacent Grids add their touching paddings together, so this one leaves its paddingTop off.
+     * The last Grid before the Page Footer takes a paddingBottom of 2x-large.
+     */}
+    <Grid paddingBottom="2x-large">
+      {/*
+       * The filter column comes first in source, so it precedes the results in the reading and tab order.
+       * It only sits beside them from the medium grid up; on narrow screens it spans the full width above them.
+       */}
+      <Grid.Cell aria-labelledby="sorteren-en-filteren-no-results" as="aside" span={{ narrow: 4, medium: 3, wide: 3 }}>
+        <Heading className="ams-visually-hidden" id="sorteren-en-filteren-no-results" level={2}>
+          Sorteren en filteren
+        </Heading>
+        <form method="get">
+          <Field className="ams-mb-l">
+            <Label htmlFor="sorteren-no-results">Sorteren</Label>
+            <Select id="sorteren-no-results" name="sorteren">
+              <Select.Option value="relevantie">Op relevantie</Select.Option>
+              <Select.Option value="nieuwste">Nieuwste eerst</Select.Option>
+            </Select>
+          </Field>
+          <FieldSet className="ams-mb-l" legend="Soort artikel">
+            <Column gap="x-small">
+              {searchTopics.map((topic) => (
+                <Checkbox key={topic} name="soort" value={topic.toLowerCase()}>
+                  {topic}
+                </Checkbox>
+              ))}
+            </Column>
+          </FieldSet>
+          {/* The design filters as soon as a box is ticked; the button keeps the form usable without that script. */}
+          <Button type="submit">Resultaten tonen</Button>
+        </form>
+      </Grid.Cell>
+      {/*
+       * A Subgrid hands the columns it spans to its own children, so the Cells inside it are placed on the
+       * columns of the page rather than on columns of their own.
+       */}
+      <Grid.Subgrid span={{ narrow: 4, medium: 5, wide: 9 }} start={{ narrow: 1, medium: 4, wide: 4 }}>
+        {/* Prose takes at most 7 of the 12 columns, so on the wide grid these Cells stop short of the 9 beside the filters. */}
+        <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+          <Heading className="ams-visually-hidden" level={2}>Zoekresultaten</Heading>
+          {/* A polite live region, so a screen reader hears the new total when the search or the filters change. */}
+          <Paragraph role="status">Geen resultaten gevonden voor ‘veiligheidsregio Amstelland’</Paragraph>
+        </Grid.Cell>
+        <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+          {/* An empty result set is not an error, so the Alert is informative rather than a warning. */}
+          <Alert heading="Geen resultaten gevonden" headingLevel={3}>
+            <Paragraph className="ams-mb-s">
+              Probeer een kortere zoekterm, een ander woord, of zoek zonder filters.
+            </Paragraph>
+            <StandaloneLink href="#">Wis alle filters</StandaloneLink>
+          </Alert>
+        </Grid.Cell>
+      </Grid.Subgrid>
+    </Grid>
+  </main>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
+  render: () => (
+    <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+      <Grid paddingTop="large">
+        <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+          <Breadcrumb>
+            <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+          </Breadcrumb>
+        </Grid.Cell>
+      </Grid>
+      <main id="inhoud">
+        {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+        <Grid paddingBottom="x-large">
+          <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading className="ams-mb-m" level={1}>
+              Zoeken
+            </Heading>
+            {/* Search Field renders its own form with role=search, so it needs no form around it. */}
+            <SearchField>
+              <SearchField.Input
+                defaultValue="veiligheidsregio Amstelland"
+                label="Zoek op amsterdam.nl"
+                name="trefwoord"
+              />
+              <SearchField.Button>Zoeken</SearchField.Button>
+            </SearchField>
+          </Grid.Cell>
+        </Grid>
+        {/*
+         * Two adjacent Grids add their touching paddings together, so this one leaves its paddingTop off.
+         * The last Grid before the Page Footer takes a paddingBottom of 2x-large.
+         */}
+        <Grid paddingBottom="2x-large">
+          {/*
+           * The filter column comes first in source, so it precedes the results in the reading and tab order.
+           * It only sits beside them from the medium grid up; on narrow screens it spans the full width above them.
+           */}
+          <Grid.Cell
+            aria-labelledby="sorteren-en-filteren-no-results"
+            as="aside"
+            span={{ narrow: 4, medium: 3, wide: 3 }}
+          >
+            <Heading className="ams-visually-hidden" id="sorteren-en-filteren-no-results" level={2}>
+              Sorteren en filteren
+            </Heading>
+            <form method="get">
+              <Field className="ams-mb-l">
+                <Label htmlFor="sorteren-no-results">Sorteren</Label>
+                <Select id="sorteren-no-results" name="sorteren">
+                  <Select.Option value="relevantie">Op relevantie</Select.Option>
+                  <Select.Option value="nieuwste">Nieuwste eerst</Select.Option>
+                </Select>
+              </Field>
+              <FieldSet className="ams-mb-l" legend="Soort artikel">
+                <Column gap="x-small">
+                  {searchTopics.map((topic) => (
+                    <Checkbox key={topic} name="soort" value={topic.toLowerCase()}>
+                      {topic}
+                    </Checkbox>
+                  ))}
+                </Column>
+              </FieldSet>
+              {/* The design filters as soon as a box is ticked; the button keeps the form usable without that script. */}
+              <Button type="submit">Resultaten tonen</Button>
+            </form>
+          </Grid.Cell>
+          {/*
+           * A Subgrid hands the columns it spans to its own children, so the Cells inside it are placed on the
+           * columns of the page rather than on columns of their own.
+           */}
+          <Grid.Subgrid span={{ narrow: 4, medium: 5, wide: 9 }} start={{ narrow: 1, medium: 4, wide: 4 }}>
+            {/* Prose takes at most 7 of the 12 columns, so on the wide grid these Cells stop short of the 9 beside the filters. */}
+            <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+              <Heading className="ams-visually-hidden" level={2}>
+                Zoekresultaten
+              </Heading>
+              {/* A polite live region, so a screen reader hears the new total when the search or the filters change. */}
+              <Paragraph role="status">Geen resultaten gevonden voor ‘veiligheidsregio Amstelland’</Paragraph>
+            </Grid.Cell>
+            <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
+              {/* An empty result set is not an error, so the Alert is informative rather than a warning. */}
+              <Alert heading="Geen resultaten gevonden" headingLevel={3}>
+                <Paragraph className="ams-mb-s">
+                  Probeer een kortere zoekterm, een ander woord, of zoek zonder filters.
+                </Paragraph>
+                <StandaloneLink href="#">Wis alle filters</StandaloneLink>
+              </Alert>
+            </Grid.Cell>
+          </Grid.Subgrid>
+        </Grid>
+      </main>
+    </>
+  ),
+}

--- a/storybook/src/pages/public/SearchResultsPage/data.ts
+++ b/storybook/src/pages/public/SearchResultsPage/data.ts
@@ -1,0 +1,72 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+export type SearchResult = {
+  readonly date: string
+  readonly id: string
+  readonly isoDate: string
+  readonly section: string
+  readonly teaser: string
+  readonly title: string
+}
+
+export const searchTopics: ReadonlyArray<string> = ['Nieuwsbericht', 'Beleid en regels', 'Product of dienst']
+
+export const searchResults: ReadonlyArray<SearchResult> = [
+  {
+    title: 'Top 400/600',
+    date: '1 juli 2023',
+    id: 'top400-600',
+    isoDate: '2023-07-01',
+    section: 'Actiecentrum Veiligheid en Zorg',
+    teaser:
+      'Om de stad veiliger te maken coördineert de gemeente, samen met haar maatschappelijke partners, vanuit het Actiecentrum Veiligheid en Zorg verschillende aanpakken op het snijvlak van veiligheid, zorg en het sociaal domein.',
+  },
+  {
+    title: 'Treiteraanpak bij ernstige overlast in de buurt',
+    date: '24 juni 2023',
+    id: 'treiteraanpak',
+    isoDate: '2023-06-24',
+    section: 'Actiecentrum Veiligheid en Zorg',
+    teaser:
+      'Bewoners die stelselmatig worden lastiggevallen door buurtgenoten kunnen een melding doen. De gemeente, de politie en de woningcorporatie bekijken samen welke maatregelen nodig zijn.',
+  },
+  {
+    title: 'Keurmerk Veilig Ondernemen aanvragen',
+    date: '19 juni 2023',
+    id: 'veilig-ondernemen',
+    isoDate: '2023-06-19',
+    section: 'Ondernemen',
+    teaser:
+      'Ondernemers in winkelgebieden kunnen meedoen aan het Keurmerk Veilig Ondernemen. Deelnemers maken samen met de politie en de brandweer afspraken over veiligheid op straat.',
+  },
+  {
+    title: 'Een buurtpreventieteam beginnen',
+    date: '12 juni 2023',
+    id: 'buurtpreventie',
+    isoDate: '2023-06-12',
+    section: 'Wonen en leefomgeving',
+    teaser:
+      'Een buurtpreventieteam bestaat uit bewoners die samen met de wijkagent letten op wat er in de straat gebeurt. De gemeente ondersteunt nieuwe teams met training en materiaal.',
+  },
+  {
+    title: 'Cameratoezicht in de openbare ruimte',
+    date: '5 juni 2023',
+    id: 'cameratoezicht',
+    isoDate: '2023-06-05',
+    section: 'Beleid en regels',
+    teaser:
+      'De burgemeester kan cameratoezicht instellen op plekken waar de openbare orde structureel onder druk staat. De beelden worden na 28 dagen verwijderd.',
+  },
+  {
+    title: 'Meldpunt Zorg en Woonoverlast',
+    date: '30 mei 2023',
+    id: 'meldpunt-zorg',
+    isoDate: '2023-05-30',
+    section: 'Zorg en ondersteuning',
+    teaser:
+      'Maakt u zich zorgen over een buurtgenoot die verward gedrag vertoont? Bij Meldpunt Zorg en Woonoverlast kunt u dat melden, ook anoniem.',
+  },
+]


### PR DESCRIPTION
# Describe the pull request

## Links

- [Storybook on main](https://designsystem.amsterdam/)
- [Search results page documentation](https://designsystem.amsterdam/?path=/docs/pages-public-search-results-page--docs), and its [Default](https://designsystem.amsterdam/?path=/story/pages-public-search-results-page--default) and [No results](https://designsystem.amsterdam/demo-DES-1949-search-results-page/?path=/story/pages-public-search-results-page--no-results) stories
- The [News overview page](https://designsystem.amsterdam/?path=/story/pages-public-news-overview-page--default), for the shortened results sentence
- [Introduction to the public page templates](https://designsystem.amsterdam/?path=/docs/pages-public-introduction--docs), which prescribes the Cell sizes this PR follows

## What

Adds a Search Results Page template with two stories, Default and No results, and a documentation page.

It also holds the sentence that announces the number of results on the News Overview Page to the line length we give running text, which it was exceeding.

## Why

Search results are one of the index pages the News Overview Page layout was designed to serve, but they differ enough to be worth their own template. Results come from anywhere on the site, so they have no image and no single content type, and the empty result set is a normal outcome that a search page has to handle well.

The introduction gives the body of a content page 7 of the 12 columns on the wide grid, for an optimal line length. The results region spans 9, and every Cell in it took all of them, so the teasers ran a third wider than any other paragraph on a public page. The News Overview Page had the same problem in its results sentence: naming the filters makes it long enough to reach that width.

## How

The layout is the one the News Overview Page introduced: a filter column beside a list of results, with the filters first in source so they precede the results in the reading and the tab order, and the results in a Grid Subgrid so their Cells sit on the columns of the page.

A few decisions worth flagging:

The filter column takes 3 columns rather than the 2 the design suggests. Two columns resolve to 158px at a 1440px viewport, which will not hold the sort Select or a label like ‘Product of dienst’.

Every Cell in the results region takes 7 columns on the wide grid. On the medium grid the region is 5 columns wide, already under the 6 the introduction allows there, so nothing changes below the wide grid. The Pagination follows the results rather than the region, so the column has one edge instead of overhanging its Cards.

The search field is repeated on the results page with the term still in it, since refining a search is the most common thing to do next. Search Field renders its own form with `role="search"`, so it stays outside the filter form rather than nesting one form in another.

A result Card has no image, so it needs no Card Content and stays vertical at every width.

The No results story covers the empty set: the count is still announced, so someone using a screen reader hears that the search ran and returned nothing, and an Alert suggests what to change instead of leaving the visitor at a dead end.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

The News Overview Page change lands here rather than in its own PR because the two templates share a layout and the rule applies to both. It is a separate commit, so it can be split off if you would rather review it on its own.

Still open with UX, carried over from the News Overview Page: the filter column is only 135px wide at iPad portrait on the medium grid.
