### PR TITLE
chore(Storybook): Leave the args that carry a default out of the code view

### DIFF
--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -69,6 +69,15 @@ Follow these guidelines:
    Changing them can therefore change snapshots; the args of an individual presentation story don’t reach Chromatic.
    This does not hold for page templates, whose stories Chromatic snapshots one by one.
 
+### Args that only serve the controls
+
+The Boolean flags of the first guideline reach the Code Panel too, teaching readers to write a `disabled={false}` that changes nothing.
+So do the event handlers an `action` or a controlled story adds, which print as an empty `() => {}`.
+`storybook/config/filterSourceProps.ts` leaves both out of the generated source.
+
+Add a Boolean prop to the list in that module as soon as a story gives it `false`, so it stays out of the code view.
+Only add a prop that is off by default: where a prop is on by default, such as Ordered List’s `markers`, `false` switches the default off and the code view has to show it.
+
 ### Choosing a control
 
 Pick the control that matches the shape of the prop.

--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -61,11 +61,13 @@ Follow these guidelines:
 1. For Boolean props, set their default value to `false`, unless this has side effects e.g. rendering a class name.
    In that case, don’t specify a value.
    Storybook will then display a button ‘Set boolean’ that shows a switch.
-2. Don’t use an empty string as a placeholder value – it can defeat component behaviour such as generating an id or rendering an optional hint.
+2. For other props, don’t set an arg to the value the prop has by default.
+   The `undefined` option labelled with that default already selects it – see [Choosing a control](#choosing-a-control) – so an arg would only add the prop to the code view.
+3. Don’t use an empty string as a placeholder value – it can defeat component behaviour such as generating an id or rendering an optional hint.
    Leave the arg out instead.
-3. Hide args with `table: { disable: true }` in the `argTypes` object if they don’t apply to the story, e.g. if the story composes multiple instances of the component.
+4. Hide args with `table: { disable: true }` in the `argTypes` object if they don’t apply to the story, e.g. if the story composes multiple instances of the component.
    We don’t hide ‘less relevant’ args in other cases, not even in stories that focus on a single prop.
-4. Note that the args and argTypes of the meta feed the Test story, which is the only story Chromatic snapshots for a component or a CSS utility – see [Test stories](#test-stories).
+5. Note that the args and argTypes of the meta feed the Test story, which is the only story Chromatic snapshots for a component or a CSS utility – see [Test stories](#test-stories).
    Changing them can therefore change snapshots; the args of an individual presentation story don’t reach Chromatic.
    This does not hold for page templates, whose stories Chromatic snapshots one by one.
 

--- a/storybook/config/filterSourceProps.test.ts
+++ b/storybook/config/filterSourceProps.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { filterSourceProps } from './filterSourceProps'
+
+describe('filterSourceProps', () => {
+  it('drops a prop that has no value', () => {
+    expect(filterSourceProps(undefined, 'icon')).toBe(false)
+  })
+
+  it('drops a Boolean flag that is off by default', () => {
+    expect(filterSourceProps(false, 'checked')).toBe(false)
+    expect(filterSourceProps(false, 'disabled')).toBe(false)
+    expect(filterSourceProps(false, 'indeterminate')).toBe(false)
+    expect(filterSourceProps(false, 'invalid')).toBe(false)
+  })
+
+  it('keeps a Boolean flag that is on', () => {
+    expect(filterSourceProps(true, 'disabled')).toBe(true)
+  })
+
+  it('keeps `false` on a prop that is on by default', () => {
+    expect(filterSourceProps(false, 'markers')).toBe(true)
+    expect(filterSourceProps(false, 'focusOnRender')).toBe(true)
+  })
+
+  it('keeps `false` on a prop the browser decides', () => {
+    expect(filterSourceProps(false, 'spellCheck')).toBe(true)
+  })
+
+  it('drops an event handler', () => {
+    expect(filterSourceProps(() => {}, 'onChange')).toBe(false)
+    expect(filterSourceProps(() => {}, 'onClick')).toBe(false)
+  })
+
+  it('keeps a function that is not an event handler', () => {
+    expect(filterSourceProps(() => {}, 'linkComponent')).toBe(true)
+  })
+
+  it('keeps a prop whose name merely starts with ‘on’', () => {
+    expect(filterSourceProps(() => {}, 'once')).toBe(true)
+  })
+
+  it('keeps the values a story sets on purpose', () => {
+    expect(filterSourceProps('secondary', 'variant')).toBe(true)
+    expect(filterSourceProps(2, 'headingLevel')).toBe(true)
+    expect(filterSourceProps('', 'label')).toBe(true)
+  })
+})

--- a/storybook/config/filterSourceProps.ts
+++ b/storybook/config/filterSourceProps.ts
@@ -1,0 +1,37 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+// The Code Panel prints every prop a story passes, so args that exist only to shape the controls table
+// end up in the source people copy. Two kinds do. Boolean flags carry `false` so the table shows a switch
+// instead of a ‘Set boolean’ button. Event handlers arrive from an `action` or from a story keeping a
+// controlled input in step, and print as an empty `() => {}` because the generator never shows a function
+// body. Neither says anything the reader has to write, so `parameters.jsx.filterProps` leaves them out.
+
+/**
+ * Boolean props that are off unless a story turns them on, so `false` is what they do anyway.
+ * A prop that is on by default – Ordered List’s `markers`, Invalid Form Alert’s `focusOnRender` – does not
+ * belong here: its `false` switches the default off, which the code view has to show.
+ */
+const offByDefaultFlags = [
+  'checked',
+  'closeable',
+  'disabled',
+  'iconBefore',
+  'iconOnly',
+  'indeterminate',
+  'invalid',
+  'multiple',
+  'optional',
+  'wrap',
+]
+
+/**
+ * Decides which props the Code Panel prints.
+ * This replaces the generator’s own filter, which drops the props that are `undefined` – hence the first clause.
+ */
+export const filterSourceProps = (value: unknown, key: string): boolean =>
+  value !== undefined &&
+  !(value === false && offByDefaultFlags.includes(key)) &&
+  !(typeof value === 'function' && /^on[A-Z]/.test(key))

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -7,6 +7,7 @@ import { clsx } from 'clsx'
 import { addons } from 'storybook/preview-api'
 
 import { collapseInlineObjects, maxInlineWidth } from './collapseInlineObjects'
+import { filterSourceProps } from './filterSourceProps'
 import { sortLiteralUnionValues } from './sortLiteralUnionValues'
 import { matchTheme, readStoredTheme, THEME_EVENT, THEME_KEY, themeNames } from './themes'
 import { viewports } from './viewports'
@@ -236,10 +237,12 @@ export const parameters = {
   // examples. The decorator above refines the language per story through `parameters.lang` or a
   // `locale` arg; docs prose keeps Storybook’s English default.
   htmlLang: 'nl',
-  // Widen the Code Panel’s line budget. Without this, react-element-to-jsx-string – which generates the
-  // source for stories with a `render` function – puts every element with more than one attribute onto
-  // multiple lines. Keeping attributes inline until a line reaches this length shows more code at once.
+  // Options for react-element-to-jsx-string, which generates the Code Panel’s source. `filterProps` leaves
+  // out the props that only serve the controls table (see the module). `maxInlineAttributesLineLength`
+  // widens the line budget: without it, every element with more than one attribute goes onto multiple
+  // lines. Keeping attributes inline until a line reaches this length shows more code at once.
   jsx: {
+    filterProps: filterSourceProps,
     maxInlineAttributesLineLength: maxInlineWidth,
   },
   options: {

--- a/storybook/src/components/Button/Button.stories.tsx
+++ b/storybook/src/components/Button/Button.stories.tsx
@@ -20,10 +20,7 @@ const meta = {
   args: {
     children: 'Versturen',
     disabled: false,
-    icon: undefined,
     iconBefore: false,
-    iconOnly: undefined,
-    variant: 'primary',
   },
   argTypes: {
     disabled: disabledArgType,

--- a/storybook/src/components/Card/Card.stories.tsx
+++ b/storybook/src/components/Card/Card.stories.tsx
@@ -108,9 +108,6 @@ export const HorizontalLayout: DefaultStory = {
 }
 
 export const TopTasks: Story = {
-  args: {
-    style: undefined,
-  },
   parameters: {
     layout: 'fullscreen',
   },

--- a/storybook/src/components/FileInput/FileInput.stories.tsx
+++ b/storybook/src/components/FileInput/FileInput.stories.tsx
@@ -14,7 +14,6 @@ const meta = {
   title: 'Components/Forms/File Input',
   component: FileInput,
   args: {
-    accept: undefined,
     disabled: false,
     multiple: false,
   },

--- a/storybook/src/components/IconButton/IconButton.stories.tsx
+++ b/storybook/src/components/IconButton/IconButton.stories.tsx
@@ -17,7 +17,6 @@ const meta = {
   args: {
     disabled: false,
     label: 'Sluiten',
-    size: undefined,
   },
   argTypes: {
     color: contrastInverseColorArgType,

--- a/storybook/src/components/OrderedList/OrderedList.stories.tsx
+++ b/storybook/src/components/OrderedList/OrderedList.stories.tsx
@@ -19,9 +19,6 @@ const meta = {
   component: OrderedList,
   args: {
     children: orderedListItems,
-    markers: undefined,
-    reversed: undefined,
-    start: undefined,
   },
   argTypes: {
     color: inverseColorArgType,

--- a/storybook/src/components/UnorderedList/UnorderedList.stories.tsx
+++ b/storybook/src/components/UnorderedList/UnorderedList.stories.tsx
@@ -21,7 +21,6 @@ const meta = {
   component: UnorderedList,
   args: {
     children: unorderedListItems,
-    markers: undefined,
   },
   argTypes: {
     color: inverseColorArgType,


### PR DESCRIPTION
# Describe the pull request

## Links

- [Checkbox](https://designsystem.amsterdam/?path=/docs/components-forms-checkbox--docs) – six props gone from the Default example.
- [Button](https://designsystem.amsterdam/?path=/docs/components-buttons-button--docs) – Primary is now `<Button>Versturen</Button>`.
- [Date Input](https://designsystem.amsterdam/?path=/docs/components-forms-date-input--docs) – one of the inputs that opened with two unused props.
- [Field Set](https://designsystem.amsterdam/?path=/docs/components-forms-field-set--docs) – the `disabled` arg #2891 just added, filtered the same way.
- [Preview deploy](https://designsystem.amsterdam/) – the whole Storybook on main.
- [Make controls consistent across all stories](https://github.com/Amsterdam/design-system/pull/2738) – the PR this cleans up after.

## What

Every form control example spelled out the props it was not using. Checkbox opened with `checked={false} disabled={false} indeterminate={false} invalid={false} onChange={() => {}} onClick={() => {}}`, Button and Icon Button with `disabled={false}`, Date Input with `disabled={false} invalid={false}`. None of those props do anything, yet the Code Panel presented all of them as code worth copying.

The args stay exactly where they are. A `filterProps` option leaves them out of the generated source instead, so the controls table keeps the switch it gained while the code view shows only the props you would actually write.

Two smaller sweeps come with it. Button seeded `variant: 'primary'`, which the labelled `undefined` option already selects. Nine args across six stories were declared as `undefined`, among them one on Card that cancelled a meta arg removed long ago.

## Why

#2738 gives Boolean props a `false` arg so their control renders as a switch rather than a ‘Set boolean’ button. Storybook offers no other way to get one: `BooleanControl` shows that button whenever the value is `undefined`, and no argType option overrides it. So the args have to stay.

What went unnoticed is that every one of them also reaches the Code Panel. An example that opens with six props nobody needs teaches the wrong API, and it does so on the components people copy from most.

## How

`storybook/config/filterSourceProps.ts` holds the rule, wired in through `parameters.jsx.filterProps`. It drops two things: a `false` on a Boolean prop that is off by default, and an event handler, which prints as an empty `() => {}` because the generator never shows a function body.

The list of Boolean props is deliberately positive rather than negative, because ‘drop every `false`’ would be wrong. Ordered List’s `markers` and Invalid Form Alert’s `focusOnRender` are on by default, so their `false` switches the default off and has to stay visible, and Text Input’s `spellCheck` is browser-decided. A positive list also fails safely: a name nobody added leaves visible noise, where a forgotten exception would leave a silently wrong snippet.

The second sweep follows from the convention #2738 settled. An optional prop offers `undefined` labelled with its default, so an arg carrying that same default adds nothing to the controls and only adds a prop to the code view.

Nothing about the controls changes, and neither does Chromatic: the variant matrix is built from argTypes, and `buildComponentProps` spreads its own value over `args`.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass

