### PR TITLE
feat(Blockquote, Figure, Link List, Table of Contents): Balance the line lengths of text

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/blockquote.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/blockquote.tokens.json
@@ -32,6 +32,12 @@
           "nl.amsterdam.type": "number"
         }
       },
+      "text-wrap": {
+        "$value": "balance",
+        "$extensions": {
+          "nl.amsterdam.type": "textWrap"
+        }
+      },
       "inverse": {
         "color": {
           "$value": "{ams.color.text.inverse}",

--- a/packages-proprietary/tokens/src/components/ams/figure.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/figure.tokens.json
@@ -40,6 +40,12 @@
             "nl.amsterdam.type": "number"
           }
         },
+        "text-wrap": {
+          "$value": "balance",
+          "$extensions": {
+            "nl.amsterdam.type": "textWrap"
+          }
+        },
         "inverse": {
           "color": {
             "$value": "{ams.color.text.inverse}",

--- a/packages-proprietary/tokens/src/components/ams/link-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/link-list.tokens.json
@@ -8,6 +8,12 @@
           "nl.amsterdam.type": "dimension"
         }
       },
+      "text-wrap": {
+        "$value": "balance",
+        "$extensions": {
+          "nl.amsterdam.type": "textWrap"
+        }
+      },
       "link": {
         "color": {
           "$value": "{ams.links.color}",

--- a/packages-proprietary/tokens/src/components/ams/table-of-contents.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/table-of-contents.tokens.json
@@ -34,6 +34,12 @@
           "nl.amsterdam.type": "number"
         }
       },
+      "text-wrap": {
+        "$value": "balance",
+        "$extensions": {
+          "nl.amsterdam.type": "textWrap"
+        }
+      },
       "list": {
         "gap": {
           "$value": "{ams.space.s}",

--- a/packages/css/src/components/blockquote/blockquote.scss
+++ b/packages/css/src/components/blockquote/blockquote.scss
@@ -19,6 +19,9 @@
   line-height: var(--ams-blockquote-line-height);
   quotes: "“" "”";
 
+  /* stylelint-disable-next-line plugin/use-baseline -- Unbalanced line lengths in non-supporting browsers are acceptable */
+  text-wrap: var(--ams-blockquote-text-wrap);
+
   @include hyphenation;
   @include text-rendering;
 

--- a/packages/css/src/components/figure/figure.scss
+++ b/packages/css/src/components/figure/figure.scss
@@ -22,6 +22,9 @@
   font-weight: var(--ams-figure-caption-font-weight);
   line-height: var(--ams-figure-caption-line-height);
 
+  /* stylelint-disable-next-line plugin/use-baseline -- Unbalanced line lengths in non-supporting browsers are acceptable */
+  text-wrap: var(--ams-figure-caption-text-wrap);
+
   @include hyphenation;
   @include text-rendering;
 }

--- a/packages/css/src/components/link-list/link-list.scss
+++ b/packages/css/src/components/link-list/link-list.scss
@@ -14,6 +14,9 @@
   display: grid;
   gap: var(--ams-link-list-gap);
 
+  /* stylelint-disable-next-line plugin/use-baseline -- Unbalanced line lengths in non-supporting browsers are acceptable */
+  text-wrap: var(--ams-link-list-text-wrap);
+
   @include hyphenation;
   @include text-rendering;
 }

--- a/packages/css/src/components/table-of-contents/table-of-contents.scss
+++ b/packages/css/src/components/table-of-contents/table-of-contents.scss
@@ -15,6 +15,9 @@
   font-weight: var(--ams-table-of-contents-font-weight);
   gap: var(--ams-table-of-contents-gap);
   line-height: var(--ams-table-of-contents-line-height);
