### PR TITLE
feat(Storybook): Add a Project Page variant with a Table of Contents and a Breakout

### DIFF
--- a/storybook/src/docs/introduction.docs.mdx
+++ b/storybook/src/docs/introduction.docs.mdx
@@ -25,7 +25,7 @@ Faster and cheaper to build and iterate with.
     <strong>1300+</strong> design tokens
   </InlineList.Item>
   <InlineList.Item>
-    <strong>32</strong> templates
+    <strong>33</strong> templates
   </InlineList.Item>
   <InlineList.Item>
     <strong>3</strong> modes

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.docs.mdx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.docs.mdx
@@ -25,8 +25,8 @@ The page has a set structure.
 It includes sections that describe what the project is, its location, the reasons for it, and the timeline for planning or execution.
 This standard format helps users compare projects and find information more easily.
 
-The ‘when’ section usually features a timeline of important milestones, shown in a Progress List.
-This gives a brief overview of the project's current status and future phases.
+The ‘when’ section usually features a timeline of important milestones, shown in a [Progress List](/docs/components-containers-progress-list--docs).
+This gives a brief overview of the project’s current status and future phases.
 
 Visual elements enhance the text.
 Large images provide context or show the impact.
@@ -35,3 +35,33 @@ A video may be included to clarify complex issues or planned changes.
 
 Related information is organized in link blocks.
 These links lead to news updates, related projects, and supporting documents, allowing users to delve deeper without overwhelming the main content.
+
+## Default
+
+Give the page a single body column and pair the link sections two per row.
+This suits a project with a handful of related sections, where a reader can take in the whole page by scrolling.
+
+## With Breakout
+
+Longer projects need more sections, and a reader who wants one of them should not have to scroll past the others to find it.
+Open such a page with a lead paragraph, list its sections in a [Table of Contents](/docs/components-navigation-table-of-contents--docs) beside the body, and give every section heading the `id` its entry points at.
+
+Place that Table of Contents in a [Breakout](/docs/components-layout-breakout--docs) rather than a [Grid](/docs/components-layout-grid--docs).
+Only a Breakout can put a Cell in a row of your choosing, which is what lets the Table of Contents come first in the reading order and still sit to the right of the body on a wide screen.
+In a Grid it would push the body down a row.
+
+A Breakout also lets an image overlap the [Spotlight](/docs/components-containers-spotlight--docs) below it, which sets a band apart from the sections around it.
+The Cell holding the Spotlight needs `has="spotlight"`, and the Cell holding the image `has="figure"`.
+Give every Cell inside that band an explicit row: a Cell without one avoids the rows the Spotlight occupies and lands underneath the band instead of in it.
+Let the image take a single row on the narrow grid, so it sits above the band rather than over it.
+
+Choose the text colour for a Spotlight from the highlight colour behind it, not from the other bands on the page.
+Yellow is a light background, so headings and paragraphs keep their default colour and only links take `color="contrast"`.
+Purple is a dark one, where everything takes `color="inverse"`.
+
+Stack a run of short link sections in one Grid Cell rather than giving each its own.
+The space between them then comes from a margin per pair, which is what the vertical space guide is written in terms of.
+Separate Cells would take it from the row gap instead, and that is a single value for the whole Grid.
+
+Contact details are a [Link List](/docs/components-navigation-link-list--docs) whose links carry an icon instead of the chevron the list draws by default.
+Keep the name and the role above it in a Paragraph: they are not links, and a list of two items reads as a set of ways to get in touch.

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.docs.mdx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.docs.mdx
@@ -60,9 +60,9 @@ Choose the text colour for a Spotlight from the highlight colour behind it, not 
 Yellow is a light background, so headings and paragraphs keep their default colour and only links take `color="contrast"`.
 Purple is a dark one, where everything takes `color="inverse"`.
 
-Stack a run of short link sections in one Grid Cell rather than giving each its own.
-[Prose](/docs/utilities-css-prose--docs) then spaces them against one another, pair by pair, as the vertical space guide asks.
-Separate Cells would take that space from the row gap instead, and that is a single value for the whole Grid.
+Give every link section a Grid Cell of its own, as the other page templates do.
+Each one is a block, and the row gap of the Grid is what sets one block apart from the next.
+[Prose](/docs/utilities-css-prose--docs) is then left with the elements within a section: its heading, its list, and the link to the wider set below them.
 
 Contact details are a [Link List](/docs/components-navigation-link-list--docs) whose links carry an icon instead of the chevron the list draws by default.
 Keep the name and the role above it in a Paragraph: they are not links, and a list of two items reads as a set of ways to get in touch.

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.docs.mdx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.docs.mdx
@@ -46,11 +46,12 @@ This suits a project with a handful of related sections, where a reader can take
 Longer projects need more sections, and a reader who wants one of them should not have to scroll past the others to find it.
 Open such a page with a lead paragraph, list its sections in a [Table of Contents](/docs/components-navigation-table-of-contents--docs) beside the body, and give every section heading the `id` its entry points at.
 
-Place that Table of Contents in a [Breakout](/docs/components-layout-breakout--docs) rather than a [Grid](/docs/components-layout-grid--docs).
-Only a Breakout can put a Cell in a row of your choosing, which is what lets the Table of Contents come first in the reading order and still sit to the right of the body on a wide screen.
-In a Grid it would push the body down a row.
+Give that Table of Contents a `rowStart` of 1 in its [Grid](/docs/components-layout-grid--docs) Cell.
+That is what lets it come first in the reading order and still sit to the right of the body on a wide screen.
+Automatic placement never moves back a column without moving down a row, so without a row of its own it would push the body down one.
+No other cell in that Grid needs a row.
 
-A Breakout also lets an image overlap the [Spotlight](/docs/components-containers-spotlight--docs) below it, which sets a band apart from the sections around it.
+Further down, a [Breakout](/docs/components-layout-breakout--docs) lets an image overlap the [Spotlight](/docs/components-containers-spotlight--docs) below it, which sets a band apart from the sections around it.
 The Cell holding the Spotlight needs `has="spotlight"`, and the Cell holding the image `has="figure"`.
 Give every Cell inside that band an explicit row: a Cell without one avoids the rows the Spotlight occupies and lands underneath the band instead of in it.
 Let the image take a single row on the narrow grid, so it sits above the band rather than over it.
@@ -60,8 +61,8 @@ Yellow is a light background, so headings and paragraphs keep their default colo
 Purple is a dark one, where everything takes `color="inverse"`.
 
 Stack a run of short link sections in one Grid Cell rather than giving each its own.
