### PR TITLE
chore(React): Correct the ref typing note in the coding conventions

### DIFF
--- a/packages/react/documentation/coding-conventions.md
+++ b/packages/react/documentation/coding-conventions.md
@@ -49,4 +49,4 @@ Some of our components can render different HTML tags; they are polymorphic.
 Spotlight and Grid Cell are examples.
 We’ve decided to use polymorphism solely for HTML tags that only support global attributes (e.g., `div`, `section`, `footer`, etc.).
 This is because other HTML tags require more complicated typing, and it is often simpler to separate the components.
-We type the refs as `any` to make React refs work with polymorphic components.
+We type the refs as `HTMLElement`, the common type of the elements these components can render, so React refs work with all of them.


### PR DESCRIPTION
## Links

- [`packages/react/documentation/coding-conventions.md`](https://github.com/Amsterdam/design-system/blob/develop/packages/react/documentation/coding-conventions.md)

## What

The coding conventions claimed that we type the refs of polymorphic components as `any`. That is not what the code does. This corrects the sentence to describe the typing we actually use.

## Why

The note contradicted the components it described. Spotlight and Grid Cell both declare `forwardRef<HTMLElement, …>`, so `HTMLElement` is the common type of the elements they can render. Anyone following the convention as written would have introduced an `any` where the codebase deliberately uses a concrete type, and would have had no reason to question it.

## How

One sentence rewritten in the polymorphic components section. It now names `HTMLElement` and says why that type works for every element these components render. No code changes, so nothing about the published packages changes.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Documentation only. There is no runtime change, no story and no visual output, so the tests, stories, exports and visual regression items above were not applicable.
