### PR TITLE
fix(Storybook): Draw an Image in a Grid Cell at its own aspect ratio

### DIFF
--- a/documentation/page-anatomy.md
+++ b/documentation/page-anatomy.md
@@ -78,6 +78,7 @@ export const anatomyLabels: AnatomyLabels = [
 
 An Image takes its height from its `aspectRatio` where a label gives it none, up to a `card`, and past that at an ever smaller share of the rest, so that it never reaches a `body`.
 It does so wherever it is: across the whole width of the page where it runs to the edges, and across the width of its own columns where it fills a Grid Cell.
+An Image that names no `aspectRatio` reserves a box of 16:9, as the token does, so leaving one out is not a way to escape the ratio.
 A cell that holds an image among other content — an article body with one halfway down it — is as tall as that content instead, so it takes a step like any other.
 Give the Image a step of its own where the flattened height reads wrong.
 

--- a/documentation/page-anatomy.md
+++ b/documentation/page-anatomy.md
@@ -77,6 +77,8 @@ export const anatomyLabels: AnatomyLabels = [
 ```
 
 An Image takes its height from its `aspectRatio` where a label gives it none, up to a `card`, and past that at an ever smaller share of the rest, so that it never reaches a `body`.
+It does so wherever it is: across the whole width of the page where it runs to the edges, and across the width of its own columns where it fills a Grid Cell.
+A cell that holds an image among other content — an article body with one halfway down it — is as tall as that content instead, so it takes a step like any other.
 Give the Image a step of its own where the flattened height reads wrong.
 
 ### Repeated cells draw themselves shorter

--- a/storybook/src/_components/PageAnatomy/PageAnatomy.tsx
+++ b/storybook/src/_components/PageAnatomy/PageAnatomy.tsx
@@ -71,19 +71,24 @@ const touchesAbove = (sections: readonly AnatomySection[], index: number): boole
   !sections[index]?.paddingTop && (index === 0 || !sections[index - 1]?.paddingBottom)
 
 /** The height a block covers, which for a Subgrid is the tallest of the cells that sit in its rows. */
-const coveringHeight = (block: AnatomyBlock, viewport: AnatomyViewport): number =>
+const coveringHeight = (block: AnatomyBlock, viewport: AnatomyViewport, mode: AnatomyMode): number =>
   block.blocks
-    ? Math.max(0, ...block.blocks.map((child) => coveringHeight(child, viewport)))
-    : blockHeight(block, viewport)
+    ? Math.max(0, ...block.blocks.map((child) => coveringHeight(child, viewport, mode)))
+    : blockHeight(block, viewport, mode)
 
 /** The strip of a block that the blocks lying on it leave in the open, above them. */
-const stripAboveOverlay = (section: AnatomySection, block: AnatomyBlock, viewport: AnatomyViewport): number => {
+const stripAboveOverlay = (
+  section: AnatomySection,
+  block: AnatomyBlock,
+  viewport: AnatomyViewport,
+  mode: AnatomyMode,
+): number => {
   const covering = Math.max(
     0,
-    ...section.blocks.filter((other) => !other.bleed).map((other) => coveringHeight(other, viewport)),
+    ...section.blocks.filter((other) => !other.bleed).map((other) => coveringHeight(other, viewport, mode)),
   )
 
-  return Math.max(0, (blockHeight(block, viewport) - covering) / 2)
+  return Math.max(0, (blockHeight(block, viewport, mode) - covering) / 2)
 }
 
 const Blocks = ({
@@ -94,34 +99,30 @@ const Blocks = ({
   readonly mode: AnatomyMode
   readonly section: AnatomySection
   readonly viewport: AnatomyViewport
-}) => {
-  const padding = space(viewport.paddingInline, viewport.width, mode)
-
-  return (
-    <div
-      className="_ams-page-anatomy__grid"
-      style={{
-        columnGap: toContainerWidth(columnGapWidth(viewport.width, mode), viewport.contentWidth),
-        gridTemplateColumns: `repeat(${viewport.columns}, minmax(0, 1fr))`,
-        paddingInline: toContainerWidth(padding, viewport.contentWidth),
-        rowGap: toContainerWidth(rowGapHeight(section.gapVertical, viewport.width, mode), viewport.contentWidth),
-      }}
-    >
-      {section.blocks.map((block, index) => (
-        <Block block={block} key={`${block.label}-${index}`} padding={padding} section={section} viewport={viewport} />
-      ))}
-    </div>
-  )
-}
+}) => (
+  <div
+    className="_ams-page-anatomy__grid"
+    style={{
+      columnGap: toContainerWidth(columnGapWidth(viewport.width, mode), viewport.contentWidth),
+      gridTemplateColumns: `repeat(${viewport.columns}, minmax(0, 1fr))`,
+      paddingInline: toContainerWidth(space(viewport.paddingInline, viewport.width, mode), viewport.contentWidth),
+      rowGap: toContainerWidth(rowGapHeight(section.gapVertical, viewport.width, mode), viewport.contentWidth),
+    }}
+  >
+    {section.blocks.map((block, index) => (
+      <Block block={block} key={`${block.label}-${index}`} mode={mode} section={section} viewport={viewport} />
+    ))}
+  </div>
+)
 
 const Block = ({
   block,
-  padding,
+  mode,
   section,
   viewport,
 }: {
   readonly block: AnatomyBlock
-  readonly padding: number
+  readonly mode: AnatomyMode
   readonly section: AnatomySection
   readonly viewport: AnatomyViewport
 }) => (
@@ -136,27 +137,23 @@ const Block = ({
       // A block that lies on top of another is centred on it, as the Grid inside an Overlap is.
       alignSelf: section.overlap && !block.bleed ? 'center' : undefined,
       // A Subgrid takes its height from the cells inside it, as the real one does.
-      blockSize: block.blocks ? undefined : toContainerWidth(blockHeight(block, viewport), viewport.contentWidth),
+      blockSize: block.blocks ? undefined : toContainerWidth(blockHeight(block, viewport, mode), viewport.contentWidth),
       gridColumn: block.bleed ? '1 / -1' : gridColumn(block.start[viewport.key], block.span[viewport.key]),
       // The blocks of an Overlap share one row; a bleed block reaches past the inline padding of the Grid.
       gridRow: section.overlap ? 1 : gridRow(block.rowSpan[viewport.key]),
-      marginInline: block.bleed ? toContainerWidth(-padding, viewport.contentWidth) : undefined,
+      marginInline: block.bleed
+        ? toContainerWidth(-space(viewport.paddingInline, viewport.width, mode), viewport.contentWidth)
+        : undefined,
       paddingBlockStart:
         section.overlap && block.bleed
           ? // Halfway down the strip left in the open, less half a line so the label centres on that point.
-            `calc(${toContainerWidth(stripAboveOverlay(section, block, viewport) / 2, viewport.contentWidth)} - 0.375rem)`
+            `calc(${toContainerWidth(stripAboveOverlay(section, block, viewport, mode) / 2, viewport.contentWidth)} - 0.375rem)`
           : undefined,
     }}
   >
     {block.blocks ? (
       block.blocks.map((child, childIndex) => (
-        <Block
-          block={child}
-          key={`${child.label}-${childIndex}`}
-          padding={padding}
-          section={section}
-          viewport={viewport}
-        />
+        <Block block={child} key={`${child.label}-${childIndex}`} mode={mode} section={section} viewport={viewport} />
       ))
     ) : (
       <span className="_ams-page-anatomy__label">
@@ -336,7 +333,7 @@ export const PageAnatomy = ({
   const { problems, sections } = readPageAnatomy(readStoryTree(of, story), labels)
   const viewports = anatomyViewports({ menu, mode })
   const widest = viewports[viewports.length - 1]?.width ?? 0
-  const drawings = viewports.map((viewport) => ({ drawn: drawnSections(sections, viewport), viewport }))
+  const drawings = viewports.map((viewport) => ({ drawn: drawnSections(sections, viewport, mode), viewport }))
 
   /**
    * Swaps one drawing for another. The two are of different heights, so a view transition carries the page across

--- a/storybook/src/_components/PageAnatomy/model.test.ts
+++ b/storybook/src/_components/PageAnatomy/model.test.ts
@@ -3,6 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
+import type { ImageProps } from '@amsterdam/design-system-react'
 import type { ReactNode } from 'react'
 
 import { Grid, Image, Overlap, Spotlight } from '@amsterdam/design-system-react'
@@ -13,6 +14,8 @@ import type { AnatomyBlock, AnatomyLabel, AnatomyLabels, AnatomyViewport, StoryM
 
 import {
   anatomyViewports,
+  blockHeight,
+  cellWidth,
   drawnSections,
   elidedLabel,
   imageHeight,
@@ -25,6 +28,8 @@ import {
 } from './model'
 
 const cell = (props: Record<string, unknown>) => createElement(Grid.Cell, props)
+
+const image = (aspectRatio?: ImageProps['aspectRatio']) => createElement(Image, { alt: '', aspectRatio, src: '' })
 
 const [narrow, medium, wide] = anatomyViewports()
 
@@ -154,6 +159,24 @@ describe('readPageAnatomy', () => {
 
     expect(block?.bleed).toBe(true)
     expect(block?.aspectRatio).toBe(5 / 16)
+  })
+
+  it('gives a Grid Cell the aspect ratio of an Image it holds on its own', () => {
+    const story = createElement(Grid, {}, cell({ children: image('4:3'), span: 5 }))
+
+    const [block] = readPageAnatomy(story, [['Lead image']]).sections[0]?.blocks ?? []
+
+    expect(block?.aspectRatio).toBe(3 / 4)
+    expect(block?.bleed).toBe(false)
+  })
+
+  it('leaves a Grid Cell that holds an Image among other content no shape of its own', () => {
+    const children = [createElement('p', { key: 'text' }, 'Body'), image('4:3')]
+    const story = createElement(Grid, {}, cell({ children, span: 7 }))
+
+    const [block] = readPageAnatomy(story, [['Article body']]).sections[0]?.blocks ?? []
+
+    expect(block?.aspectRatio).toBeUndefined()
   })
 
   it('resolves the step of the scale a label names to the height it stands for', () => {
@@ -401,6 +424,53 @@ describe('paddingHeight and rowGapHeight', () => {
     expect(rowGapHeight(undefined, 1440)).toBe(60)
     expect(rowGapHeight('large', 1440)).toBe(36)
     expect(rowGapHeight('none', 1440)).toBe(0)
+  })
+})
+
+describe('cellWidth', () => {
+  it('measures a cell across its columns and the gaps in between them', () => {
+    // The wide Grid runs across 1440 pixels, less a 2x-large padding of 90 on either side, over 12 columns of 50
+    // and 11 gaps of 60.
+    expect(cellWidth(12, wide!)).toBe(1260)
+    expect(cellWidth(5, wide!)).toBe(490)
+    expect(cellWidth(1, wide!)).toBe(50)
+  })
+
+  it('takes the smaller inline padding of Compact Mode', () => {
+    const [, , compactWide] = anatomyViewports({ mode: 'compact' })
+
+    expect(cellWidth(12, compactWide!, 'compact')).toBe(1376)
+  })
+})
+
+describe('blockHeight', () => {
+  it('draws a full-bleed Image across the whole width the Grid runs across', () => {
+    const story = createElement(Image, { alt: '', aspectRatio: '16:5', src: '' })
+
+    const [block] = readPageAnatomy(story, [['Hero image']]).sections[0]?.blocks ?? []
+
+    // A sixteenth of five of the 1440 the wide Grid runs across, flattened as every image is.
+    expect(blockHeight(block!, wide!)).toBe(imageHeight(450))
+  })
+
+  it('draws an Image in a Grid Cell across the width of that cell alone', () => {
+    const span = { narrow: 4, medium: 4, wide: 5 }
+    const story = createElement(Grid, {}, cell({ children: image('4:3'), span }))
+
+    const [block] = readPageAnatomy(story, [['Lead image']]).sections[0]?.blocks ?? []
+
+    // Three quarters of a cell 490 wide on the wide Grid, and of one 272 wide on the narrow one.
+    expect(blockHeight(block!, wide!)).toBe(imageHeight(367.5))
+    expect(blockHeight(block!, narrow!)).toBe(imageHeight(204))
+  })
+
+  it('draws a block that has no shape of its own to the step its label names', () => {
+    const story = createElement(Grid, {}, cell({ span: 5 }))
+
+    const [block] =
+      readPageAnatomy(story, [[{ height: 'panel', label: 'Table of contents' }]]).sections[0]?.blocks ?? []
+
+    expect(blockHeight(block!, wide!)).toBe(192)
   })
 })
 

--- a/storybook/src/_components/PageAnatomy/model.test.ts
+++ b/storybook/src/_components/PageAnatomy/model.test.ts
@@ -170,6 +170,14 @@ describe('readPageAnatomy', () => {
     expect(block?.bleed).toBe(false)
   })
 
+  it('reads an Image that names no aspect ratio as the 16:9 its token reserves', () => {
+    const story = createElement(Grid, {}, cell({ children: image(), span: 5 }))
+
+    const [block] = readPageAnatomy(story, [['Map']]).sections[0]?.blocks ?? []
+
+    expect(block?.aspectRatio).toBe(9 / 16)
+  })
+
   it('leaves a Grid Cell that holds an Image among other content no shape of its own', () => {
     const children = [createElement('p', { key: 'text' }, 'Body'), image('4:3')]
     const story = createElement(Grid, {}, cell({ children, span: 7 }))

--- a/storybook/src/_components/PageAnatomy/model.ts
+++ b/storybook/src/_components/PageAnatomy/model.ts
@@ -192,7 +192,10 @@ export type AnatomyBlock = {
    * transparent variant removes, so a transparent cell is drawn as bare page rather than as a block.
    */
   readonly appearance?: string
-  /** The aspect ratio of an Image, as a height divided by a width, where its label sets no height of its own. */
+  /**
+   * The aspect ratio of an Image, as a height divided by a width, where its label sets no height of its own. A block
+   * that has one takes its shape from the width it runs across.
+   */
   readonly aspectRatio?: number
   /** Whether the block runs to the edges of the page, outside the inline padding of the Grid. */
   readonly bleed: boolean
@@ -234,7 +237,7 @@ export type PageAnatomy = {
   readonly sections: readonly AnatomySection[]
 }
 
-/** The height a full-bleed block takes, as a fraction of the width of the page. */
+/** The height an Image takes, as a fraction of the width it runs across. */
 const aspectRatios: Record<string, number> = {
   '1:1': 1,
   '16:5': 5 / 16,
@@ -286,17 +289,32 @@ const perViewport = <T>(read: (viewport: AnatomyViewport) => T): Record<Breakpoi
   Object.fromEntries(anatomyViewports().map((viewport) => [viewport.key, read(viewport)])) as Record<Breakpoint, T>
 
 /**
+ * The aspect ratio of an Image that is the whole of what a Grid Cell holds, which gives the cell its shape.
+ *
+ * A cell that holds an image among other content – an article body with one halfway down it – is as tall as that
+ * content, which nothing in the story says, so it keeps the height its label gives it.
+ */
+const readCellRatio = (children: ReactNode): number | undefined => {
+  const [only, ...rest] = Children.toArray(children)
+
+  if (rest.length > 0 || !isValidElement(only) || displayNameOf(only) !== 'Image') return undefined
+
+  return aspectRatios[String(propsOf(only)['aspectRatio'])]
+}
+
+/**
  * Reads a Grid Cell or a Grid Subgrid. Both take the same placement props.
  *
  * A cell inside a Subgrid is placed on the columns of that Subgrid, which are the columns of the Grid it covers.
  * Its own columns are numbered from one again, so a span of ‘all’ is the span of the Subgrid rather than of the Grid.
  */
 const readCell = (element: ReactElement, columns?: Record<Breakpoint, number>): AnatomyBlock => {
-  const { appearance, rowSpan, span, start } = propsOf(element)
+  const { appearance, children, rowSpan, span, start } = propsOf(element)
   const available = (viewport: AnatomyViewport) => columns?.[viewport.key] ?? viewport.columns
 
   return {
     appearance: appearance as string | undefined,
+    aspectRatio: readCellRatio(children as ReactNode),
     bleed: false,
     height: perViewport(() => defaultBlockHeight),
     label: '',
@@ -510,7 +528,20 @@ export const readPageAnatomy = (story: ReactNode, labels: AnatomyLabels): PageAn
 }
 
 /**
- * The height an Image is drawn at, from the height its aspect ratio gives it across the page.
+ * The width of a Grid Cell that spans a number of columns, in pixels of the page it stands for.
+ *
+ * The columns divide the width the Grid runs across, less its inline padding on either side and a gap in between
+ * each pair. A cell that covers several of them covers the gaps in between as well.
+ */
+export const cellWidth = (span: number, viewport: AnatomyViewport, mode?: AnatomyMode): number => {
+  const gap = columnGapWidth(viewport.width, mode)
+  const inside = viewport.contentWidth - 2 * space(viewport.paddingInline, viewport.width, mode)
+
+  return ((inside - (viewport.columns - 1) * gap) / viewport.columns) * span + (span - 1) * gap
+}
+
+/**
+ * The height an Image is drawn at, from the height its aspect ratio gives it over the width it runs across.
  *
  * Up to `imageHeightInFull` that is the height itself; past it, every further pixel adds a little less than the one
  * before, so the drawing approaches `tallestImageHeight` without ever reaching it. Any aspect ratio therefore
@@ -525,12 +556,21 @@ export const imageHeight = (height: number): number => {
   return imageHeightInFull + (room * beyond) / (beyond + room)
 }
 
-/** The height of a block at a viewport, in pixels of the page it stands for. */
-export const blockHeight = (block: AnatomyBlock, viewport: AnatomyViewport): number =>
-  block.aspectRatio ? imageHeight(block.aspectRatio * viewport.contentWidth) : block.height[viewport.key]
+/**
+ * The height of a block at a viewport, in pixels of the page it stands for.
+ *
+ * An Image takes its shape from the width it runs across: the whole of the content width where it bleeds past the
+ * Grid, and the width of its own columns where it sits in a cell.
+ */
+export const blockHeight = (block: AnatomyBlock, viewport: AnatomyViewport, mode?: AnatomyMode): number =>
+  block.aspectRatio
+    ? imageHeight(
+        block.aspectRatio * (block.bleed ? viewport.contentWidth : cellWidth(block.span[viewport.key], viewport, mode)),
+      )
+    : block.height[viewport.key]
 
 /** Whether two Grid Cells are drawn alike at a viewport, and so read as a repeat of one another. */
-const repeats = (block: AnatomyBlock, other: AnatomyBlock, viewport: AnatomyViewport): boolean =>
+const repeats = (block: AnatomyBlock, other: AnatomyBlock, viewport: AnatomyViewport, mode?: AnatomyMode): boolean =>
   !block.blocks &&
   !other.blocks &&
   !block.bleed &&
@@ -539,7 +579,7 @@ const repeats = (block: AnatomyBlock, other: AnatomyBlock, viewport: AnatomyView
   block.appearance === other.appearance &&
   block.span[viewport.key] === other.span[viewport.key] &&
   block.rowSpan[viewport.key] === other.rowSpan[viewport.key] &&
-  blockHeight(block, viewport) === blockHeight(other, viewport)
+  blockHeight(block, viewport, mode) === blockHeight(other, viewport, mode)
 
 /**
  * The number of cells of a run that lie beside one another on one row, counted from the column the run starts at.
@@ -593,6 +633,7 @@ export const elideRepeats = (
   blocks: readonly AnatomyBlock[],
   viewport: AnatomyViewport,
   columns: number,
+  mode?: AnatomyMode,
 ): readonly AnatomyBlock[] => {
   const drawn: AnatomyBlock[] = []
   let index = 0
@@ -602,14 +643,14 @@ export const elideRepeats = (
 
     // A Subgrid holds its own cells on its own columns, so a run inside it is measured against those.
     if (block.blocks) {
-      drawn.push({ ...block, blocks: elideRepeats(block.blocks, viewport, block.span[viewport.key]) })
+      drawn.push({ ...block, blocks: elideRepeats(block.blocks, viewport, block.span[viewport.key], mode) })
       index += 1
       continue
     }
 
     let end = index + 1
 
-    while (end < blocks.length && repeats(block, blocks[end]!, viewport)) end += 1
+    while (end < blocks.length && repeats(block, blocks[end]!, viewport, mode)) end += 1
 
     const run = end - index
     const perRow = cellsPerRow(blocks.slice(index, end), columns, viewport)
@@ -641,9 +682,10 @@ export const elideRepeats = (
 export const drawnSections = (
   sections: readonly AnatomySection[],
   viewport: AnatomyViewport,
+  mode?: AnatomyMode,
 ): readonly AnatomySection[] =>
   sections.map((section) =>
-    section.overlap ? section : { ...section, blocks: elideRepeats(section.blocks, viewport, viewport.columns) },
+    section.overlap ? section : { ...section, blocks: elideRepeats(section.blocks, viewport, viewport.columns, mode) },
   )
 
 /**

--- a/storybook/src/_components/PageAnatomy/model.ts
+++ b/storybook/src/_components/PageAnatomy/model.ts
@@ -247,6 +247,9 @@ const aspectRatios: Record<string, number> = {
   '9:16': 16 / 9,
 }
 
+/** The `ams.image.aspect-ratio` token, which an Image reserves a box of where it names no ratio of its own. */
+const defaultAspectRatio = aspectRatios['16:9']!
+
 type Props = Record<string, unknown>
 
 const propsOf = (element: ReactElement): Props => (element.props ?? {}) as Props
@@ -288,6 +291,10 @@ const readColumns = (value: unknown, viewport: AnatomyViewport, columns?: number
 const perViewport = <T>(read: (viewport: AnatomyViewport) => T): Record<Breakpoint, T> =>
   Object.fromEntries(anatomyViewports().map((viewport) => [viewport.key, read(viewport)])) as Record<Breakpoint, T>
 
+/** The aspect ratio an Image reserves a box of, which is the token's 16:9 where it names none of its own. */
+const imageRatio = (element: ReactElement): number =>
+  aspectRatios[String(propsOf(element)['aspectRatio'])] ?? defaultAspectRatio
+
 /**
  * The aspect ratio of an Image that is the whole of what a Grid Cell holds, which gives the cell its shape.
  *
@@ -299,7 +306,7 @@ const readCellRatio = (children: ReactNode): number | undefined => {
 
   if (rest.length > 0 || !isValidElement(only) || displayNameOf(only) !== 'Image') return undefined
 
-  return aspectRatios[String(propsOf(only)['aspectRatio'])]
+  return imageRatio(only)
 }
 
 /**
@@ -380,7 +387,7 @@ const findGrid = (node: ReactNode): ReactElement | undefined => {
 
 /** An Image is a block of its own: it has no Grid, and runs to the edges of the page. */
 const readImage = (element: ReactElement): AnatomyBlock => ({
-  aspectRatio: aspectRatios[String(propsOf(element)['aspectRatio'])],
+  aspectRatio: imageRatio(element),
   bleed: true,
   height: perViewport(() => defaultBlockHeight),
   label: '',

--- a/storybook/src/pages/public/InformationPage/anatomyLabels.ts
+++ b/storybook/src/pages/public/InformationPage/anatomyLabels.ts
@@ -12,8 +12,8 @@ import type { AnatomyLabels } from '#storybook/_components/PageAnatomy/model'
  */
 export const anatomyLabels: AnatomyLabels = [
   [{ height: 'line', label: 'Breadcrumb' }],
-  // The introductory image takes its height from its aspect ratio, and the lead paragraph beside it reaches about as
-  // far on the wide grid and past it on the two narrower ones, which a card would draw the other way around.
-  [{ height: 'title', label: 'Page title' }, { height: 'panel', label: 'Lead paragraph' }, 'Introductory image'],
+  // The lead image takes its height from its aspect ratio, and the lead paragraph beside it reaches about as far on
+  // the wide grid and past it on the two narrower ones, which a card would draw the other way around.
+  [{ height: 'title', label: 'Page title' }, { height: 'panel', label: 'Lead paragraph' }, 'Lead image'],
   [{ height: 'body', label: 'Information body' }],
 ]

--- a/storybook/src/pages/public/InformationPage/anatomyLabels.ts
+++ b/storybook/src/pages/public/InformationPage/anatomyLabels.ts
@@ -12,6 +12,8 @@ import type { AnatomyLabels } from '#storybook/_components/PageAnatomy/model'
  */
 export const anatomyLabels: AnatomyLabels = [
   [{ height: 'line', label: 'Breadcrumb' }],
-  [{ height: 'title', label: 'Page title' }, { height: 'card', label: 'Lead paragraph' }, 'Introductory image'],
+  // The introductory image takes its height from its aspect ratio, and the lead paragraph beside it reaches about as
+  // far on the wide grid and past it on the two narrower ones, which a card would draw the other way around.
+  [{ height: 'title', label: 'Page title' }, { height: 'panel', label: 'Lead paragraph' }, 'Introductory image'],
   [{ height: 'body', label: 'Information body' }],
 ]


### PR DESCRIPTION
# Draw an Image in a Grid Cell at its own aspect ratio

## Links

- [Storybook on main](https://designsystem.amsterdam/)
- [Information Page](https://designsystem.amsterdam/?path=/docs/pages-public-information-page--docs), the one drawing that changes: its lead image takes a shape of its own, and the lead paragraph beside it a panel.
- [Project Page](https://designsystem.amsterdam/?path=/docs/pages-public-project-page--docs), where the map is held at a panel by its label rather than drawn at 16:9.
- [Article Page](https://designsystem.amsterdam/?path=/docs/pages-public-article-page--docs), a full-bleed hero, which is drawn exactly as it was.
- [Page anatomy documentation](https://github.com/Amsterdam/design-system/blob/develop/documentation/page-anatomy.md), where the rules for heights now cover an Image in a Cell.

## What

The schematic that opens every page template’s documentation page read an aspect ratio only from an Image that runs to the edges of the page. An Image inside a Grid Cell fell through to the height a label gives a block, so the Information Page drew its lead image as a flat block beside a lead paragraph half again as tall, where on the page itself the two are about the same height.

A Grid Cell that holds nothing but an Image now takes that Image’s ratio, and a block that has one is measured against the width it actually runs across: the whole content width where it bleeds past the Grid, and the width of its own columns where it sits in one. An Image that names no `aspectRatio` counts as the 16:9 its token reserves, wherever it is. Both then go through the same flattening curve as before, so no image reaches a `body`.

Two labels follow from that. The lead image of the Information Page loses the height it was given and takes its own shape, and the lead paragraph beside it becomes a `panel` rather than a `card`, because a card would draw the pair the other way around from the page it stands for. Its name changes to ‘Lead image’ as well, which is what the page’s own documentation has called it since #2873.

## Why

A cell four columns wide is not the width of the page, so the one measure the drawing had was wrong for every image but a full-bleed one. The result was a schematic that reported an image as a band of no particular shape, and an `anatomyLabels.ts` that had to guess a height for something the story already states exactly.

A ratio taken from the wrong width is worse than no ratio at all: it would have drawn a cell spanning five of twelve columns at more than twice its height. That is why the height and the width had to move together rather than the ratio simply being read one level further down the tree.

## How

`cellWidth` divides the width the Grid runs across into its columns, less the inline padding on either side and the gaps in between, and gives a cell as many of those as it spans plus the gaps it covers. `blockHeight` picks that or the full content width by whether the block bleeds, and hands the result to `imageHeight` as before.

A cell takes the ratio only when the Image is the whole of what it holds. An article body with an image halfway down it is as tall as that body, which nothing in the story states, so it keeps the step its label names. A label that names a step still clears the ratio, so a drawing that reads wrong can always be overruled by hand.

The Grid mode reaches further than it did. A cell’s width depends on the padding and the gaps that mode gives it, so `blockHeight` takes the mode, and with it the elision: two cells only count as a repeat of one another where they are drawn at the same height.

The measurements were checked against the real page rather than estimated. In a built Storybook the lead image cell measures 204, 276 and 368 pixels at the three Grid variants, which is what `blockHeight` derives before flattening, and the lead paragraph beside it reaches 441, 380 and 338 — taller than the image on the two narrower grids, a little shorter on the wide one, which is the order the drawing now shows.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

No visual change is expected. The drawing lives on documentation pages, which are not snapshotted, and the one story that is — `Components/Docs/Page Anatomy/Test` — draws the Article, Home and News Overview pages and the internal Navigation Page, none of which has a cell that holds an Image on its own.

The map of the Project Page is the only other such cell. Its label names a `panel`, which clears the ratio, so it is drawn at 192 rather than the 228 its 16:9 would give it on the wide grid. That reads as the deliberate choice it is — the scale lists a map as a panel — so I left it, but it is the one place where dropping a step would now change a drawing.

