### PR TITLE
chore(Storybook): Point the Compact Mode link at the Density section

### DIFF
--- a/storybook/src/docs/developer-guide/getting-started.docs.mdx
+++ b/storybook/src/docs/developer-guide/getting-started.docs.mdx
@@ -68,7 +68,7 @@ You shouldn’t need a reset stylesheet.
 
 ## Compact Mode
 
-If you use [Compact Mode](/docs/docs-developer-guide-modes--docs#compact-mode),
+If you use [Compact Mode](/docs/docs-developer-guide-modes--docs#density),
 import the stylesheets in this order – the compact tokens override the spacious ones.
 
 {/* prettier-ignore */}


### PR DESCRIPTION
## Links

- [Feature branch deploy](https://amsterdam.github.io/design-system/demo-compact-mode-docs-anchor)
- [Getting Started](https://amsterdam.github.io/design-system/demo-compact-mode-docs-anchor/?path=/docs/docs-developer-guide-getting-started--docs), the page carrying the corrected link
- [Modes](https://amsterdam.github.io/design-system/demo-compact-mode-docs-anchor/?path=/docs/docs-developer-guide-modes--docs), the page it points at

## What

The Compact Mode link on the Getting Started page pointed at `#compact-mode` on the Modes page. That anchor doesn’t exist there, so the link landed at the top of the page rather than at the section it promised. It now points at `#density`.

## Why

The Modes page is organised by dimension rather than by mode name. `## Density` covers Spacious and Compact Mode together in a single comparison table, and `## Fidelity` covers Lo-fi Mode. There is no `## Compact Mode` heading to link to, and adding one would split the subject of that table across two sections.

That heading does exist on several other pages, including the Getting Started page itself, immediately above the broken link. That is the likely origin of the mistake.

## How

One line changed. The sibling link to Lo-fi Mode in the next section already pointed at `#fidelity`, so both links now address the section rather than the mode, and they read consistently.

Verified against a build of Storybook rather than by inspection: the compiled Modes page emits exactly two headings, with the ids `density` and `fidelity`, and no `compact-mode` id anywhere. The string `#compact-mode` no longer appears in the compiled Getting Started page. A grep across the repository confirms this was the only use of the dead anchor; every other Compact Mode link addresses the Modes page without one. `pnpm --filter=storybook run build` completes and Prettier passes.

This predates the page template docs restructure and is unrelated to it.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

No visual change: this only redirects an in-page link, so nothing in the rendered components or pages moves.
