### PR TITLE
feat(Grid): Let a Cell and a Subgrid start at a row of your choosing

### DIFF
--- a/packages/css/src/components/grid/_mixins.scss
+++ b/packages/css/src/components/grid/_mixins.scss
@@ -187,19 +187,38 @@
 }
 
 // Cell row span
+// The end line rather than the `grid-row` shorthand, which would reset the start line a Cell may also set.
 
 @mixin ams-grid__cell--row-span($i) {
-  grid-row: span $i;
+  grid-row-end: span $i;
 }
 
 @mixin ams-grid__cell--row-span-medium($i) {
   @media (min-width: $ams-breakpoint-medium) {
-    grid-row: span $i;
+    grid-row-end: span $i;
   }
 }
 
 @mixin ams-grid__cell--row-span-wide($i) {
   @media (min-width: $ams-breakpoint-wide) {
-    grid-row: span $i;
+    grid-row-end: span $i;
+  }
+}
+
+// Cell row start
+
+@mixin ams-grid__cell--row-start($i) {
+  grid-row-start: $i;
+}
+
+@mixin ams-grid__cell--row-start-medium($i) {
+  @media (min-width: $ams-breakpoint-medium) {
+    grid-row-start: $i;
+  }
+}
+
+@mixin ams-grid__cell--row-start-wide($i) {
+  @media (min-width: $ams-breakpoint-wide) {
+    grid-row-start: $i;
   }
 }

--- a/packages/css/src/components/grid/grid.scss
+++ b/packages/css/src/components/grid/grid.scss
@@ -185,3 +185,30 @@ $ams-grid-row-span-max: 4;
     }
   }
 }
+
+// Cell and Subgrid row start
+
+@for $i from 1 through $ams-grid-row-span-max {
+  .ams-grid__cell--row-start-#{$i},
+  .ams-grid__subgrid--row-start-#{$i} {
+    @include ams-grid__cell--row-start($i);
+  }
+}
+
+@media (min-width: $ams-breakpoint-medium) {
+  @for $i from 1 through $ams-grid-row-span-max {
+    .ams-grid__cell--row-start-#{$i}-medium,
+    .ams-grid__subgrid--row-start-#{$i}-medium {
+      @include ams-grid__cell--row-start-medium($i);
+    }
+  }
+}
+
+@media (min-width: $ams-breakpoint-wide) {
+  @for $i from 1 through $ams-grid-row-span-max {
+    .ams-grid__cell--row-start-#{$i}-wide,
+    .ams-grid__subgrid--row-start-#{$i}-wide {
+      @include ams-grid__cell--row-start-wide($i);
+    }
+  }
+}

--- a/packages/react/src/Grid/GridCell.test.tsx
+++ b/packages/react/src/Grid/GridCell.test.tsx
@@ -141,6 +141,32 @@ describe('GridCell', () => {
     )
   })
 