+
+  /* stylelint-disable-next-line plugin/use-baseline -- Unbalanced line lengths in non-supporting browsers are acceptable */
+  text-wrap: var(--ams-table-of-contents-text-wrap);
 }
 
 .ams-table-of-contents__list {

--- a/storybook/src/components/Blockquote/Blockquote.docs.mdx
+++ b/storybook/src/components/Blockquote/Blockquote.docs.mdx
@@ -55,6 +55,8 @@ Authors cannot forget them or reach for the wrong pair, and the same curly doubl
 A Blockquote has no vertical margins of its own.
 This makes vertical rhythm a property of the layout rather than of the component, which is why [Margin](/docs/utilities-css-margin--docs) and [Prose](/docs/utilities-css-prose--docs) provide it.
 
+A quotation that runs onto more than one line has its line lengths balanced, so it does not end on a single short word.
+
 Words that are too long for the line are hyphenated rather than left to overflow.
 The browser decides where to split them, so the [language of the document](/docs/docs-developer-guide-localisation--docs#specify-the-language-for-the-entire-document) must be set correctly.
 

--- a/storybook/src/components/Figure/Figure.docs.mdx
+++ b/storybook/src/components/Figure/Figure.docs.mdx
@@ -59,6 +59,8 @@ It keeps the ordinary text colour instead of being greyed down, so a reader who 
 A Figure has no margins of its own.
 Browsers indent a `figure` by default; that indent is removed, which makes vertical rhythm a property of the layout rather than of the component.
 
+A caption that runs onto more than one line has its line lengths balanced, so it does not end on a single short word.
+
 Words that are too long for the line are hyphenated rather than left to overflow.
 The browser decides where to split them, so the [language of the document](/docs/docs-developer-guide-localisation--docs#specify-the-language-for-the-entire-document) must be set correctly.
 

--- a/storybook/src/components/LinkList/LinkList.docs.mdx
+++ b/storybook/src/components/LinkList/LinkList.docs.mdx
@@ -91,6 +91,8 @@ Therefore, it is blue and clickable.
 The chevron stays beside the first line of a link that wraps, rather than centring itself against the whole block.
 A list of long links keeps a straight column of chevrons that way, in the place a list marker would occupy.
 
+A link that runs onto more than one line has its line lengths balanced, so a narrow column does not strand a single short word on the last line.
+
 Links are not underlined until the pointer is over them.
 The chevron identifies them in the meantime, the same way it does for a [Standalone Link](/docs/components-navigation-standalone-link--docs), which is what lets the two be swapped for one another.
 

--- a/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
+++ b/storybook/src/components/TableOfContents/TableOfContents.docs.mdx
@@ -93,6 +93,8 @@ The toggle sits beside the link rather than inside it, so expanding a branch and
 
 A chevron turns half a circle when a branch opens, animated only for users who have not asked for reduced motion.
 
+A link that runs onto more than one line has its line lengths balanced, so a narrow column does not strand a single short word on the last line.
+
 The link for the current page is set in bold and in a colour of its own.
 
 ## Accessibility


### PR DESCRIPTION
## Links

- [Deploy on main](https://designsystem.amsterdam/)
- [Table of Contents](https://designsystem.amsterdam/?path=/docs/components-navigation-table-of-contents--docs)
- [Link List](https://designsystem.amsterdam/?path=/docs/components-navigation-link-list--docs)
- [Blockquote](https://designsystem.amsterdam/?path=/docs/components-text-blockquote--docs)
- [Figure](https://designsystem.amsterdam/?path=/docs/components-media-figure--docs)

## What

Table of Contents, Link List, Blockquote and Figure now balance their line lengths, through a new `text-wrap` token for each. This is the same treatment a Description List Term and a large Paragraph already get.

## Why

All four put short text in a measure that is often narrow: a Table of Contents or a Link List in a sidebar or a footer column, a caption under an image in a third-width Grid Cell, a pull quote beside running text. Greedy line breaking strands a single short word on the last line there, which reads badly at that width.

One thing to be aware of, since it was the original motivation: balancing does not remove hyphenation. Chromium balances by shrinking the available width until the line count would grow, and at that narrower width `hyphens: auto` finds break opportunities it did not have before. Across a sample of six Dutch labels at a 168px measure, one lost a hyphen and two gained one. Removing automatic hyphenation instead is worse, because `overflow-wrap: break-word` then chops compounds with no hyphen at all. So hyphenation stays, and the gain here is the even line lengths rather than fewer hyphens. This matches Heading, Label, Field Set and Description List Term, which all pair balancing with `hyphens: auto` already.

## How

Each component gets a `text-wrap` token set to `balance`, declared on the element that owns its text style. Because `text-wrap` is inherited, that is the component root for Table of Contents, Link List and Blockquote, so the declaration is not repeated per link or per variant. For Figure it is the caption, which is where all its other typography tokens live and the only text the component has.

Two things worth knowing about how far this reaches. The Link List link is `inline-flex`, and balancing still reaches its label through the anonymous flex item, with the chevron staying on the first line. And Chromium stops balancing above six lines, so a long Blockquote gets no balancing while a short pull quote does, which is the right way round but means the effect is not uniform across quotation lengths.

Nothing else in the repo is a candidate on this reasoning. Badge, Button, Breadcrumb, Tab Navigation and Standalone Link shrink-wrap to their content, so they only wrap when explicitly constrained. File List shows file names, which are data. Paragraph, the list components and Prose carry running copy, which hits the six-line ceiling. Progress List step labels and Table header cells are plausible but want measuring first.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

