### PR TITLE
feat(Storybook): Space section headings as the vertical space guidance asks

### DIFF
--- a/storybook/src/_components/PageAnatomy/PageAnatomy.tsx
+++ b/storybook/src/_components/PageAnatomy/PageAnatomy.tsx
@@ -141,6 +141,10 @@ const Block = ({
       gridColumn: block.bleed ? '1 / -1' : gridColumn(block.start[viewport.key], block.span[viewport.key]),
       // The blocks of an Overlap share one row; a bleed block reaches past the inline padding of the Grid.
       gridRow: section.overlap ? 1 : gridRow(block.rowSpan[viewport.key]),
+      // A margin utility on the Cell, which is what spaces it where the Grid has given up its row gap.
+      marginBlockEnd: block.spaceAfter
+        ? toContainerWidth(space(block.spaceAfter, viewport.width, mode), viewport.contentWidth)
+        : undefined,
       marginInline: block.bleed
         ? toContainerWidth(-space(viewport.paddingInline, viewport.width, mode), viewport.contentWidth)
         : undefined,
@@ -149,6 +153,13 @@ const Block = ({
           ? // Halfway down the strip left in the open, less half a line so the label centres on that point.
             `calc(${toContainerWidth(stripAboveOverlay(section, block, viewport, mode) / 2, viewport.contentWidth)} - 0.375rem)`
           : undefined,
+      // A Subgrid spaces its own rows, and takes the gap of the Grid where it names none.
+      rowGap: block.blocks
+        ? toContainerWidth(
+            rowGapHeight(block.gapVertical ?? section.gapVertical, viewport.width, mode),
+            viewport.contentWidth,
+          )
+        : undefined,
     }}
   >
     {block.blocks ? (

--- a/storybook/src/_components/PageAnatomy/model.test.ts
+++ b/storybook/src/_components/PageAnatomy/model.test.ts
@@ -433,6 +433,13 @@ describe('paddingHeight and rowGapHeight', () => {
     expect(rowGapHeight('large', 1440)).toBe(36)
     expect(rowGapHeight('none', 1440)).toBe(0)
   })
+
+  // A Subgrid states this where the Grid around it has given its own gap up, so it has to measure the same as
+  // the default a Grid gives.
+  it('reads an x-large row gap as the one it defaults to', () => {
+    expect(rowGapHeight('x-large', 1440)).toBe(rowGapHeight(undefined, 1440))
+    expect(rowGapHeight('x-large', 1440)).toBe(60)
+  })
 })
 
 describe('cellWidth', () => {

--- a/storybook/src/_components/PageAnatomy/model.ts
+++ b/storybook/src/_components/PageAnatomy/model.ts
@@ -104,8 +104,11 @@ const columnGapToken: SpaceToken = 'xl'
 /** The space token behind each value of the Grid padding props. */
 const paddingTokens = { large: 'l', 'x-large': 'xl', '2x-large': '2xl' } as const
 
-/** The space token behind each value of the Grid `gapVertical` prop. Its default is `x-large`. */
-const rowGapTokens = { '2x-large': '2xl', large: 'l', none: undefined } as const
+/**
+ * The space token behind each value of the Grid `gapVertical` prop. Its default is `x-large`.
+ * A Subgrid takes `x-large` as well, to state the gap the Grid gives by default where the Grid has given it up.
+ */
+const rowGapTokens = { '2x-large': '2xl', large: 'l', none: undefined, 'x-large': 'xl' } as const
 
 type Padding = keyof typeof paddingTokens
 type Gap = keyof typeof rowGapTokens
@@ -209,11 +212,21 @@ export type AnatomyBlock = {
    * marker, and its last row. Only a marker carries it, and a marker holds nothing else.
    */
   readonly elided?: ElidedRows
+  /**
+   * The row gap a Subgrid sets for the blocks it holds. Without one it takes the gap of the Grid, as the real
+   * Subgrid does through `row-gap: inherit`.
+   */
+  readonly gapVertical?: Gap
   /** The height of the block, per Grid variant. */
   readonly height: Record<Breakpoint, number>
   readonly label: string
   /** The number of rows the block spans, per Grid variant. */
   readonly rowSpan: Record<Breakpoint, number | undefined>
+  /**
+   * The space an `ams-mb-*` utility on the Cell puts below it. A Grid that has given up its row gap leaves the
+   * spacing to these, so the drawing has to read them to show the page it stands for.
+   */
+  readonly spaceAfter?: SpaceToken
   /** The number of columns the block spans, per Grid variant. */
   readonly span: Record<Breakpoint, number>
   /** The column the block starts at, per Grid variant. Undefined leaves the placement to the browser. */
@@ -309,6 +322,18 @@ const readCellRatio = (children: ReactNode): number | undefined => {
   return imageRatio(only)
 }
 
+/** The space tokens of the margin utilities, longest first so that `xs` is not read as an `s`. */
+const spaceAfterPattern = /(?:^|\s)ams-mb-(2xl|xl|xs|s|m|l)(?:\s|$)/
+
+/**
+ * The space an `ams-mb-*` utility on a Cell puts below it.
+ *
+ * A Grid that gives up its row gap leaves the spacing to these, so a drawing that ignored them would show a heading
+ * sitting against the section it introduces.
+ */
+const readSpaceAfter = (className: unknown): SpaceToken | undefined =>
+  typeof className === 'string' ? (spaceAfterPattern.exec(className)?.[1] as SpaceToken | undefined) : undefined
+
 /**
  * Reads a Grid Cell or a Grid Subgrid. Both take the same placement props.
  *
@@ -316,16 +341,18 @@ const readCellRatio = (children: ReactNode): number | undefined => {
  * Its own columns are numbered from one again, so a span of ‘all’ is the span of the Subgrid rather than of the Grid.
  */
 const readCell = (element: ReactElement, columns?: Record<Breakpoint, number>): AnatomyBlock => {
-  const { appearance, children, rowSpan, span, start } = propsOf(element)
+  const { appearance, children, className, gapVertical, rowSpan, span, start } = propsOf(element)
   const available = (viewport: AnatomyViewport) => columns?.[viewport.key] ?? viewport.columns
 
   return {
     appearance: appearance as string | undefined,
     aspectRatio: readCellRatio(children as ReactNode),
     bleed: false,
+    gapVertical: gapVertical as Gap | undefined,
     height: perViewport(() => defaultBlockHeight),
     label: '',
     rowSpan: perViewport((viewport) => readColumns(rowSpan, viewport)),
+    spaceAfter: readSpaceAfter(className),
     // A cell without a `span` spans a single column, as `grid-column-end: auto` does.
     span: perViewport((viewport) => readColumns(span, viewport, available(viewport)) ?? 1),
     start: perViewport((viewport) => readColumns(start, viewport, available(viewport))),

--- a/storybook/src/_components/PageAnatomy/model.ts
+++ b/storybook/src/_components/PageAnatomy/model.ts
@@ -223,8 +223,8 @@ export type AnatomyBlock = {
   /** The number of rows the block spans, per Grid variant. */
   readonly rowSpan: Record<Breakpoint, number | undefined>
   /**
-   * The space an `ams-mb-*` utility on the Cell puts below it. A Grid that has given up its row gap leaves the
-   * spacing to these, so the drawing has to read them to show the page it stands for.
+   * The space the content of the Cell puts below itself with an `ams-mb-*` utility. A Grid that has given up its
+   * row gap leaves the spacing to that margin, so the drawing has to read it to show the page it stands for.
    */
   readonly spaceAfter?: SpaceToken
   /** The number of columns the block spans, per Grid variant. */
@@ -326,13 +326,20 @@ const readCellRatio = (children: ReactNode): number | undefined => {
 const spaceAfterPattern = /(?:^|\s)ams-mb-(2xl|xl|xs|s|m|l)(?:\s|$)/
 
 /**
- * The space an `ams-mb-*` utility on a Cell puts below it.
+ * The space the content of a Cell puts below itself with an `ams-mb-*` utility.
  *
- * A Grid that gives up its row gap leaves the spacing to these, so a drawing that ignored them would show a heading
- * sitting against the section it introduces.
+ * A Grid that gives up its row gap leaves the spacing to that margin, so a drawing that ignored it would show a
+ * heading sitting against the section it introduces. The utility goes on the content rather than on the Cell,
+ * which only ever takes the props of the Grid, so this reads the last thing the Cell holds: a grid item opens an
+ * independent formatting context, so the margin of that last child adds to the height of the Cell rather than
+ * collapsing through it.
  */
-const readSpaceAfter = (className: unknown): SpaceToken | undefined =>
-  typeof className === 'string' ? (spaceAfterPattern.exec(className)?.[1] as SpaceToken | undefined) : undefined
+const readSpaceAfter = (children: ReactNode): SpaceToken | undefined => {
+  const last = Children.toArray(children).filter(isValidElement).at(-1)
+  const className = last ? propsOf(last)['className'] : undefined
+
+  return typeof className === 'string' ? (spaceAfterPattern.exec(className)?.[1] as SpaceToken | undefined) : undefined
+}
 
 /**
  * Reads a Grid Cell or a Grid Subgrid. Both take the same placement props.
@@ -341,7 +348,7 @@ const readSpaceAfter = (className: unknown): SpaceToken | undefined =>
  * Its own columns are numbered from one again, so a span of ‘all’ is the span of the Subgrid rather than of the Grid.
  */
 const readCell = (element: ReactElement, columns?: Record<Breakpoint, number>): AnatomyBlock => {
-  const { appearance, children, className, gapVertical, rowSpan, span, start } = propsOf(element)
+  const { appearance, children, gapVertical, rowSpan, span, start } = propsOf(element)
   const available = (viewport: AnatomyViewport) => columns?.[viewport.key] ?? viewport.columns
 
   return {
@@ -352,7 +359,7 @@ const readCell = (element: ReactElement, columns?: Record<Breakpoint, number>): 
     height: perViewport(() => defaultBlockHeight),
     label: '',
     rowSpan: perViewport((viewport) => readColumns(rowSpan, viewport)),
-    spaceAfter: readSpaceAfter(className),
+    spaceAfter: readSpaceAfter(children as ReactNode),
     // A cell without a `span` spans a single column, as `grid-column-end: auto` does.
     span: perViewport((viewport) => readColumns(span, viewport, available(viewport)) ?? 1),
     start: perViewport((viewport) => readColumns(start, viewport, available(viewport))),

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -164,54 +164,61 @@ const meta = {
        * aria-labelledby names that landmark after the heading below, whose id exists only to be referenced here.
        */}
       {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
-      <Grid aria-labelledby="meer-nieuws" as="aside" paddingBottom="2x-large" paddingTop="x-large">
-        <Grid.Cell span="all">
+      {/*
+       * The Grid gives up its row gap so the heading can set the medium the vertical space guidance asks for
+       * below a heading shown at the largest size, and the Subgrid puts the regular gap back between the Cells
+       * it holds. Left to the row gap, the heading would sit an x-large from the section it introduces.
+       */}
+      <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
+        <Grid.Cell className="ams-mb-m" span="all">
           <Heading id="meer-nieuws" level={2} size="level-1">
             Meer nieuws
           </Heading>
         </Grid.Cell>
-        <Grid.Cell span={4}>
-          <Card>
-            {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
-            <Card.Image alt="" src={exampleImageSource(640, 360, 1)} />
-            <Card.HeadingGroup tagline="Nieuws">
-              <Card.Heading level={3}>
-                <Card.Link href="#">Waarom we op zoek zijn naar vleermuizen</Card.Link>
-              </Card.Heading>
-            </Card.HeadingGroup>
-            <Paragraph>
-              U kunt &apos;s avonds ecologen in oranje hesjes tegenkomen. Zij zijn op zoek naar vleermuizen. Dat heeft
-              te maken met het verduurzamen van woningen.
-            </Paragraph>
-          </Card>
-        </Grid.Cell>
-        <Grid.Cell span={4}>
-          <Card>
-            <Card.Image alt="" src={exampleImageSource(640, 360, 2)} />
-            <Card.HeadingGroup tagline="Nieuws">
-              <Card.Heading level={3}>
-                <Card.Link href="#">Meer aandacht voor voetgangers, een jaar lang</Card.Link>
-              </Card.Heading>
-            </Card.HeadingGroup>
-            <Paragraph>
-              We gaan de veiligheid voor voetgangers verbeteren, meer ruimte maken, en lopen en wandelen stimuleren.
-            </Paragraph>
-          </Card>
-        </Grid.Cell>
-        <Grid.Cell span={4}>
-          <Card>
-            <Card.Image alt="" src={exampleImageSource(640, 360, 3)} />
-            <Card.HeadingGroup tagline="Nieuws">
-              <Card.Heading level={3}>
-                <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>
-              </Card.Heading>
-            </Card.HeadingGroup>
-            <Paragraph>
-              Afvalboten, bakfietsen en ondergrondse containers. We experimenteren met nieuwe manieren om afval op te
-              halen in het centrum.
-            </Paragraph>
-          </Card>
-        </Grid.Cell>
+        <Grid.Subgrid gapVertical="x-large" span="all">
+          <Grid.Cell span={4}>
+            <Card>
+              {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
+              <Card.Image alt="" src={exampleImageSource(640, 360, 1)} />
+              <Card.HeadingGroup tagline="Nieuws">
+                <Card.Heading level={3}>
+                  <Card.Link href="#">Waarom we op zoek zijn naar vleermuizen</Card.Link>
+                </Card.Heading>
+              </Card.HeadingGroup>
+              <Paragraph>
+                U kunt &apos;s avonds ecologen in oranje hesjes tegenkomen. Zij zijn op zoek naar vleermuizen. Dat heeft
+                te maken met het verduurzamen van woningen.
+              </Paragraph>
+            </Card>
+          </Grid.Cell>
+          <Grid.Cell span={4}>
+            <Card>
+              <Card.Image alt="" src={exampleImageSource(640, 360, 2)} />
+              <Card.HeadingGroup tagline="Nieuws">
+                <Card.Heading level={3}>
+                  <Card.Link href="#">Meer aandacht voor voetgangers, een jaar lang</Card.Link>
+                </Card.Heading>
+              </Card.HeadingGroup>
+              <Paragraph>
+                We gaan de veiligheid voor voetgangers verbeteren, meer ruimte maken, en lopen en wandelen stimuleren.
+              </Paragraph>
+            </Card>
+          </Grid.Cell>
+          <Grid.Cell span={4}>
+            <Card>
+              <Card.Image alt="" src={exampleImageSource(640, 360, 3)} />
+              <Card.HeadingGroup tagline="Nieuws">
+                <Card.Heading level={3}>
+                  <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>
+                </Card.Heading>
+              </Card.HeadingGroup>
+              <Paragraph>
+                Afvalboten, bakfietsen en ondergrondse containers. We experimenteren met nieuwe manieren om afval op te
+                halen in het centrum.
+              </Paragraph>
+            </Card>
+          </Grid.Cell>
+        </Grid.Subgrid>
       </Grid>
     </>
   ),
@@ -333,46 +340,53 @@ export const Default: StoryObj = {
    * aria-labelledby names that landmark after the heading below, whose id exists only to be referenced here.
    */}
   {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
-  <Grid aria-labelledby="meer-nieuws" as="aside" paddingBottom="2x-large" paddingTop="x-large">
-    <Grid.Cell span="all">
+  {/*
+   * The Grid gives up its row gap so the heading can set the medium the vertical space guidance asks for
+   * below a heading shown at the largest size, and the Subgrid puts the regular gap back between the Cells
+   * it holds. Left to the row gap, the heading would sit an x-large from the section it introduces.
+   */}
+  <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
+    <Grid.Cell className="ams-mb-m" span="all">
       <Heading id="meer-nieuws" level={2} size="level-1">Meer nieuws</Heading>
     </Grid.Cell>
-    <Grid.Cell span={4}>
-      <Card>
-        {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
-        <Card.Image alt="" src="https://picsum.photos/640/360?random=1" />
-        <Card.HeadingGroup tagline="Nieuws">
-          <Card.Heading level={3}>
-            <Card.Link href="#">Waarom we op zoek zijn naar vleermuizen</Card.Link>
-          </Card.Heading>
-        </Card.HeadingGroup>
-        <Paragraph>
-          U kunt 's avonds ecologen in oranje hesjes tegenkomen. Zij zijn op zoek naar vleermuizen.
-        </Paragraph>
-      </Card>
-    </Grid.Cell>
-    <Grid.Cell span={4}>
-      <Card>
-        <Card.Image alt="" src="https://picsum.photos/640/360?random=2" />
-        <Card.HeadingGroup tagline="Nieuws">
-          <Card.Heading level={3}>
-            <Card.Link href="#">Meer aandacht voor voetgangers, een jaar lang</Card.Link>
-          </Card.Heading>
-        </Card.HeadingGroup>
-        <Paragraph>We gaan de veiligheid voor voetgangers verbeteren en meer ruimte maken.</Paragraph>
-      </Card>
-    </Grid.Cell>
-    <Grid.Cell span={4}>
-      <Card>
-        <Card.Image alt="" src="https://picsum.photos/640/360?random=3" />
-        <Card.HeadingGroup tagline="Nieuws">
-          <Card.Heading level={3}>
-            <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>
-          </Card.Heading>
-        </Card.HeadingGroup>
-        <Paragraph>Afvalboten, bakfietsen en ondergrondse containers in het centrum.</Paragraph>
-      </Card>
-    </Grid.Cell>
+    <Grid.Subgrid gapVertical="x-large" span="all">
+      <Grid.Cell span={4}>
+        <Card>
+          {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
+          <Card.Image alt="" src="https://picsum.photos/640/360?random=1" />
+          <Card.HeadingGroup tagline="Nieuws">
+            <Card.Heading level={3}>
+              <Card.Link href="#">Waarom we op zoek zijn naar vleermuizen</Card.Link>
+            </Card.Heading>
+          </Card.HeadingGroup>
+          <Paragraph>
+            U kunt 's avonds ecologen in oranje hesjes tegenkomen. Zij zijn op zoek naar vleermuizen.
+          </Paragraph>
+        </Card>
+      </Grid.Cell>
+      <Grid.Cell span={4}>
+        <Card>
+          <Card.Image alt="" src="https://picsum.photos/640/360?random=2" />
+          <Card.HeadingGroup tagline="Nieuws">
+            <Card.Heading level={3}>
+              <Card.Link href="#">Meer aandacht voor voetgangers, een jaar lang</Card.Link>
+            </Card.Heading>
+          </Card.HeadingGroup>
+          <Paragraph>We gaan de veiligheid voor voetgangers verbeteren en meer ruimte maken.</Paragraph>
+        </Card>
+      </Grid.Cell>
+      <Grid.Cell span={4}>
+        <Card>
+          <Card.Image alt="" src="https://picsum.photos/640/360?random=3" />
+          <Card.HeadingGroup tagline="Nieuws">
+            <Card.Heading level={3}>
+              <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>
+            </Card.Heading>
+          </Card.HeadingGroup>
+          <Paragraph>Afvalboten, bakfietsen en ondergrondse containers in het centrum.</Paragraph>
+        </Card>
+      </Grid.Cell>
+    </Grid.Subgrid>
   </Grid>
 </>`,
         language: 'tsx',

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -165,9 +165,9 @@ const meta = {
        */}
       {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
       {/*
-       * The Grid gives up its row gap so the heading can set the medium the vertical space guidance asks for
-       * below a heading shown at the largest size, and the Subgrid puts the regular gap back between the Cells
-       * it holds. Left to the row gap, the heading would sit an x-large from the section it introduces.
+       * The row gap would put an x-large below the heading, where the guidance asks for a medium at this size.
+       * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+       * between the Cells.
        */}
       <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell className="ams-mb-m" span="all">
@@ -341,9 +341,9 @@ export const Default: StoryObj = {
    */}
   {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
   {/*
-   * The Grid gives up its row gap so the heading can set the medium the vertical space guidance asks for
-   * below a heading shown at the largest size, and the Subgrid puts the regular gap back between the Cells
-   * it holds. Left to the row gap, the heading would sit an x-large from the section it introduces.
+   * The row gap would put an x-large below the heading, where the guidance asks for a medium at this size.
+   * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+   * between the Cells.
    */}
   <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell className="ams-mb-m" span="all">

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -170,8 +170,8 @@ const meta = {
        * between the Cells.
        */}
       <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
-        <Grid.Cell className="ams-mb-m" span="all">
-          <Heading id="meer-nieuws" level={2} size="level-1">
+        <Grid.Cell span="all">
+          <Heading className="ams-mb-m" id="meer-nieuws" level={2} size="level-1">
             Meer nieuws
           </Heading>
         </Grid.Cell>
@@ -346,8 +346,8 @@ export const Default: StoryObj = {
    * between the Cells.
    */}
   <Grid aria-labelledby="meer-nieuws" as="aside" gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
-    <Grid.Cell className="ams-mb-m" span="all">
-      <Heading id="meer-nieuws" level={2} size="level-1">Meer nieuws</Heading>
+    <Grid.Cell span="all">
+      <Heading className="ams-mb-m" id="meer-nieuws" level={2} size="level-1">Meer nieuws</Heading>
     </Grid.Cell>
     <Grid.Subgrid gapVertical="x-large" span="all">
       <Grid.Cell span={4}>

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -35,9 +35,9 @@ const meta = {
        * between the Cells.
        */}
       <Grid gapVertical="none" paddingVertical="x-large">
-        <Grid.Cell className="ams-mb-m" span="all">
+        <Grid.Cell span="all">
           {/* Second level in the outline (the hidden h1 is first), shown at the largest size. */}
-          <Heading level={2} size="level-1">
+          <Heading className="ams-mb-m" level={2} size="level-1">
             {topTaskSection.title}
           </Heading>
         </Grid.Cell>
@@ -83,8 +83,8 @@ const meta = {
       </Spotlight>
       {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
       <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
-        <Grid.Cell className="ams-mb-m" span="all">
-          <Heading level={2} size="level-1">
+        <Grid.Cell span="all">
+          <Heading className="ams-mb-m" level={2} size="level-1">
             {newsSection.title}
           </Heading>
         </Grid.Cell>
@@ -134,9 +134,9 @@ export const Default: StoryObj = {
    * between the Cells.
    */}
   <Grid gapVertical="none" paddingVertical="x-large">
-    <Grid.Cell className="ams-mb-m" span="all">
+    <Grid.Cell span="all">
       {/* Second level in the outline (the hidden h1 is first), shown at the largest size. */}
-      <Heading level={2} size="level-1">{topTaskSection.title}</Heading>
+      <Heading className="ams-mb-m" level={2} size="level-1">{topTaskSection.title}</Heading>
     </Grid.Cell>
     <Grid.Subgrid gapVertical="x-large" span="all">
       {/*
@@ -176,8 +176,8 @@ export const Default: StoryObj = {
   </Spotlight>
   {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
   <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
-    <Grid.Cell className="ams-mb-m" span="all">
-      <Heading level={2} size="level-1">{newsSection.title}</Heading>
+    <Grid.Cell span="all">
+      <Heading className="ams-mb-m" level={2} size="level-1">{newsSection.title}</Heading>
     </Grid.Cell>
     <Grid.Subgrid gapVertical="x-large" span="all">
       {newsSection.items.map(({ title, description, image }) => (

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -29,31 +29,38 @@ const meta = {
        * silently if that story ever switches to a render function, leaving this hero empty.
        */}
       <Overlap>{OverlapStory.args?.children}</Overlap>
-      <Grid paddingVertical="x-large">
-        <Grid.Cell span="all">
+      {/*
+       * The Grid gives up its row gap so the heading can set the medium the vertical space guidance asks for
+       * below a heading shown at the largest size, and the Subgrid puts the regular gap back between the Cells
+       * it holds. Left to the row gap, the heading would sit an x-large from the section it introduces.
+       */}
+      <Grid gapVertical="none" paddingVertical="x-large">
+        <Grid.Cell className="ams-mb-m" span="all">
           {/* Second level in the outline (the hidden h1 is first), shown at the largest size. */}
           <Heading level={2} size="level-1">
             {topTaskSection.title}
           </Heading>
         </Grid.Cell>
-        {/*
-         * Cells flow from the left in source order, so no section here needs a start. On the wide grid the top
-         * tasks fit four to a row at {{ narrow: 4, medium: 4, wide: 3 }} and three preview cards at span={4}
-         * fill the row exactly; on the medium grid both drop to two per row, and on the narrow grid every cell
-         * is full width. The two Spotlight blocks at {{ narrow: 4, medium: 4, wide: 6 }} sit side by side on
-         * both the wide and medium grids, and stack on the narrow one.
-         */}
-        {topTaskSection.tasks.map(({ title, description }) => (
-          <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
-            <Card>
-              {/* Card.Link stretches over the whole Card, so the entire Card is one clickable link. */}
-              <Card.Heading level={3}>
-                <Card.Link href="#">{title}</Card.Link>
-              </Card.Heading>
-              <Paragraph>{description}</Paragraph>
-            </Card>
-          </Grid.Cell>
-        ))}
+        <Grid.Subgrid gapVertical="x-large" span="all">
+          {/*
+           * Cells flow from the left in source order, so no section here needs a start. On the wide grid the top
+           * tasks fit four to a row at {{ narrow: 4, medium: 4, wide: 3 }} and three preview cards at span={4}
+           * fill the row exactly; on the medium grid both drop to two per row, and on the narrow grid every cell
+           * is full width. The two Spotlight blocks at {{ narrow: 4, medium: 4, wide: 6 }} sit side by side on
+           * both the wide and medium grids, and stack on the narrow one.
+           */}
+          {topTaskSection.tasks.map(({ title, description }) => (
+            <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
+              <Card>
+                {/* Card.Link stretches over the whole Card, so the entire Card is one clickable link. */}
+                <Card.Heading level={3}>
+                  <Card.Link href="#">{title}</Card.Link>
+                </Card.Heading>
+                <Paragraph>{description}</Paragraph>
+              </Card>
+            </Grid.Cell>
+          ))}
+        </Grid.Subgrid>
       </Grid>
       {/*
        * These highlights are part of the homepage’s own content, so the Spotlight stays a plain band inside <main>.
@@ -75,27 +82,29 @@ const meta = {
         </Grid>
       </Spotlight>
       {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
-      <Grid paddingBottom="2x-large" paddingTop="x-large">
-        <Grid.Cell span="all">
+      <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
+        <Grid.Cell className="ams-mb-m" span="all">
           <Heading level={2} size="level-1">
             {newsSection.title}
           </Heading>
         </Grid.Cell>
-        {newsSection.items.map(({ title, description, image }) => (
-          <Grid.Cell key={title} span={4}>
-            <Card>
-              {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
-              <Card.Image alt="" src={image} />
-              {/* Card.HeadingGroup adds a short tagline above the Card’s heading. */}
-              <Card.HeadingGroup tagline="Nieuws">
-                <Card.Heading level={3}>
-                  <Card.Link href="#">{title}</Card.Link>
-                </Card.Heading>
-              </Card.HeadingGroup>
-              <Paragraph>{description}</Paragraph>
-            </Card>
-          </Grid.Cell>
-        ))}
+        <Grid.Subgrid gapVertical="x-large" span="all">
+          {newsSection.items.map(({ title, description, image }) => (
+            <Grid.Cell key={title} span={4}>
+              <Card>
+                {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
+                <Card.Image alt="" src={image} />
+                {/* Card.HeadingGroup adds a short tagline above the Card’s heading. */}
+                <Card.HeadingGroup tagline="Nieuws">
+                  <Card.Heading level={3}>
+                    <Card.Link href="#">{title}</Card.Link>
+                  </Card.Heading>
+                </Card.HeadingGroup>
+                <Paragraph>{description}</Paragraph>
+              </Card>
+            </Grid.Cell>
+          ))}
+        </Grid.Subgrid>
       </Grid>
     </main>
   ),
@@ -119,29 +128,36 @@ export const Default: StoryObj = {
   <h1 className="ams-visually-hidden">Homepage van de gemeente Amsterdam</h1>
   {/* A hero that overlaps a full-width image with the block beneath it – see the Overlap component. */}
   <Overlap>{/* … */}</Overlap>
-  <Grid paddingVertical="x-large">
-    <Grid.Cell span="all">
+  {/*
+   * The Grid gives up its row gap so the heading can set the medium the vertical space guidance asks for
+   * below a heading shown at the largest size, and the Subgrid puts the regular gap back between the Cells
+   * it holds. Left to the row gap, the heading would sit an x-large from the section it introduces.
+   */}
+  <Grid gapVertical="none" paddingVertical="x-large">
+    <Grid.Cell className="ams-mb-m" span="all">
       {/* Second level in the outline (the hidden h1 is first), shown at the largest size. */}
       <Heading level={2} size="level-1">{topTaskSection.title}</Heading>
     </Grid.Cell>
-    {/*
-     * Cells flow from the left in source order, so no section here needs a start. On the wide grid the top
-     * tasks fit four to a row at {{ narrow: 4, medium: 4, wide: 3 }} and three preview cards at span={4}
-     * fill the row exactly; on the medium grid both drop to two per row, and on the narrow grid every cell
-     * is full width. The two Spotlight blocks at {{ narrow: 4, medium: 4, wide: 6 }} sit side by side on
-     * both the wide and medium grids, and stack on the narrow one.
-     */}
-    {topTaskSection.tasks.map(({ title, description }) => (
-      <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
-        <Card>
-          {/* Card.Link stretches over the whole Card, so the entire Card is one clickable link. */}
-          <Card.Heading level={3}>
-            <Card.Link href="#">{title}</Card.Link>
-          </Card.Heading>
-          <Paragraph>{description}</Paragraph>
-        </Card>
-      </Grid.Cell>
-    ))}
+    <Grid.Subgrid gapVertical="x-large" span="all">
+      {/*
+       * Cells flow from the left in source order, so no section here needs a start. On the wide grid the top
+       * tasks fit four to a row at {{ narrow: 4, medium: 4, wide: 3 }} and three preview cards at span={4}
+       * fill the row exactly; on the medium grid both drop to two per row, and on the narrow grid every cell
+       * is full width. The two Spotlight blocks at {{ narrow: 4, medium: 4, wide: 6 }} sit side by side on
+       * both the wide and medium grids, and stack on the narrow one.
+       */}
+      {topTaskSection.tasks.map(({ title, description }) => (
+        <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
+          <Card>
+            {/* Card.Link stretches over the whole Card, so the entire Card is one clickable link. */}
+            <Card.Heading level={3}>
+              <Card.Link href="#">{title}</Card.Link>
+            </Card.Heading>
+            <Paragraph>{description}</Paragraph>
+          </Card>
+        </Grid.Cell>
+      ))}
+    </Grid.Subgrid>
   </Grid>
   {/*
    * These highlights are part of the homepage’s own content, so the Spotlight stays a plain band inside <main>.
@@ -159,25 +175,27 @@ export const Default: StoryObj = {
     </Grid>
   </Spotlight>
   {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
-  <Grid paddingBottom="2x-large" paddingTop="x-large">
-    <Grid.Cell span="all">
+  <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
+    <Grid.Cell className="ams-mb-m" span="all">
       <Heading level={2} size="level-1">{newsSection.title}</Heading>
     </Grid.Cell>
-    {newsSection.items.map(({ title, description, image }) => (
-      <Grid.Cell key={title} span={4}>
-        <Card>
-          {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
-          <Card.Image alt="" src={image} />
-          {/* Card.HeadingGroup adds a short tagline above the Card’s heading. */}
-          <Card.HeadingGroup tagline="Nieuws">
-            <Card.Heading level={3}>
-              <Card.Link href="#">{title}</Card.Link>
-            </Card.Heading>
-          </Card.HeadingGroup>
-          <Paragraph>{description}</Paragraph>
-        </Card>
-      </Grid.Cell>
-    ))}
+    <Grid.Subgrid gapVertical="x-large" span="all">
+      {newsSection.items.map(({ title, description, image }) => (
+        <Grid.Cell key={title} span={4}>
+          <Card>
+            {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
+            <Card.Image alt="" src={image} />
+            {/* Card.HeadingGroup adds a short tagline above the Card’s heading. */}
+            <Card.HeadingGroup tagline="Nieuws">
+              <Card.Heading level={3}>
+                <Card.Link href="#">{title}</Card.Link>
+              </Card.Heading>
+            </Card.HeadingGroup>
+            <Paragraph>{description}</Paragraph>
+          </Card>
+        </Grid.Cell>
+      ))}
+    </Grid.Subgrid>
   </Grid>
 </main>`,
         language: 'tsx',

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -30,9 +30,9 @@ const meta = {
        */}
       <Overlap>{OverlapStory.args?.children}</Overlap>
       {/*
-       * The Grid gives up its row gap so the heading can set the medium the vertical space guidance asks for
-       * below a heading shown at the largest size, and the Subgrid puts the regular gap back between the Cells
-       * it holds. Left to the row gap, the heading would sit an x-large from the section it introduces.
+       * The row gap would put an x-large below the heading, where the guidance asks for a medium at this size.
+       * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+       * between the Cells.
        */}
       <Grid gapVertical="none" paddingVertical="x-large">
         <Grid.Cell className="ams-mb-m" span="all">
@@ -129,9 +129,9 @@ export const Default: StoryObj = {
   {/* A hero that overlaps a full-width image with the block beneath it – see the Overlap component. */}
   <Overlap>{/* … */}</Overlap>
   {/*
-   * The Grid gives up its row gap so the heading can set the medium the vertical space guidance asks for
-   * below a heading shown at the largest size, and the Subgrid puts the regular gap back between the Cells
-   * it holds. Left to the row gap, the heading would sit an x-large from the section it introduces.
+   * The row gap would put an x-large below the heading, where the guidance asks for a medium at this size.
+   * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+   * between the Cells.
    */}
   <Grid gapVertical="none" paddingVertical="x-large">
     <Grid.Cell className="ams-mb-m" span="all">

--- a/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
+++ b/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
@@ -544,17 +544,17 @@ export const Group: StoryObj = {
         </Grid.Cell>
       </Grid>
     </Spotlight>
-    {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
     {/*
-     * The row gap would put an x-large below each heading, where the guidance asks for a small at this size.
-     * So the Grid gives up its gap, each heading sets the space itself, and the Subgrids put the gap back
-     * between the Cards. The first Subgrid also carries the x-large that belongs above the next heading.
+     * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+     * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+     * between the Cards. Each of the two sections takes a Grid of its own, so the boundary between them is
+     * the padding of the second rather than a margin on the Subgrid of the first.
      */}
-    <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
+    <Grid gapVertical="none" paddingTop="x-large">
       <Grid.Cell span="all">
         <Heading className="ams-mb-s" level={2}>Raadsleden</Heading>
       </Grid.Cell>
-      <Grid.Subgrid className="ams-mb-xl" gapVertical="x-large" span="all">
+      <Grid.Subgrid gapVertical="x-large" span="all">
         {/* Preview cards take a span of 4, so they fit three to a row on the wide grid and two on the medium one. */}
         {councilMembers.map(({ name, role }) => (
           <Grid.Cell key={name} span={4}>
@@ -574,6 +574,9 @@ export const Group: StoryObj = {
           </Grid.Cell>
         ))}
       </Grid.Subgrid>
+    </Grid>
+    {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+    <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
       <Grid.Cell span="all">
         <Heading className="ams-mb-s" level={2}>Fractievertegenwoordigers</Heading>
       </Grid.Cell>
@@ -739,19 +742,19 @@ export const Group: StoryObj = {
             </Grid.Cell>
           </Grid>
         </Spotlight>
-        {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
         {/*
-         * The row gap would put an x-large below each heading, where the guidance asks for a small at this size.
-         * So the Grid gives up its gap, each heading sets the space itself, and the Subgrids put the gap back
-         * between the Cards. The first Subgrid also carries the x-large that belongs above the next heading.
+         * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+         * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+         * between the Cards. Each of the two sections takes a Grid of its own, so the boundary between them is
+         * the padding of the second rather than a margin on the Subgrid of the first.
          */}
-        <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
+        <Grid gapVertical="none" paddingTop="x-large">
           <Grid.Cell span="all">
             <Heading className="ams-mb-s" level={2}>
               Raadsleden
             </Heading>
           </Grid.Cell>
-          <Grid.Subgrid className="ams-mb-xl" gapVertical="x-large" span="all">
+          <Grid.Subgrid gapVertical="x-large" span="all">
             {/* Preview cards take a span of 4, so they fit three to a row on the wide grid and two on the medium one. */}
             {councilMembers.map(({ name, role }) => (
               <Grid.Cell key={name} span={4}>
@@ -771,6 +774,9 @@ export const Group: StoryObj = {
               </Grid.Cell>
             ))}
           </Grid.Subgrid>
+        </Grid>
+        {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+        <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
           <Grid.Cell span="all">
             <Heading className="ams-mb-s" level={2}>
               Fractievertegenwoordigers

--- a/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
+++ b/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
@@ -460,9 +460,9 @@ export const Group: StoryObj = {
       </Grid.Cell>
     </Grid>
     {/*
-     * A Grid of its own, so its row gap can go: the heading then sets the small the vertical space guidance
-     * asks for below a level 2 heading, and the Subgrid puts the regular gap back between the Cells it holds.
-     * It sets no paddingTop, because the paddingBottom of the Content Header above already spaces the two.
+     * A Grid of its own, so its row gap can go. That gap would put an x-large below the heading, where the
+     * guidance asks for a small at this size, so the heading sets the space itself and the Subgrid puts the
+     * gap back between the Cells. It sets no paddingTop: the Content Header above already spaces the two.
      */}
     <Grid gapVertical="none" paddingBottom="x-large">
       {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
@@ -546,9 +546,9 @@ export const Group: StoryObj = {
     </Spotlight>
     {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
     {/*
-     * The Grid gives up its row gap so each heading can set the small the vertical space guidance asks for
-     * below a level 2 heading, and the Subgrids put the regular gap back between the Cards they hold. The
-     * first Subgrid carries the x-large the guidance asks for above the heading of the next section.
+     * The row gap would put an x-large below each heading, where the guidance asks for a small at this size.
+     * So the Grid gives up its gap, each heading sets the space itself, and the Subgrids put the gap back
+     * between the Cards. The first Subgrid also carries the x-large that belongs above the next heading.
      */}
     <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
       <Grid.Cell className="ams-mb-s" span="all">
@@ -638,9 +638,9 @@ export const Group: StoryObj = {
           </Grid.Cell>
         </Grid>
         {/*
-         * A Grid of its own, so its row gap can go: the heading then sets the small the vertical space guidance
-         * asks for below a level 2 heading, and the Subgrid puts the regular gap back between the Cells it holds.
-         * It sets no paddingTop, because the paddingBottom of the Content Header above already spaces the two.
+         * A Grid of its own, so its row gap can go. That gap would put an x-large below the heading, where the
+         * guidance asks for a small at this size, so the heading sets the space itself and the Subgrid puts the
+         * gap back between the Cells. It sets no paddingTop: the Content Header above already spaces the two.
          */}
         <Grid gapVertical="none" paddingBottom="x-large">
           {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
@@ -743,9 +743,9 @@ export const Group: StoryObj = {
         </Spotlight>
         {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
         {/*
-         * The Grid gives up its row gap so each heading can set the small the vertical space guidance asks for
-         * below a level 2 heading, and the Subgrids put the regular gap back between the Cards they hold. The
-         * first Subgrid carries the x-large the guidance asks for above the heading of the next section.
+         * The row gap would put an x-large below each heading, where the guidance asks for a small at this size.
+         * So the Grid gives up its gap, each heading sets the space itself, and the Subgrids put the gap back
+         * between the Cards. The first Subgrid also carries the x-large that belongs above the next heading.
          */}
         <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
           <Grid.Cell className="ams-mb-s" span="all">
@@ -843,8 +843,9 @@ export const Location: StoryObj = {
       </Grid.Cell>
     </Grid>
     {/*
-     * The Grid gives up its row gap so the heading can set the small the vertical space guidance asks for
-     * below a level 2 heading, and the Subgrid puts the regular gap back between the Cells it holds.
+     * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+     * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+     * between the Cells.
      */}
     <Grid gapVertical="none" paddingVertical="x-large">
       {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
@@ -1013,8 +1014,9 @@ export const Location: StoryObj = {
           </Grid.Cell>
         </Grid>
         {/*
-         * The Grid gives up its row gap so the heading can set the small the vertical space guidance asks for
-         * below a level 2 heading, and the Subgrid puts the regular gap back between the Cells it holds.
+         * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+         * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+         * between the Cells.
          */}
         <Grid gapVertical="none" paddingVertical="x-large">
           {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
@@ -1250,8 +1252,9 @@ export const LocationLarge: StoryObj = {
       </Grid.Cell>
     </Grid>
     {/*
-     * The Grid gives up its row gap so the heading can set the small the vertical space guidance asks for
-     * below a level 2 heading, and the Subgrid puts the regular gap back between the Cells it holds.
+     * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+     * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+     * between the Cells.
      */}
     <Grid gapVertical="none" paddingBottom="x-large">
       <Grid.Cell className="ams-mb-s" span="all">
@@ -1540,8 +1543,9 @@ export const LocationLarge: StoryObj = {
           </Grid.Cell>
         </Grid>
         {/*
-         * The Grid gives up its row gap so the heading can set the small the vertical space guidance asks for
-         * below a level 2 heading, and the Subgrid puts the regular gap back between the Cells it holds.
+         * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+         * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+         * between the Cells.
          */}
         <Grid gapVertical="none" paddingBottom="x-large">
           <Grid.Cell className="ams-mb-s" span="all">

--- a/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
+++ b/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
@@ -466,8 +466,8 @@ export const Group: StoryObj = {
      */}
     <Grid gapVertical="none" paddingBottom="x-large">
       {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
-      <Grid.Cell className="ams-mb-s" span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading level={2}>Adres en contact</Heading>
+      <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-s" level={2}>Adres en contact</Heading>
       </Grid.Cell>
       <Grid.Subgrid gapVertical="x-large" span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
@@ -551,8 +551,8 @@ export const Group: StoryObj = {
      * between the Cards. The first Subgrid also carries the x-large that belongs above the next heading.
      */}
     <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
-      <Grid.Cell className="ams-mb-s" span="all">
-        <Heading level={2}>Raadsleden</Heading>
+      <Grid.Cell span="all">
+        <Heading className="ams-mb-s" level={2}>Raadsleden</Heading>
       </Grid.Cell>
       <Grid.Subgrid className="ams-mb-xl" gapVertical="x-large" span="all">
         {/* Preview cards take a span of 4, so they fit three to a row on the wide grid and two on the medium one. */}
@@ -574,8 +574,8 @@ export const Group: StoryObj = {
           </Grid.Cell>
         ))}
       </Grid.Subgrid>
-      <Grid.Cell className="ams-mb-s" span="all">
-        <Heading level={2}>Fractievertegenwoordigers</Heading>
+      <Grid.Cell span="all">
+        <Heading className="ams-mb-s" level={2}>Fractievertegenwoordigers</Heading>
       </Grid.Cell>
       <Grid.Subgrid gapVertical="x-large" span="all">
         {groupRepresentatives.map(({ name, role }) => (
@@ -644,12 +644,10 @@ export const Group: StoryObj = {
          */}
         <Grid gapVertical="none" paddingBottom="x-large">
           {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
-          <Grid.Cell
-            className="ams-mb-s"
-            span={{ narrow: 4, medium: 8, wide: 10 }}
-            start={{ narrow: 1, medium: 1, wide: 2 }}
-          >
-            <Heading level={2}>Adres en contact</Heading>
+          <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading className="ams-mb-s" level={2}>
+              Adres en contact
+            </Heading>
           </Grid.Cell>
           <Grid.Subgrid
             gapVertical="x-large"
@@ -748,8 +746,10 @@ export const Group: StoryObj = {
          * between the Cards. The first Subgrid also carries the x-large that belongs above the next heading.
          */}
         <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
-          <Grid.Cell className="ams-mb-s" span="all">
-            <Heading level={2}>Raadsleden</Heading>
+          <Grid.Cell span="all">
+            <Heading className="ams-mb-s" level={2}>
+              Raadsleden
+            </Heading>
           </Grid.Cell>
           <Grid.Subgrid className="ams-mb-xl" gapVertical="x-large" span="all">
             {/* Preview cards take a span of 4, so they fit three to a row on the wide grid and two on the medium one. */}
@@ -771,8 +771,10 @@ export const Group: StoryObj = {
               </Grid.Cell>
             ))}
           </Grid.Subgrid>
-          <Grid.Cell className="ams-mb-s" span="all">
-            <Heading level={2}>Fractievertegenwoordigers</Heading>
+          <Grid.Cell span="all">
+            <Heading className="ams-mb-s" level={2}>
+              Fractievertegenwoordigers
+            </Heading>
           </Grid.Cell>
           <Grid.Subgrid gapVertical="x-large" span="all">
             {groupRepresentatives.map(({ name, role }) => (
@@ -849,8 +851,8 @@ export const Location: StoryObj = {
      */}
     <Grid gapVertical="none" paddingVertical="x-large">
       {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
-      <Grid.Cell className="ams-mb-s" span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading level={2}>Faciliteiten</Heading>
+      <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-s" level={2}>Faciliteiten</Heading>
       </Grid.Cell>
       <Grid.Subgrid gapVertical="x-large" span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
@@ -1020,12 +1022,10 @@ export const Location: StoryObj = {
          */}
         <Grid gapVertical="none" paddingVertical="x-large">
           {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
-          <Grid.Cell
-            className="ams-mb-s"
-            span={{ narrow: 4, medium: 8, wide: 10 }}
-            start={{ narrow: 1, medium: 1, wide: 2 }}
-          >
-            <Heading level={2}>Faciliteiten</Heading>
+          <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading className="ams-mb-s" level={2}>
+              Faciliteiten
+            </Heading>
           </Grid.Cell>
           <Grid.Subgrid
             gapVertical="x-large"
@@ -1257,8 +1257,8 @@ export const LocationLarge: StoryObj = {
      * between the Cells.
      */}
     <Grid gapVertical="none" paddingBottom="x-large">
-      <Grid.Cell className="ams-mb-s" span="all">
-        <Heading level={2}>Zalen en sportmogelijkheden</Heading>
+      <Grid.Cell span="all">
+        <Heading className="ams-mb-s" level={2}>Zalen en sportmogelijkheden</Heading>
       </Grid.Cell>
       <Grid.Subgrid gapVertical="x-large" span="all">
         {/* Preview cards take a span of 4, so they fit three to a row on the wide grid and two on the medium one. */}
@@ -1298,8 +1298,8 @@ export const LocationLarge: StoryObj = {
     </Grid>
     <Grid gapVertical="none" paddingBottom="x-large">
       {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
-      <Grid.Cell className="ams-mb-s" span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading level={2}>Faciliteiten</Heading>
+      <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-s" level={2}>Faciliteiten</Heading>
       </Grid.Cell>
       <Grid.Subgrid gapVertical="x-large" span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
@@ -1548,8 +1548,10 @@ export const LocationLarge: StoryObj = {
          * between the Cells.
          */}
         <Grid gapVertical="none" paddingBottom="x-large">
-          <Grid.Cell className="ams-mb-s" span="all">
-            <Heading level={2}>Zalen en sportmogelijkheden</Heading>
+          <Grid.Cell span="all">
+            <Heading className="ams-mb-s" level={2}>
+              Zalen en sportmogelijkheden
+            </Heading>
           </Grid.Cell>
           <Grid.Subgrid gapVertical="x-large" span="all">
             {/* Preview cards take a span of 4, so they fit three to a row on the wide grid and two on the medium one. */}
@@ -1589,12 +1591,10 @@ export const LocationLarge: StoryObj = {
         </Grid>
         <Grid gapVertical="none" paddingBottom="x-large">
           {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
-          <Grid.Cell
-            className="ams-mb-s"
-            span={{ narrow: 4, medium: 8, wide: 10 }}
-            start={{ narrow: 1, medium: 1, wide: 2 }}
-          >
-            <Heading level={2}>Faciliteiten</Heading>
+          <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading className="ams-mb-s" level={2}>
+              Faciliteiten
+            </Heading>
           </Grid.Cell>
           <Grid.Subgrid
             gapVertical="x-large"

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -247,9 +247,9 @@ const meta = {
         </Grid>
         <Spotlight color="azure">
           {/*
-           * The Grid gives up its row gap so the heading can set the small the vertical space guidance asks for
-           * below a level 2 heading, and the Subgrid puts the regular gap back between the Cells it holds. Left
-           * to the row gap, the heading would sit an x-large from the section it introduces.
+           * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+           * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+           * between the Cells.
            */}
           <Grid gapVertical="none" paddingVertical="x-large">
             <Grid.Cell className="ams-mb-s" span="all">
@@ -533,9 +533,9 @@ export const Default: StoryObj = {
     </Grid>
     <Spotlight color="azure">
       {/*
-       * The Grid gives up its row gap so the heading can set the small the vertical space guidance asks for
-       * below a level 2 heading, and the Subgrid puts the regular gap back between the Cells it holds. Left
-       * to the row gap, the heading would sit an x-large from the section it introduces.
+       * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+       * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+       * between the Cells.
        */}
       <Grid gapVertical="none" paddingVertical="x-large">
         <Grid.Cell className="ams-mb-s" span="all">

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -246,41 +246,48 @@ const meta = {
           </Grid.Cell>
         </Grid>
         <Spotlight color="azure">
-          <Grid paddingVertical="x-large">
-            <Grid.Cell span="all">
+          {/*
+           * The Grid gives up its row gap so the heading can set the small the vertical space guidance asks for
+           * below a level 2 heading, and the Subgrid puts the regular gap back between the Cells it holds. Left
+           * to the row gap, the heading would sit an x-large from the section it introduces.
+           */}
+          <Grid gapVertical="none" paddingVertical="x-large">
+            <Grid.Cell className="ams-mb-s" span="all">
               <Heading color="inverse" level={2}>
                 Zelfbouw
               </Heading>
             </Grid.Cell>
-            {/* The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens. */}
-            <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 3 }}>
-              <Paragraph color="inverse">Meer over de verschillende vormen van zelfbouw vindt u op:</Paragraph>
-              <StandaloneLink color="inverse" href="#">
-                Zelfbouw
-              </StandaloneLink>
-            </Grid.Cell>
-            <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 3 }}>
-              <Paragraph color="inverse">
-                Op de kavelkaart is te zien welke kavels in de toekomst op Centrumeiland vrij komen.
-              </Paragraph>
-              <StandaloneLink color="inverse" href="#">
-                Aanbod kavels
-              </StandaloneLink>
-            </Grid.Cell>
-            <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 3 }}>
-              <Paragraph color="inverse">
-                Op zoek naar medebouwers of samen met anderen bouwen? Plaats een oproep.
-              </Paragraph>
-              <StandaloneLink color="inverse" href="#">
-                Prikbord
-              </StandaloneLink>
-            </Grid.Cell>
-            <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 3 }}>
-              <Paragraph color="inverse">Meld u aan en blijf op de hoogte over zelfbouw in Amsterdam.</Paragraph>
-              <StandaloneLink color="inverse" href="#">
-                Nieuwsbrief zelfbouw
-              </StandaloneLink>
-            </Grid.Cell>
+            <Grid.Subgrid gapVertical="x-large" span="all">
+              {/* The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens. */}
+              <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 3 }}>
+                <Paragraph color="inverse">Meer over de verschillende vormen van zelfbouw vindt u op:</Paragraph>
+                <StandaloneLink color="inverse" href="#">
+                  Zelfbouw
+                </StandaloneLink>
+              </Grid.Cell>
+              <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 3 }}>
+                <Paragraph color="inverse">
+                  Op de kavelkaart is te zien welke kavels in de toekomst op Centrumeiland vrij komen.
+                </Paragraph>
+                <StandaloneLink color="inverse" href="#">
+                  Aanbod kavels
+                </StandaloneLink>
+              </Grid.Cell>
+              <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 3 }}>
+                <Paragraph color="inverse">
+                  Op zoek naar medebouwers of samen met anderen bouwen? Plaats een oproep.
+                </Paragraph>
+                <StandaloneLink color="inverse" href="#">
+                  Prikbord
+                </StandaloneLink>
+              </Grid.Cell>
+              <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 3 }}>
+                <Paragraph color="inverse">Meld u aan en blijf op de hoogte over zelfbouw in Amsterdam.</Paragraph>
+                <StandaloneLink color="inverse" href="#">
+                  Nieuwsbrief zelfbouw
+                </StandaloneLink>
+              </Grid.Cell>
+            </Grid.Subgrid>
           </Grid>
         </Spotlight>
         <Grid paddingVertical="x-large">
@@ -351,41 +358,43 @@ const meta = {
          * rather than repeating the azure of the first.
          */}
         <Spotlight>
-          <Grid paddingVertical="x-large">
-            <Grid.Cell span="all">
+          <Grid gapVertical="none" paddingVertical="x-large">
+            <Grid.Cell className="ams-mb-s" span="all">
               <Heading color="inverse" level={2}>
                 Contact
               </Heading>
             </Grid.Cell>
-            <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 6 }}>
-              <Paragraph color="inverse">
-                Vragen over zelfbouw op Centrumeiland:{' '}
-                <Link color="inverse" href="mailto:zelfbouwcentrumeiland@amsterdam.nl">
-                  zelfbouwcentrumeiland@amsterdam.nl
-                </Link>
-              </Paragraph>
-              <Paragraph color="inverse">
-                Elke donderdag is er van 16.00 uur tot 17.00 uur een telefonisch spreekuur. Aanmelden via e-mail.
-              </Paragraph>
-            </Grid.Cell>
-            <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-              {/* These lines are kept in one Paragraph so they read as a single contact block, not as running text. */}
-              <Paragraph color="inverse">
-                Maud van Esch
-                <br />
-                Omgevingsmanager IJburg
-                <br />
-                <Link color="inverse" href="mailto:m.van.esch@amsterdam.nl">
-                  m.van.esch@amsterdam.nl
-                </Link>
-                <br />
-                <Link color="inverse" href="tel:+316645899537">
-                  06 4589 9537
-                </Link>
-                <br />
-                Voor vragen over werkzaamheden of bouwactiviteiten
-              </Paragraph>
-            </Grid.Cell>
+            <Grid.Subgrid gapVertical="x-large" span="all">
+              <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 6 }}>
+                <Paragraph color="inverse">
+                  Vragen over zelfbouw op Centrumeiland:{' '}
+                  <Link color="inverse" href="mailto:zelfbouwcentrumeiland@amsterdam.nl">
+                    zelfbouwcentrumeiland@amsterdam.nl
+                  </Link>
+                </Paragraph>
+                <Paragraph color="inverse">
+                  Elke donderdag is er van 16.00 uur tot 17.00 uur een telefonisch spreekuur. Aanmelden via e-mail.
+                </Paragraph>
+              </Grid.Cell>
+              <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+                {/* These lines are kept in one Paragraph so they read as a single contact block, not as running text. */}
+                <Paragraph color="inverse">
+                  Maud van Esch
+                  <br />
+                  Omgevingsmanager IJburg
+                  <br />
+                  <Link color="inverse" href="mailto:m.van.esch@amsterdam.nl">
+                    m.van.esch@amsterdam.nl
+                  </Link>
+                  <br />
+                  <Link color="inverse" href="tel:+316645899537">
+                    06 4589 9537
+                  </Link>
+                  <br />
+                  Voor vragen over werkzaamheden of bouwactiviteiten
+                </Paragraph>
+              </Grid.Cell>
+            </Grid.Subgrid>
           </Grid>
         </Spotlight>
         {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
@@ -523,18 +532,25 @@ export const Default: StoryObj = {
       </Grid.Cell>
     </Grid>
     <Spotlight color="azure">
-      <Grid paddingVertical="x-large">
-        <Grid.Cell span="all">
+      {/*
+       * The Grid gives up its row gap so the heading can set the small the vertical space guidance asks for
+       * below a level 2 heading, and the Subgrid puts the regular gap back between the Cells it holds. Left
+       * to the row gap, the heading would sit an x-large from the section it introduces.
+       */}
+      <Grid gapVertical="none" paddingVertical="x-large">
+        <Grid.Cell className="ams-mb-s" span="all">
           <Heading color="inverse" level={2}>Zelfbouw</Heading>
         </Grid.Cell>
-        {/* The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens. */}
-        <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 3 }}>
-          <Paragraph color="inverse">
-            Meer over de verschillende vormen van zelfbouw vindt u op:
-          </Paragraph>
-          <StandaloneLink color="inverse" href="#">Zelfbouw</StandaloneLink>
-        </Grid.Cell>
-        {/* … three more columns (Aanbod kavels, Prikbord, Nieuwsbrief zelfbouw) … */}
+        <Grid.Subgrid gapVertical="x-large" span="all">
+          {/* The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens. */}
+          <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 3 }}>
+            <Paragraph color="inverse">
+              Meer over de verschillende vormen van zelfbouw vindt u op:
+            </Paragraph>
+            <StandaloneLink color="inverse" href="#">Zelfbouw</StandaloneLink>
+          </Grid.Cell>
+          {/* … three more columns (Aanbod kavels, Prikbord, Nieuwsbrief zelfbouw) … */}
+        </Grid.Subgrid>
       </Grid>
     </Spotlight>
     <Grid paddingVertical="x-large">
@@ -567,26 +583,28 @@ export const Default: StoryObj = {
      * rather than repeating the azure of the first.
      */}
     <Spotlight>
-      <Grid paddingVertical="x-large">
-        <Grid.Cell span="all">
+      <Grid gapVertical="none" paddingVertical="x-large">
+        <Grid.Cell className="ams-mb-s" span="all">
           <Heading color="inverse" level={2}>Contact</Heading>
         </Grid.Cell>
-        <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 6 }}>
-          <Paragraph color="inverse">
-            Vragen over zelfbouw op Centrumeiland:{' '}
-            <Link color="inverse" href="mailto:zelfbouwcentrumeiland@amsterdam.nl">zelfbouwcentrumeiland@amsterdam.nl</Link>
-          </Paragraph>
-        </Grid.Cell>
-        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-          {/* These lines are kept in one Paragraph so they read as a single contact block, not as running text. */}
-          <Paragraph color="inverse">
-            Maud van Esch
-            <br />
-            Omgevingsmanager IJburg
-            <br />
-            <Link color="inverse" href="mailto:m.van.esch@amsterdam.nl">m.van.esch@amsterdam.nl</Link>
-          </Paragraph>
-        </Grid.Cell>
+        <Grid.Subgrid gapVertical="x-large" span="all">
+          <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 6 }}>
+            <Paragraph color="inverse">
+              Vragen over zelfbouw op Centrumeiland:{' '}
+              <Link color="inverse" href="mailto:zelfbouwcentrumeiland@amsterdam.nl">zelfbouwcentrumeiland@amsterdam.nl</Link>
+            </Paragraph>
+          </Grid.Cell>
+          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+            {/* These lines are kept in one Paragraph so they read as a single contact block, not as running text. */}
+            <Paragraph color="inverse">
+              Maud van Esch
+              <br />
+              Omgevingsmanager IJburg
+              <br />
+              <Link color="inverse" href="mailto:m.van.esch@amsterdam.nl">m.van.esch@amsterdam.nl</Link>
+            </Paragraph>
+          </Grid.Cell>
+        </Grid.Subgrid>
       </Grid>
     </Spotlight>
     {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -252,8 +252,8 @@ const meta = {
            * between the Cells.
            */}
           <Grid gapVertical="none" paddingVertical="x-large">
-            <Grid.Cell className="ams-mb-s" span="all">
-              <Heading color="inverse" level={2}>
+            <Grid.Cell span="all">
+              <Heading className="ams-mb-s" color="inverse" level={2}>
                 Zelfbouw
               </Heading>
             </Grid.Cell>
@@ -359,8 +359,8 @@ const meta = {
          */}
         <Spotlight>
           <Grid gapVertical="none" paddingVertical="x-large">
-            <Grid.Cell className="ams-mb-s" span="all">
-              <Heading color="inverse" level={2}>
+            <Grid.Cell span="all">
+              <Heading className="ams-mb-s" color="inverse" level={2}>
                 Contact
               </Heading>
             </Grid.Cell>
@@ -538,8 +538,8 @@ export const Default: StoryObj = {
        * between the Cells.
        */}
       <Grid gapVertical="none" paddingVertical="x-large">
-        <Grid.Cell className="ams-mb-s" span="all">
-          <Heading color="inverse" level={2}>Zelfbouw</Heading>
+        <Grid.Cell span="all">
+          <Heading className="ams-mb-s" color="inverse" level={2}>Zelfbouw</Heading>
         </Grid.Cell>
         <Grid.Subgrid gapVertical="x-large" span="all">
           {/* The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens. */}
@@ -584,8 +584,8 @@ export const Default: StoryObj = {
      */}
     <Spotlight>
       <Grid gapVertical="none" paddingVertical="x-large">
-        <Grid.Cell className="ams-mb-s" span="all">
-          <Heading color="inverse" level={2}>Contact</Heading>
+        <Grid.Cell span="all">
+          <Heading className="ams-mb-s" color="inverse" level={2}>Contact</Heading>
         </Grid.Cell>
         <Grid.Subgrid gapVertical="x-large" span="all">
           <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 6 }}>


### PR DESCRIPTION
# Space section headings as the vertical space guidance asks

## Links

- [Docs/Guidelines/Vertical space](https://designsystem.amsterdam/?path=/docs/docs-guidelines-vertical-space--docs) — the table these values come from
- [Grid](https://designsystem.amsterdam/?path=/docs/components-layout-grid--docs) — the Subgrid and its `gapVertical`
- [Preview deploy](https://designsystem.amsterdam/) — the whole Storybook on main
- The templates that move: [Home page](https://designsystem.amsterdam/?path=/story/pages-public-home-page--default) · [Article page](https://designsystem.amsterdam/?path=/story/pages-public-article-page--default) · [Project page](https://designsystem.amsterdam/?path=/story/pages-public-project-page--default) · [Profile page, Group](https://designsystem.amsterdam/?path=/story/pages-public-profile-page--group)

## What

A section heading that sits alone in a Grid Cell, with a row of Cards or link sections after it, now takes the space below it that the vertical space guidance asks for. On the Home Page and the Article Page that is a medium, on the Project Page and the Profile Page a small.

## Why

A heading in a Cell of its own can only be spaced by the row gap of its Grid, and that gap is an x-large. The guidance asks for a medium below a heading shown at the largest size and a small below a level 2 heading, so every one of these headings sat two or three steps too far from the section it introduces.

## How

The Grid gives up its row gap with `gapVertical="none"`, the heading sets the space with a margin utility, and the Cells below it go in a `Grid.Subgrid` at `gapVertical="x-large"`, which is the gap the Grid used to give them. That Subgrid value arrived in #2878 and exists for this.

The margin goes on the heading rather than on the Cell around it, because a Cell takes the props of the Grid and nothing else. The space is the same either way: a Cell is a grid item, so it opens an independent formatting context and the margin of the last thing it holds adds to its height rather than collapsing through it.

Two things follow from zeroing a Grid's row gap, and both are about a boundary disappearing with it. Where a section shares a Grid with the Content Header, it needs a Grid of its own, since the header depends on that row gap for the space between its title, its lead and the image beside them. Where two of these sections share a Grid, they need a Grid each as well, so that the boundary between them is the padding of the second rather than a margin on the first. Both come out value for value: the new Grid sets no `paddingTop` where the one above it already carries a `paddingBottom`, and takes the padding the old Grid had otherwise.

The page anatomy had to learn all of this. It took every measure of vertical space from the row gap of the Grid, so a section that gives that gap up drew its heading against the cells below it. It now reads the margin on the content of a Cell and the gap a Subgrid sets for the cells it holds, and the row gap table gained the `x-large` it was missing, which is the value a Subgrid states to restore the default.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [ ] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Six commits. The first moves the Home, Article and Project Page headings, and the last moves the two card sections of the Profile Page into a Grid each. The four in between are meant to move nothing on the page: two reword comments, one moves the margin utility from a Cell onto the heading inside it, and one is the page anatomy catching up.

Those four are value for value by construction rather than by measurement, so the Chromatic build is the thing that decides it. Build 1590 ran against the third commit and found four visual changes, all of them expected. Anything beyond those four in the next build is worth looking at rather than accepting.

There is no ticket for this one. It came out of laying out the Profile Page, where the same heading could not take the space the guidance prescribes.