-The space between them then comes from a margin per pair, which is what the vertical space guide is written in terms of.
-Separate Cells would take it from the row gap instead, and that is a single value for the whole Grid.
+[Prose](/docs/utilities-css-prose--docs) then spaces them against one another, pair by pair, as the vertical space guide asks.
+Separate Cells would take that space from the row gap instead, and that is a single value for the whole Grid.
 
 Contact details are a [Link List](/docs/components-navigation-link-list--docs) whose links carry an icon instead of the chevron the list draws by default.
 Keep the name and the role above it in a Paragraph: they are not links, and a list of two items reads as a set of ways to get in touch.

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -831,23 +831,19 @@ export const WithBreakout: StoryObj = {
           <LinkList.Link href="#">Fietsenstalling Julianaplein opent in het voorjaar (14 juli 2026)</LinkList.Link>
           <LinkList.Link href="#">Bushaltes verplaatst naar de Spaklerweg (2 juni 2026)</LinkList.Link>
           <LinkList.Link href="#">Terugblik op de informatieavond van 21 mei (28 mei 2026)</LinkList.Link>
-          {/* A bottom margin on the second to last link sets the closing link apart from the items above it. */}
-          <LinkList.Link className="ams-mb-m" href="#">
-            Wandschildering in de stationshal gerestaureerd (9 april 2026)
-          </LinkList.Link>
-          <LinkList.Link href="#">Bekijk al het nieuws over dit project</LinkList.Link>
+          <LinkList.Link href="#">Wandschildering in de stationshal gerestaureerd (9 april 2026)</LinkList.Link>
         </LinkList>
+        {/* A link to the wider set is about the list rather than one of it, so it sits outside as a Standalone Link. */}
+        <StandaloneLink href="#">Bekijk al het nieuws over dit project</StandaloneLink>
       </Grid.Cell>
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
         <Heading id="werk-aan-de-weg" level={2} size="level-3">Werk aan de weg</Heading>
         <LinkList>
           <LinkList.Link href="#">Amstelstationstraat: afsluiting tot en met 12 september</LinkList.Link>
           <LinkList.Link href="#">Julianaplein: omleiding voor fietsers</LinkList.Link>
-          <LinkList.Link className="ams-mb-m" href="#">
-            Spaklerweg: nachtelijke afsluitingen
-          </LinkList.Link>
-          <LinkList.Link href="#">Bekijk alle wegwerkzaamheden in Oost</LinkList.Link>
+          <LinkList.Link href="#">Spaklerweg: nachtelijke afsluitingen</LinkList.Link>
         </LinkList>
+        <StandaloneLink href="#">Bekijk alle wegwerkzaamheden in Oost</StandaloneLink>
       </Grid.Cell>
     </Grid>
     {/*
@@ -951,20 +947,16 @@ export const WithBreakout: StoryObj = {
           <LinkList.Link href="#">Bereikbaarheid tijdens de werkzaamheden</LinkList.Link>
           <LinkList.Link href="#">Duurzaam en circulair bouwen</LinkList.Link>
           <LinkList.Link href="#">Groen en biodiversiteit</LinkList.Link>
-          <LinkList.Link className="ams-mb-m" href="#">
-            Toegankelijkheid van het station
-          </LinkList.Link>
-          <LinkList.Link href="#">Bekijk alle thema’s</LinkList.Link>
+          <LinkList.Link href="#">Toegankelijkheid van het station</LinkList.Link>
         </LinkList>
+        <StandaloneLink href="#">Bekijk alle thema’s</StandaloneLink>
         <Heading id="documenten" level={2} size="level-3">Documenten</Heading>
         <LinkList>
           <LinkList.Link href="#">Nota van uitgangspunten Amstelstation (pdf, 2,4 MB)</LinkList.Link>
           <LinkList.Link href="#">Voorlopig ontwerp Julianaplein (pdf, 8,1 MB)</LinkList.Link>
-          <LinkList.Link className="ams-mb-m" href="#">
-            Verkeersbesluit Amstelstationstraat (pdf, 310 kB)
-          </LinkList.Link>
-          <LinkList.Link href="#">Bekijk alle documenten</LinkList.Link>
+          <LinkList.Link href="#">Verkeersbesluit Amstelstationstraat (pdf, 310 kB)</LinkList.Link>
         </LinkList>
+        <StandaloneLink href="#">Bekijk alle documenten</StandaloneLink>
         <Heading id="video" level={2} size="level-3">Video</Heading>
         {/*
          * A Paragraph between the heading and the image: the vertical space guide documents no value for
@@ -1282,12 +1274,10 @@ export const WithBreakout: StoryObj = {
               <LinkList.Link href="#">Fietsenstalling Julianaplein opent in het voorjaar (14 juli 2026)</LinkList.Link>
               <LinkList.Link href="#">Bushaltes verplaatst naar de Spaklerweg (2 juni 2026)</LinkList.Link>
               <LinkList.Link href="#">Terugblik op de informatieavond van 21 mei (28 mei 2026)</LinkList.Link>
-              {/* A bottom margin on the second to last link sets the closing link apart from the items above it. */}
-              <LinkList.Link className="ams-mb-m" href="#">
-                Wandschildering in de stationshal gerestaureerd (9 april 2026)
-              </LinkList.Link>
-              <LinkList.Link href="#">Bekijk al het nieuws over dit project</LinkList.Link>
+              <LinkList.Link href="#">Wandschildering in de stationshal gerestaureerd (9 april 2026)</LinkList.Link>
             </LinkList>
+            {/* A link to the wider set is about the list rather than one of it, so it sits outside as a Standalone Link. */}
+            <StandaloneLink href="#">Bekijk al het nieuws over dit project</StandaloneLink>
           </Grid.Cell>
           <Grid.Cell
             className="ams-prose"
@@ -1300,11 +1290,9 @@ export const WithBreakout: StoryObj = {
             <LinkList>
               <LinkList.Link href="#">Amstelstationstraat: afsluiting tot en met 12 september</LinkList.Link>
               <LinkList.Link href="#">Julianaplein: omleiding voor fietsers</LinkList.Link>
-              <LinkList.Link className="ams-mb-m" href="#">
-                Spaklerweg: nachtelijke afsluitingen
-              </LinkList.Link>
-              <LinkList.Link href="#">Bekijk alle wegwerkzaamheden in Oost</LinkList.Link>
+              <LinkList.Link href="#">Spaklerweg: nachtelijke afsluitingen</LinkList.Link>
             </LinkList>
+            <StandaloneLink href="#">Bekijk alle wegwerkzaamheden in Oost</StandaloneLink>
           </Grid.Cell>
         </Grid>
         {/*
@@ -1416,22 +1404,18 @@ export const WithBreakout: StoryObj = {
               <LinkList.Link href="#">Bereikbaarheid tijdens de werkzaamheden</LinkList.Link>
               <LinkList.Link href="#">Duurzaam en circulair bouwen</LinkList.Link>
               <LinkList.Link href="#">Groen en biodiversiteit</LinkList.Link>
-              <LinkList.Link className="ams-mb-m" href="#">
-                Toegankelijkheid van het station
-              </LinkList.Link>
-              <LinkList.Link href="#">Bekijk alle thema’s</LinkList.Link>
+              <LinkList.Link href="#">Toegankelijkheid van het station</LinkList.Link>
             </LinkList>
+            <StandaloneLink href="#">Bekijk alle thema’s</StandaloneLink>
             <Heading id="documenten" level={2} size="level-3">
               Documenten
             </Heading>
             <LinkList>
               <LinkList.Link href="#">Nota van uitgangspunten Amstelstation (pdf, 2,4 MB)</LinkList.Link>
               <LinkList.Link href="#">Voorlopig ontwerp Julianaplein (pdf, 8,1 MB)</LinkList.Link>
-              <LinkList.Link className="ams-mb-m" href="#">
-                Verkeersbesluit Amstelstationstraat (pdf, 310 kB)
-              </LinkList.Link>
-              <LinkList.Link href="#">Bekijk alle documenten</LinkList.Link>
+              <LinkList.Link href="#">Verkeersbesluit Amstelstationstraat (pdf, 310 kB)</LinkList.Link>
             </LinkList>
+            <StandaloneLink href="#">Bekijk alle documenten</StandaloneLink>
             <Heading id="video" level={2} size="level-3">
               Video
             </Heading>

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import {
   Breadcrumb,
+  Breakout,
   Grid,
   Heading,
   Image,
@@ -17,7 +18,9 @@ import {
   ProgressList,
   Spotlight,
   StandaloneLink,
+  TableOfContents,
 } from '@amsterdam/design-system-react'
+import { MailIcon, PhoneIcon } from '@amsterdam/design-system-react-icons'
 
 import { exampleImageSource } from '#storybook/_common/exampleContent'
 
@@ -619,4 +622,890 @@ export const Default: StoryObj = {
       },
     },
   },
+}
+
+export const WithBreakout: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        // Because this story’s `render` takes no argument, the Code Panel prints its source as written, the story
+        // wrapper and its types included. Provide the source by hand so the panel shows the markup to compose,
+        // without that scaffolding.
+        code: `<>
+  {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+  <Grid paddingTop="large">
+    <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+      <Breadcrumb>
+        <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+        <Breadcrumb.Link href="#">Bouwprojecten en verkeersprojecten</Breadcrumb.Link>
+        <Breadcrumb.Link href="#">Oost</Breadcrumb.Link>
+      </Breadcrumb>
+    </Grid.Cell>
+  </Grid>
+  {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
+  {/*
+   * The Spotlight bands below carry the project’s own content rather than supporting content, so they
+   * sit inside <main>. That makes <main> the wrapper around several Grids instead of a Grid itself.
+   */}
+  <main id="inhoud">
+    {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+    <Grid paddingBottom="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading className="ams-mb-m" level={1}>
+          Amstelstation: vernieuwing van het station en het stationsplein
+        </Heading>
+        <Paragraph size="large">
+          Het Amstelstation en het plein ervoor worden de komende jaren vernieuwd. Het station krijgt een ruimere
+          hal en een tweede ingang aan de zuidkant. Reizigers houden tijdens de werkzaamheden toegang tot de trein,
+          de metro en de tram.
+        </Paragraph>
+      </Grid.Cell>
+      {/* The slider spans the full grid width, where the title above it keeps to the narrower header cell. */}
+      <Grid.Cell span="all">
+        {/*
+         * ImageSlider takes an array of images. Each entry accepts the props of an Image plus an
+         * optional caption; only alt is required.
+         */}
+        {/* controls adds the previous and next buttons. The thumbnails below render either way. */}
+        <ImageSlider controls images={images} />
+      </Grid.Cell>
+    </Grid>
+    {/*
+     * A Spotlight for news that matters only for a while. Yellow is a light highlight colour, so the
+     * heading and the paragraph keep their default colour and only the link takes color="contrast".
+     */}
+    <Spotlight color="yellow">
+      <Grid paddingVertical="x-large">
+        <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+          <Heading className="ams-mb-s" level={2}>Amstelstationstraat afgesloten tot en met 12 september</Heading>
+          <Paragraph className="ams-mb-m">
+            Tot en met 12 september vervangen we de riolering onder de Amstelstationstraat. Doorgaand autoverkeer
+            rijdt om via de Wibautstraat. De ingang van het station aan de kant van het Julianaplein blijft de hele
+            periode open.
+          </Paragraph>
+          <StandaloneLink color="contrast" href="#">
+            Bekijk de omleidingsroutes
+          </StandaloneLink>
+        </Grid.Cell>
+      </Grid>
+    </Spotlight>
+    {/*
+     * The Table of Contents comes first in source, so it precedes the body in the reading and tab order.
+     * gridRowStart then puts it beside the body on the wide grid rather than above it: Grid.Cell offers
+     * rowSpan but no rowStart, and without a row of its own the cell joins the automatic placement, where
+     * a body Cell starting at an earlier column can no longer share its row. No other cell needs one.
+     */}
+    <Grid paddingVertical="x-large">
+      <Grid.Cell
+        span={{ narrow: 4, medium: 8, wide: 3 }}
+        start={{ narrow: 1, medium: 1, wide: 10 }}
+        style={{ gridRowStart: 1 }}
+      >
+        {/* The Table of Contents renders its own heading, at the size of a level 3 Heading. */}
+        <TableOfContents heading="Op deze pagina">
+          <TableOfContents.List>
+            <TableOfContents.Link href="#wat" label="Wat gaan we doen" />
+            <TableOfContents.Link href="#waar" label="Waar" />
+            <TableOfContents.Link href="#wanneer" label="Wanneer" />
+            <TableOfContents.Link href="#nieuws" label="Nieuws" />
+            <TableOfContents.Link href="#werk-aan-de-weg" label="Werk aan de weg" />
+            <TableOfContents.Link href="#deelprojecten" label="Deelprojecten" />
+            <TableOfContents.Link href="#themas" label="Thema’s" />
+            <TableOfContents.Link href="#documenten" label="Documenten" />
+            <TableOfContents.Link href="#video" label="Video" />
+            <TableOfContents.Link href="#meer-informatie" label="Meer informatie" />
+            <TableOfContents.Link href="#blijf-op-de-hoogte" label="Blijf op de hoogte" />
+          </TableOfContents.List>
+        </TableOfContents>
+      </Grid.Cell>
+      {/* This cell is not ams-prose, so every element but the last sets its own bottom margin. */}
+      <Grid.Cell
+        span={{ narrow: 4, medium: 6, wide: 7 }}
+        start={{ narrow: 1, medium: 2, wide: 3 }}
+      >
+        {/* Every section heading carries the id its Table of Contents entry points at. */}
+        <Heading className="ams-mb-s" id="wat" level={2}>Wat gaan we doen</Heading>
+        <Paragraph className="ams-mb-m">
+          De stationshal van het Amstelstation is te klein voor het aantal reizigers dat er dagelijks doorheen
+          loopt. We vergroten de hal, verbreden de perrontrappen en maken een tweede ingang aan de zuidkant van het
+          station.
+        </Paragraph>
+        <Paragraph className="ams-mb-m">
+          Op het Julianaplein komt meer ruimte voor voetgangers en fietsers. De taxistandplaats en de bushaltes
+          verhuizen naar de oostkant van het plein. Daaronder komt een fietsenstalling met 7.000 plekken.
+        </Paragraph>
+        <Paragraph className="ams-mb-m">
+          Het stationsgebouw uit 1939 blijft behouden. De gevels en de grote hal met de wandschildering worden
+          gerestaureerd.
+        </Paragraph>
+        <StandaloneLink className="ams-mb-xl" href="#">
+          Lees meer over het ontwerp van het nieuwe station
+        </StandaloneLink>
+        <Heading className="ams-mb-s" id="waar" level={2}>Waar</Heading>
+        <Paragraph className="ams-mb-m">
+          Het Amstelstation ligt in stadsdeel Oost, tussen de Wibautstraat en de Amstel. Het project loopt van het
+          Julianaplein aan de noordkant tot de Spaklerweg aan de zuidkant.
+        </Paragraph>
+        <Paragraph className="ams-mb-xl">
+          De werkzaamheden raken de buurten Weesperzijde, Omval en Amstelkwartier. Bewoners en ondernemers krijgen
+          bericht voordat het werk in hun straat begint.
+        </Paragraph>
+        <Heading className="ams-mb-s" id="wanneer" level={2}>Wanneer</Heading>
+        <Paragraph className="ams-mb-l">
+          De vernieuwing gebeurt in stappen, zodat het station open blijft. We beginnen aan de zuidkant en werken
+          toe naar het Julianaplein. De laatste werkzaamheden ronden we naar verwachting in 2030 af.
+        </Paragraph>
+        {/*
+         * A ProgressList shows a timeline. status="completed" marks a finished step, status="current"
+         * the one in progress, and a step with no status is still to come. Substeps are nested by hand
+         * in a ProgressList.Substeps; hasSubsteps only tells the CSS about them, so that it draws the
+         * connecting lines correctly. collapsible gives every step its own fold button and decides what
+         * opens first: completed steps start collapsed, all others expanded, so the finished years here
+         * arrive folded. headingLevel is 3 because the list sits under the ‘Wanneer’ heading of level 2.
+         */}
+        <ProgressList collapsible headingLevel={3}>
+          {/*
+           * A Substep takes any content, so a month gets a level 4 Heading above its description. That is
+           * one level below the step headings the list renders itself.
+           */}
+          <ProgressList.Step hasSubsteps heading="2024" status="completed">
+            <ProgressList.Substeps>
+              <ProgressList.Substep status="completed">
+                <Heading level={4}>Maart</Heading>
+                <Paragraph>Sloop van de fietsenstalling aan de Spaklerweg.</Paragraph>
+              </ProgressList.Substep>
+              <ProgressList.Substep status="completed">
+                <Heading level={4}>Oktober</Heading>
+                <Paragraph>Start bouw van de tijdelijke stationshal aan de zuidkant.</Paragraph>
+              </ProgressList.Substep>
+            </ProgressList.Substeps>
+          </ProgressList.Step>
+          <ProgressList.Step hasSubsteps heading="2025" status="completed">
+            <ProgressList.Substeps>
+              <ProgressList.Substep status="completed">
+                <Heading level={4}>Januari</Heading>
+                <Paragraph>Tijdelijke stationshal in gebruik genomen.</Paragraph>
+              </ProgressList.Substep>
+              <ProgressList.Substep status="completed">
+                <Heading level={4}>September</Heading>
+                <Paragraph>
+                  Start vervanging van de riolering onder de <Link href="#">Amstelstationstraat</Link>.
+                </Paragraph>
+              </ProgressList.Substep>
+            </ProgressList.Substeps>
+          </ProgressList.Step>
+          <ProgressList.Step hasSubsteps heading="2026" status="current">
+            <ProgressList.Substeps>
+              <ProgressList.Substep status="current">
+                <Heading level={4}>Maart</Heading>
+                <Paragraph>Start verbouwing van de bestaande stationshal.</Paragraph>
+              </ProgressList.Substep>
+              <ProgressList.Substep>
+                <Heading level={4}>November</Heading>
+                <Paragraph>De nieuwe perrontrappen gaan open voor reizigers.</Paragraph>
+              </ProgressList.Substep>
+            </ProgressList.Substeps>
+          </ProgressList.Step>
+          <ProgressList.Step hasSubsteps heading="2028">
+            <ProgressList.Substeps>
+              <ProgressList.Substep>
+                <Heading level={4}>Voorjaar</Heading>
+                <Paragraph>Oplevering van de fietsenstalling onder het Julianaplein.</Paragraph>
+              </ProgressList.Substep>
+            </ProgressList.Substeps>
+          </ProgressList.Step>
+          <ProgressList.Step hasSubsteps heading="2030">
+            <ProgressList.Substeps>
+              <ProgressList.Substep>
+                <Heading level={4}>Najaar</Heading>
+                <Paragraph>Het plein en de tweede ingang aan de zuidkant zijn klaar.</Paragraph>
+              </ProgressList.Substep>
+            </ProgressList.Substeps>
+          </ProgressList.Step>
+        </ProgressList>
+      </Grid.Cell>
+      {/*
+       * These two Cells set no rowStart: the rows above them are taken, so they fall in underneath the
+       * body on every grid, in source order.
+       */}
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+        <Heading className="ams-mb-xs" id="nieuws" level={2} size="level-3">Nieuws</Heading>
+        <LinkList>
+          <LinkList.Link href="#">Fietsenstalling Julianaplein opent in het voorjaar (14 juli 2026)</LinkList.Link>
+          <LinkList.Link href="#">Bushaltes verplaatst naar de Spaklerweg (2 juni 2026)</LinkList.Link>
+          <LinkList.Link href="#">Terugblik op de informatieavond van 21 mei (28 mei 2026)</LinkList.Link>
+          {/* A bottom margin on the second to last link sets the closing link apart from the items above it. */}
+          <LinkList.Link className="ams-mb-m" href="#">
+            Wandschildering in de stationshal gerestaureerd (9 april 2026)
+          </LinkList.Link>
+          <LinkList.Link href="#">Bekijk al het nieuws over dit project</LinkList.Link>
+        </LinkList>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+        <Heading className="ams-mb-xs" id="werk-aan-de-weg" level={2} size="level-3">Werk aan de weg</Heading>
+        <LinkList>
+          <LinkList.Link href="#">Amstelstationstraat: afsluiting tot en met 12 september</LinkList.Link>
+          <LinkList.Link href="#">Julianaplein: omleiding voor fietsers</LinkList.Link>
+          <LinkList.Link className="ams-mb-m" href="#">
+            Spaklerweg: nachtelijke afsluitingen
+          </LinkList.Link>
+          <LinkList.Link href="#">Bekijk alle wegwerkzaamheden in Oost</LinkList.Link>
+        </LinkList>
+      </Grid.Cell>
+    </Grid>
+    {/*
+     * A Breakout lets an image overlap the Spotlight below it. The Cell with has="spotlight" stretches
+     * over the gaps and margins around it, so only that band reaches the edges of the Page; the image
+     * keeps to the grid. Both Cells need explicit rows, and so does everything inside the Spotlight:
+     * an automatically placed cell avoids the rows the Spotlight already occupies.
+     */}
+    {/*
+     * That stretch is a negative block margin of one x-large, so the band paints an x-large below the
+     * last row. Without a paddingBottom to land in, it would cover the space the next Grid opens with
+     * and leave its heading against the colour.
+     */}
+    <Breakout paddingBottom="x-large">
+      <Breakout.Cell colSpan="all" has="spotlight" rowSpan={3} rowStart={2}>
+        <Spotlight color="yellow" />
+      </Breakout.Cell>
+      {/*
+       * A map of the project area is not decorative: a reader looks at it to see where the work is, so
+       * it takes an alt. Name the subject and how far it reaches, and leave the rest to the ‘Waar’
+       * section, which carries the same information in words.
+       */}
+      {/* On the narrow grid the image takes a single row, so it sits above the band rather than over it. */}
+      <Breakout.Cell colSpan="all" has="figure" rowSpan={{ narrow: 1, medium: 2, wide: 2 }} rowStart={1}>
+        <Image
+          alt="Kaart van het stationsgebied met de locaties van de deelprojecten."
+          src="https://picsum.photos/1440/810"
+        />
+      </Breakout.Cell>
+      <Breakout.Cell
+        colSpan={{ narrow: 4, medium: 6, wide: 7 }}
+        colStart={{ narrow: 1, medium: 2, wide: 3 }}
+        rowStart={{ narrow: 2, medium: 3, wide: 3 }}
+      >
+        <Heading className="ams-mb-s" id="deelprojecten" level={2}>Deelprojecten</Heading>
+        <Paragraph>
+          De vernieuwing bestaat uit deelprojecten die deels tegelijk lopen. Elk deelproject heeft een eigen
+          planning en een eigen aanspreekpunt.
+        </Paragraph>
+      </Breakout.Cell>
+      <Breakout.Cell
+        colSpan={{ narrow: 4, medium: 4, wide: 5 }}
+        colStart={{ narrow: 1, medium: 1, wide: 2 }}
+        rowStart={{ narrow: 3, medium: 4, wide: 4 }}
+      >
+        <Heading className="ams-mb-xs" level={3}>Station en perrons</Heading>
+        <LinkList>
+          <LinkList.Link color="contrast" href="#">
+            Verbouwing van de stationshal
+          </LinkList.Link>
+          <LinkList.Link color="contrast" href="#">
+            Nieuwe perrontrappen
+          </LinkList.Link>
+          <LinkList.Link color="contrast" href="#">
+            Tweede ingang aan de zuidkant
+          </LinkList.Link>
+          <LinkList.Link color="contrast" href="#">
+            Restauratie van de wandschildering
+          </LinkList.Link>
+          <LinkList.Link color="contrast" href="#">
+            Toegankelijkheid van de perrons
+          </LinkList.Link>
+        </LinkList>
+      </Breakout.Cell>
+      <Breakout.Cell
+        colSpan={{ narrow: 4, medium: 4, wide: 5 }}
+        colStart={{ narrow: 1, medium: 5, wide: 7 }}
+        rowStart={{ narrow: 4, medium: 4, wide: 4 }}
+      >
+        <Heading className="ams-mb-xs" level={3}>Plein en omgeving</Heading>
+        <LinkList>
+          <LinkList.Link color="contrast" href="#">
+            Herinrichting van het Julianaplein
+          </LinkList.Link>
+          <LinkList.Link color="contrast" href="#">
+            Fietsenstalling onder het plein
+          </LinkList.Link>
+          <LinkList.Link color="contrast" href="#">
+            Bus- en tramhaltes
+          </LinkList.Link>
+          <LinkList.Link color="contrast" href="#">
+            Riolering Amstelstationstraat
+          </LinkList.Link>
+          <LinkList.Link color="contrast" href="#">
+            Groen langs de Amstel
+          </LinkList.Link>
+        </LinkList>
+      </Breakout.Cell>
+    </Breakout>
+    <Grid paddingVertical="x-large">
+      {/*
+       * One Cell holds all five link sections. Their spacing then comes from a margin per pair, where
+       * separate Cells would take it from the row gap, which is one value for the whole Grid.
+       */}
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+        <Heading className="ams-mb-xs" id="themas" level={2} size="level-3">Thema’s</Heading>
+        <LinkList className="ams-mb-l">
+          <LinkList.Link href="#">Bereikbaarheid tijdens de werkzaamheden</LinkList.Link>
+          <LinkList.Link href="#">Duurzaam en circulair bouwen</LinkList.Link>
+          <LinkList.Link href="#">Groen en biodiversiteit</LinkList.Link>
+          <LinkList.Link className="ams-mb-m" href="#">
+            Toegankelijkheid van het station
+          </LinkList.Link>
+          <LinkList.Link href="#">Bekijk alle thema’s</LinkList.Link>
+        </LinkList>
+        <Heading className="ams-mb-xs" id="documenten" level={2} size="level-3">Documenten</Heading>
+        <LinkList className="ams-mb-l">
+          <LinkList.Link href="#">Nota van uitgangspunten Amstelstation (pdf, 2,4 MB)</LinkList.Link>
+          <LinkList.Link href="#">Voorlopig ontwerp Julianaplein (pdf, 8,1 MB)</LinkList.Link>
+          <LinkList.Link className="ams-mb-m" href="#">
+            Verkeersbesluit Amstelstationstraat (pdf, 310 kB)
+          </LinkList.Link>
+          <LinkList.Link href="#">Bekijk alle documenten</LinkList.Link>
+        </LinkList>
+        <Heading className="ams-mb-xs" id="video" level={2} size="level-3">Video</Heading>
+        {/*
+         * A Paragraph between the heading and the image: the vertical space guide documents no value for
+         * a heading directly above an image, which is a sign to introduce the image in words first.
+         */}
+        <Paragraph className="ams-mb-l">
+          In deze animatie ziet u hoe het station en het plein er na de vernieuwing uitzien.
+        </Paragraph>
+        {/* This image carries no information the text does not, so it takes an empty alt. */}
+        <Image alt="" className="ams-mb-l" src="https://picsum.photos/1280/720" />
+        <StandaloneLink className="ams-mb-l" href="#">
+          Bekijk meer video’s over dit project
+        </StandaloneLink>
+        <Heading className="ams-mb-xs" id="meer-informatie" level={2} size="level-3">Meer informatie</Heading>
+        <LinkList className="ams-mb-l">
+          <LinkList.Link href="#">Amstelkwartier: woningbouw en openbare ruimte</LinkList.Link>
+          <LinkList.Link href="#">Wibautstraat: vernieuwing van de rijbanen</LinkList.Link>
+          <LinkList.Link href="#">Fietsparkeren in Amsterdam</LinkList.Link>
+          <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
+        </LinkList>
+        <Heading className="ams-mb-xs" id="blijf-op-de-hoogte" level={2} size="level-3">Blijf op de hoogte</Heading>
+        <LinkList>
+          <LinkList.Link href="#">Nieuwsbrief vernieuwing Amstelstation</LinkList.Link>
+          <LinkList.Link href="#">Informatieavonden en inloopspreekuren</LinkList.Link>
+          <LinkList.Link href="#">Instagram: Amstelstation</LinkList.Link>
+        </LinkList>
+      </Grid.Cell>
+    </Grid>
+    {/*
+     * The highlight colours have no prescribed meaning, so this band takes the default purple rather
+     * than repeating the yellow above. Purple is a dark background, so everything in it takes
+     * color="inverse".
+     */}
+    <Spotlight>
+      <Grid paddingVertical="x-large">
+        <Grid.Cell span="all">
+          {/*
+           * The Page Footer heads its own contact block ‘Contact’ as well, so someone browsing the page
+           * by heading meets the word twice. The hidden phrase tells the two apart without repeating
+           * ‘over dit project’ on screen, where the surrounding page already says so.
+           */}
+          <Heading className="ams-mb-s" color="inverse" level={2}>
+            Contact<span className="ams-visually-hidden"> over dit project</span>
+          </Heading>
+        </Grid.Cell>
+        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+          <Paragraph className="ams-mb-m" color="inverse">
+            Hilde Verkerk
+            <br />
+            Omgevingsmanager
+          </Paragraph>
+          {/* A Link List of contact details: an icon per link replaces the chevron the list draws by default. */}
+          <LinkList>
+            <LinkList.Link color="inverse" href="mailto:h.verkerk@amsterdam.nl" icon={<MailIcon />}>
+              h.verkerk@amsterdam.nl
+            </LinkList.Link>
+            <LinkList.Link color="inverse" href="tel:+31618342210" icon={<PhoneIcon />}>
+              06 1834 2210
+            </LinkList.Link>
+          </LinkList>
+        </Grid.Cell>
+        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+          <Paragraph className="ams-mb-m" color="inverse">
+            Joris Bramer
+            <br />
+            Communicatieadviseur
+          </Paragraph>
+          <LinkList>
+            <LinkList.Link color="inverse" href="mailto:j.bramer@amsterdam.nl" icon={<MailIcon />}>
+              j.bramer@amsterdam.nl
+            </LinkList.Link>
+            <LinkList.Link color="inverse" href="tel:+31611294478" icon={<PhoneIcon />}>
+              06 1129 4478
+            </LinkList.Link>
+          </LinkList>
+        </Grid.Cell>
+      </Grid>
+    </Spotlight>
+    {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+    <Grid paddingBottom="2x-large" paddingTop="x-large">
+      <Grid.Cell span="all">
+        <Image
+          alt="Kaart van het projectgebied, van het Julianaplein tot de Spaklerweg."
+          src="https://picsum.photos/1440/810"
+        />
+      </Grid.Cell>
+    </Grid>
+  </main>
+</>`,
+        language: 'tsx',
+      },
+    },
+  },
+  render: () => (
+    <>
+      {/* Keep the breadcrumb in its own Grid above <main>, so it sits outside the main content region. */}
+      <Grid paddingTop="large">
+        <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+          <Breadcrumb>
+            <Breadcrumb.Link href="#">Home</Breadcrumb.Link>
+            <Breadcrumb.Link href="#">Bouwprojecten en verkeersprojecten</Breadcrumb.Link>
+            <Breadcrumb.Link href="#">Oost</Breadcrumb.Link>
+          </Breadcrumb>
+        </Grid.Cell>
+      </Grid>
+      {/* The Skip Link in the Page Layout targets this id, so the next Tab press lands in the main content. */}
+      {/*
+       * The Spotlight bands below carry the project’s own content rather than supporting content, so they
+       * sit inside <main>. That makes <main> the wrapper around several Grids instead of a Grid itself.
+       */}
+      <main id="inhoud">
+        {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
+        <Grid paddingBottom="x-large">
+          <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+            <Heading className="ams-mb-m" level={1}>
+              Amstelstation: vernieuwing van het station en het stationsplein
+            </Heading>
+            <Paragraph size="large">
+              Het Amstelstation en het plein ervoor worden de komende jaren vernieuwd. Het station krijgt een ruimere
+              hal en een tweede ingang aan de zuidkant. Reizigers houden tijdens de werkzaamheden toegang tot de trein,
+              de metro en de tram.
+            </Paragraph>
+          </Grid.Cell>
+          {/* The slider spans the full grid width, where the title above it keeps to the narrower header cell. */}
+          <Grid.Cell span="all">
+            {/*
+             * ImageSlider takes an array of images. Each entry accepts the props of an Image plus an
+             * optional caption; only alt is required.
+             */}
+            {/* controls adds the previous and next buttons. The thumbnails below render either way. */}
+            <ImageSlider controls images={images} />
+          </Grid.Cell>
+        </Grid>
+        {/*
+         * A Spotlight for news that matters only for a while. Yellow is a light highlight colour, so the
+         * heading and the paragraph keep their default colour and only the link takes color="contrast".
+         */}
+        <Spotlight color="yellow">
+          <Grid paddingVertical="x-large">
+            <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+              <Heading className="ams-mb-s" level={2}>
+                Amstelstationstraat afgesloten tot en met 12 september
+              </Heading>
+              <Paragraph className="ams-mb-m">
+                Tot en met 12 september vervangen we de riolering onder de Amstelstationstraat. Doorgaand autoverkeer
+                rijdt om via de Wibautstraat. De ingang van het station aan de kant van het Julianaplein blijft de hele
+                periode open.
+              </Paragraph>
+              <StandaloneLink color="contrast" href="#">
+                Bekijk de omleidingsroutes
+              </StandaloneLink>
+            </Grid.Cell>
+          </Grid>
+        </Spotlight>
+        {/*
+         * The Table of Contents comes first in source, so it precedes the body in the reading and tab order.
+         * gridRowStart then puts it beside the body on the wide grid rather than above it: Grid.Cell offers
+         * rowSpan but no rowStart, and without a row of its own the cell joins the automatic placement, where
+         * a body Cell starting at an earlier column can no longer share its row. No other cell needs one.
+         */}
+        <Grid paddingVertical="x-large">
+          <Grid.Cell
+            span={{ narrow: 4, medium: 8, wide: 3 }}
+            start={{ narrow: 1, medium: 1, wide: 10 }}
+            style={{ gridRowStart: 1 }}
+          >
+            {/* The Table of Contents renders its own heading, at the size of a level 3 Heading. */}
+            <TableOfContents heading="Op deze pagina">
+              <TableOfContents.List>
+                <TableOfContents.Link href="#wat" label="Wat gaan we doen" />
+                <TableOfContents.Link href="#waar" label="Waar" />
+                <TableOfContents.Link href="#wanneer" label="Wanneer" />
+                <TableOfContents.Link href="#nieuws" label="Nieuws" />
+                <TableOfContents.Link href="#werk-aan-de-weg" label="Werk aan de weg" />
+                <TableOfContents.Link href="#deelprojecten" label="Deelprojecten" />
+                <TableOfContents.Link href="#themas" label="Thema’s" />
+                <TableOfContents.Link href="#documenten" label="Documenten" />
+                <TableOfContents.Link href="#video" label="Video" />
+                <TableOfContents.Link href="#meer-informatie" label="Meer informatie" />
+                <TableOfContents.Link href="#blijf-op-de-hoogte" label="Blijf op de hoogte" />
+              </TableOfContents.List>
+            </TableOfContents>
+          </Grid.Cell>
+          {/* This cell is not ams-prose, so every element but the last sets its own bottom margin. */}
+          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+            {/* Every section heading carries the id its Table of Contents entry points at. */}
+            <Heading className="ams-mb-s" id="wat" level={2}>
+              Wat gaan we doen
+            </Heading>
+            <Paragraph className="ams-mb-m">
+              De stationshal van het Amstelstation is te klein voor het aantal reizigers dat er dagelijks doorheen
+              loopt. We vergroten de hal, verbreden de perrontrappen en maken een tweede ingang aan de zuidkant van het
+              station.
+            </Paragraph>
+            <Paragraph className="ams-mb-m">
+              Op het Julianaplein komt meer ruimte voor voetgangers en fietsers. De taxistandplaats en de bushaltes
+              verhuizen naar de oostkant van het plein. Daaronder komt een fietsenstalling met 7.000 plekken.
+            </Paragraph>
+            <Paragraph className="ams-mb-m">
+              Het stationsgebouw uit 1939 blijft behouden. De gevels en de grote hal met de wandschildering worden
+              gerestaureerd.
+            </Paragraph>
+            <StandaloneLink className="ams-mb-xl" href="#">
+              Lees meer over het ontwerp van het nieuwe station
+            </StandaloneLink>
+            <Heading className="ams-mb-s" id="waar" level={2}>
+              Waar
+            </Heading>
+            <Paragraph className="ams-mb-m">
+              Het Amstelstation ligt in stadsdeel Oost, tussen de Wibautstraat en de Amstel. Het project loopt van het
+              Julianaplein aan de noordkant tot de Spaklerweg aan de zuidkant.
+            </Paragraph>
+            <Paragraph className="ams-mb-xl">
+              De werkzaamheden raken de buurten Weesperzijde, Omval en Amstelkwartier. Bewoners en ondernemers krijgen
+              bericht voordat het werk in hun straat begint.
+            </Paragraph>
+            <Heading className="ams-mb-s" id="wanneer" level={2}>
+              Wanneer
+            </Heading>
+            <Paragraph className="ams-mb-l">
+              De vernieuwing gebeurt in stappen, zodat het station open blijft. We beginnen aan de zuidkant en werken
+              toe naar het Julianaplein. De laatste werkzaamheden ronden we naar verwachting in 2030 af.
+            </Paragraph>
+            {/*
+             * A ProgressList shows a timeline. status="completed" marks a finished step, status="current"
+             * the one in progress, and a step with no status is still to come. Substeps are nested by hand
+             * in a ProgressList.Substeps; hasSubsteps only tells the CSS about them, so that it draws the
+             * connecting lines correctly. collapsible gives every step its own fold button and decides what
+             * opens first: completed steps start collapsed, all others expanded, so the finished years here
+             * arrive folded. headingLevel is 3 because the list sits under the ‘Wanneer’ heading of level 2.
+             */}
+            <ProgressList collapsible headingLevel={3}>
+              {/*
+               * A Substep takes any content, so a month gets a level 4 Heading above its description. That is
+               * one level below the step headings the list renders itself.
+               */}
+              <ProgressList.Step hasSubsteps heading="2024" status="completed">
+                <ProgressList.Substeps>
+                  <ProgressList.Substep status="completed">
+                    <Heading level={4}>Maart</Heading>
+                    <Paragraph>Sloop van de fietsenstalling aan de Spaklerweg.</Paragraph>
+                  </ProgressList.Substep>
+                  <ProgressList.Substep status="completed">
+                    <Heading level={4}>Oktober</Heading>
+                    <Paragraph>Start bouw van de tijdelijke stationshal aan de zuidkant.</Paragraph>
+                  </ProgressList.Substep>
+                </ProgressList.Substeps>
+              </ProgressList.Step>
+              <ProgressList.Step hasSubsteps heading="2025" status="completed">
+                <ProgressList.Substeps>
+                  <ProgressList.Substep status="completed">
+                    <Heading level={4}>Januari</Heading>
+                    <Paragraph>Tijdelijke stationshal in gebruik genomen.</Paragraph>
+                  </ProgressList.Substep>
+                  <ProgressList.Substep status="completed">
+                    <Heading level={4}>September</Heading>
+                    <Paragraph>
+                      Start vervanging van de riolering onder de <Link href="#">Amstelstationstraat</Link>.
+                    </Paragraph>
+                  </ProgressList.Substep>
+                </ProgressList.Substeps>
+              </ProgressList.Step>
+              <ProgressList.Step hasSubsteps heading="2026" status="current">
+                <ProgressList.Substeps>
+                  <ProgressList.Substep status="current">
+                    <Heading level={4}>Maart</Heading>
+                    <Paragraph>Start verbouwing van de bestaande stationshal.</Paragraph>
+                  </ProgressList.Substep>
+                  <ProgressList.Substep>
+                    <Heading level={4}>November</Heading>
+                    <Paragraph>De nieuwe perrontrappen gaan open voor reizigers.</Paragraph>
+                  </ProgressList.Substep>
+                </ProgressList.Substeps>
+              </ProgressList.Step>
+              <ProgressList.Step hasSubsteps heading="2028">
+                <ProgressList.Substeps>
+                  <ProgressList.Substep>
+                    <Heading level={4}>Voorjaar</Heading>
+                    <Paragraph>Oplevering van de fietsenstalling onder het Julianaplein.</Paragraph>
+                  </ProgressList.Substep>
+                </ProgressList.Substeps>
+              </ProgressList.Step>
+              <ProgressList.Step hasSubsteps heading="2030">
+                <ProgressList.Substeps>
+                  <ProgressList.Substep>
+                    <Heading level={4}>Najaar</Heading>
+                    <Paragraph>Het plein en de tweede ingang aan de zuidkant zijn klaar.</Paragraph>
+                  </ProgressList.Substep>
+                </ProgressList.Substeps>
+              </ProgressList.Step>
+            </ProgressList>
+          </Grid.Cell>
+          {/*
+           * These two Cells set no rowStart: the rows above them are taken, so they fall in underneath the
+           * body on every grid, in source order.
+           */}
+          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+            <Heading className="ams-mb-xs" id="nieuws" level={2} size="level-3">
+              Nieuws
+            </Heading>
+            <LinkList>
+              <LinkList.Link href="#">Fietsenstalling Julianaplein opent in het voorjaar (14 juli 2026)</LinkList.Link>
+              <LinkList.Link href="#">Bushaltes verplaatst naar de Spaklerweg (2 juni 2026)</LinkList.Link>
+              <LinkList.Link href="#">Terugblik op de informatieavond van 21 mei (28 mei 2026)</LinkList.Link>
+              {/* A bottom margin on the second to last link sets the closing link apart from the items above it. */}
+              <LinkList.Link className="ams-mb-m" href="#">
+                Wandschildering in de stationshal gerestaureerd (9 april 2026)
+              </LinkList.Link>
+              <LinkList.Link href="#">Bekijk al het nieuws over dit project</LinkList.Link>
+            </LinkList>
+          </Grid.Cell>
+          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+            <Heading className="ams-mb-xs" id="werk-aan-de-weg" level={2} size="level-3">
+              Werk aan de weg
+            </Heading>
+            <LinkList>
+              <LinkList.Link href="#">Amstelstationstraat: afsluiting tot en met 12 september</LinkList.Link>
+              <LinkList.Link href="#">Julianaplein: omleiding voor fietsers</LinkList.Link>
+              <LinkList.Link className="ams-mb-m" href="#">
+                Spaklerweg: nachtelijke afsluitingen
+              </LinkList.Link>
+              <LinkList.Link href="#">Bekijk alle wegwerkzaamheden in Oost</LinkList.Link>
+            </LinkList>
+          </Grid.Cell>
+        </Grid>
+        {/*
+         * A Breakout lets an image overlap the Spotlight below it. The Cell with has="spotlight" stretches
+         * over the gaps and margins around it, so only that band reaches the edges of the Page; the image
+         * keeps to the grid. Both Cells need explicit rows, and so does everything inside the Spotlight:
+         * an automatically placed cell avoids the rows the Spotlight already occupies.
+         */}
+        {/*
+         * That stretch is a negative block margin of one x-large, so the band paints an x-large below the
+         * last row. Without a paddingBottom to land in, it would cover the space the next Grid opens with
+         * and leave its heading against the colour.
+         */}
+        <Breakout paddingBottom="x-large">
+          <Breakout.Cell colSpan="all" has="spotlight" rowSpan={3} rowStart={2}>
+            <Spotlight color="yellow" />
+          </Breakout.Cell>
+          {/*
+           * A map of the project area is not decorative: a reader looks at it to see where the work is, so
+           * it takes an alt. Name the subject and how far it reaches, and leave the rest to the ‘Waar’
+           * section, which carries the same information in words.
+           */}
+          {/* On the narrow grid the image takes a single row, so it sits above the band rather than over it. */}
+          <Breakout.Cell colSpan="all" has="figure" rowSpan={{ narrow: 1, medium: 2, wide: 2 }} rowStart={1}>
+            <Image
+              alt="Kaart van het stationsgebied met de locaties van de deelprojecten."
+              src={exampleImageSource(1440, 810, 2)}
+            />
+          </Breakout.Cell>
+          <Breakout.Cell
+            colSpan={{ narrow: 4, medium: 6, wide: 7 }}
+            colStart={{ narrow: 1, medium: 2, wide: 3 }}
+            rowStart={{ narrow: 2, medium: 3, wide: 3 }}
+          >
+            <Heading className="ams-mb-s" id="deelprojecten" level={2}>
+              Deelprojecten
+            </Heading>
+            <Paragraph>
+              De vernieuwing bestaat uit deelprojecten die deels tegelijk lopen. Elk deelproject heeft een eigen
+              planning en een eigen aanspreekpunt.
+            </Paragraph>
+          </Breakout.Cell>
+          <Breakout.Cell
+            colSpan={{ narrow: 4, medium: 4, wide: 5 }}
+            colStart={{ narrow: 1, medium: 1, wide: 2 }}
+            rowStart={{ narrow: 3, medium: 4, wide: 4 }}
+          >
+            <Heading className="ams-mb-xs" level={3}>
+              Station en perrons
+            </Heading>
+            <LinkList>
+              <LinkList.Link color="contrast" href="#">
+                Verbouwing van de stationshal
+              </LinkList.Link>
+              <LinkList.Link color="contrast" href="#">
+                Nieuwe perrontrappen
+              </LinkList.Link>
+              <LinkList.Link color="contrast" href="#">
+                Tweede ingang aan de zuidkant
+              </LinkList.Link>
+              <LinkList.Link color="contrast" href="#">
+                Restauratie van de wandschildering
+              </LinkList.Link>
+              <LinkList.Link color="contrast" href="#">
+                Toegankelijkheid van de perrons
+              </LinkList.Link>
+            </LinkList>
+          </Breakout.Cell>
+          <Breakout.Cell
+            colSpan={{ narrow: 4, medium: 4, wide: 5 }}
+            colStart={{ narrow: 1, medium: 5, wide: 7 }}
+            rowStart={{ narrow: 4, medium: 4, wide: 4 }}
+          >
+            <Heading className="ams-mb-xs" level={3}>
+              Plein en omgeving
+            </Heading>
+            <LinkList>
+              <LinkList.Link color="contrast" href="#">
+                Herinrichting van het Julianaplein
+              </LinkList.Link>
+              <LinkList.Link color="contrast" href="#">
+                Fietsenstalling onder het plein
+              </LinkList.Link>
+              <LinkList.Link color="contrast" href="#">
+                Bus- en tramhaltes
+              </LinkList.Link>
+              <LinkList.Link color="contrast" href="#">
+                Riolering Amstelstationstraat
+              </LinkList.Link>
+              <LinkList.Link color="contrast" href="#">
+                Groen langs de Amstel
+              </LinkList.Link>
+            </LinkList>
+          </Breakout.Cell>
+        </Breakout>
+        <Grid paddingVertical="x-large">
+          {/*
+           * One Cell holds all five link sections. Their spacing then comes from a margin per pair, where
+           * separate Cells would take it from the row gap, which is one value for the whole Grid.
+           */}
+          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+            <Heading className="ams-mb-xs" id="themas" level={2} size="level-3">
+              Thema’s
+            </Heading>
+            <LinkList className="ams-mb-l">
+              <LinkList.Link href="#">Bereikbaarheid tijdens de werkzaamheden</LinkList.Link>
+              <LinkList.Link href="#">Duurzaam en circulair bouwen</LinkList.Link>
+              <LinkList.Link href="#">Groen en biodiversiteit</LinkList.Link>
+              <LinkList.Link className="ams-mb-m" href="#">
+                Toegankelijkheid van het station
+              </LinkList.Link>
+              <LinkList.Link href="#">Bekijk alle thema’s</LinkList.Link>
+            </LinkList>
+            <Heading className="ams-mb-xs" id="documenten" level={2} size="level-3">
+              Documenten
+            </Heading>
+            <LinkList className="ams-mb-l">
+              <LinkList.Link href="#">Nota van uitgangspunten Amstelstation (pdf, 2,4 MB)</LinkList.Link>
+              <LinkList.Link href="#">Voorlopig ontwerp Julianaplein (pdf, 8,1 MB)</LinkList.Link>
+              <LinkList.Link className="ams-mb-m" href="#">
+                Verkeersbesluit Amstelstationstraat (pdf, 310 kB)
+              </LinkList.Link>
+              <LinkList.Link href="#">Bekijk alle documenten</LinkList.Link>
+            </LinkList>
+            <Heading className="ams-mb-xs" id="video" level={2} size="level-3">
+              Video
+            </Heading>
+            {/*
+             * A Paragraph between the heading and the image: the vertical space guide documents no value for
+             * a heading directly above an image, which is a sign to introduce the image in words first.
+             */}
+            <Paragraph className="ams-mb-l">
+              In deze animatie ziet u hoe het station en het plein er na de vernieuwing uitzien.
+            </Paragraph>
+            {/* This image carries no information the text does not, so it takes an empty alt. */}
+            <Image alt="" className="ams-mb-l" src={exampleImageSource(1280, 720, 3)} />
+            <StandaloneLink className="ams-mb-l" href="#">
+              Bekijk meer video’s over dit project
+            </StandaloneLink>
+            <Heading className="ams-mb-xs" id="meer-informatie" level={2} size="level-3">
+              Meer informatie
+            </Heading>
+            <LinkList className="ams-mb-l">
+              <LinkList.Link href="#">Amstelkwartier: woningbouw en openbare ruimte</LinkList.Link>
+              <LinkList.Link href="#">Wibautstraat: vernieuwing van de rijbanen</LinkList.Link>
+              <LinkList.Link href="#">Fietsparkeren in Amsterdam</LinkList.Link>
+              <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
+            </LinkList>
+            <Heading className="ams-mb-xs" id="blijf-op-de-hoogte" level={2} size="level-3">
+              Blijf op de hoogte
+            </Heading>
+            <LinkList>
+              <LinkList.Link href="#">Nieuwsbrief vernieuwing Amstelstation</LinkList.Link>
+              <LinkList.Link href="#">Informatieavonden en inloopspreekuren</LinkList.Link>
+              <LinkList.Link href="#">Instagram: Amstelstation</LinkList.Link>
+            </LinkList>
+          </Grid.Cell>
+        </Grid>
+        {/*
+         * The highlight colours have no prescribed meaning, so this band takes the default purple rather
+         * than repeating the yellow above. Purple is a dark background, so everything in it takes
+         * color="inverse".
+         */}
+        <Spotlight>
+          <Grid paddingVertical="x-large">
+            <Grid.Cell span="all">
+              {/*
+               * The Page Footer heads its own contact block ‘Contact’ as well, so someone browsing the page
+               * by heading meets the word twice. The hidden phrase tells the two apart without repeating
+               * ‘over dit project’ on screen, where the surrounding page already says so.
+               */}
+              <Heading className="ams-mb-s" color="inverse" level={2}>
+                Contact<span className="ams-visually-hidden"> over dit project</span>
+              </Heading>
+            </Grid.Cell>
+            <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+              <Paragraph className="ams-mb-m" color="inverse">
+                Hilde Verkerk
+                <br />
+                Omgevingsmanager
+              </Paragraph>
+              {/* A Link List of contact details: an icon per link replaces the chevron the list draws by default. */}
+              <LinkList>
+                <LinkList.Link color="inverse" href="mailto:h.verkerk@amsterdam.nl" icon={<MailIcon />}>
+                  h.verkerk@amsterdam.nl
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="tel:+31618342210" icon={<PhoneIcon />}>
+                  06 1834 2210
+                </LinkList.Link>
+              </LinkList>
+            </Grid.Cell>
+            <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+              <Paragraph className="ams-mb-m" color="inverse">
+                Joris Bramer
+                <br />
+                Communicatieadviseur
+              </Paragraph>
+              <LinkList>
+                <LinkList.Link color="inverse" href="mailto:j.bramer@amsterdam.nl" icon={<MailIcon />}>
+                  j.bramer@amsterdam.nl
+                </LinkList.Link>
+                <LinkList.Link color="inverse" href="tel:+31611294478" icon={<PhoneIcon />}>
+                  06 1129 4478
+                </LinkList.Link>
+              </LinkList>
+            </Grid.Cell>
+          </Grid>
+        </Spotlight>
+        {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
+        <Grid paddingBottom="2x-large" paddingTop="x-large">
+          <Grid.Cell span="all">
+            <Image
+              alt="Kaart van het projectgebied, van het Julianaplein tot de Spaklerweg."
+              src={exampleImageSource(1440, 810, 4)}
+            />
+          </Grid.Cell>
+        </Grid>
+      </main>
+    </>
+  ),
 }

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -1002,7 +1002,12 @@ export const WithBreakout: StoryObj = {
      * color="inverse".
      */}
     <Spotlight>
-      <Grid paddingVertical="x-large">
+      {/*
+       * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+       * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+       * between the Cells.
+       */}
+      <Grid gapVertical="none" paddingVertical="x-large">
         <Grid.Cell span="all">
           {/*
            * The Page Footer heads its own contact block ‘Contact’ as well, so someone browsing the page
@@ -1013,37 +1018,39 @@ export const WithBreakout: StoryObj = {
             Contact<span className="ams-visually-hidden"> over dit project</span>
           </Heading>
         </Grid.Cell>
-        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-          <Paragraph className="ams-mb-m" color="inverse">
-            Hilde Verkerk
-            <br />
-            Omgevingsmanager
-          </Paragraph>
-          {/* A Link List of contact details: an icon per link replaces the chevron the list draws by default. */}
-          <LinkList>
-            <LinkList.Link color="inverse" href="mailto:h.verkerk@amsterdam.nl" icon={<MailIcon />}>
-              h.verkerk@amsterdam.nl
-            </LinkList.Link>
-            <LinkList.Link color="inverse" href="tel:+31618342210" icon={<PhoneIcon />}>
-              06 1834 2210
-            </LinkList.Link>
-          </LinkList>
-        </Grid.Cell>
-        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-          <Paragraph className="ams-mb-m" color="inverse">
-            Joris Bramer
-            <br />
-            Communicatieadviseur
-          </Paragraph>
-          <LinkList>
-            <LinkList.Link color="inverse" href="mailto:j.bramer@amsterdam.nl" icon={<MailIcon />}>
-              j.bramer@amsterdam.nl
-            </LinkList.Link>
-            <LinkList.Link color="inverse" href="tel:+31611294478" icon={<PhoneIcon />}>
-              06 1129 4478
-            </LinkList.Link>
-          </LinkList>
-        </Grid.Cell>
+        <Grid.Subgrid gapVertical="x-large" span="all">
+          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+            <Paragraph className="ams-mb-m" color="inverse">
+              Hilde Verkerk
+              <br />
+              Omgevingsmanager
+            </Paragraph>
+            {/* A Link List of contact details: an icon per link replaces the chevron the list draws by default. */}
+            <LinkList>
+              <LinkList.Link color="inverse" href="mailto:h.verkerk@amsterdam.nl" icon={<MailIcon />}>
+                h.verkerk@amsterdam.nl
+              </LinkList.Link>
+              <LinkList.Link color="inverse" href="tel:+31618342210" icon={<PhoneIcon />}>
+                06 1834 2210
+              </LinkList.Link>
+            </LinkList>
+          </Grid.Cell>
+          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+            <Paragraph className="ams-mb-m" color="inverse">
+              Joris Bramer
+              <br />
+              Communicatieadviseur
+            </Paragraph>
+            <LinkList>
+              <LinkList.Link color="inverse" href="mailto:j.bramer@amsterdam.nl" icon={<MailIcon />}>
+                j.bramer@amsterdam.nl
+              </LinkList.Link>
+              <LinkList.Link color="inverse" href="tel:+31611294478" icon={<PhoneIcon />}>
+                06 1129 4478
+              </LinkList.Link>
+            </LinkList>
+          </Grid.Cell>
+        </Grid.Subgrid>
       </Grid>
     </Spotlight>
     {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}
@@ -1458,7 +1465,12 @@ export const WithBreakout: StoryObj = {
          * color="inverse".
          */}
         <Spotlight>
-          <Grid paddingVertical="x-large">
+          {/*
+           * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+           * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
+           * between the Cells.
+           */}
+          <Grid gapVertical="none" paddingVertical="x-large">
             <Grid.Cell span="all">
               {/*
                * The Page Footer heads its own contact block ‘Contact’ as well, so someone browsing the page
@@ -1469,37 +1481,39 @@ export const WithBreakout: StoryObj = {
                 Contact<span className="ams-visually-hidden"> over dit project</span>
               </Heading>
             </Grid.Cell>
-            <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-              <Paragraph className="ams-mb-m" color="inverse">
-                Hilde Verkerk
-                <br />
-                Omgevingsmanager
-              </Paragraph>
-              {/* A Link List of contact details: an icon per link replaces the chevron the list draws by default. */}
-              <LinkList>
-                <LinkList.Link color="inverse" href="mailto:h.verkerk@amsterdam.nl" icon={<MailIcon />}>
-                  h.verkerk@amsterdam.nl
-                </LinkList.Link>
-                <LinkList.Link color="inverse" href="tel:+31618342210" icon={<PhoneIcon />}>
-                  06 1834 2210
-                </LinkList.Link>
-              </LinkList>
-            </Grid.Cell>
-            <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-              <Paragraph className="ams-mb-m" color="inverse">
-                Joris Bramer
-                <br />
-                Communicatieadviseur
-              </Paragraph>
-              <LinkList>
-                <LinkList.Link color="inverse" href="mailto:j.bramer@amsterdam.nl" icon={<MailIcon />}>
-                  j.bramer@amsterdam.nl
-                </LinkList.Link>
-                <LinkList.Link color="inverse" href="tel:+31611294478" icon={<PhoneIcon />}>
-                  06 1129 4478
-                </LinkList.Link>
-              </LinkList>
-            </Grid.Cell>
+            <Grid.Subgrid gapVertical="x-large" span="all">
+              <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+                <Paragraph className="ams-mb-m" color="inverse">
+                  Hilde Verkerk
+                  <br />
+                  Omgevingsmanager
+                </Paragraph>
+                {/* A Link List of contact details: an icon per link replaces the chevron the list draws by default. */}
+                <LinkList>
+                  <LinkList.Link color="inverse" href="mailto:h.verkerk@amsterdam.nl" icon={<MailIcon />}>
+                    h.verkerk@amsterdam.nl
+                  </LinkList.Link>
+                  <LinkList.Link color="inverse" href="tel:+31618342210" icon={<PhoneIcon />}>
+                    06 1834 2210
+                  </LinkList.Link>
+                </LinkList>
+              </Grid.Cell>
+              <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
+                <Paragraph className="ams-mb-m" color="inverse">
+                  Joris Bramer
+                  <br />
+                  Communicatieadviseur
+                </Paragraph>
+                <LinkList>
+                  <LinkList.Link color="inverse" href="mailto:j.bramer@amsterdam.nl" icon={<MailIcon />}>
+                    j.bramer@amsterdam.nl
+                  </LinkList.Link>
+                  <LinkList.Link color="inverse" href="tel:+31611294478" icon={<PhoneIcon />}>
+                    06 1129 4478
+                  </LinkList.Link>
+                </LinkList>
+              </Grid.Cell>
+            </Grid.Subgrid>
           </Grid>
         </Spotlight>
         {/* The last Grid before the Page Footer takes a paddingBottom of 2x-large. */}

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -676,7 +676,7 @@ export const WithBreakout: StoryObj = {
     <Spotlight color="yellow">
       <Grid paddingVertical="x-large">
         <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-          <Heading level={2}>Amstelstationstraat afgesloten tot en met 12 september</Heading>
+          <Heading level={2} size="level-3">Amstelstationstraat afgesloten tot en met 12 september</Heading>
           <Paragraph>
             Tot en met 12 september vervangen we de riolering onder de Amstelstationstraat. Doorgaand autoverkeer
             rijdt om via de Wibautstraat. De ingang van het station aan de kant van het Julianaplein blijft de hele
@@ -988,7 +988,7 @@ export const WithBreakout: StoryObj = {
      */}
     <Spotlight>
       {/*
-       * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+       * The row gap would put an x-large below the heading, where the guidance asks for an x-small at this size.
        * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
        * between the Cells.
        */}
@@ -999,7 +999,7 @@ export const WithBreakout: StoryObj = {
            * by heading meets the word twice. The hidden phrase tells the two apart without repeating
            * ‘over dit project’ on screen, where the surrounding page already says so.
            */}
-          <Heading className="ams-mb-s" color="inverse" level={2}>
+          <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">
             Contact<span className="ams-visually-hidden"> over dit project</span>
           </Heading>
         </Grid.Cell>
@@ -1107,7 +1107,9 @@ export const WithBreakout: StoryObj = {
               span={{ narrow: 4, medium: 6, wide: 7 }}
               start={{ narrow: 1, medium: 2, wide: 3 }}
             >
-              <Heading level={2}>Amstelstationstraat afgesloten tot en met 12 september</Heading>
+              <Heading level={2} size="level-3">
+                Amstelstationstraat afgesloten tot en met 12 september
+              </Heading>
               <Paragraph>
                 Tot en met 12 september vervangen we de riolering onder de Amstelstationstraat. Doorgaand autoverkeer
                 rijdt om via de Wibautstraat. De ingang van het station aan de kant van het Julianaplein blijft de hele
@@ -1453,7 +1455,7 @@ export const WithBreakout: StoryObj = {
          */}
         <Spotlight>
           {/*
-           * The row gap would put an x-large below the heading, where the guidance asks for a small at this size.
+           * The row gap would put an x-large below the heading, where the guidance asks for an x-small at this size.
            * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
            * between the Cells.
            */}
@@ -1464,7 +1466,7 @@ export const WithBreakout: StoryObj = {
                * by heading meets the word twice. The hidden phrase tells the two apart without repeating
                * ‘over dit project’ on screen, where the surrounding page already says so.
                */}
-              <Heading className="ams-mb-s" color="inverse" level={2}>
+              <Heading className="ams-mb-xs" color="inverse" level={2} size="level-3">
                 Contact<span className="ams-visually-hidden"> over dit project</span>
               </Heading>
             </Grid.Cell>

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -690,16 +690,13 @@ export const WithBreakout: StoryObj = {
     </Spotlight>
     {/*
      * The Table of Contents comes first in source, so it precedes the body in the reading and tab order.
-     * gridRowStart then puts it beside the body on the wide grid rather than above it: Grid.Cell offers
-     * rowSpan but no rowStart, and without a row of its own the cell joins the automatic placement, where
-     * a body Cell starting at an earlier column can no longer share its row. No other cell needs one.
+     * rowStart then puts it beside the body on the wide grid rather than above it: without a row of its
+     * own the cell joins the automatic placement, which never moves back a column without moving down a
+     * row, so the body Cell starting at an earlier column could no longer share its row. No other cell
+     * needs one.
      */}
     <Grid paddingVertical="x-large">
-      <Grid.Cell
-        span={{ narrow: 4, medium: 8, wide: 3 }}
-        start={{ narrow: 1, medium: 1, wide: 10 }}
-        style={{ gridRowStart: 1 }}
-      >
+      <Grid.Cell rowStart={1} span={{ narrow: 4, medium: 8, wide: 3 }} start={{ narrow: 1, medium: 1, wide: 10 }}>
         {/* The Table of Contents renders its own heading, at the size of a level 3 Heading. */}
         <TableOfContents heading="Op deze pagina">
           <TableOfContents.List>
@@ -1132,16 +1129,13 @@ export const WithBreakout: StoryObj = {
         </Spotlight>
         {/*
          * The Table of Contents comes first in source, so it precedes the body in the reading and tab order.
-         * gridRowStart then puts it beside the body on the wide grid rather than above it: Grid.Cell offers
-         * rowSpan but no rowStart, and without a row of its own the cell joins the automatic placement, where
-         * a body Cell starting at an earlier column can no longer share its row. No other cell needs one.
+         * rowStart then puts it beside the body on the wide grid rather than above it: without a row of its
+         * own the cell joins the automatic placement, which never moves back a column without moving down a
+         * row, so the body Cell starting at an earlier column could no longer share its row. No other cell
+         * needs one.
          */}
         <Grid paddingVertical="x-large">
-          <Grid.Cell
-            span={{ narrow: 4, medium: 8, wide: 3 }}
-            start={{ narrow: 1, medium: 1, wide: 10 }}
-            style={{ gridRowStart: 1 }}
-          >
+          <Grid.Cell rowStart={1} span={{ narrow: 4, medium: 8, wide: 3 }} start={{ narrow: 1, medium: 1, wide: 10 }}>
             {/* The Table of Contents renders its own heading, at the size of a level 3 Heading. */}
             <TableOfContents heading="Op deze pagina">
               <TableOfContents.List>

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -751,10 +751,13 @@ export const WithBreakout: StoryObj = {
           bericht voordat het werk in hun straat begint.
         </Paragraph>
         <Heading className="ams-mb-s" id="wanneer" level={2}>Wanneer</Heading>
-        <Paragraph className="ams-mb-l">
+        <Paragraph>
           De vernieuwing gebeurt in stappen, zodat het station open blijft. We beginnen aan de zuidkant en werken
           toe naar het Julianaplein. De laatste werkzaamheden ronden we naar verwachting in 2030 af.
         </Paragraph>
+      </Grid.Cell>
+      {/* A Progress List is a block of its own, so it takes its own Grid Cell and the row gap spaces it. */}
+      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
         {/*
          * A ProgressList shows a timeline. status="completed" marks a finished step, status="current"
          * the one in progress, and a step with no status is still to come. Substeps are nested by hand
@@ -1184,10 +1187,13 @@ export const WithBreakout: StoryObj = {
             <Heading className="ams-mb-s" id="wanneer" level={2}>
               Wanneer
             </Heading>
-            <Paragraph className="ams-mb-l">
+            <Paragraph>
               De vernieuwing gebeurt in stappen, zodat het station open blijft. We beginnen aan de zuidkant en werken
               toe naar het Julianaplein. De laatste werkzaamheden ronden we naar verwachting in 2030 af.
             </Paragraph>
+          </Grid.Cell>
+          {/* A Progress List is a block of its own, so it takes its own Grid Cell and the row gap spaces it. */}
+          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
             {/*
              * A ProgressList shows a timeline. status="completed" marks a finished step, status="current"
              * the one in progress, and a step with no status is still to come. Substeps are nested by hand

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -937,10 +937,7 @@ export const WithBreakout: StoryObj = {
       </Breakout.Cell>
     </Breakout>
     <Grid paddingVertical="x-large">
-      {/*
-       * One Cell holds all five link sections, so ams-prose spaces them against one another. Separate
-       * Cells would take that space from the row gap, which is one value for the whole Grid.
-       */}
+      {/* Every link section is a block of its own, so each takes a Grid Cell and the row gap spaces them. */}
       <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
         <Heading id="themas" level={2} size="level-3">Thema’s</Heading>
         <LinkList>
@@ -950,6 +947,8 @@ export const WithBreakout: StoryObj = {
           <LinkList.Link href="#">Toegankelijkheid van het station</LinkList.Link>
         </LinkList>
         <StandaloneLink href="#">Bekijk alle thema’s</StandaloneLink>
+      </Grid.Cell>
+      <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
         <Heading id="documenten" level={2} size="level-3">Documenten</Heading>
         <LinkList>
           <LinkList.Link href="#">Nota van uitgangspunten Amstelstation (pdf, 2,4 MB)</LinkList.Link>
@@ -957,6 +956,8 @@ export const WithBreakout: StoryObj = {
           <LinkList.Link href="#">Verkeersbesluit Amstelstationstraat (pdf, 310 kB)</LinkList.Link>
         </LinkList>
         <StandaloneLink href="#">Bekijk alle documenten</StandaloneLink>
+      </Grid.Cell>
+      <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
         <Heading id="video" level={2} size="level-3">Video</Heading>
         {/*
          * A Paragraph between the heading and the image: the vertical space guide documents no value for
@@ -966,6 +967,8 @@ export const WithBreakout: StoryObj = {
         {/* This image carries no information the text does not, so it takes an empty alt. */}
         <Image alt="" src="https://picsum.photos/1280/720" />
         <StandaloneLink href="#">Bekijk meer video’s over dit project</StandaloneLink>
+      </Grid.Cell>
+      <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
         <Heading id="meer-informatie" level={2} size="level-3">Meer informatie</Heading>
         <LinkList>
           <LinkList.Link href="#">Amstelkwartier: woningbouw en openbare ruimte</LinkList.Link>
@@ -973,6 +976,8 @@ export const WithBreakout: StoryObj = {
           <LinkList.Link href="#">Fietsparkeren in Amsterdam</LinkList.Link>
           <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
         </LinkList>
+      </Grid.Cell>
+      <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
         <Heading id="blijf-op-de-hoogte" level={2} size="level-3">Blijf op de hoogte</Heading>
         <LinkList>
           <LinkList.Link href="#">Nieuwsbrief vernieuwing Amstelstation</LinkList.Link>
@@ -1390,10 +1395,7 @@ export const WithBreakout: StoryObj = {
           </Breakout.Cell>
         </Breakout>
         <Grid paddingVertical="x-large">
-          {/*
-           * One Cell holds all five link sections, so ams-prose spaces them against one another. Separate
-           * Cells would take that space from the row gap, which is one value for the whole Grid.
-           */}
+          {/* Every link section is a block of its own, so each takes a Grid Cell and the row gap spaces them. */}
           <Grid.Cell
             className="ams-prose"
             span={{ narrow: 4, medium: 6, wide: 7 }}
@@ -1409,6 +1411,12 @@ export const WithBreakout: StoryObj = {
               <LinkList.Link href="#">Toegankelijkheid van het station</LinkList.Link>
             </LinkList>
             <StandaloneLink href="#">Bekijk alle thema’s</StandaloneLink>
+          </Grid.Cell>
+          <Grid.Cell
+            className="ams-prose"
+            span={{ narrow: 4, medium: 6, wide: 7 }}
+            start={{ narrow: 1, medium: 2, wide: 3 }}
+          >
             <Heading id="documenten" level={2} size="level-3">
               Documenten
             </Heading>
@@ -1418,6 +1426,12 @@ export const WithBreakout: StoryObj = {
               <LinkList.Link href="#">Verkeersbesluit Amstelstationstraat (pdf, 310 kB)</LinkList.Link>
             </LinkList>
             <StandaloneLink href="#">Bekijk alle documenten</StandaloneLink>
+          </Grid.Cell>
+          <Grid.Cell
+            className="ams-prose"
+            span={{ narrow: 4, medium: 6, wide: 7 }}
+            start={{ narrow: 1, medium: 2, wide: 3 }}
+          >
             <Heading id="video" level={2} size="level-3">
               Video
             </Heading>
@@ -1429,6 +1443,12 @@ export const WithBreakout: StoryObj = {
             {/* This image carries no information the text does not, so it takes an empty alt. */}
             <Image alt="" src={exampleImageSource(1280, 720, 3)} />
             <StandaloneLink href="#">Bekijk meer video’s over dit project</StandaloneLink>
+          </Grid.Cell>
+          <Grid.Cell
+            className="ams-prose"
+            span={{ narrow: 4, medium: 6, wide: 7 }}
+            start={{ narrow: 1, medium: 2, wide: 3 }}
+          >
             <Heading id="meer-informatie" level={2} size="level-3">
               Meer informatie
             </Heading>
@@ -1438,6 +1458,12 @@ export const WithBreakout: StoryObj = {
               <LinkList.Link href="#">Fietsparkeren in Amsterdam</LinkList.Link>
               <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
             </LinkList>
+          </Grid.Cell>
+          <Grid.Cell
+            className="ams-prose"
+            span={{ narrow: 4, medium: 6, wide: 7 }}
+            start={{ narrow: 1, medium: 2, wide: 3 }}
+          >
             <Heading id="blijf-op-de-hoogte" level={2} size="level-3">
               Blijf op de hoogte
             </Heading>

--- a/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
+++ b/storybook/src/pages/public/ProjectPage/ProjectPage.stories.tsx
@@ -650,10 +650,9 @@ export const WithBreakout: StoryObj = {
   <main id="inhoud">
     {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
     <Grid paddingBottom="x-large">
-      <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-        <Heading className="ams-mb-m" level={1}>
-          Amstelstation: vernieuwing van het station en het stationsplein
-        </Heading>
+      {/* ams-prose sets the vertical rhythm between the elements of this Content Header. */}
+      <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
+        <Heading level={1}>Amstelstation: vernieuwing van het station en het stationsplein</Heading>
         <Paragraph size="large">
           Het Amstelstation en het plein ervoor worden de komende jaren vernieuwd. Het station krijgt een ruimere
           hal en een tweede ingang aan de zuidkant. Reizigers houden tijdens de werkzaamheden toegang tot de trein,
@@ -676,9 +675,9 @@ export const WithBreakout: StoryObj = {
      */}
     <Spotlight color="yellow">
       <Grid paddingVertical="x-large">
-        <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-          <Heading className="ams-mb-s" level={2}>Amstelstationstraat afgesloten tot en met 12 september</Heading>
-          <Paragraph className="ams-mb-m">
+        <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+          <Heading level={2}>Amstelstationstraat afgesloten tot en met 12 september</Heading>
+          <Paragraph>
             Tot en met 12 september vervangen we de riolering onder de Amstelstationstraat. Doorgaand autoverkeer
             rijdt om via de Wibautstraat. De ingang van het station aan de kant van het Julianaplein blijft de hele
             periode open.
@@ -718,39 +717,37 @@ export const WithBreakout: StoryObj = {
           </TableOfContents.List>
         </TableOfContents>
       </Grid.Cell>
-      {/* This cell is not ams-prose, so every element but the last sets its own bottom margin. */}
       <Grid.Cell
+        className="ams-prose"
         span={{ narrow: 4, medium: 6, wide: 7 }}
         start={{ narrow: 1, medium: 2, wide: 3 }}
       >
         {/* Every section heading carries the id its Table of Contents entry points at. */}
-        <Heading className="ams-mb-s" id="wat" level={2}>Wat gaan we doen</Heading>
-        <Paragraph className="ams-mb-m">
+        <Heading id="wat" level={2}>Wat gaan we doen</Heading>
+        <Paragraph>
           De stationshal van het Amstelstation is te klein voor het aantal reizigers dat er dagelijks doorheen
           loopt. We vergroten de hal, verbreden de perrontrappen en maken een tweede ingang aan de zuidkant van het
           station.
         </Paragraph>
-        <Paragraph className="ams-mb-m">
+        <Paragraph>
           Op het Julianaplein komt meer ruimte voor voetgangers en fietsers. De taxistandplaats en de bushaltes
           verhuizen naar de oostkant van het plein. Daaronder komt een fietsenstalling met 7.000 plekken.
         </Paragraph>
-        <Paragraph className="ams-mb-m">
+        <Paragraph>
           Het stationsgebouw uit 1939 blijft behouden. De gevels en de grote hal met de wandschildering worden
           gerestaureerd.
         </Paragraph>
-        <StandaloneLink className="ams-mb-xl" href="#">
-          Lees meer over het ontwerp van het nieuwe station
-        </StandaloneLink>
-        <Heading className="ams-mb-s" id="waar" level={2}>Waar</Heading>
-        <Paragraph className="ams-mb-m">
+        <StandaloneLink href="#">Lees meer over het ontwerp van het nieuwe station</StandaloneLink>
+        <Heading id="waar" level={2}>Waar</Heading>
+        <Paragraph>
           Het Amstelstation ligt in stadsdeel Oost, tussen de Wibautstraat en de Amstel. Het project loopt van het
           Julianaplein aan de noordkant tot de Spaklerweg aan de zuidkant.
         </Paragraph>
-        <Paragraph className="ams-mb-xl">
+        <Paragraph>
           De werkzaamheden raken de buurten Weesperzijde, Omval en Amstelkwartier. Bewoners en ondernemers krijgen
           bericht voordat het werk in hun straat begint.
         </Paragraph>
-        <Heading className="ams-mb-s" id="wanneer" level={2}>Wanneer</Heading>
+        <Heading id="wanneer" level={2}>Wanneer</Heading>
         <Paragraph>
           De vernieuwing gebeurt in stappen, zodat het station open blijft. We beginnen aan de zuidkant en werken
           toe naar het Julianaplein. De laatste werkzaamheden ronden we naar verwachting in 2030 af.
@@ -831,8 +828,8 @@ export const WithBreakout: StoryObj = {
        * These two Cells set no rowStart: the rows above them are taken, so they fall in underneath the
        * body on every grid, in source order.
        */}
-      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-        <Heading className="ams-mb-xs" id="nieuws" level={2} size="level-3">Nieuws</Heading>
+      <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+        <Heading id="nieuws" level={2} size="level-3">Nieuws</Heading>
         <LinkList>
           <LinkList.Link href="#">Fietsenstalling Julianaplein opent in het voorjaar (14 juli 2026)</LinkList.Link>
           <LinkList.Link href="#">Bushaltes verplaatst naar de Spaklerweg (2 juni 2026)</LinkList.Link>
@@ -844,8 +841,8 @@ export const WithBreakout: StoryObj = {
           <LinkList.Link href="#">Bekijk al het nieuws over dit project</LinkList.Link>
         </LinkList>
       </Grid.Cell>
-      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-        <Heading className="ams-mb-xs" id="werk-aan-de-weg" level={2} size="level-3">Werk aan de weg</Heading>
+      <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+        <Heading id="werk-aan-de-weg" level={2} size="level-3">Werk aan de weg</Heading>
         <LinkList>
           <LinkList.Link href="#">Amstelstationstraat: afsluiting tot en met 12 september</LinkList.Link>
           <LinkList.Link href="#">Julianaplein: omleiding voor fietsers</LinkList.Link>
@@ -884,22 +881,24 @@ export const WithBreakout: StoryObj = {
         />
       </Breakout.Cell>
       <Breakout.Cell
+        className="ams-prose"
         colSpan={{ narrow: 4, medium: 6, wide: 7 }}
         colStart={{ narrow: 1, medium: 2, wide: 3 }}
         rowStart={{ narrow: 2, medium: 3, wide: 3 }}
       >
-        <Heading className="ams-mb-s" id="deelprojecten" level={2}>Deelprojecten</Heading>
+        <Heading id="deelprojecten" level={2}>Deelprojecten</Heading>
         <Paragraph>
           De vernieuwing bestaat uit deelprojecten die deels tegelijk lopen. Elk deelproject heeft een eigen
           planning en een eigen aanspreekpunt.
         </Paragraph>
       </Breakout.Cell>
       <Breakout.Cell
+        className="ams-prose"
         colSpan={{ narrow: 4, medium: 4, wide: 5 }}
         colStart={{ narrow: 1, medium: 1, wide: 2 }}
         rowStart={{ narrow: 3, medium: 4, wide: 4 }}
       >
-        <Heading className="ams-mb-xs" level={3}>Station en perrons</Heading>
+        <Heading level={3}>Station en perrons</Heading>
         <LinkList>
           <LinkList.Link color="contrast" href="#">
             Verbouwing van de stationshal
@@ -919,11 +918,12 @@ export const WithBreakout: StoryObj = {
         </LinkList>
       </Breakout.Cell>
       <Breakout.Cell
+        className="ams-prose"
         colSpan={{ narrow: 4, medium: 4, wide: 5 }}
         colStart={{ narrow: 1, medium: 5, wide: 7 }}
         rowStart={{ narrow: 4, medium: 4, wide: 4 }}
       >
-        <Heading className="ams-mb-xs" level={3}>Plein en omgeving</Heading>
+        <Heading level={3}>Plein en omgeving</Heading>
         <LinkList>
           <LinkList.Link color="contrast" href="#">
             Herinrichting van het Julianaplein
@@ -945,12 +945,12 @@ export const WithBreakout: StoryObj = {
     </Breakout>
     <Grid paddingVertical="x-large">
       {/*
-       * One Cell holds all five link sections. Their spacing then comes from a margin per pair, where
-       * separate Cells would take it from the row gap, which is one value for the whole Grid.
+       * One Cell holds all five link sections, so ams-prose spaces them against one another. Separate
+       * Cells would take that space from the row gap, which is one value for the whole Grid.
        */}
-      <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-        <Heading className="ams-mb-xs" id="themas" level={2} size="level-3">Thema’s</Heading>
-        <LinkList className="ams-mb-l">
+      <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+        <Heading id="themas" level={2} size="level-3">Thema’s</Heading>
+        <LinkList>
           <LinkList.Link href="#">Bereikbaarheid tijdens de werkzaamheden</LinkList.Link>
           <LinkList.Link href="#">Duurzaam en circulair bouwen</LinkList.Link>
           <LinkList.Link href="#">Groen en biodiversiteit</LinkList.Link>
@@ -959,8 +959,8 @@ export const WithBreakout: StoryObj = {
           </LinkList.Link>
           <LinkList.Link href="#">Bekijk alle thema’s</LinkList.Link>
         </LinkList>
-        <Heading className="ams-mb-xs" id="documenten" level={2} size="level-3">Documenten</Heading>
-        <LinkList className="ams-mb-l">
+        <Heading id="documenten" level={2} size="level-3">Documenten</Heading>
+        <LinkList>
           <LinkList.Link href="#">Nota van uitgangspunten Amstelstation (pdf, 2,4 MB)</LinkList.Link>
           <LinkList.Link href="#">Voorlopig ontwerp Julianaplein (pdf, 8,1 MB)</LinkList.Link>
           <LinkList.Link className="ams-mb-m" href="#">
@@ -968,27 +968,23 @@ export const WithBreakout: StoryObj = {
           </LinkList.Link>
           <LinkList.Link href="#">Bekijk alle documenten</LinkList.Link>
         </LinkList>
-        <Heading className="ams-mb-xs" id="video" level={2} size="level-3">Video</Heading>
+        <Heading id="video" level={2} size="level-3">Video</Heading>
         {/*
          * A Paragraph between the heading and the image: the vertical space guide documents no value for
          * a heading directly above an image, which is a sign to introduce the image in words first.
          */}
-        <Paragraph className="ams-mb-l">
-          In deze animatie ziet u hoe het station en het plein er na de vernieuwing uitzien.
-        </Paragraph>
+        <Paragraph>In deze animatie ziet u hoe het station en het plein er na de vernieuwing uitzien.</Paragraph>
         {/* This image carries no information the text does not, so it takes an empty alt. */}
-        <Image alt="" className="ams-mb-l" src="https://picsum.photos/1280/720" />
-        <StandaloneLink className="ams-mb-l" href="#">
-          Bekijk meer video’s over dit project
-        </StandaloneLink>
-        <Heading className="ams-mb-xs" id="meer-informatie" level={2} size="level-3">Meer informatie</Heading>
-        <LinkList className="ams-mb-l">
+        <Image alt="" src="https://picsum.photos/1280/720" />
+        <StandaloneLink href="#">Bekijk meer video’s over dit project</StandaloneLink>
+        <Heading id="meer-informatie" level={2} size="level-3">Meer informatie</Heading>
+        <LinkList>
           <LinkList.Link href="#">Amstelkwartier: woningbouw en openbare ruimte</LinkList.Link>
           <LinkList.Link href="#">Wibautstraat: vernieuwing van de rijbanen</LinkList.Link>
           <LinkList.Link href="#">Fietsparkeren in Amsterdam</LinkList.Link>
           <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
         </LinkList>
-        <Heading className="ams-mb-xs" id="blijf-op-de-hoogte" level={2} size="level-3">Blijf op de hoogte</Heading>
+        <Heading id="blijf-op-de-hoogte" level={2} size="level-3">Blijf op de hoogte</Heading>
         <LinkList>
           <LinkList.Link href="#">Nieuwsbrief vernieuwing Amstelstation</LinkList.Link>
           <LinkList.Link href="#">Informatieavonden en inloopspreekuren</LinkList.Link>
@@ -1019,8 +1015,8 @@ export const WithBreakout: StoryObj = {
           </Heading>
         </Grid.Cell>
         <Grid.Subgrid gapVertical="x-large" span="all">
-          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-            <Paragraph className="ams-mb-m" color="inverse">
+          <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 6 }}>
+            <Paragraph color="inverse">
               Hilde Verkerk
               <br />
               Omgevingsmanager
@@ -1035,8 +1031,8 @@ export const WithBreakout: StoryObj = {
               </LinkList.Link>
             </LinkList>
           </Grid.Cell>
-          <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-            <Paragraph className="ams-mb-m" color="inverse">
+          <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 6 }}>
+            <Paragraph color="inverse">
               Joris Bramer
               <br />
               Communicatieadviseur
@@ -1088,10 +1084,13 @@ export const WithBreakout: StoryObj = {
       <main id="inhoud">
         {/* The Grid after the Breadcrumb has no paddingTop, so the breadcrumb and the page title read as one block. */}
         <Grid paddingBottom="x-large">
-          <Grid.Cell span={{ narrow: 4, medium: 7, wide: 9 }} start={{ narrow: 1, medium: 1, wide: 2 }}>
-            <Heading className="ams-mb-m" level={1}>
-              Amstelstation: vernieuwing van het station en het stationsplein
-            </Heading>
+          {/* ams-prose sets the vertical rhythm between the elements of this Content Header. */}
+          <Grid.Cell
+            className="ams-prose"
+            span={{ narrow: 4, medium: 7, wide: 9 }}
+            start={{ narrow: 1, medium: 1, wide: 2 }}
+          >
+            <Heading level={1}>Amstelstation: vernieuwing van het station en het stationsplein</Heading>
             <Paragraph size="large">
               Het Amstelstation en het plein ervoor worden de komende jaren vernieuwd. Het station krijgt een ruimere
               hal en een tweede ingang aan de zuidkant. Reizigers houden tijdens de werkzaamheden toegang tot de trein,
@@ -1114,11 +1113,13 @@ export const WithBreakout: StoryObj = {
          */}
         <Spotlight color="yellow">
           <Grid paddingVertical="x-large">
-            <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-              <Heading className="ams-mb-s" level={2}>
-                Amstelstationstraat afgesloten tot en met 12 september
-              </Heading>
-              <Paragraph className="ams-mb-m">
+            <Grid.Cell
+              className="ams-prose"
+              span={{ narrow: 4, medium: 6, wide: 7 }}
+              start={{ narrow: 1, medium: 2, wide: 3 }}
+            >
+              <Heading level={2}>Amstelstationstraat afgesloten tot en met 12 september</Heading>
+              <Paragraph>
                 Tot en met 12 september vervangen we de riolering onder de Amstelstationstraat. Doorgaand autoverkeer
                 rijdt om via de Wibautstraat. De ingang van het station aan de kant van het Julianaplein blijft de hele
                 periode open.
@@ -1158,40 +1159,41 @@ export const WithBreakout: StoryObj = {
               </TableOfContents.List>
             </TableOfContents>
           </Grid.Cell>
-          {/* This cell is not ams-prose, so every element but the last sets its own bottom margin. */}
-          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
+          <Grid.Cell
+            className="ams-prose"
+            span={{ narrow: 4, medium: 6, wide: 7 }}
+            start={{ narrow: 1, medium: 2, wide: 3 }}
+          >
             {/* Every section heading carries the id its Table of Contents entry points at. */}
-            <Heading className="ams-mb-s" id="wat" level={2}>
+            <Heading id="wat" level={2}>
               Wat gaan we doen
             </Heading>
-            <Paragraph className="ams-mb-m">
+            <Paragraph>
               De stationshal van het Amstelstation is te klein voor het aantal reizigers dat er dagelijks doorheen
               loopt. We vergroten de hal, verbreden de perrontrappen en maken een tweede ingang aan de zuidkant van het
               station.
             </Paragraph>
-            <Paragraph className="ams-mb-m">
+            <Paragraph>
               Op het Julianaplein komt meer ruimte voor voetgangers en fietsers. De taxistandplaats en de bushaltes
               verhuizen naar de oostkant van het plein. Daaronder komt een fietsenstalling met 7.000 plekken.
             </Paragraph>
-            <Paragraph className="ams-mb-m">
+            <Paragraph>
               Het stationsgebouw uit 1939 blijft behouden. De gevels en de grote hal met de wandschildering worden
               gerestaureerd.
             </Paragraph>
-            <StandaloneLink className="ams-mb-xl" href="#">
-              Lees meer over het ontwerp van het nieuwe station
-            </StandaloneLink>
-            <Heading className="ams-mb-s" id="waar" level={2}>
+            <StandaloneLink href="#">Lees meer over het ontwerp van het nieuwe station</StandaloneLink>
+            <Heading id="waar" level={2}>
               Waar
             </Heading>
-            <Paragraph className="ams-mb-m">
+            <Paragraph>
               Het Amstelstation ligt in stadsdeel Oost, tussen de Wibautstraat en de Amstel. Het project loopt van het
               Julianaplein aan de noordkant tot de Spaklerweg aan de zuidkant.
             </Paragraph>
-            <Paragraph className="ams-mb-xl">
+            <Paragraph>
               De werkzaamheden raken de buurten Weesperzijde, Omval en Amstelkwartier. Bewoners en ondernemers krijgen
               bericht voordat het werk in hun straat begint.
             </Paragraph>
-            <Heading className="ams-mb-s" id="wanneer" level={2}>
+            <Heading id="wanneer" level={2}>
               Wanneer
             </Heading>
             <Paragraph>
@@ -1274,8 +1276,12 @@ export const WithBreakout: StoryObj = {
            * These two Cells set no rowStart: the rows above them are taken, so they fall in underneath the
            * body on every grid, in source order.
            */}
-          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-            <Heading className="ams-mb-xs" id="nieuws" level={2} size="level-3">
+          <Grid.Cell
+            className="ams-prose"
+            span={{ narrow: 4, medium: 6, wide: 7 }}
+            start={{ narrow: 1, medium: 2, wide: 3 }}
+          >
+            <Heading id="nieuws" level={2} size="level-3">
               Nieuws
             </Heading>
             <LinkList>
@@ -1289,8 +1295,12 @@ export const WithBreakout: StoryObj = {
               <LinkList.Link href="#">Bekijk al het nieuws over dit project</LinkList.Link>
             </LinkList>
           </Grid.Cell>
-          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-            <Heading className="ams-mb-xs" id="werk-aan-de-weg" level={2} size="level-3">
+          <Grid.Cell
+            className="ams-prose"
+            span={{ narrow: 4, medium: 6, wide: 7 }}
+            start={{ narrow: 1, medium: 2, wide: 3 }}
+          >
+            <Heading id="werk-aan-de-weg" level={2} size="level-3">
               Werk aan de weg
             </Heading>
             <LinkList>
@@ -1331,11 +1341,12 @@ export const WithBreakout: StoryObj = {
             />
           </Breakout.Cell>
           <Breakout.Cell
+            className="ams-prose"
             colSpan={{ narrow: 4, medium: 6, wide: 7 }}
             colStart={{ narrow: 1, medium: 2, wide: 3 }}
             rowStart={{ narrow: 2, medium: 3, wide: 3 }}
           >
-            <Heading className="ams-mb-s" id="deelprojecten" level={2}>
+            <Heading id="deelprojecten" level={2}>
               Deelprojecten
             </Heading>
             <Paragraph>
@@ -1344,13 +1355,12 @@ export const WithBreakout: StoryObj = {
             </Paragraph>
           </Breakout.Cell>
           <Breakout.Cell
+            className="ams-prose"
             colSpan={{ narrow: 4, medium: 4, wide: 5 }}
             colStart={{ narrow: 1, medium: 1, wide: 2 }}
             rowStart={{ narrow: 3, medium: 4, wide: 4 }}
           >
-            <Heading className="ams-mb-xs" level={3}>
-              Station en perrons
-            </Heading>
+            <Heading level={3}>Station en perrons</Heading>
             <LinkList>
               <LinkList.Link color="contrast" href="#">
                 Verbouwing van de stationshal
@@ -1370,13 +1380,12 @@ export const WithBreakout: StoryObj = {
             </LinkList>
           </Breakout.Cell>
           <Breakout.Cell
+            className="ams-prose"
             colSpan={{ narrow: 4, medium: 4, wide: 5 }}
             colStart={{ narrow: 1, medium: 5, wide: 7 }}
             rowStart={{ narrow: 4, medium: 4, wide: 4 }}
           >
-            <Heading className="ams-mb-xs" level={3}>
-              Plein en omgeving
-            </Heading>
+            <Heading level={3}>Plein en omgeving</Heading>
             <LinkList>
               <LinkList.Link color="contrast" href="#">
                 Herinrichting van het Julianaplein
@@ -1398,14 +1407,18 @@ export const WithBreakout: StoryObj = {
         </Breakout>
         <Grid paddingVertical="x-large">
           {/*
-           * One Cell holds all five link sections. Their spacing then comes from a margin per pair, where
-           * separate Cells would take it from the row gap, which is one value for the whole Grid.
+           * One Cell holds all five link sections, so ams-prose spaces them against one another. Separate
+           * Cells would take that space from the row gap, which is one value for the whole Grid.
            */}
-          <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-            <Heading className="ams-mb-xs" id="themas" level={2} size="level-3">
+          <Grid.Cell
+            className="ams-prose"
+            span={{ narrow: 4, medium: 6, wide: 7 }}
+            start={{ narrow: 1, medium: 2, wide: 3 }}
+          >
+            <Heading id="themas" level={2} size="level-3">
               Thema’s
             </Heading>
-            <LinkList className="ams-mb-l">
+            <LinkList>
               <LinkList.Link href="#">Bereikbaarheid tijdens de werkzaamheden</LinkList.Link>
               <LinkList.Link href="#">Duurzaam en circulair bouwen</LinkList.Link>
               <LinkList.Link href="#">Groen en biodiversiteit</LinkList.Link>
@@ -1414,10 +1427,10 @@ export const WithBreakout: StoryObj = {
               </LinkList.Link>
               <LinkList.Link href="#">Bekijk alle thema’s</LinkList.Link>
             </LinkList>
-            <Heading className="ams-mb-xs" id="documenten" level={2} size="level-3">
+            <Heading id="documenten" level={2} size="level-3">
               Documenten
             </Heading>
-            <LinkList className="ams-mb-l">
+            <LinkList>
               <LinkList.Link href="#">Nota van uitgangspunten Amstelstation (pdf, 2,4 MB)</LinkList.Link>
               <LinkList.Link href="#">Voorlopig ontwerp Julianaplein (pdf, 8,1 MB)</LinkList.Link>
               <LinkList.Link className="ams-mb-m" href="#">
@@ -1425,31 +1438,27 @@ export const WithBreakout: StoryObj = {
               </LinkList.Link>
               <LinkList.Link href="#">Bekijk alle documenten</LinkList.Link>
             </LinkList>
-            <Heading className="ams-mb-xs" id="video" level={2} size="level-3">
+            <Heading id="video" level={2} size="level-3">
               Video
             </Heading>
             {/*
              * A Paragraph between the heading and the image: the vertical space guide documents no value for
              * a heading directly above an image, which is a sign to introduce the image in words first.
              */}
-            <Paragraph className="ams-mb-l">
-              In deze animatie ziet u hoe het station en het plein er na de vernieuwing uitzien.
-            </Paragraph>
+            <Paragraph>In deze animatie ziet u hoe het station en het plein er na de vernieuwing uitzien.</Paragraph>
             {/* This image carries no information the text does not, so it takes an empty alt. */}
-            <Image alt="" className="ams-mb-l" src={exampleImageSource(1280, 720, 3)} />
-            <StandaloneLink className="ams-mb-l" href="#">
-              Bekijk meer video’s over dit project
-            </StandaloneLink>
-            <Heading className="ams-mb-xs" id="meer-informatie" level={2} size="level-3">
+            <Image alt="" src={exampleImageSource(1280, 720, 3)} />
+            <StandaloneLink href="#">Bekijk meer video’s over dit project</StandaloneLink>
+            <Heading id="meer-informatie" level={2} size="level-3">
               Meer informatie
             </Heading>
-            <LinkList className="ams-mb-l">
+            <LinkList>
               <LinkList.Link href="#">Amstelkwartier: woningbouw en openbare ruimte</LinkList.Link>
               <LinkList.Link href="#">Wibautstraat: vernieuwing van de rijbanen</LinkList.Link>
               <LinkList.Link href="#">Fietsparkeren in Amsterdam</LinkList.Link>
               <LinkList.Link href="#">Meer projecten in Oost</LinkList.Link>
             </LinkList>
-            <Heading className="ams-mb-xs" id="blijf-op-de-hoogte" level={2} size="level-3">
+            <Heading id="blijf-op-de-hoogte" level={2} size="level-3">
               Blijf op de hoogte
             </Heading>
             <LinkList>
@@ -1482,8 +1491,8 @@ export const WithBreakout: StoryObj = {
               </Heading>
             </Grid.Cell>
             <Grid.Subgrid gapVertical="x-large" span="all">
-              <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-                <Paragraph className="ams-mb-m" color="inverse">
+              <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 6 }}>
+                <Paragraph color="inverse">
                   Hilde Verkerk
                   <br />
                   Omgevingsmanager
@@ -1498,8 +1507,8 @@ export const WithBreakout: StoryObj = {
                   </LinkList.Link>
                 </LinkList>
               </Grid.Cell>
-              <Grid.Cell span={{ narrow: 4, medium: 4, wide: 6 }}>
-                <Paragraph className="ams-mb-m" color="inverse">
+              <Grid.Cell className="ams-prose" span={{ narrow: 4, medium: 4, wide: 6 }}>
+                <Paragraph color="inverse">
                   Joris Bramer
                   <br />
                   Communicatieadviseur


### PR DESCRIPTION
# Add a Project Page variant with a Table of Contents and a Breakout

## Links

- [With Breakout](https://designsystem.amsterdam/?path=/story/pages-public-project-page--with-breakout) – the new story in the main deploy.
- [Project page](https://designsystem.amsterdam/?path=/docs/pages-public-project-page--docs) – its documentation page, with the guidance this adds.
- [Preview deploy](https://designsystem.amsterdam/) – the whole Storybook on main.

## What

Adds a `WithBreakout` story beside `Default` on the Project Page, for a project with more sections than a reader wants to scroll past. It opens with a lead paragraph, lists its sections in a Table of Contents beside the body, and gives every section heading the `id` its entry points at.

Two layout ideas the public templates did not have yet. A Table of Contents that precedes the body in the reading order and still sits to its right on the wide grid, placed with the `rowStart` prop from #2886. And an image that overlaps the Spotlight below it, which sets a band apart from the sections around it.

## Why

The design for a construction and traffic project page has more sections than the existing template shows, and lists them in an ‘Op deze pagina’ sidebar. The single body column of the Default story suits a project a reader can take in by scrolling; this one suits a project where they want one section and should be able to jump to it.

Content is an invented Amstelstation renewal project.

## How

The story was written before several conventions landed on develop, so most of the commits bring it in step with them rather than adding markup. Each is its own commit, and each is value-for-value: a visual difference is a mistake rather than a judgement call.

Prose replaces the hand-picked margins, as #2873 did for every other template. Three pairs change value where the guidance moved: a Paragraph before a Standalone Link drops from medium to small, and a Link List below a level 3 heading rises from x-small to small. Eleven Cells take `ams-prose` and 31 margin utilities go, per copy. Two margins survive in the whole story, both a section heading whose Grid gives up its row gap.

The Progress List moves into a Grid Cell of its own, joining the other components that take their space from the Grid. The contact Spotlight puts its heading in a Cell above a Subgrid, so the heading spaces itself where the row gap would be too wide. Both Spotlight headings take `size="level-3"`, since a heading of a block takes a size one step smaller. The four sections ending in a link to the wider set move that link out of the list as a Standalone Link.

The Table of Contents uses `rowStart` rather than the inline `gridRowStart` it was written with. The documentation page had said to place it in a Breakout, because at the time only a Breakout could name a row; it describes the prop now.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

Expect visual changes on this story throughout, since most of the branch is a spacing conversion. The Standalone Links and the smaller Spotlight headings each shift the blocks around them slightly.

Two heading sizes are open questions rather than settled, and would welcome a second opinion:

The ‘Deelprojecten’ heading keeps the size of its level. It introduces a lead paragraph, which reads as a content body, but the section as a whole is a group of two link blocks, which would take a size one step smaller. It is the one heading on the page where the two readings disagree.

Its two subsection headings, ‘Station en perrons’ and ‘Plein en omgeving’, are level 3 above a Link List. By the rule they would take `size="level-4"`, but #2887 applied the rule only at level 2, and these are the only headings of their shape in the templates, so there is no precedent to follow. They are left at the size of their level.

The Anatomy section draws the Default story only. Giving `WithBreakout` its own drawing needs a second labels export and a change to the shared `anatomyLabels.test.ts`, which globs one file per directory; the Profile Page has five stories and draws one, so this follows that.