+  it('renders no class name for an undefined value for rowStart', () => {
+    const { container } = render(<Grid.Cell />)
+
+    const elementWithRowStartClass = container.querySelector('[class*="ams-grid__cell--row-start"]')
+
+    expect(elementWithRowStartClass).not.toBeInTheDocument()
+  })
+
+  it('renders a class name for a single number value for rowStart', () => {
+    const { container } = render(<Grid.Cell rowStart={2} />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('ams-grid__cell--row-start-2')
+  })
+
+  it('renders class names for an object value for rowStart', () => {
+    const { container } = render(<Grid.Cell rowStart={{ narrow: 1, medium: 3, wide: 4 }} />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass(
+      'ams-grid__cell--row-start-1 ams-grid__cell--row-start-3-medium ams-grid__cell--row-start-4-wide',
+    )
+  })
+
   it('renders the correct class name for the “all” value of span', () => {
     const { container } = render(<Grid.Cell span="all" />)
 

--- a/packages/react/src/Grid/GridCell.tsx
+++ b/packages/react/src/Grid/GridCell.tsx
@@ -58,6 +58,14 @@ export type GridCellProps = {
    * Accepts a number or an object of numbers per grid variant.
    */
   readonly rowSpan?: GridRowNumber | GridRowNumbers
+  /**
+   * The index of the grid row the cell starts at.
+   * Accepts a number or an object of numbers per grid variant.
+   *
+   * Only needed to place a cell before a sibling that starts at an earlier column:
+   * automatic placement never moves back a column without moving down a row.
+   */
+  readonly rowStart?: GridRowNumber | GridRowNumbers
 } & Readonly<PropsWithChildren<HTMLAttributes<HTMLElement>>> &
   (GridCellSpanAllProp | GridCellSpanAndStartProps)
 
@@ -67,7 +75,7 @@ export type GridCellProps = {
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-layout-grid--docs Grid docs at Amsterdam Design System}
  */
 export const GridCell = forwardRef<HTMLElement, GridCellProps>(
-  ({ appearance, as, children, className, rowSpan, span, start, ...restProps }, ref) => {
+  ({ appearance, as, children, className, rowSpan, rowStart, span, start, ...restProps }, ref) => {
     const Tag = (as ?? 'div') as ElementType
 
     return (
@@ -76,7 +84,7 @@ export const GridCell = forwardRef<HTMLElement, GridCellProps>(
         className={clsx(
           'ams-grid__cell',
           appearance && `ams-grid__cell--${appearance}`,
-          gridCellClasses(span, start, rowSpan),
+          gridCellClasses(span, start, rowSpan, rowStart),
           className,
         )}
         ref={ref}

--- a/packages/react/src/Grid/GridSubgrid.test.tsx
+++ b/packages/react/src/Grid/GridSubgrid.test.tsx
@@ -37,12 +37,13 @@ describe('GridSubgrid', () => {
     expect(component).toHaveClass('ams-grid__subgrid extra')
   })
 
-  it('renders no class names for undefined values for span, start and rowSpan', () => {
+  it('renders no class names for undefined values for span, start, rowSpan and rowStart', () => {
     const { container } = render(<Grid.Subgrid />)
 
     expect(container.querySelector('[class*="ams-grid__subgrid--span"]')).not.toBeInTheDocument()
     expect(container.querySelector('[class*="ams-grid__subgrid--start"]')).not.toBeInTheDocument()
     expect(container.querySelector('[class*="ams-grid__subgrid--row-span"]')).not.toBeInTheDocument()
+    expect(container.querySelector('[class*="ams-grid__subgrid--row-start"]')).not.toBeInTheDocument()
   })
 
   it('renders class names for single number values for span and start', () => {
@@ -79,6 +80,14 @@ describe('GridSubgrid', () => {
     const component = container.querySelector(':only-child')
 
     expect(component).toHaveClass('ams-grid__subgrid--row-span-2')
+  })
+
+  it('renders a class name for a single number value for rowStart', () => {
+    const { container } = render(<Grid.Subgrid rowStart={2} />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('ams-grid__subgrid--row-start-2')
   })
 
   it.each(gridGaps)('renders a class name for the %s vertical gap', (gap) => {

--- a/packages/react/src/Grid/GridSubgrid.test.tsx
+++ b/packages/react/src/Grid/GridSubgrid.test.tsx
@@ -90,6 +90,18 @@ describe('GridSubgrid', () => {
     expect(component).toHaveClass('ams-grid__subgrid--row-start-2')
   })
 
+  it('renders class names for objects for rowSpan and rowStart', () => {
+    const { container } = render(
+      <Grid.Subgrid rowSpan={{ narrow: 1, medium: 2, wide: 3 }} rowStart={{ narrow: 2, medium: 3, wide: 4 }} />,
+    )
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass(
+      'ams-grid__subgrid--row-span-1 ams-grid__subgrid--row-span-2-medium ams-grid__subgrid--row-span-3-wide ams-grid__subgrid--row-start-2 ams-grid__subgrid--row-start-3-medium ams-grid__subgrid--row-start-4-wide',
+    )
+  })
+
   it.each(gridGaps)('renders a class name for the %s vertical gap', (gap) => {
     const { container } = render(<Grid.Subgrid gapVertical={gap} />)
 

--- a/packages/react/src/Grid/GridSubgrid.tsx
+++ b/packages/react/src/Grid/GridSubgrid.tsx
@@ -55,6 +55,14 @@ export type GridSubgridProps = {
    * Accepts a number or an object of numbers per grid variant.
    */
   readonly rowSpan?: GridRowNumber | GridRowNumbers
+  /**
+   * The index of the grid row the subgrid starts at.
+   * Accepts a number or an object of numbers per grid variant.
+   *
+   * Only needed to place a subgrid before a sibling that starts at an earlier column:
+   * automatic placement never moves back a column without moving down a row.
+   */
+  readonly rowStart?: GridRowNumber | GridRowNumbers
 } & Readonly<PropsWithChildren<HTMLAttributes<HTMLElement>>> &
   (GridSubgridSpanAllProp | GridSubgridSpanAndStartProps)
 
@@ -65,7 +73,7 @@ export type GridSubgridProps = {
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-layout-grid--docs Grid docs at Amsterdam Design System}
  */
 export const GridSubgrid = forwardRef<HTMLElement, GridSubgridProps>(
-  ({ as, children, className, gapVertical, rowSpan, span, start, ...restProps }, ref) => {
+  ({ as, children, className, gapVertical, rowSpan, rowStart, span, start, ...restProps }, ref) => {
     const Tag = (as ?? 'div') as ElementType
 
     return (
@@ -74,7 +82,7 @@ export const GridSubgrid = forwardRef<HTMLElement, GridSubgridProps>(
         className={clsx(
           'ams-grid__subgrid',
           gapVertical && `ams-grid__subgrid--gap-vertical--${gapVertical}`,
-          gridSubgridClasses(span, start, rowSpan),
+          gridSubgridClasses(span, start, rowSpan, rowStart),
           className,
         )}
         ref={ref}

--- a/packages/react/src/Grid/gridCellClasses.ts
+++ b/packages/react/src/Grid/gridCellClasses.ts
@@ -20,8 +20,10 @@ export const gridCellClasses = (
   colSpan?: GridCellProps['span'],
   colStart?: GridCellProps['start'],
   rowSpan?: GridCellProps['rowSpan'],
+  rowStart?: GridCellProps['rowStart'],
 ): string[] => [
   ...addGridClass('ams-grid__cell--span-', colSpan),
   ...addGridClass('ams-grid__cell--start-', colStart),
   ...addGridClass('ams-grid__cell--row-span-', rowSpan),
+  ...addGridClass('ams-grid__cell--row-start-', rowStart),
 ]

--- a/packages/react/src/Grid/gridSubgridClasses.ts
+++ b/packages/react/src/Grid/gridSubgridClasses.ts
@@ -11,8 +11,10 @@ export const gridSubgridClasses = (
   colSpan?: GridSubgridProps['span'],
   colStart?: GridSubgridProps['start'],
   rowSpan?: GridSubgridProps['rowSpan'],
+  rowStart?: GridSubgridProps['rowStart'],
 ): string[] => [
   ...addGridClass('ams-grid__subgrid--span-', colSpan),
   ...addGridClass('ams-grid__subgrid--start-', colStart),
   ...addGridClass('ams-grid__subgrid--row-span-', rowSpan),
+  ...addGridClass('ams-grid__subgrid--row-start-', rowStart),
 ]

--- a/packages/react/src/Grid/index.ts
+++ b/packages/react/src/Grid/index.ts
@@ -4,6 +4,6 @@
  */
 
 export { Grid } from './Grid'
-export type { GridColumnNumber, GridColumnNumbers, GridProps } from './Grid'
+export type { GridColumnNumber, GridColumnNumbers, GridProps, GridRowNumber, GridRowNumbers } from './Grid'
 export type { GridCellProps } from './GridCell'
 export type { GridSubgridProps } from './GridSubgrid'

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -27,6 +27,11 @@ Every direct child of a Grid must be a Cell or a Subgrid.
 Size and position it with the `span` and `start` props, which accept responsive values.
 Its `appearance` controls the background in Compact Mode.
 
+`rowSpan` lets a Cell cover several rows, and `rowStart` puts it in a row of your choosing.
+Reach for `rowStart` only where automatic placement cannot do the job: it never moves back a column without moving down a row, so a Cell that comes first in the source and sits to the right of the one after it pushes that one down.
+A sidebar on the trailing side needs a row of its own for that reason; one on the leading side does not, because placement runs towards it.
+Set it on the sidebar rather than on everything around it, and leave the rest to automatic placement.
+
 <Canvas of={GridCellStories.Cell} />
 
 <Controls of={GridCellStories.Cell} />
@@ -39,6 +44,9 @@ Every direct child of a Subgrid must be a Cell.
 
 Use it for a region beside a sidebar, such as the results of an index page next to a filter column.
 Without it, a Cell inside a Cell has no columns to align to.
+
+It takes `rowSpan` and `rowStart` for the same reasons a Cell does.
+A Subgrid is placed as one item, so a region beside a sidebar on the trailing side takes a `rowStart` of its own.
 
 Its rows take the vertical gap of the Grid, so the region keeps the rhythm of the page.
 Give it its own `gapVertical` to space its rows differently.

--- a/storybook/src/components/Grid/Grid.test.stories.tsx
+++ b/storybook/src/components/Grid/Grid.test.stories.tsx
@@ -28,6 +28,7 @@ const half = { narrow: 2, medium: 4, wide: 6 } as const
 const threeQuarters = { narrow: 3, medium: 6, wide: 9 } as const
 const secondQuarter = { narrow: 2, medium: 3, wide: 4 } as const
 const thirdQuarter = { narrow: 3, medium: 5, wide: 7 } as const
+const fourthQuarter = { narrow: 4, medium: 7, wide: 10 } as const
 
 /*
  * The first row sits on the columns of the page. The Cells of the Subgrid below it must line up with
@@ -104,6 +105,29 @@ const SubgridRowSpanCase = () => (
   </Grid>
 )
 
+/*
+ * A trailing-side sidebar that comes first in the source: automatic placement would push the wider Cells
+ * after it down a row, because it never moves back a column without moving down one. A rowStart of 1 on the
+ * sidebar alone keeps them level. The last case does the same for a Subgrid, which is placed as one item.
+ */
+const RowStartCase = () => (
+  <Grid paddingVertical="large">
+    <Grid.Cell {...item} rowStart={1} span={quarter} start={fourthQuarter} />
+    <Grid.Cell {...item} span={threeQuarters} />
+    <Grid.Cell {...item} span={threeQuarters} />
+  </Grid>
+)
+
+const SubgridRowStartCase = () => (
+  <Grid paddingVertical="large">
+    <Grid.Cell {...item} rowStart={1} span={quarter} start={fourthQuarter} />
+    <Grid.Subgrid span={threeQuarters}>
+      <Grid.Cell {...item} span={quarter} />
+      <Grid.Cell {...item} span={quarter} />
+    </Grid.Subgrid>
+  </Grid>
+)
+
 export const Test: Story = {
   args: {
     children: [<Grid.Cell key={1} span="all" />, <Grid.Cell key={2} span="all" />],
@@ -118,6 +142,8 @@ export const Test: Story = {
       <SubgridCase gapVertical="none" subgridGapVertical="x-large" />
       <SubgridPlacementCase />
       <SubgridRowSpanCase />
+      <RowStartCase />
+      <SubgridRowStartCase />
     </div>
   ),
   tags: ['!dev', '!autodocs'],


### PR DESCRIPTION
# Let a Cell and a Subgrid start at a row of your choosing

## Links

- [Grid](https://designsystem.amsterdam/?path=/docs/components-layout-grid--docs) – the documentation page, with the new paragraphs under Cell and Subgrid.
- Feature branch deploy links follow once the first deployment is ready.

## What

Adds a `rowStart` prop to `Grid.Cell` and `Grid.Subgrid`, which places the item in a row of your choosing. It takes a number or an object of numbers per grid variant, in the same 1 to 4 range that `rowSpan` and `Breakout.Cell` already use.

Row span moves from the `grid-row` shorthand to `grid-row-end`. For a Cell that only sets a `rowSpan` nothing changes; this is what lets a span and a start sit on the same Cell.

`GridRowNumber` and `GridRowNumbers` are now re-exported from `Grid/index.ts`, so both row props can be typed by a consumer. They were declared but never exported, unlike their column counterparts, which meant `rowSpan` could not be typed either.

## Why

`Breakout.Cell` has had `rowStart` since it was written, and `Grid.Cell` has only ever had `rowSpan`. A layout that needed to name a row therefore had to leave the component API and write `style={{ gridRowStart: 1 }}`, which is what the Project Page template does today.

The case that needs it is a sidebar on the trailing side that comes first in the source. Automatic placement walks items in source order and never moves back a column without moving down a row, so a Table of Contents at column 10 pushes a body Cell at column 3 down a row. Putting the Table of Contents after the body fixes the placement but moves it after the whole body in the reading and tab order, which defeats the point of a contents list.

A Subgrid does not solve this one. It solves the mirror image — a sidebar on the leading side, where placement runs forwards, which is the News Overview and Search Results pattern — but a Subgrid is itself an automatically placed item, so it drops the same row. That is why it gets the prop too.

## How

The class generation mirrors `Breakout.Cell` exactly, down to the value range, so the two components stay recognisable as siblings. Cell and Subgrid share the emitted rules, as they already do for row span.

Switching row span to `grid-row-end` is the one subtlety worth a look during review. The `grid-row` shorthand sets the start line as well as the end line, so with the shorthand in place a Cell carrying both props would have its named row reset depending on which rule won. `Breakout` was already written this way for the same reason. A Cell with only a `rowSpan` is unaffected, because its start line was automatic either way; verified in the browser that such a Cell renders at the same position and the same height as before.

Cost is 24 selectors, 125 bytes gzipped.

The documentation says when to reach for the prop and, as importantly, when not to: a leading-side sidebar needs nothing, and only the sidebar itself should carry a row, not everything around it.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

This is the first of two branches for DES-1951. The Project Page template that motivated the prop follows in a stacked pull request, and replaces its inline `gridRowStart` with it, so this one goes first.

The Grid test story gains two cases: a trailing-side sidebar with Cells after it, and the same with a Subgrid.

`Breakout` has the same export gap: `BreakoutRowNumber` and `BreakoutRowNumbers` are declared in `Breakout.tsx` but not re-exported from its own index. Left alone here, since this pull request is about the Grid.

