### PR TITLE
feat(Link List): Use a Standalone Link where a Link List says the wrong thing

### DIFF
--- a/storybook/src/components/LinkList/LinkList.docs.mdx
+++ b/storybook/src/components/LinkList/LinkList.docs.mdx
@@ -37,6 +37,10 @@ Use a Link List to present multiple links within a theme.
 
 ### When not to use
 
+Do not put a link to the wider set in the list itself.
+A list of three news items and a fourth link reading ‘More news’ says that all four are the same kind of thing, where the last one is about the set rather than one of it.
+Give that link a [Standalone Link](/docs/components-navigation-standalone-link--docs) below the list instead, as in the example.
+
 For additional guidelines, refer to the [Link](/docs/components-navigation-link--docs) component.
 
 ## Examples
@@ -47,6 +51,14 @@ A list of links often appears in a block with a [Heading](/docs/components-text-
 Use a size of ‘level-3’ for the Heading and add a small bottom margin.
 
 <Canvas of={LinkListStories.WithHeading} />
+
+### A link to the wider set
+
+A list of links is often drawn from a longer one, with a link to the rest below it.
+That link goes outside the list, as a [Standalone Link](/docs/components-navigation-standalone-link--docs): it points at the set the list came from rather than being one of its members, and a reader hears the list end before it.
+[Prose](/docs/utilities-css-prose--docs) spaces the two, so neither takes a margin of its own.
+
+<Canvas of={LinkListStories.LinkToTheWiderSet} />
 
 ### Custom icons
 

--- a/storybook/src/components/LinkList/LinkList.docs.mdx
+++ b/storybook/src/components/LinkList/LinkList.docs.mdx
@@ -41,6 +41,10 @@ Do not put a link to the wider set in the list itself.
 A list of three news items and a fourth link reading ‘More news’ says that all four are the same kind of thing, where the last one is about the set rather than one of it.
 Give that link a [Standalone Link](/docs/components-navigation-standalone-link--docs) below the list instead, as in the example.
 
+Do not use a Link List for a single link.
+It is announced as a list of one item, which tells a reader nothing they could not see.
+A [Standalone Link](/docs/components-navigation-standalone-link--docs) is the component for one link on a line of its own.
+
 For additional guidelines, refer to the [Link](/docs/components-navigation-link--docs) component.
 
 ## Examples

--- a/storybook/src/components/LinkList/LinkList.stories.tsx
+++ b/storybook/src/components/LinkList/LinkList.stories.tsx
@@ -5,7 +5,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { Heading } from '@amsterdam/design-system-react'
+import { Heading, StandaloneLink } from '@amsterdam/design-system-react'
 import { HouseIcon, PhoneIcon, SpeechBalloonEllipsisIcon } from '@amsterdam/design-system-react-icons'
 import { LinkList } from '@amsterdam/design-system-react/src'
 
@@ -46,6 +46,17 @@ export const WithHeading: Story = {
     </div>
   ),
 }
