### PR TITLE
chore(Tokens): Correct the built CSS file count in the lint README

### DIFF
--- a/packages-proprietary/tokens/lint/README.md
+++ b/packages-proprietary/tokens/lint/README.md
@@ -67,8 +67,8 @@ The tokens have to be built before the check can read them:
 pnpm --filter @amsterdam/design-system-tokens run build
 ```
 
-All four built CSS files are read.
-Today `index.css` declares every token, `compact.css` redeclares a denser subset, and the two `.theme.css` variants declare the same names under a different selector, so reading `index.css` alone would give the same answer.
+All six built CSS files are read.
+Today `index.css` declares every token, `compact.css` redeclares the subset that makes layouts denser, `lo-fi.css` redeclares the subset that renders components as a greyscale sketch, and the three `.theme.css` variants declare the same names under a different selector, so reading `index.css` alone would give the same answer.
 Reading all of them means a build output added later is covered without a change here.
 
 When none can be read, the check says so and fails rather than reporting every token as unused.


### PR DESCRIPTION
# Describe the pull request

## Links

- [The Requirements section of the unused token check README](https://github.com/Amsterdam/design-system/blob/develop/packages-proprietary/tokens/lint/README.md#requirements)
- #2831, which added Lo-fi mode and with it the two built CSS files this sentence had missed

## What

The Requirements section of `packages-proprietary/tokens/lint/README.md` claimed that four built CSS files are read, and named `index.css`, `compact.css` and "the two `.theme.css` variants". It now says six, and describes the lo-fi pair alongside the compact one.

## Why

The count went stale. The check globs `packages-proprietary/tokens/dist/*.css`, and the build emits a CSS pair per mode: `index.css` and `index.theme.css`, `compact.css` and `compact.theme.css`, and since Lo-fi mode `lo-fi.css` and `lo-fi.theme.css`. Running the check prints "Checked 1229 tokens from 6 built files", so the README disagreed with its own output. The `.theme.css` clause was stale in the same way, since there are three of those variants now rather than two.

## How

Only the two sentences that carry the count changed, and the paragraph keeps its shape. The mode files are described in the words `packages-proprietary/tokens/AGENTS.md` already uses for them, so the two documents characterise compact and lo-fi the same way.

The paragraph ends by concluding that reading `index.css` alone would give the same answer, which holds only if no mode file introduces a token name the base set lacks. That is worth confirming rather than assuming, so I flattened the DTCG sources using the same trailing-`default` rule as the `name/customKebab` transform. `index` defines 1229 token names, matching the check's own output; `compact` redeclares 44 and `lo-fi` 57, and neither contributes a single name absent from `index`. `AGENTS.md` also states this as a rule for mode files, so the conclusion is sound both today and by design.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

This changes prose in a package README only. There is no source, story or token change, so there is nothing to see in the feature branch deploy.
