### PR TITLE
feat(Grid): Add an x-large vertical gap option to Subgrid

### DIFF
--- a/packages/css/src/components/grid/_mixins.scss
+++ b/packages/css/src/components/grid/_mixins.scss
@@ -137,6 +137,11 @@
   row-gap: var(--ams-grid-row-gap-l);
 }
 
+/* Restates the row gap a Grid has by default, for a Subgrid that would otherwise inherit a narrower one. */
+@mixin ams-grid__subgrid--gap-vertical--x-large {
+  row-gap: var(--ams-grid-row-gap-xl);
+}
+
 @mixin ams-grid__subgrid--gap-vertical--2x-large {
   row-gap: var(--ams-grid-row-gap-2xl);
 }

--- a/packages/css/src/components/grid/grid.scss
+++ b/packages/css/src/components/grid/grid.scss
@@ -81,6 +81,10 @@ $ams-grid-row-span-max: 4;
   @include ams-grid__subgrid--gap-vertical--large;
 }
 
+.ams-grid__subgrid--gap-vertical--x-large {
+  @include ams-grid__subgrid--gap-vertical--x-large;
+}
+
 .ams-grid__subgrid--gap-vertical--2x-large {
   @include ams-grid__subgrid--gap-vertical--2x-large;
 }

--- a/packages/react/src/Grid/GridSubgrid.tsx
+++ b/packages/react/src/Grid/GridSubgrid.tsx
@@ -8,10 +8,17 @@ import type { ElementType, HTMLAttributes, PropsWithChildren } from 'react'
 import { clsx } from 'clsx'
 import { forwardRef } from 'react'
 
-import type { GridColumnNumber, GridColumnNumbers, GridGap, GridRowNumber, GridRowNumbers } from './Grid'
+import type { GridColumnNumber, GridColumnNumbers, GridRowNumber, GridRowNumbers } from './Grid'
 import type { GridCellTag } from './GridCell'
 
 import { gridSubgridClasses } from './gridSubgridClasses'
+
+/**
+ * A Subgrid inherits the row gap of the Grid, so it needs a value for the x-large that Grid has by default.
+ * Without it, a Subgrid inside a Grid that lowers its gap has no way back to the regular spacing.
+ */
+export const gridSubgridGaps = ['none', 'large', 'x-large', '2x-large'] as const
+export type GridSubgridGap = (typeof gridSubgridGaps)[number]
 
 type GridSubgridSpanAllProp = {
   /** Lets the subgrid span the full width of all grid variants. */
@@ -42,7 +49,7 @@ export type GridSubgridProps = {
    * The amount of space between the rows of the subgrid.
    * Defaults to the vertical gap of the Grid.
    */
-  readonly gapVertical?: GridGap
+  readonly gapVertical?: GridSubgridGap
   /**
    * The amount of grid rows the subgrid spans.
    * Accepts a number or an object of numbers per grid variant.

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -42,6 +42,7 @@ Without it, a Cell inside a Cell has no columns to align to.
 
 Its rows take the vertical gap of the Grid, so the region keeps the rhythm of the page.
 Give it its own `gapVertical` to space its rows differently.
+It takes `x-large` as well, which the Grid has no need of: that is the gap a Grid gives by default, and only a Subgrid can end up without it, in a Grid that lowered or removed its own.
 
 <Canvas of={GridSubgridStories.Subgrid} />
 

--- a/storybook/src/components/Grid/Grid.test.stories.tsx
+++ b/storybook/src/components/Grid/Grid.test.stories.tsx
@@ -4,6 +4,7 @@
  */
 
 import type { GridGap } from '@amsterdam/design-system-react/src/Grid/Grid'
+import type { GridSubgridGap } from '@amsterdam/design-system-react/src/Grid/GridSubgrid'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Grid } from '@amsterdam/design-system-react/src'
@@ -38,7 +39,7 @@ const SubgridCase = ({
   subgridGapVertical,
 }: {
   readonly gapVertical?: GridGap
-  readonly subgridGapVertical?: GridGap
+  readonly subgridGapVertical?: GridSubgridGap
 }) => (
   <Grid gapVertical={gapVertical} paddingVertical="large">
     <Grid.Cell {...item} span={quarter} />
@@ -113,6 +114,8 @@ export const Test: Story = {
       <SubgridCase />
       <SubgridCase gapVertical="none" />
       <SubgridCase subgridGapVertical="2x-large" />
+      {/* The reason x-large exists: the Grid drops its gap, and the Subgrid puts the regular one back. */}
+      <SubgridCase gapVertical="none" subgridGapVertical="x-large" />
       <SubgridPlacementCase />
       <SubgridRowSpanCase />
     </div>

--- a/storybook/src/components/Grid/GridSubgrid.stories.tsx
+++ b/storybook/src/components/Grid/GridSubgrid.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
         labels: { undefined: 'inherit (default)' },
         type: 'radio',
       },
-      options: ['none', 'large', undefined, '2x-large'],
+      options: [undefined, 'none', 'large', 'x-large', '2x-large'],
     },
   },
   decorators: [


### PR DESCRIPTION
## Links

- (Deploy links follow once the first build is up.)

## What

`gapVertical` on a Grid Subgrid accepts `x-large`.

The value is on the Subgrid alone. A Grid already has an x-large row gap by default, so the option would only ever restate that there, and `GridGap` keeps the `none | large | 2x-large` it has today. The Subgrid takes a type of its own, `GridSubgridGap`.

## Why

A Subgrid takes the row gap of the Grid it sits in, through `row-gap: inherit`, and the scale offered no way back to the x-large a Grid gives by default. A Grid that lowered or removed its own gap passed that on to every Subgrid inside it, and nothing could space their Cells normally again.

That blocks a composition the vertical space guidance asks for. A section heading should sit a small above the content it introduces, but a heading in a Grid Cell of its own can only be spaced by the row gap, whose smallest step above zero is large. The way to reach the prescribed value is to set `gapVertical="none"` on the Grid and let the heading Cell carry the margin utility — and until now that left every Subgrid in that Grid without a gap.

With this the pattern works: a Grid at `none`, a heading Cell carrying the margin the guidance asks for, then a Subgrid at `x-large` holding the Cells below it.

## How

The mixin and the class follow the ones beside them and use the existing `--ams-grid-row-gap-xl`, so no token changes were needed.

The visual test gains the case the option exists for: a Grid that drops its gap with a Subgrid that puts the regular one back. The three cases already there are unaffected.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

There is no ticket for this one; it came out of laying out a page template where the heading above a list could not take the space the guidance prescribes.

The type split is the part worth a second opinion. `GridGap` and `GridSubgridGap` now differ by one value, which is a little more surface than a single shared scale — the alternative was giving Grid an option that only restates its own default.