+export const LinkToTheWiderSet: Story = {
+  ...StoryTemplate,
+  render: ({ children, ...args }) => (
+    // ams-prose sets the medium the vertical space guidance asks for between the list and the link below it.
+    <div className="ams-prose">
+      <LinkList {...args}>{children}</LinkList>
+      <StandaloneLink href="#">Alle onderwerpen</StandaloneLink>
+    </div>
+  ),
+}
+
 export const CustomIcons: Story = {
   ...StoryTemplate,
   args: {

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -567,8 +567,8 @@ export const WithImageGallery: StoryObj = {
               Proef elektrische fietsen voor sociale huurders op Strandeiland en Centrumeiland
             </LinkList.Link>
             <LinkList.Link color="inverse" href="#">Definitief ontwerp voor nieuwe Jaap Eden IJshal</LinkList.Link>
-            <LinkList.Link color="inverse" href="#">Meer persberichten</LinkList.Link>
           </LinkList>
+          <StandaloneLink color="inverse" href="#">Meer persberichten</StandaloneLink>
         </Grid.Cell>
         <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
           <Heading color="inverse" level={2} size="level-3">Besluiten B en W</Heading>
@@ -576,8 +576,8 @@ export const WithImageGallery: StoryObj = {
             <LinkList.Link color="inverse" href="#">Nieuws uit B en W 9 juli 2025</LinkList.Link>
             <LinkList.Link color="inverse" href="#">Nieuws uit B en W 2 juli 2025</LinkList.Link>
             <LinkList.Link color="inverse" href="#">Nieuws uit B en W 25 juni 2025</LinkList.Link>
-            <LinkList.Link color="inverse" href="#">Meer besluiten B en W</LinkList.Link>
           </LinkList>
+          <StandaloneLink color="inverse" href="#">Meer besluiten B en W</StandaloneLink>
         </Grid.Cell>
       </Grid>
     </Spotlight>
@@ -723,10 +723,10 @@ export const WithImageGallery: StoryObj = {
                 <LinkList.Link color="inverse" href="#">
                   Definitief ontwerp voor nieuwe Jaap Eden IJshal
                 </LinkList.Link>
-                <LinkList.Link color="inverse" href="#">
-                  Meer persberichten
-                </LinkList.Link>
               </LinkList>
+              <StandaloneLink color="inverse" href="#">
+                Meer persberichten
+              </StandaloneLink>
             </Grid.Cell>
             <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
               <Heading color="inverse" level={2} size="level-3">
@@ -742,10 +742,10 @@ export const WithImageGallery: StoryObj = {
                 <LinkList.Link color="inverse" href="#">
                   Nieuws uit B en W 25 juni 2025
                 </LinkList.Link>
-                <LinkList.Link color="inverse" href="#">
-                  Meer besluiten B en W
-                </LinkList.Link>
               </LinkList>
+              <StandaloneLink color="inverse" href="#">
+                Meer besluiten B en W
+              </StandaloneLink>
             </Grid.Cell>
           </Grid>
         </Spotlight>

--- a/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
+++ b/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
@@ -939,9 +939,7 @@ export const Location: StoryObj = {
       </Grid.Cell>
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading level={2} size="level-3">Zie ook</Heading>
-        <LinkList>
-          <LinkList.Link href="#">Urban Sport Zone Zeeburgereiland</LinkList.Link>
-        </LinkList>
+        <StandaloneLink href="#">Urban Sport Zone Zeeburgereiland</StandaloneLink>
       </Grid.Cell>
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
         <Heading level={2} size="level-3">Auto of fiets parkeren</Heading>
@@ -1144,9 +1142,7 @@ export const Location: StoryObj = {
             <Heading level={2} size="level-3">
               Zie ook
             </Heading>
-            <LinkList>
-              <LinkList.Link href="#">Urban Sport Zone Zeeburgereiland</LinkList.Link>
-            </LinkList>
+            <StandaloneLink href="#">Urban Sport Zone Zeeburgereiland</StandaloneLink>
           </Grid.Cell>
           <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
             <Heading level={2} size="level-3">
@@ -1365,11 +1361,7 @@ export const LocationLarge: StoryObj = {
             naam, de sport, de zaal, de begindatum en einddatum, de tijden van uw voorkeur en een korte omschrijving
             van uw activiteit.
           </Paragraph>
-          <LinkList>
-            <LinkList.Link color="inverse" href="mailto:sportverhuur@amsterdam.nl" icon={MailIcon}>
-              Stuur uw aanvraag per e-mail in
-            </LinkList.Link>
-          </LinkList>
+          <StandaloneLink color="inverse" href="mailto:sportverhuur@amsterdam.nl" icon={MailIcon}>Stuur uw aanvraag per e-mail in</StandaloneLink>
         </Grid.Cell>
         <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
           <Heading color="inverse" level={2}>Evenementen</Heading>
@@ -1672,11 +1664,9 @@ export const LocationLarge: StoryObj = {
                 naam, de sport, de zaal, de begindatum en einddatum, de tijden van uw voorkeur en een korte omschrijving
                 van uw activiteit.
               </Paragraph>
-              <LinkList>
-                <LinkList.Link color="inverse" href="mailto:sportverhuur@amsterdam.nl" icon={MailIcon}>
-                  Stuur uw aanvraag per e-mail in
-                </LinkList.Link>
-              </LinkList>
+              <StandaloneLink color="inverse" href="mailto:sportverhuur@amsterdam.nl" icon={MailIcon}>
+                Stuur uw aanvraag per e-mail in
+              </StandaloneLink>
             </Grid.Cell>
             <Grid.Cell
               className="ams-prose"
@@ -1920,9 +1910,7 @@ export const Sublocation: StoryObj = {
       </Grid.Cell>
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Heading level={2} size="level-3">Zie ook</Heading>
-        <LinkList>
-          <LinkList.Link href="#">Alle sportparken in Amsterdam</LinkList.Link>
-        </LinkList>
+        <StandaloneLink href="#">Alle sportparken in Amsterdam</StandaloneLink>
       </Grid.Cell>
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
         <Heading level={2} size="level-3">Parkeren</Heading>
@@ -2098,9 +2086,7 @@ export const Sublocation: StoryObj = {
             <Heading level={2} size="level-3">
               Zie ook
             </Heading>
-            <LinkList>
-              <LinkList.Link href="#">Alle sportparken in Amsterdam</LinkList.Link>
-            </LinkList>
+            <StandaloneLink href="#">Alle sportparken in Amsterdam</StandaloneLink>
           </Grid.Cell>
           <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
             <Heading level={2} size="level-3">

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -307,11 +307,9 @@ const meta = {
               <LinkList.Link href="#">Nieuwe bruggen op IJburg</LinkList.Link>
               <LinkList.Link href="#">IJburg: nieuwe eilanden en woningbouw</LinkList.Link>
               <LinkList.Link href="#">IJburg - stations Bijlmer Arena en Weesp: nieuwe busverbindingen</LinkList.Link>
-              <LinkList.Link className="ams-mb-m" href="#">
-                IJburg: verlengen IJtram
-              </LinkList.Link>
-              <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
+              <LinkList.Link href="#">IJburg: verlengen IJtram</LinkList.Link>
             </LinkList>
+            <StandaloneLink href="#">Meer projecten in Oost</StandaloneLink>
           </Grid.Cell>
           <Grid.Cell
             className="ams-prose"
@@ -560,8 +558,8 @@ export const Default: StoryObj = {
         <LinkList>
           <LinkList.Link href="#">Blok 16: Amsterdams nabuurschap, een nieuwe vorm van zelfbouw</LinkList.Link>
           <LinkList.Link href="#">Woningaanbod Centrumeiland</LinkList.Link>
-          <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
         </LinkList>
+        <StandaloneLink href="#">Meer projecten in Oost</StandaloneLink>
       </Grid.Cell>
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 5, wide: 7 }}>
         <Heading level={2} size="level-3">Ontwikkeling Centrumeiland, herfst 2025</Heading>

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -331,9 +331,7 @@ const meta = {
             <Heading level={2} size="level-3">
               Plannen en publicaties
             </Heading>
-            <LinkList>
-              <LinkList.Link href="#">Plannen en publicaties Centrumeiland</LinkList.Link>
-            </LinkList>
+            <StandaloneLink href="#">Plannen en publicaties Centrumeiland</StandaloneLink>
           </Grid.Cell>
           <Grid.Cell
             className="ams-prose"


### PR DESCRIPTION
# Use a Standalone Link where a Link List says the wrong thing

## Links

- [Link List](https://designsystem.amsterdam/?path=/docs/components-navigation-link-list--docs) — the guidance and the new example
- [Standalone Link](https://designsystem.amsterdam/?path=/docs/components-navigation-standalone-link--docs) — the component these links move to
- [Preview deploy](https://designsystem.amsterdam/) — the whole Storybook on main
- The templates that change: [Navigation page](https://designsystem.amsterdam/?path=/story/pages-public-navigation-page--default) · [Project page](https://designsystem.amsterdam/?path=/story/pages-public-project-page--default) · [Profile page](https://designsystem.amsterdam/?path=/story/pages-public-profile-page--location)

## What

Two shapes of Link List say something the page does not mean, and both become a Standalone Link.

A list that ends in a link to the wider set, such as three news items followed by ‘Meer persberichten’. Six of those, on the Navigation Page and the Project Page.

A list holding a single link. Seven of those, on the Profile Page and the Project Page.

Link List gains an example of the first, and a line under When not to use for each.

## Why

A Link List is a list, and a list says its items are the same kind of thing. A link to the wider set is not one of the items: it is about the set. A reader hears a list of four with nothing to tell the fourth apart from the three it does not belong with.

A list of one has the opposite problem. It announces a list with one item in it, which tells a reader nothing they could not already see, and it costs them a level of structure to step through.

One of these lists shows what the modelling error looks like from the outside. The Project Page put a margin utility on the seventh of eight links to push the eighth away from the ones above it: space used to express a distinction the markup denies. That margin goes with the link it was separating.

## How

Each converted link keeps the props it had, including the `color="inverse"` inside a Spotlight and, in one case, a Mail icon that Standalone Link takes as well.

Nothing gains a margin. Every one of these sits in a Cell that already sets [Prose](https://designsystem.amsterdam/?path=/docs/utilities-css-prose--docs), which gives a Link List followed by a Standalone Link the medium the vertical space guidance asks for.

Lists built from a variable are left alone. They render one item in an example and as many as the data holds elsewhere, so their length is not a property of the markup.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [ ] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [ ] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Expect visual changes on the Navigation, Project and Profile Page stories: a Standalone Link sits a medium below the list where a list item sat a list gap below its neighbour, so those blocks grow slightly. The new Link List story is a new snapshot.

The Project Page keeps a discrepancy this PR does not touch: its Code Panel source is shorter than what the story renders, three links against eight in one section and two against four in another. Both copies are converted the same way, but if that difference is drift rather than a deliberate abbreviation it wants its own fix.
