### PR TITLE
chore: Tighten the Node engine to ^24.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "private": true,
   "engines": {
-    "node": "^24",
+    "node": "^24.15.0",
     "pnpm": "^11"
   },
   "packageManager": "pnpm@11.18.0+sha512.33d83c77da82f49fba836925c6f1b841181ec3132b670639bd012f7075f5c7cf634c5f870147c19aae7478fac01df09d8892e880454896edd23ee9b33757563c",


### PR DESCRIPTION
# Describe the pull request

## Links

- [npm-check-updates 23.0.0 release notes](https://github.com/raineorshine/npm-check-updates/releases/tag/v23.0.0)
- Prerequisite for #2868

## What

Raises `engines.node` in the root `package.json` from `^24` to `^24.15.0`.

No other manifest in the workspace declares `engines`, and the root package is private, so nothing about this reaches consumers of the published packages. It only affects who can install this repository.

## Why

Upgrading npm-check-updates to 23 in #2868 raises the floor of our dependency tree to `^22.22.2 || ^24.15.0 || >=26.0.0`. We set `engineStrict` in `pnpm-workspace.yaml`, which turns an unsatisfied range into a failed install rather than a warning, and pnpm applies that check to the root project as well as to its dependencies.

If the upgrade lands first, anyone still on a 24 release older than 24.15.0 gets an install error naming `npm-check-updates@23.0.0`, a development dependency that has nothing to do with whatever they were working on. Declaring the floor first turns that into an error naming this repository and the version it asks for, which is the message worth reading.

CI is unaffected either way. `.nvmrc` pins only the major, and `actions/setup-node` resolves that to the newest 24 release, which already satisfies both ranges.

## How

A single line in the root manifest, verified against `pnpm install` and `npmPkgJsonLint`.

Worth knowing before merging: anyone whose nvm still has an older 24 release selected will need `nvm install 24` before their next `pnpm install`. Surfacing that is the point of merging this ahead of #2868, so that the upgrade itself then passes without comment.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

No stories or documentation pages reference a Node version, so there is nothing to update alongside this. The change is confined to the root manifest.
