### PR TITLE
chore(docs): Recount the statistics on the Introduction home page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ For details, rely on the official documentation and per-package instructions:
 - Page templates: [documentation/page-anatomy.md](documentation/page-anatomy.md) — how a page template documents its own layout with a schematic read from its story.
 - Git and contribution workflow: [documentation/git.md](documentation/git.md), [documentation/code-reviews.md](documentation/code-reviews.md), and [documentation/publishing.md](documentation/publishing.md).
 - Release notes: [documentation/release-notes.md](documentation/release-notes.md) — how to summarise a release for the people who use the design system, and why the changelogs alone are not enough.
+- Introduction statistics: [documentation/introduction-statistics.md](documentation/introduction-statistics.md) — how the six figures on the Storybook home page are counted, and when to recount them.
 
 Key agent expectations:
 

--- a/documentation/introduction-statistics.md
+++ b/documentation/introduction-statistics.md
@@ -1,0 +1,117 @@
+<!-- @license CC0-1.0 -->
+
+# Introduction statistics
+
+The Storybook home page opens with a band of six figures: components, icons, design tokens, templates, modes and tests.
+They live in the `InlineList` near the top of [storybook/src/docs/introduction.docs.mdx](../storybook/src/docs/introduction.docs.mdx).
+
+The band is a claim about the size of the design system, so each figure needs a rule that someone else can apply and arrive at the same number.
+This describes those rules, the commands that produce them, and the places where counting goes wrong.
+
+Count on an up-to-date `develop`, unless a branch's own work is what the figures are meant to announce.
+Fetch first: a figure counted against a stale tree is wrong in a way nothing later will catch.
+
+## What each figure counts
+
+### Components
+
+The distinct root directories re-exported from `packages/react/src/index.ts`.
+
+```bash
+grep -oE "from '\./[A-Z][A-Za-z]+'" packages/react/src/index.ts | sort -u | wc -l
+```
+
+Exported, not present.
+A directory can exist without being part of the public API — `ComboBox` was in that position in July 2026 — and the figure claims what someone installing the package can use.
+
+### Icons
+
+The outlined icons in `packages-proprietary/react-icons/src`: every `.tsx` file except the `*Fill*` variants.
+
+```bash
+find packages-proprietary/react-icons/src -name '*.tsx' | grep -iv index | wc -l
+find packages-proprietary/react-icons/src -name '*.tsx' | grep -iE 'fill' | wc -l
+```
+
+Subtract the second from the first.
+A filled icon is the same icon in another weight rather than another thing to reach for, so counting both would inflate the figure by more than half.
+
+### Design tokens
+
+The `$value` leaves under the three token source directories.
+
+```bash
+grep -rho '"\$value"' \
+  packages-proprietary/tokens/src/brand \
+  packages-proprietary/tokens/src/common \
+  packages-proprietary/tokens/src/components | wc -l
+```
+
+Count the source, not `dist`.
+The build emits a token several times over — once per format, and again per mode — so a figure taken from the output measures the build rather than the system.
+
+### Templates
+
+The page stories under `storybook/src/pages`, counted individually.
+
+```bash
+grep -rhcE "^export const [A-Z]" storybook/src/pages --include="*.stories.tsx" | paste -sd+ - | bc
+```
+
+Every story counts, not every directory.
+A page template with five stories offers five layouts to start from, which is what the figure is telling people.
+
+### Modes
+
+The distinct modes, taken from `themeNames` in `storybook/config/themes.ts`.
+
+That list holds more names than there are modes, because Lo-fi combines with each density rather than sitting beside them: four names — Spacious, Spacious Lo-fi, Compact, Compact Lo-fi — describe three modes.
+Read the axes, not the length of the array.
+
+### Tests
+
+The React unit suite plus the stories Chromatic snapshots.
+
+Run the suite rather than counting it, and add the skipped cases to the passing ones:
+
+```bash
+pnpm --filter @amsterdam/design-system-react exec vitest run
+```
+
+For the visual side, read `onlyStoryNames` in `storybook/chromatic.config.json` and count what it matches.
+The patterns have grown over time — components first, then pages, utilities and modes — so read the file each time instead of reusing the last set.
+Two rules operate side by side: for components, utilities and modes only the story named `Test` is captured, while under `Pages/` every story is.
+
+## Rounding
+
+Components, templates and modes are exact.
+
+Icons round down to the nearest ten, and design tokens and tests to the nearest hundred, each written with a trailing `+`.
+Rounding down is what makes the `+` true, so a figure never rounds up even when it is a handful short.
+
+## Where counting goes wrong
+
+**Grepping for `it(` undercounts the unit tests.**
+In July 2026 the grep returned 1165 against a suite of 1310, and in August 1259 against 1414 — a gap of roughly a tenth, in the direction that makes the figure look safe.
+Run the suite.
+
+**`src/_components` holds Test stories too.**
+Seventeen of them are titled `Components/Docs/*`, so they match the Chromatic pattern for components while sitting nowhere near `src/components`.
+Counting only `src/components` loses them.
+
+**Snapshots are not tests.**
+Chromatic captures more than one snapshot per story, and the multiplier lives in its project settings rather than in this repository.
+The figure counts tests.
+
+**A figure can fall.**
+Tests dropped from `1500+` to `1300+` in July 2026 when the rule above was first applied to a claim that predated it.
+Report the number the rule gives and say that it fell, rather than reaching for a wider definition that rescues the old one.
+
+**A recount can be undone by a merge.**
+That same `1300+` returned to `1500+` in [#2797](https://github.com/Amsterdam/design-system/pull/2797), which had branched before the recount landed.
+Check what the figures were on `develop` before assuming the page is simply out of date.
+
+## When to recount
+
+The figures do not update themselves, and every one of them moves.
+Recount when a release is being prepared, when the page is being edited for another reason, and after work that adds a component, a page template, a mode or a body of tokens.

--- a/documentation/introduction-statistics.md
+++ b/documentation/introduction-statistics.md
@@ -99,9 +99,19 @@ Run the suite.
 Seventeen of them are titled `Components/Docs/*`, so they match the Chromatic pattern for components while sitting nowhere near `src/components`.
 Counting only `src/components` loses them.
 
-**Snapshots are not tests.**
-Chromatic captures more than one snapshot per story, and the multiplier lives in its project settings rather than in this repository.
-The figure counts tests.
+**Snapshots are not tests, and neither is the check title.**
+Chromatic captures more than one snapshot per story — two, at the time of writing — and the multiplier lives in its project settings rather than in this repository.
+The `UI Tests` check reports a third number again: on build 1593 it read `417 tests unchanged` while the run had matched 123.
+
+Take the number from the run log, which states the rule it applied:
+
+```text
+Running 123 tests for stories matching 'Components/**/**/Test', … (skipping 295 tests)
+→ Tested 418 stories across 108 components; captured 246 snapshots
+```
+
+Three numbers, one of them the answer.
+The figure counts tests run, not stories published and not snapshots captured.
 
 **A figure can fall.**
 Tests dropped from `1500+` to `1300+` in July 2026 when the rule above was first applied to a claim that predated it.

--- a/storybook/src/docs/introduction.docs.mdx
+++ b/storybook/src/docs/introduction.docs.mdx
@@ -22,10 +22,10 @@ Faster and cheaper to build and iterate with.
     <strong>220+</strong> icons
   </InlineList.Item>
   <InlineList.Item>
-    <strong>1200+</strong> design tokens
+    <strong>1300+</strong> design tokens
   </InlineList.Item>
   <InlineList.Item>
-    <strong>21</strong> templates
+    <strong>32</strong> templates
   </InlineList.Item>
   <InlineList.Item>
     <strong>3</strong> modes


### PR DESCRIPTION
## Links

- [Deploy on main](https://designsystem.amsterdam/)
- [Introduction](https://designsystem.amsterdam/?path=/docs/docs-introduction--docs): the home page, with the recounted statistics band below the opening lines.

## What

Recounts the six figures in the statistics band at the top of the Introduction home page, and writes down how each one is counted.

Design tokens go from 1200+ to 1300+, and templates from 21 to 32. The other four are unchanged: 65 components, 220+ icons, 3 modes, 1500+ tests.

A new `documentation/introduction-statistics.md` records the rule behind each figure, the command that produces it, how it rounds, and the ways a recount goes wrong. It is linked from `AGENTS.md` alongside the other reference documents.

## Why

The band is a claim about the size of the design system, and it does not update itself. Templates had drifted furthest: the page still said 21 while eleven more page stories had landed since, so the figure understated the templates on offer by a third.

Until now the counting rules were not written down anywhere. Each recount reconstructed them, which is slow and gives different answers depending on what the person happened to look at — the tests figure alone has been counted three different ways. Writing them down makes the numbers reproducible and reviewable.

## How

Counted on an up-to-date `develop`:

- **Components — 65.** Distinct root directories re-exported from `packages/react/src/index.ts`. Exported rather than present, since the figure claims what the published package offers.
- **Icons — 226, shown as 220+.** Every `.tsx` in `react-icons/src` except the `*Fill*` variants; a filled icon is the same icon in another weight.
- **Design tokens — 1329, shown as 1300+.** `$value` leaves under the `brand`, `common` and `components` token sources. Counted from source, because the build emits each token once per format and again per mode.
- **Templates — 32.** Page stories under `storybook/src/pages`, counted individually: a template with five stories offers five layouts to start from.
- **Modes — 3.** Spacious, Compact and Lo-fi. `themeNames` lists four names because Lo-fi combines with each density rather than sitting beside them.
- **Tests — 1537, shown as 1500+.** 1414 from the React unit suite plus 123 stories matched by `onlyStoryNames` in `chromatic.config.json`.

Exact figures for components, templates and modes; the others round down to the nearest ten or hundred, so the trailing `+` stays true.

## Checklist

- [x] Add or update unit tests (not necessary — the figures are prose, and nothing in the repository enforces them)
- [x] Add or update documentation (this PR is largely documentation)
- [x] Add or update stories (not necessary)
- [x] Add or update exports in index.\* files (not necessary)
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- Two counts are easy to get wrong and are called out in the new document. Grepping for `it(` undercounts the unit suite by about a tenth, so the suite has to be run. And seventeen `Test` stories live under `src/_components` titled `Components/Docs/*`, so they match the Chromatic pattern for components while sitting nowhere near `src/components`.
- The tests figure reads 1500+ both before and after, but not for the same reason. It was recounted to 1300+ in #2751; #2797 had branched before that landed and restored 1500+ without meaning to. The suite has since grown past it, so the number is right again — the new document records the episode so the next recount checks the history before assuming the page is merely stale.
- Visual review focus: none expected. Only the two figures in the band change, and the documentation is not rendered in Storybook.
