### PR TITLE
chore(Storybook): Correct the heading sizes and the Card text on the Profile Page

### DIFF
--- a/storybook/src/components/Heading/Heading.docs.mdx
+++ b/storybook/src/components/Heading/Heading.docs.mdx
@@ -37,10 +37,19 @@ The `level` prop has no default; determine the correct level for each instance.
 Every page should have one Heading with level 1.
 Do not skip levels: a level 2 Heading must be followed by level 3, not level 4.
 
-- Content pages, e.g. for articles, products, events etc. must not use the size prop on their Headings.
-- Most Headings on overview pages, e.g. Card, Table of Contents, and Link Sections, use a size of 'level-3'.
-- The same applies to large sections – e.g. Accordion, Alert, Dialog and the caption of a Table.
-  Most of them can be given a different size if appropriate.
+#### Sections and blocks
+
+The size follows what the Heading introduces.
+
+A heading of a **section** keeps the size of its level and sets no `size`: a run of body text, or a group of blocks such as a row of Cards.
+
+A heading of a **single block** takes a `size` one step smaller, so a level 2 Heading takes `size="level-3"`.
+Such a block is one of several beside or below one another, each holding a short paragraph, a Link List, or a single link.
+At the size of its own level the heading outweighs the few lines it introduces.
+
+The `level` follows the outline of the page either way.
+
+Components that carry a heading of their own — Accordion, Alert, Card, Dialog, Table of Contents, and the caption of a Table — size it themselves.
 
 ### How to write
 

--- a/storybook/src/components/Heading/Heading.docs.mdx
+++ b/storybook/src/components/Heading/Heading.docs.mdx
@@ -41,10 +41,11 @@ Do not skip levels: a level 2 Heading must be followed by level 3, not level 4.
 
 The size follows what the Heading introduces.
 
-A heading of a **section** keeps the size of its level and sets no `size`: a run of body text, or a group of blocks such as a row of Cards.
+A heading keeps the size of its level, and sets no `size`, when it introduces a **content body**: a section of an article, or the entry a navigation page shows beside its navigation.
 
-A heading of a **single block** takes a `size` one step smaller, so a level 2 Heading takes `size="level-3"`.
-Such a block is one of several beside or below one another, each holding a short paragraph, a Link List, or a single link.
+A heading of a **block** takes a `size` one step smaller, so a level 2 Heading takes `size="level-3"`.
+That is a block holding a short paragraph, a Link List, or a single link, and equally the heading above a group of such blocks or a row of Cards.
+Overview and navigation pages are built from these, and content pages carry them too, in a Spotlight or at the foot of the page.
 At the size of its own level the heading outweighs the few lines it introduces.
 
 The `level` follows the outline of the page either way.

--- a/storybook/src/pages/public/Introduction.docs.mdx
+++ b/storybook/src/pages/public/Introduction.docs.mdx
@@ -63,6 +63,11 @@ The general structure for a page is:
 Public websites cannot use the [Menu](/docs/components-navigation-menu--docs) component.
 They should offer navigation using the Page Header only.
 
