### PR TITLE
feat(Field Set): Accept the native disabled attribute

### DIFF
--- a/packages/react/src/FieldSet/FieldSet.test.tsx
+++ b/packages/react/src/FieldSet/FieldSet.test.tsx
@@ -51,6 +51,19 @@ describe('FieldSet', () => {
     expect(component).toHaveClass('ams-field-set--invalid')
   })
 
+  it('disables itself and the controls it contains', () => {
+    render(
+      <FieldSet disabled legend="Test">
+        <input type="text" />
+      </FieldSet>,
+    )
+
+    const component = screen.getByRole('group', { name: 'Test' })
+
+    expect(component).toHaveAttribute('disabled')
+    expect(screen.getByRole('textbox')).toBeDisabled()
+  })
+
   it('supports ForwardRef in React', () => {
     const ref = createRef<HTMLFieldSetElement>()
 

--- a/packages/react/src/FieldSet/FieldSet.tsx
+++ b/packages/react/src/FieldSet/FieldSet.tsx
@@ -3,7 +3,7 @@
  * Copyright Gemeente Amsterdam
  */
 
-import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
+import type { FieldsetHTMLAttributes, ForwardedRef, PropsWithChildren } from 'react'
 
 import { clsx } from 'clsx'
 import { forwardRef } from 'react'
@@ -28,7 +28,7 @@ export type FieldSetProps = {
    */
   readonly legendIsPageHeading?: boolean
 } & HintProps &
-  Readonly<PropsWithChildren<HTMLAttributes<HTMLFieldSetElement>>>
+  Readonly<PropsWithChildren<FieldsetHTMLAttributes<HTMLFieldSetElement>>>
 
 /**
  * Groups a set of Radio buttons or Checkboxes, or other related form fields.

--- a/storybook/src/components/FieldSet/FieldSet.docs.mdx
+++ b/storybook/src/components/FieldSet/FieldSet.docs.mdx
@@ -68,6 +68,15 @@ Do not use rich text (such as links or lists) in an Error Message. [Find out why
 
 <Canvas of={FieldSetStories.WithValidation} />
 
+### Disabled
+
+A disabled Field Set disables every form control it contains, in a single attribute rather than one per control.
+
+The Field Set itself keeps its appearance: the legend and the labels stay in their usual colour.
+Each control inside shows that it is unavailable in its own way, so a [Text Input](/docs/components-forms-text-input--docs) takes the same grey fill and grey text it has when it is disabled on its own.
+
+<Canvas of={FieldSetStories.Disabled} />
+
 ### With Heading in Legend
 
 If the Field Set holds the only question on the page, its Legend serves as the main heading as well.

--- a/storybook/src/components/FieldSet/FieldSet.stories.tsx
+++ b/storybook/src/components/FieldSet/FieldSet.stories.tsx
@@ -17,6 +17,7 @@ import {
 } from '@amsterdam/design-system-react'
 import { FieldSet } from '@amsterdam/design-system-react/src'
 
+import { disabledArgType } from '#storybook/_common/argTypes'
 import { exampleFamilyName, exampleGivenName } from '#storybook/_common/exampleContent'
 
 const familyName = exampleFamilyName()
@@ -26,8 +27,12 @@ const meta = {
   title: 'Components/Forms/Field Set',
   component: FieldSet,
   args: {
+    disabled: false,
     invalid: false,
     legend: 'Wat is uw naam?',
+  },
+  argTypes: {
+    disabled: disabledArgType,
   },
   decorators: [
     (Story) => (

--- a/storybook/src/components/FieldSet/FieldSet.stories.tsx
+++ b/storybook/src/components/FieldSet/FieldSet.stories.tsx
@@ -183,6 +183,28 @@ export const WithValidation: Story = {
   ),
 }
 
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+  render: (args) => (
+    <FieldSet {...args}>
+      <Field>
+        <Label htmlFor="input-d1" inFieldSet>
+          Voornaam
+        </Label>
+        <TextInput id="input-d1" value={givenName} />
+      </Field>
+      <Field>
+        <Label htmlFor="input-d2" inFieldSet>
+          Achternaam
+        </Label>
+        <TextInput id="input-d2" value={familyName} />
+      </Field>
+    </FieldSet>
+  ),
+}
+
 export const WithHeadingInLegend: Story = {
   args: {
     legendIsPageHeading: true,

--- a/storybook/src/components/FieldSet/FieldSet.test.stories.tsx
+++ b/storybook/src/components/FieldSet/FieldSet.test.stories.tsx
@@ -23,13 +23,15 @@ type Story = StoryObj<typeof meta>
 export const Test: Story = {
   args: {
     children: (
-      // We add a label to prevent Chromatic from raising an accessibility error.
+      // The label names the input, which Chromatic needs, and wraps it so that no id repeats across the variants.
       <div>
-        <label htmlFor="input-a1">Voornaam</label>
-        <input id="input-a1" value="Yassine" />
+        <label>
+          Voornaam
+          <input readOnly value="Yassine" />
+        </label>
       </div>
     ),
   },
-  render: (args, context) => renderComponentVariants(FieldSet, { args }, context),
+  render: (args, context) => renderComponentVariants(FieldSet, { args, variants: ['disabled'] }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }


### PR DESCRIPTION
# Accept the native disabled attribute

## Links

- [Field Set documentation in the main deploy](https://designsystem.amsterdam/?path=/docs/components-forms-field-set--docs)
- [The new Disabled story](https://designsystem.amsterdam/?path=/story/components-forms-field-set--disabled)

## What

Field Set accepts the native `disabled` attribute, which disables every form control nested inside it. A Disabled story and a matching section in the documentation show what that looks like, the controls table gains a `disabled` row, and the test story covers the state in Chromatic.

## Why

`<fieldset disabled>` is a real HTML feature and Field Set renders a `<fieldset>`, so the behaviour was already there at runtime, since the rest props were spread onto the element all along. Only the type stood in the way: the props extended `HTMLAttributes<HTMLFieldSetElement>`, which does not carry `disabled`, so passing it was a type error.

This came out of an audit of the components under Components/Forms for whether each one shows its disabled state. Field Set was the only component with a real disabled state that could not expose it. The others that have no Disabled story, being Character Count, Error Message, Field, File List, Invalid Form Alert and Label, have no disabled state at all and need nothing.

## How

The props now extend `FieldsetHTMLAttributes<HTMLFieldSetElement>`, the interface React provides for this element. It adds `form` and `name` alongside `disabled`, both equally valid fieldset attributes that the rest-props spread already carried to the element. That matches how the other form components type their props, rather than hand-picking a single native attribute.

No CSS was needed. The stylesheet draws nothing for the disabled state: the legend and the labels keep their colour, and the whole visible difference comes from the controls inside matching `:disabled` and taking their own styles.

The controls table gets its `disabled` row the way Checkbox and Switch get theirs, through `meta.args` and the shared `disabledArgType`, because react-docgen-typescript does not report attributes inherited from React’s own types. In the test story the label now wraps its input rather than pointing at it with `htmlFor`, so that markup repeats across all 24 variants without repeating an id.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

The Field Set test story will come back changed in Chromatic. Its matrix grows from 10 cells to 24, and the label markup differs.
