### PR TITLE
chore(Storybook): Let the authoring styles reach items inside a Subgrid

### DIFF
--- a/storybook/src/_styles/authoring.css
+++ b/storybook/src/_styles/authoring.css
@@ -83,10 +83,12 @@
     min-block-size: 3rem;
   }
 
-  /** Repeat declarations and increase specificity to override Grid Cell background and padding in Compact Mode.
-      A Subgrid passes the columns of the Grid on to its own Cells, so they need the same treatment. */
-  ._ams-grid-columns-guide + :is(.ams-breakout, .ams-grid) > &,
-  ._ams-grid-columns-guide + :is(.ams-breakout, .ams-grid) > .ams-grid__subgrid > & {
+  /**
+   * Repeat declarations and increase specificity to override Grid Cell background and padding in Compact Mode.
+   * A descendant combinator rather than a child one, so items inside a Grid Subgrid are covered too;
+   * combinators carry no specificity of their own, so the override still wins.
+   */
+  ._ams-grid-columns-guide + :is(.ams-breakout, .ams-grid) & {
     background-color: var(--_ams-color-pink);
     border-color: var(--_ams-color-grey);
     border-style: dashed;

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "jsx": "react-jsx",
-    "lib": ["es2021", "dom"],
     "noEmit": true,
     "paths": {
       "#storybook/*": ["./src/*"],

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "jsx": "react-jsx",
+    "lib": ["es2021", "dom"],
     "noEmit": true,
     "paths": {
       "#storybook/*": ["./src/*"],


### PR DESCRIPTION
## Links

- [`storybook/src/_styles/authoring.css`](https://github.com/Amsterdam/design-system/blob/develop/storybook/src/_styles/authoring.css)

## What

The rule that gives an example item its size and its dashed outline now uses one descendant selector instead of listing the children of the Grid and of the Subgrid separately.

## Why

The selector named two positions, one for a Cell directly in the Grid and one for a Cell in a Subgrid. A descendant combinator covers both, and any nesting a future example introduces, without repeating the selector.

## How

The change relies on combinators carrying no specificity of their own, so the block still overrides the Grid Cell styles it is written to beat. Specificity is three class selectors before and after.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

This PR started out carrying a second change, raising the Storybook TypeScript `lib` to ES2021. That has been removed, and the branch no longer touches `tsconfig.json`.

The reasoning behind it had expired. It was written when the root config still inherited ES2020, which does not declare `Intl.ListFormat`. The root config now sets `["dom", "es2023"]`, so the feature is already available, and pinning ES2021 in Storybook only narrowed what it could use. It broke the build too: `Children.toArray(...).at(-1)` in the Page Anatomy model needs ES2022 array typings.

Worth a visual check before merging, since `authoring.css` styles the example items on the Grid and Breakout story canvases. The published packages are untouched.
