### PR TITLE
chore(Tokens): Record which tokens have to hold a single value

### DIFF
--- a/packages-proprietary/tokens/AGENTS.md
+++ b/packages-proprietary/tokens/AGENTS.md
@@ -42,6 +42,22 @@ Token files use the `.tokens.json` extension and follow the DTCG format:
 - Use the `$extensions` field for Amsterdam-specific metadata (e.g. `nl.amsterdam.type`, `nl.amsterdam.subtype`). Common `$extensions` types include `fontSize`, `lineHeight`, and `space` (via `nl.amsterdam.subtype`). See existing component tokens for examples.
 - Variant tokens are nested under the component (e.g. `ams.badge.azure.background-color`).
 
+## Tokens that must hold a single value
+
+A token read through `calc()`, `max()`, `min()` or `clamp()`, or assigned to a CSS longhand, cannot hold two values.
+Given two, the declaration is invalid at computed-value time and the property falls back to its initial value rather than to the token, so the spacing disappears rather than degrading.
+Nothing enforces this yet, so every such token carries a `nl.amsterdam.hint` that says so, in one of two wordings:
+
+- `Must be a single value: it is used in a calculation, which two values would invalidate.`
+- `Must be a single value: it sets a longhand property, which takes only one.`
+
+Use the calculation wording when both reasons apply, and append the sentence to whatever hint the token already carries.
+Deprecated aliases are skipped, since they forward to the token that carries the note.
+
+Decide from the stylesheet, not from the token name, because the two do not always agree.
+`ams.skeleton.list.gap` and `ams.table-of-contents.item.gap` set the `row-gap` and `column-gap` longhands despite being named for the shorthand, so both need the note.
+A token that really does set `gap` does not need the note, since that shorthand takes two values, and the design system ships two-value tokens on purpose — `ams.dialog.header.padding-block` is one.
+
 ## Modes
 
 Token files can have mode variants that override a subset of values; the mode names are listed in `build.js`.

--- a/packages-proprietary/tokens/src/components/ams/description-list.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/description-list.tokens.json
@@ -164,6 +164,7 @@
         "column-gap": {
           "$value": "{ams.space.l}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/grid.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/grid.tokens.json
@@ -8,6 +8,7 @@
       "column-gap": {
         "$value": "{ams.space.xl}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }

--- a/packages-proprietary/tokens/src/components/ams/page-footer.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/page-footer.tokens.json
@@ -11,6 +11,7 @@
         "column-gap": {
           "$value": "{ams.space.l}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -34,6 +35,7 @@
         "row-gap": {
           "$value": "{ams.space.xs}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/page-header.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/page-header.tokens.json
@@ -73,6 +73,7 @@
         "column-gap": {
           "$value": "{ams.space.m}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -189,6 +190,7 @@
         "column-gap": {
           "$value": "{ams.space.l}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -196,6 +198,7 @@
         "row-gap": {
           "$value": "{ams.space.xs}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -211,6 +214,7 @@
           "column-gap": {
             "$value": "{ams.space.xs}",
             "$extensions": {
+              "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space",
               "nl.amsterdam.type": "dimension"
             }
@@ -312,6 +316,7 @@
         "column-gap": {
           "$value": "{ams.space.l}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -319,6 +324,7 @@
         "row-gap": {
           "$value": "{ams.space.l}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }

--- a/packages-proprietary/tokens/src/components/ams/skeleton.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/skeleton.tokens.json
@@ -89,6 +89,7 @@
         "gap": {
           "$value": "{ams.unordered-list.gap}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }
@@ -128,7 +129,7 @@
             },
             "$type": "dimension",
             "$extensions": {
-              "nl.amsterdam.hint": "Together with the item padding and the marker width, starts the line at the 2.5rem text indent of Unordered List.",
+              "nl.amsterdam.hint": "Together with the item padding and the marker width, starts the line at the 2.5rem text indent of Unordered List. Must be a single value: it sets a longhand property, which takes only one.",
               "nl.amsterdam.subtype": "space"
             }
           },

--- a/packages-proprietary/tokens/src/components/ams/standalone-link.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/standalone-link.tokens.json
@@ -10,6 +10,7 @@
       "column-gap": {
         "$value": "{ams.space.s}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }

--- a/packages-proprietary/tokens/src/components/ams/table-of-contents.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/table-of-contents.tokens.json
@@ -71,6 +71,7 @@
         "gap": {
           "$value": "{ams.space.xs}",
           "$extensions": {
+            "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
             "nl.amsterdam.subtype": "space",
             "nl.amsterdam.type": "dimension"
           }


### PR DESCRIPTION
## Links

- [`packages-proprietary/tokens/AGENTS.md`](https://github.com/Amsterdam/design-system/blob/develop/packages-proprietary/tokens/AGENTS.md)

## What

Records which tokens have to hold a single value, as a `nl.amsterdam.hint` on each of them, and writes the rule down in the tokens AGENTS.md.

Fourteen tokens across Description List, Grid, Page Footer, Page Header, Skeleton, Standalone Link and Table of Contents gain the note. One of them already carried a hint, which now ends with the new sentence.

## Why

A token read through `calc()`, `max()`, `min()` or `clamp()`, or assigned to a CSS longhand, cannot hold two values. Given two, the declaration is invalid at computed-value time and the property falls back to its initial value rather than to the token. The spacing disappears rather than degrading, which is a failure that is easy to introduce and hard to spot.

Nothing enforces this yet, so the constraint has to be visible on the token itself. Anyone changing one of these values needs to know that a second value breaks it.

## How

Each affected token carries one of two sentences, depending on whether the constraint comes from a calculation or from a longhand, appended to whatever hint it already had.

The set was resolved from the stylesheets rather than from the token names, because the two do not always agree. `ams.skeleton.list.gap` sets `row-gap` and `ams.table-of-contents.item.gap` sets `column-gap`, so both need the note despite being named for the shorthand. A token that really does set `gap` does not, since that shorthand takes two values, and the design system ships two-value tokens on purpose: `ams.dialog.header.padding-block` is one.

Deprecated aliases are skipped, since they forward to the token that carries the note.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Metadata only. Every change is inside `$extensions`, so no token value moves and the built CSS is identical.

A linter that checks the constraint rather than describing it would be the natural follow-up, and the wording is deliberately consistent so it can be matched.