+## Headings on a page
+
+Below the page title, a [Heading](/docs/components-text-heading--docs#sections-and-blocks) that introduces a section keeps the size of its level, and one that introduces a single block takes a `size` one step smaller.
+Most of the sections below are groups of such blocks.
+
 ## Vertical space between sections
 
 Between the Page Header and the Page Footer, the Page holds a sequence of sections.

--- a/storybook/src/pages/public/Introduction.docs.mdx
+++ b/storybook/src/pages/public/Introduction.docs.mdx
@@ -65,8 +65,8 @@ They should offer navigation using the Page Header only.
 
 ## Headings on a page
 
-Below the page title, a [Heading](/docs/components-text-heading--docs#sections-and-blocks) that introduces a section keeps the size of its level, and one that introduces a single block takes a `size` one step smaller.
-Most of the sections below are groups of such blocks.
+Below the page title, a [Heading](/docs/components-text-heading--docs#sections-and-blocks) keeps the size of its level where it introduces a content body, and takes a `size` one step smaller where it introduces a block or a group of blocks.
+Most of the sections below are groups of blocks, so on all but the content page types every heading under the title takes the smaller size.
 
 ## Vertical space between sections
 

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -515,7 +515,7 @@ export const WithImageGallery: StoryObj = {
     <Grid paddingVertical="x-large">
       {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }}>
-        <Heading level={2}>Burgemeester en wethouders</Heading>
+        <Heading level={2} size="level-3">Burgemeester en wethouders</Heading>
         <Paragraph>
           Het college bestaat uit de burgemeester en 9 wethouders en wordt ambtelijk ondersteund door de
           gemeentesecretaris.
@@ -657,7 +657,9 @@ export const WithImageGallery: StoryObj = {
         <Grid paddingVertical="x-large">
           {/* This cell is as wide as a regular content body, but it start-aligns with the grid it introduces. */}
           <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }}>
-            <Heading level={2}>Burgemeester en wethouders</Heading>
+            <Heading level={2} size="level-3">
+              Burgemeester en wethouders
+            </Heading>
             <Paragraph>
               Het college bestaat uit de burgemeester en 9 wethouders en wordt ambtelijk ondersteund door de
               gemeentesecretaris.

--- a/storybook/src/pages/public/ProfilePage/ProfilePage.docs.mdx
+++ b/storybook/src/pages/public/ProfilePage/ProfilePage.docs.mdx
@@ -60,8 +60,8 @@ A Subgrid hands the columns it spans to its own Cells, so each column stacks on 
 Two Subgrids that each span the whole narrow grid also lay the right column out below the left one there, rather than interleaving the two.
 
 A Subgrid is also what lets a section heading sit the space the guidance asks for above the sections it introduces.
-A heading in a Cell of its own is spaced by the row gap of the Grid, which is an x-large where a level 2 heading asks for a small.
-Give that Grid a `gapVertical` of `none`, let the heading Cell set the small with an `ams-mb-s`, and put the Cells below it in a Subgrid with a `gapVertical` of `x-large`, which is the gap the Grid used to give them.
+A heading in a Cell of its own is spaced by the row gap of the Grid, which is an x-large where the guidance asks for a small or less.
+Give that Grid a `gapVertical` of `none`, let the heading Cell set the right amount with an `ams-mb-*` utility, and put the Cells below it in a Subgrid with a `gapVertical` of `x-large`, which is the gap the Grid used to give them.
 A section that shares its Grid with the Content Header needs a Grid of its own first, since the header depends on that row gap.
 
 ## Layout and spacing

--- a/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
+++ b/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
@@ -507,7 +507,7 @@ export const Group: StoryObj = {
       <Grid paddingVertical="x-large">
         {/* ams-prose sets the vertical rhythm between the elements of a cell, so none of them needs a margin. */}
         <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading color="inverse" level={2}>Persberichten</Heading>
+          <Heading color="inverse" level={2} size="level-3">Persberichten</Heading>
           <Paragraph color="inverse">De fractie laat van zich horen over de onderwerpen die in de raad spelen.</Paragraph>
           <LinkList>
             <LinkList.Link color="inverse" href="#">
@@ -525,7 +525,7 @@ export const Group: StoryObj = {
           </StandaloneLink>
         </Grid.Cell>
         <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
-          <Heading color="inverse" level={2}>Toespraken</Heading>
+          <Heading color="inverse" level={2} size="level-3">Toespraken</Heading>
           <Paragraph color="inverse">Lees na wat de fractie in de raadsvergaderingen naar voren bracht.</Paragraph>
           <LinkList>
             <LinkList.Link color="inverse" href="#">
@@ -699,7 +699,7 @@ export const Group: StoryObj = {
               span={{ narrow: 4, medium: 4, wide: 5 }}
               start={{ narrow: 1, medium: 1, wide: 2 }}
             >
-              <Heading color="inverse" level={2}>
+              <Heading color="inverse" level={2} size="level-3">
                 Persberichten
               </Heading>
               <Paragraph color="inverse">
@@ -721,7 +721,7 @@ export const Group: StoryObj = {
               </StandaloneLink>
             </Grid.Cell>
             <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
-              <Heading color="inverse" level={2}>
+              <Heading color="inverse" level={2} size="level-3">
                 Toespraken
               </Heading>
               <Paragraph color="inverse">Lees na wat de fractie in de raadsvergaderingen naar voren bracht.</Paragraph>
@@ -1245,7 +1245,7 @@ export const LocationLarge: StoryObj = {
     </Grid>
     <Grid paddingBottom="x-large">
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading level={2}>Over de Apollohal</Heading>
+        <Heading level={2} size="level-3">Over de Apollohal</Heading>
         <Paragraph>
           De Apollohal is een sporthal in Amsterdam-Zuid met moderne voorzieningen en een rijke sporthistorie. Het
           gebouw heeft 1 grote zaal en 2 gymzalen en is geschikt voor veel verschillende sporten en evenementen.
@@ -1338,7 +1338,7 @@ export const LocationLarge: StoryObj = {
     <Spotlight as="section">
       <Grid paddingVertical="x-large">
         <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading color="inverse" level={2}>Reserveren voor 1 tot 3 uur</Heading>
+          <Heading color="inverse" level={2} size="level-3">Reserveren voor 1 tot 3 uur</Heading>
           <Paragraph color="inverse">
             Huurt u een zaal voor 1 tot 3 uur? Dan reserveert u die zelf online in het reserveringssysteem.
           </Paragraph>
@@ -1355,7 +1355,7 @@ export const LocationLarge: StoryObj = {
           </LinkList>
         </Grid.Cell>
         <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
-          <Heading color="inverse" level={2}>Langer dan 3 uur reserveren</Heading>
+          <Heading color="inverse" level={2} size="level-3">Langer dan 3 uur reserveren</Heading>
           <Paragraph color="inverse">
             Heeft u een zaal langer dan 3 uur nodig? Stuur dan een e-mail naar sportverhuur@amsterdam.nl. Vermeld uw
             naam, de sport, de zaal, de begindatum en einddatum, de tijden van uw voorkeur en een korte omschrijving
@@ -1364,7 +1364,7 @@ export const LocationLarge: StoryObj = {
           <StandaloneLink color="inverse" href="mailto:sportverhuur@amsterdam.nl" icon={MailIcon}>Stuur uw aanvraag per e-mail in</StandaloneLink>
         </Grid.Cell>
         <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-          <Heading color="inverse" level={2}>Evenementen</Heading>
+          <Heading color="inverse" level={2} size="level-3">Evenementen</Heading>
           <Paragraph color="inverse">
             In de grote zaal is plaats voor 550 toeschouwers. De zaal is geschikt voor sportevenementen, markten,
             yoga-evenementen, dansworkshops en concerten. In de hele Apollohal kunnen maximaal 1.000 bezoekers
@@ -1376,7 +1376,7 @@ export const LocationLarge: StoryObj = {
           </Paragraph>
         </Grid.Cell>
         <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
-          <Heading color="inverse" level={2}>Huisregels en tarieven</Heading>
+          <Heading color="inverse" level={2} size="level-3">Huisregels en tarieven</Heading>
           <Paragraph color="inverse">
             In de huisregels leest u wat er wel en niet mag in de Apollohal. In het tarievenoverzicht ziet u wat het
             huren van een zaal kost.
@@ -1394,14 +1394,14 @@ export const LocationLarge: StoryObj = {
     </Spotlight>
     <Grid paddingVertical="x-large">
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading level={2}>Gevonden voorwerpen</Heading>
+        <Heading level={2} size="level-3">Gevonden voorwerpen</Heading>
         <Paragraph>
           Bent u iets kwijtgeraakt in de Apollohal? Vraag ernaar bij de balie in de voorhal. Wij bewaren gevonden
           voorwerpen 4 weken.
         </Paragraph>
       </Grid.Cell>
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
-        <Heading level={2}>Contact en openingstijden</Heading>
+        <Heading level={2} size="level-3">Contact en openingstijden</Heading>
         <Paragraph>
           Apollolaan 4
           <br />
@@ -1414,28 +1414,28 @@ export const LocationLarge: StoryObj = {
         <Paragraph>Maandag tot en met zondag van 08.30 tot 23.00 uur.</Paragraph>
       </Grid.Cell>
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading level={2}>Rolstoeltoegankelijk</Heading>
+        <Heading level={2} size="level-3">Rolstoeltoegankelijk</Heading>
         <Paragraph>
           De Apollohal is rolstoeltoegankelijk. Er is een aangepaste ingang, een lift naar de bovenzaal en er zijn 3
           rolstoeltoegankelijke toiletten.
         </Paragraph>
       </Grid.Cell>
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
-        <Heading level={2}>Fietsenstalling</Heading>
+        <Heading level={2} size="level-3">Fietsenstalling</Heading>
         <Paragraph>
           Voor de ingang staan fietsenrekken voor ongeveer 100 fietsen. Zet uw fiets in een rek, zodat de ingang
           vrij blijft.
         </Paragraph>
       </Grid.Cell>
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading level={2}>Openbaar vervoer</Heading>
+        <Heading level={2} size="level-3">Openbaar vervoer</Heading>
         <Paragraph>
           Tram 12 stopt aan de Apollolaan, op 2 minuten lopen van de hal. Tram 5 en 24 en bus 246 stoppen bij het
           Olympiaplein, op 8 minuten lopen.
         </Paragraph>
       </Grid.Cell>
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
-        <Heading level={2}>Betaald parkeren</Heading>
+        <Heading level={2} size="level-3">Betaald parkeren</Heading>
         <Paragraph>
           Bij de Apollohal zijn 12 parkeerplaatsen: 8 gewone plaatsen, 2 plaatsen voor elektrische auto’s en 2
           gehandicaptenparkeerplaatsen. U betaalt het reguliere parkeertarief van de buurt.
@@ -1532,7 +1532,9 @@ export const LocationLarge: StoryObj = {
             span={{ narrow: 4, medium: 6, wide: 7 }}
             start={{ narrow: 1, medium: 1, wide: 2 }}
           >
-            <Heading level={2}>Over de Apollohal</Heading>
+            <Heading level={2} size="level-3">
+              Over de Apollohal
+            </Heading>
             <Paragraph>
               De Apollohal is een sporthal in Amsterdam-Zuid met moderne voorzieningen en een rijke sporthistorie. Het
               gebouw heeft 1 grote zaal en 2 gymzalen en is geschikt voor veel verschillende sporten en evenementen.
@@ -1637,7 +1639,7 @@ export const LocationLarge: StoryObj = {
               span={{ narrow: 4, medium: 4, wide: 5 }}
               start={{ narrow: 1, medium: 1, wide: 2 }}
             >
-              <Heading color="inverse" level={2}>
+              <Heading color="inverse" level={2} size="level-3">
                 Reserveren voor 1 tot 3 uur
               </Heading>
               <Paragraph color="inverse">
@@ -1656,7 +1658,7 @@ export const LocationLarge: StoryObj = {
               </LinkList>
             </Grid.Cell>
             <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
-              <Heading color="inverse" level={2}>
+              <Heading color="inverse" level={2} size="level-3">
                 Langer dan 3 uur reserveren
               </Heading>
               <Paragraph color="inverse">
@@ -1673,7 +1675,7 @@ export const LocationLarge: StoryObj = {
               span={{ narrow: 4, medium: 4, wide: 5 }}
               start={{ narrow: 1, medium: 1, wide: 2 }}
             >
-              <Heading color="inverse" level={2}>
+              <Heading color="inverse" level={2} size="level-3">
                 Evenementen
               </Heading>
               <Paragraph color="inverse">
@@ -1687,7 +1689,7 @@ export const LocationLarge: StoryObj = {
               </Paragraph>
             </Grid.Cell>
             <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
-              <Heading color="inverse" level={2}>
+              <Heading color="inverse" level={2} size="level-3">
                 Huisregels en tarieven
               </Heading>
               <Paragraph color="inverse">
@@ -1711,14 +1713,18 @@ export const LocationLarge: StoryObj = {
             span={{ narrow: 4, medium: 4, wide: 5 }}
             start={{ narrow: 1, medium: 1, wide: 2 }}
           >
-            <Heading level={2}>Gevonden voorwerpen</Heading>
+            <Heading level={2} size="level-3">
+              Gevonden voorwerpen
+            </Heading>
             <Paragraph>
               Bent u iets kwijtgeraakt in de Apollohal? Vraag ernaar bij de balie in de voorhal. Wij bewaren gevonden
               voorwerpen 4 weken.
             </Paragraph>
           </Grid.Cell>
           <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
-            <Heading level={2}>Contact en openingstijden</Heading>
+            <Heading level={2} size="level-3">
+              Contact en openingstijden
+            </Heading>
             <Paragraph>
               Apollolaan 4
               <br />
@@ -1735,14 +1741,18 @@ export const LocationLarge: StoryObj = {
             span={{ narrow: 4, medium: 4, wide: 5 }}
             start={{ narrow: 1, medium: 1, wide: 2 }}
           >
-            <Heading level={2}>Rolstoeltoegankelijk</Heading>
+            <Heading level={2} size="level-3">
+              Rolstoeltoegankelijk
+            </Heading>
             <Paragraph>
               De Apollohal is rolstoeltoegankelijk. Er is een aangepaste ingang, een lift naar de bovenzaal en er zijn 3
               rolstoeltoegankelijke toiletten.
             </Paragraph>
           </Grid.Cell>
           <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
-            <Heading level={2}>Fietsenstalling</Heading>
+            <Heading level={2} size="level-3">
+              Fietsenstalling
+            </Heading>
             <Paragraph>
               Voor de ingang staan fietsenrekken voor ongeveer 100 fietsen. Zet uw fiets in een rek, zodat de ingang
               vrij blijft.
@@ -1753,14 +1763,18 @@ export const LocationLarge: StoryObj = {
             span={{ narrow: 4, medium: 4, wide: 5 }}
             start={{ narrow: 1, medium: 1, wide: 2 }}
           >
-            <Heading level={2}>Openbaar vervoer</Heading>
+            <Heading level={2} size="level-3">
+              Openbaar vervoer
+            </Heading>
             <Paragraph>
               Tram 12 stopt aan de Apollolaan, op 2 minuten lopen van de hal. Tram 5 en 24 en bus 246 stoppen bij het
               Olympiaplein, op 8 minuten lopen.
             </Paragraph>
           </Grid.Cell>
           <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }}>
-            <Heading level={2}>Betaald parkeren</Heading>
+            <Heading level={2} size="level-3">
+              Betaald parkeren
+            </Heading>
             <Paragraph>
               Bij de Apollohal zijn 12 parkeerplaatsen: 8 gewone plaatsen, 2 plaatsen voor elektrische auto’s en 2
               gehandicaptenparkeerplaatsen. U betaalt het reguliere parkeertarief van de buurt.

--- a/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
+++ b/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
@@ -569,7 +569,7 @@ export const Group: StoryObj = {
                 {/* Card.Link stretches over the whole Card, so the entire Card is one clickable link. */}
                 <Card.Link href="#">{name}</Card.Link>
               </Card.Heading>
-              <Paragraph size="small">{role}</Paragraph>
+              <Paragraph>{role}</Paragraph>
             </Card>
           </Grid.Cell>
         ))}
@@ -588,7 +588,7 @@ export const Group: StoryObj = {
               <Card.Heading level={3}>
                 <Card.Link href="#">{name}</Card.Link>
               </Card.Heading>
-              <Paragraph size="small">{role}</Paragraph>
+              <Paragraph>{role}</Paragraph>
             </Card>
           </Grid.Cell>
         ))}
@@ -769,7 +769,7 @@ export const Group: StoryObj = {
                     {/* Card.Link stretches over the whole Card, so the entire Card is one clickable link. */}
                     <Card.Link href="#">{name}</Card.Link>
                   </Card.Heading>
-                  <Paragraph size="small">{role}</Paragraph>
+                  <Paragraph>{role}</Paragraph>
                 </Card>
               </Grid.Cell>
             ))}
@@ -790,7 +790,7 @@ export const Group: StoryObj = {
                   <Card.Heading level={3}>
                     <Card.Link href="#">{name}</Card.Link>
                   </Card.Heading>
-                  <Paragraph size="small">{role}</Paragraph>
+                  <Paragraph>{role}</Paragraph>
                 </Card>
               </Grid.Cell>
             ))}
@@ -1273,7 +1273,7 @@ export const LocationLarge: StoryObj = {
               {/* Card.Link stretches over the whole Card, so the entire Card is one clickable link. */}
               <Card.Link href="#">Grote zaal</Card.Link>
             </Card.Heading>
-            <Paragraph size="small">Badminton, basketbal, handbal, korfbal, volleybal en zaalvoetbal.</Paragraph>
+            <Paragraph>Badminton, basketbal, handbal, korfbal, volleybal en zaalvoetbal.</Paragraph>
           </Card>
         </Grid.Cell>
         <Grid.Cell span={4}>
@@ -1282,7 +1282,7 @@ export const LocationLarge: StoryObj = {
             <Card.Heading level={3}>
               <Card.Link href="#">Du Midi benedenzaal</Card.Link>
             </Card.Heading>
-            <Paragraph size="small">Badminton, basketbal, volleybal, dansen en vechtsport.</Paragraph>
+            <Paragraph>Badminton, basketbal, volleybal, dansen en vechtsport.</Paragraph>
           </Card>
         </Grid.Cell>
         <Grid.Cell span={4}>
@@ -1291,7 +1291,7 @@ export const LocationLarge: StoryObj = {
             <Card.Heading level={3}>
               <Card.Link href="#">Du Midi bovenzaal</Card.Link>
             </Card.Heading>
-            <Paragraph size="small">
+            <Paragraph>
               Badminton, basketbal, korfbal, volleybal, schermen, dansen en vechtsport.
             </Paragraph>
           </Card>
@@ -1564,7 +1564,7 @@ export const LocationLarge: StoryObj = {
                   {/* Card.Link stretches over the whole Card, so the entire Card is one clickable link. */}
                   <Card.Link href="#">Grote zaal</Card.Link>
                 </Card.Heading>
-                <Paragraph size="small">Badminton, basketbal, handbal, korfbal, volleybal en zaalvoetbal.</Paragraph>
+                <Paragraph>Badminton, basketbal, handbal, korfbal, volleybal en zaalvoetbal.</Paragraph>
               </Card>
             </Grid.Cell>
             <Grid.Cell span={4}>
@@ -1573,7 +1573,7 @@ export const LocationLarge: StoryObj = {
                 <Card.Heading level={3}>
                   <Card.Link href="#">Du Midi benedenzaal</Card.Link>
                 </Card.Heading>
-                <Paragraph size="small">Badminton, basketbal, volleybal, dansen en vechtsport.</Paragraph>
+                <Paragraph>Badminton, basketbal, volleybal, dansen en vechtsport.</Paragraph>
               </Card>
             </Grid.Cell>
             <Grid.Cell span={4}>
@@ -1582,9 +1582,7 @@ export const LocationLarge: StoryObj = {
                 <Card.Heading level={3}>
                   <Card.Link href="#">Du Midi bovenzaal</Card.Link>
                 </Card.Heading>
-                <Paragraph size="small">
-                  Badminton, basketbal, korfbal, volleybal, schermen, dansen en vechtsport.
-                </Paragraph>
+                <Paragraph>Badminton, basketbal, korfbal, volleybal, schermen, dansen en vechtsport.</Paragraph>
               </Card>
             </Grid.Cell>
           </Grid.Subgrid>

--- a/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
+++ b/storybook/src/pages/public/ProfilePage/ProfilePage.stories.tsx
@@ -467,7 +467,7 @@ export const Group: StoryObj = {
     <Grid gapVertical="none" paddingBottom="x-large">
       {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
       <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading className="ams-mb-s" level={2}>Adres en contact</Heading>
+        <Heading className="ams-mb-s" level={2} size="level-3">Adres en contact</Heading>
       </Grid.Cell>
       <Grid.Subgrid gapVertical="x-large" span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
@@ -552,7 +552,7 @@ export const Group: StoryObj = {
      */}
     <Grid gapVertical="none" paddingTop="x-large">
       <Grid.Cell span="all">
-        <Heading className="ams-mb-s" level={2}>Raadsleden</Heading>
+        <Heading className="ams-mb-s" level={2} size="level-3">Raadsleden</Heading>
       </Grid.Cell>
       <Grid.Subgrid gapVertical="x-large" span="all">
         {/* Preview cards take a span of 4, so they fit three to a row on the wide grid and two on the medium one. */}
@@ -578,7 +578,7 @@ export const Group: StoryObj = {
     {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
     <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
       <Grid.Cell span="all">
-        <Heading className="ams-mb-s" level={2}>Fractievertegenwoordigers</Heading>
+        <Heading className="ams-mb-s" level={2} size="level-3">Fractievertegenwoordigers</Heading>
       </Grid.Cell>
       <Grid.Subgrid gapVertical="x-large" span="all">
         {groupRepresentatives.map(({ name, role }) => (
@@ -648,7 +648,7 @@ export const Group: StoryObj = {
         <Grid gapVertical="none" paddingBottom="x-large">
           {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
           <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-            <Heading className="ams-mb-s" level={2}>
+            <Heading className="ams-mb-s" level={2} size="level-3">
               Adres en contact
             </Heading>
           </Grid.Cell>
@@ -750,7 +750,7 @@ export const Group: StoryObj = {
          */}
         <Grid gapVertical="none" paddingTop="x-large">
           <Grid.Cell span="all">
-            <Heading className="ams-mb-s" level={2}>
+            <Heading className="ams-mb-s" level={2} size="level-3">
               Raadsleden
             </Heading>
           </Grid.Cell>
@@ -778,7 +778,7 @@ export const Group: StoryObj = {
         {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
         <Grid gapVertical="none" paddingBottom="2x-large" paddingTop="x-large">
           <Grid.Cell span="all">
-            <Heading className="ams-mb-s" level={2}>
+            <Heading className="ams-mb-s" level={2} size="level-3">
               Fractievertegenwoordigers
             </Heading>
           </Grid.Cell>
@@ -851,14 +851,14 @@ export const Location: StoryObj = {
       </Grid.Cell>
     </Grid>
     {/*
-     * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+     * The row gap would put an x-large below the heading, where the guidance asks for an x-small at this size.
      * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
      * between the Cells.
      */}
     <Grid gapVertical="none" paddingVertical="x-large">
       {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
       <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading className="ams-mb-s" level={2}>Faciliteiten</Heading>
+        <Heading className="ams-mb-xs" level={2} size="level-3">Faciliteiten</Heading>
       </Grid.Cell>
       <Grid.Subgrid gapVertical="x-large" span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
@@ -957,7 +957,7 @@ export const Location: StoryObj = {
     <Grid paddingBottom="2x-large">
       {/* The heading and the map share a Cell, so Prose spaces them rather than the Grid’s row gap. */}
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading level={2}>Locatie</Heading>
+        <Heading level={2} size="level-3">Locatie</Heading>
         <Image
           alt="Kaart met de ligging van Sportpark Riekerhaven aan de Anderlechtlaan in Amsterdam Nieuw-West."
           aspectRatio="16:9"
@@ -1020,14 +1020,14 @@ export const Location: StoryObj = {
           </Grid.Cell>
         </Grid>
         {/*
-         * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+         * The row gap would put an x-large below the heading, where the guidance asks for an x-small at this size.
          * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
          * between the Cells.
          */}
         <Grid gapVertical="none" paddingVertical="x-large">
           {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
           <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-            <Heading className="ams-mb-s" level={2}>
+            <Heading className="ams-mb-xs" level={2} size="level-3">
               Faciliteiten
             </Heading>
           </Grid.Cell>
@@ -1166,7 +1166,9 @@ export const Location: StoryObj = {
             span={{ narrow: 4, medium: 8, wide: 10 }}
             start={{ narrow: 1, medium: 1, wide: 2 }}
           >
-            <Heading level={2}>Locatie</Heading>
+            <Heading level={2} size="level-3">
+              Locatie
+            </Heading>
             <Image
               alt="Kaart met de ligging van Sportpark Riekerhaven aan de Anderlechtlaan in Amsterdam Nieuw-West."
               aspectRatio="16:9"
@@ -1260,7 +1262,7 @@ export const LocationLarge: StoryObj = {
      */}
     <Grid gapVertical="none" paddingBottom="x-large">
       <Grid.Cell span="all">
-        <Heading className="ams-mb-s" level={2}>Zalen en sportmogelijkheden</Heading>
+        <Heading className="ams-mb-s" level={2} size="level-3">Zalen en sportmogelijkheden</Heading>
       </Grid.Cell>
       <Grid.Subgrid gapVertical="x-large" span="all">
         {/* Preview cards take a span of 4, so they fit three to a row on the wide grid and two on the medium one. */}
@@ -1301,7 +1303,7 @@ export const LocationLarge: StoryObj = {
     <Grid gapVertical="none" paddingBottom="x-large">
       {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
       <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading className="ams-mb-s" level={2}>Faciliteiten</Heading>
+        <Heading className="ams-mb-xs" level={2} size="level-3">Faciliteiten</Heading>
       </Grid.Cell>
       <Grid.Subgrid gapVertical="x-large" span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
         <Grid.Cell span={{ narrow: 4, medium: 4, wide: 5 }}>
@@ -1446,7 +1448,7 @@ export const LocationLarge: StoryObj = {
     <Grid paddingBottom="2x-large">
       {/* The heading, the paragraph and the map share a Cell, so Prose spaces them rather than the Grid’s row gap. */}
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading level={2}>Locatie en plattegrond</Heading>
+        <Heading level={2} size="level-3">Locatie en plattegrond</Heading>
         <Paragraph>
           De Apollohal staat op de hoek van de Apollolaan en het Muzenplein. Bekijk de indeling van de zalen op de{' '}
           <Link href="#">plattegrond van de Apollohal (PDF, 228 kB)</Link>.
@@ -1549,7 +1551,7 @@ export const LocationLarge: StoryObj = {
          */}
         <Grid gapVertical="none" paddingBottom="x-large">
           <Grid.Cell span="all">
-            <Heading className="ams-mb-s" level={2}>
+            <Heading className="ams-mb-s" level={2} size="level-3">
               Zalen en sportmogelijkheden
             </Heading>
           </Grid.Cell>
@@ -1590,7 +1592,7 @@ export const LocationLarge: StoryObj = {
         <Grid gapVertical="none" paddingBottom="x-large">
           {/* The heading spans the columns its two sections occupy, so it starts where they do. */}
           <Grid.Cell span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-            <Heading className="ams-mb-s" level={2}>
+            <Heading className="ams-mb-xs" level={2} size="level-3">
               Faciliteiten
             </Heading>
           </Grid.Cell>
@@ -1787,7 +1789,9 @@ export const LocationLarge: StoryObj = {
             span={{ narrow: 4, medium: 8, wide: 10 }}
             start={{ narrow: 1, medium: 1, wide: 2 }}
           >
-            <Heading level={2}>Locatie en plattegrond</Heading>
+            <Heading level={2} size="level-3">
+              Locatie en plattegrond
+            </Heading>
             <Paragraph>
               De Apollohal staat op de hoek van de Apollolaan en het Muzenplein. Bekijk de indeling van de zalen op de{' '}
               <Link href="#">plattegrond van de Apollohal (PDF, 228 kB)</Link>.
@@ -1844,7 +1848,7 @@ export const Sublocation: StoryObj = {
     </Grid>
     <Grid paddingVertical="x-large">
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 5 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading level={2}>Faciliteiten</Heading>
+        <Heading level={2} size="level-3">Faciliteiten</Heading>
         <UnorderedList>
           <UnorderedList.Item>4 kunstgrasvelden voor voetbal</UnorderedList.Item>
           <UnorderedList.Item>2 natuurgrasvelden voor voetbal</UnorderedList.Item>
@@ -1936,7 +1940,7 @@ export const Sublocation: StoryObj = {
     <Grid paddingBottom="2x-large">
       {/* The heading and the map share a Cell, so Prose spaces them rather than the Grid’s row gap. */}
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 8, wide: 10 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading level={2}>Locatie</Heading>
+        <Heading level={2} size="level-3">Locatie</Heading>
         <Image
           alt="Kaart met de ligging van Sportpark Sloten aan de Sloterweg in Nieuw-West."
           aspectRatio="16:9"
@@ -1992,7 +1996,9 @@ export const Sublocation: StoryObj = {
             span={{ narrow: 4, medium: 4, wide: 5 }}
             start={{ narrow: 1, medium: 1, wide: 2 }}
           >
-            <Heading level={2}>Faciliteiten</Heading>
+            <Heading level={2} size="level-3">
+              Faciliteiten
+            </Heading>
             <UnorderedList>
               <UnorderedList.Item>4 kunstgrasvelden voor voetbal</UnorderedList.Item>
               <UnorderedList.Item>2 natuurgrasvelden voor voetbal</UnorderedList.Item>
@@ -2118,7 +2124,9 @@ export const Sublocation: StoryObj = {
             span={{ narrow: 4, medium: 8, wide: 10 }}
             start={{ narrow: 1, medium: 1, wide: 2 }}
           >
-            <Heading level={2}>Locatie</Heading>
+            <Heading level={2} size="level-3">
+              Locatie
+            </Heading>
             <Image
               alt="Kaart met de ligging van Sportpark Sloten aan de Sloterweg in Nieuw-West."
               aspectRatio="16:9"

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -247,13 +247,13 @@ const meta = {
         </Grid>
         <Spotlight color="azure">
           {/*
-           * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+           * The row gap would put an x-large below the heading, where the guidance asks for an x-small at this size.
            * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
            * between the Cells.
            */}
           <Grid gapVertical="none" paddingVertical="x-large">
             <Grid.Cell span="all">
-              <Heading className="ams-mb-s" color="inverse" level={2}>
+              <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">
                 Zelfbouw
               </Heading>
             </Grid.Cell>
@@ -356,7 +356,7 @@ const meta = {
         <Spotlight>
           <Grid gapVertical="none" paddingVertical="x-large">
             <Grid.Cell span="all">
-              <Heading className="ams-mb-s" color="inverse" level={2}>
+              <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">
                 Contact
               </Heading>
             </Grid.Cell>
@@ -529,13 +529,13 @@ export const Default: StoryObj = {
     </Grid>
     <Spotlight color="azure">
       {/*
-       * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+       * The row gap would put an x-large below the heading, where the guidance asks for an x-small at this size.
        * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
        * between the Cells.
        */}
       <Grid gapVertical="none" paddingVertical="x-large">
         <Grid.Cell span="all">
-          <Heading className="ams-mb-s" color="inverse" level={2}>Zelfbouw</Heading>
+          <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">Zelfbouw</Heading>
         </Grid.Cell>
         <Grid.Subgrid gapVertical="x-large" span="all">
           {/* The promo cells span 3 columns of the wide grid, so four of them line up only on wide screens. */}
@@ -581,7 +581,7 @@ export const Default: StoryObj = {
     <Spotlight>
       <Grid gapVertical="none" paddingVertical="x-large">
         <Grid.Cell span="all">
-          <Heading className="ams-mb-s" color="inverse" level={2}>Contact</Heading>
+          <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">Contact</Heading>
         </Grid.Cell>
         <Grid.Subgrid gapVertical="x-large" span="all">
           <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 6 }}>


### PR DESCRIPTION
# Correct the heading sizes and the Card text on the Profile Page

## Links

- [Location Large](https://designsystem.amsterdam/?path=/story/pages-public-profile-page--location-large) and [Group](https://designsystem.amsterdam/?path=/story/pages-public-profile-page--group) — the two stories that change
- [Heading](https://designsystem.amsterdam/?path=/docs/components-text-heading--docs#sections-and-blocks) — the new Usage guidelines section
- [Public websites](https://designsystem.amsterdam/?path=/docs/pages-public-introduction--docs#headings-on-a-page) — the pointer to it
- [Preview deploy](https://designsystem.amsterdam/) — the whole Storybook on main

## What

Thirteen level 2 Headings on the Profile Page take `size="level-3"`: the four Spotlight blocks and the six practical detail blocks of Location Large, its "Over de Apollohal" section, and the two Spotlight blocks of Group. Ten Paragraphs in the Cards of that page lose `size="small"`.

The Heading docs get a "Sections and blocks" section under Usage guidelines, in place of three bullets that said content pages must never use the size prop. The public websites introduction points at it in two lines.

## Why

A level 2 Heading keeps the size of its level when it introduces a section: a run of body text, or a group of blocks such as a row of Cards. A heading that introduces a single block takes a size one step smaller. Such a block holds a short paragraph, a Link List, or a single link, and at the full size the heading outweighs the few lines below it. Location Large drew all of them at full size. Group had the same problem in its Spotlight, where the Person story beside it was already right.

The three bullets this replaces did not describe that. They tied the size to the kind of page rather than to what the heading introduces, which does not hold: content pages carry these blocks too, in a Spotlight or among the practical details at the foot of the page.

Cards carry their text in a regular Paragraph. The small size is for a publication date, as the Card docs already said. On this page it held the role of a council member and the sports each hall of the Apollohal is fit for, and shrinking those only costs legibility.

## How

The `level` is untouched, so the document outline is unchanged. Prose spaces a heading by the size it is drawn at rather than by its level, so the margins below these headings follow on their own and no page sets one by hand.

Both copies of every story change: the render and the hand-written `parameters.docs.source.code`.

The other page templates were checked against the rule. Article, Product, Information, Form Flow, Project, Navigation and the internal pages already follow it. Two things are deliberately left alone. The Article Page draws "Meer nieuws" one size larger than its level, over the card row at the foot, as an emphasis. The Navigation Page nests one level deeper, where the level 3 group headings take no size, as a comment in that story explains, so the docs state the level 2 case only.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Expect visual changes on the Profile Page: the Group and Location Large stories.

