### PR TITLE
fix(Storybook): Render no duplicate configurations in the test story matrix

### DIFF
--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -163,7 +163,8 @@ It unhides the arg, offers a text control, and sets the description – `childre
 
 Test stories (`*.test.stories.tsx`) render all states of a component in the single story named ‘Test’, which is the only story Chromatic snapshots for a component.
 They inherit the component’s meta and must not define argTypes of their own.
-Note that `renderComponentVariants` reads the meta’s argTypes to build its variant matrix – changing options or hiding args can change what the Test story renders and snapshots.
+Note that `renderComponentVariants` reads both the argTypes and the args of the meta to build its variant matrix – changing options, hiding args, or giving an arg a value can change what the Test story renders and snapshots.
+The matrix holds each configuration once: it opens every state with the component as the meta’s args leave it, and leaves out any prop value that baseline already shows, whether the meta set it or the prop defaults to it.
 
 CSS utilities under `Utilities/` have test stories as well, but cannot use `renderComponentVariants`.
 The component next to each utility is a mock that renders a bare element; the utility class comes from the story’s `render`, so a generated matrix would show elements without the class on them.

--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -169,6 +169,9 @@ The matrix holds each configuration once: it opens every state with the componen
 A `play` function has to allow for that matrix rendering the component more than once, since `args.children` repeat with it: a query for a single element throws where a test id or a role occurs once per configuration.
 Either take the first match, as Tabs and Image Slider do, or give the interaction its own instance outside the matrix, as Accordion does.
 
+The same goes for axe’s `heading-order` rule, which describes a document outline where the matrix shows heading levels side by side and leaves out the level the baseline already shows.
+A test story whose component takes a heading level therefore disables that rule, and only that rule: checks that hold per component, such as colour contrast, stay on.
+
 CSS utilities under `Utilities/` have test stories as well, but cannot use `renderComponentVariants`.
 The component next to each utility is a mock that renders a bare element; the utility class comes from the story’s `render`, so a generated matrix would show elements without the class on them.
 Their test stories build the matrix by hand instead, covering the scale the CSS ships: all five gaps, all six margins, all six aspect ratios, and both sides of the container query.

--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -166,6 +166,9 @@ They inherit the component’s meta and must not define argTypes of their own.
 Note that `renderComponentVariants` reads both the argTypes and the args of the meta to build its variant matrix – changing options, hiding args, or giving an arg a value can change what the Test story renders and snapshots.
 The matrix holds each configuration once: it opens every state with the component as the meta’s args leave it, and leaves out any prop value that baseline already shows, whether the meta set it or the prop defaults to it.
 
+A `play` function has to allow for that matrix rendering the component more than once, since `args.children` repeat with it: a query for a single element throws where a test id or a role occurs once per configuration.
+Either take the first match, as Tabs and Image Slider do, or give the interaction its own instance outside the matrix, as Accordion does.
+
 CSS utilities under `Utilities/` have test stories as well, but cannot use `renderComponentVariants`.
 The component next to each utility is a mock that renders a bare element; the utility class comes from the story’s `render`, so a generated matrix would show elements without the class on them.
 Their test stories build the matrix by hand instead, covering the scale the CSS ships: all five gaps, all six margins, all six aspect ratios, and both sides of the container query.

--- a/storybook/src/_common/buildComponentProps.test.ts
+++ b/storybook/src/_common/buildComponentProps.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { ChevronDownIcon } from '@amsterdam/design-system-react-icons'
+import { createElement } from 'react'
 import { describe, expect, it } from 'vitest'
 
 import { buildComponentProps } from './buildComponentProps'
@@ -89,5 +90,25 @@ describe('buildComponentProps', () => {
   it('injects a unique accessibleNameId derived from the variant when the flag is set', () => {
     const result = buildComponentProps({ ...baseParams, acceptsAccessibleNameId: true })
     expect(result).toMatchObject({ accessibleNameId: 'variant-none-color-primary-default' })
+  })
+
+  it('names an icon variant by its component rather than stringifying its source', () => {
+    const result = buildComponentProps({
+      ...baseParams,
+      acceptsAccessibleName: true,
+      propName: 'icon',
+      variant: ChevronDownIcon,
+    })
+    expect(result).toMatchObject({ accessibleName: `none-icon-${ChevronDownIcon.name}-default` })
+  })
+
+  it('names an icon variant passed as an element by its element type', () => {
+    const result = buildComponentProps({
+      ...baseParams,
+      acceptsAccessibleName: true,
+      propName: 'icon',
+      variant: createElement('svg'),
+    })
+    expect(result).toMatchObject({ accessibleName: 'none-icon-svg-default' })
   })
 })

--- a/storybook/src/_common/buildComponentProps.test.ts
+++ b/storybook/src/_common/buildComponentProps.test.ts
@@ -7,6 +7,8 @@ import { ChevronDownIcon } from '@amsterdam/design-system-react-icons'
 import { createElement } from 'react'
 import { describe, expect, it } from 'vitest'
 
+import type { BuildComponentPropsParams } from './renderComponentVariantTypes'
+
 import { buildComponentProps } from './buildComponentProps'
 
 const baseParams = {
@@ -17,7 +19,7 @@ const baseParams = {
   sizePropName: 'size',
   state: 'default',
   variant: 'primary',
-}
+} satisfies BuildComponentPropsParams
 
 describe('buildComponentProps', () => {
   it('spreads args and sets the variant on the target prop', () => {

--- a/storybook/src/_common/buildComponentProps.ts
+++ b/storybook/src/_common/buildComponentProps.ts
@@ -5,12 +5,33 @@
 
 import { clsx } from 'clsx'
 
-import type { BuildComponentPropsParams } from './renderComponentVariantTypes'
+import type { BuildComponentPropsParams, VariantMatrixEntry } from './renderComponentVariantTypes'
+
+/**
+ * The props the matrix sets from the cell itself, whatever a story’s args hold.
+ * Varying one on the prop axis shows nothing: the value below wins over it.
+ */
+export const DERIVED_PROP_NAMES = ['accessibleName', 'accessibleNameId']
+
+/**
+ * Names a cell of the variant matrix, uniquely among its siblings. Serves as the
+ * React key and as the accessible name for the components that take one.
+ */
+export const variantKeyFor = ({
+  propName,
+  size,
+  state,
+  variant,
+}: Pick<VariantMatrixEntry, 'propName' | 'size' | 'state' | 'variant'>): string =>
+  propName ? `${size ?? 'none'}-${propName}-${String(variant)}-${state}` : `${size ?? 'none'}-baseline-${state}`
 
 /**
  * Assembles the props for a single component instance in the variant matrix.
  * Handles state classes (`hover`), disabled flag, size routing and the
  * inverse background trigger defined in authoring.css.
+ *
+ * A cell without a `propName` is the baseline, which varies no prop at all and so
+ * shows the component as the story's own args leave it, in this state and size.
  *
  * For components that render an ARIA landmark and expose `accessibleName`
  * / `accessibleNameId` props, a per-variant value is injected so each
@@ -28,7 +49,7 @@ export const buildComponentProps = ({
   state,
   variant,
 }: BuildComponentPropsParams) => {
-  const variantKey = `${size ?? 'none'}-${propName}-${String(variant)}-${state}`
+  const variantKey = variantKeyFor({ propName, size, state, variant })
 
   return {
     ...args,
@@ -39,7 +60,7 @@ export const buildComponentProps = ({
       state === 'hovered' && 'hover',
       typeof variant === 'string' && variant === 'inverse' && state !== 'disabled' && '_ams-page-background--dark',
     ),
-    ...(propName !== sizePropName && { [propName]: variant }),
+    ...(propName && propName !== sizePropName && { [propName]: variant }),
     ...(acceptsAccessibleName && { accessibleName: variantKey }),
     ...(acceptsAccessibleNameId && { accessibleNameId: `variant-${variantKey}` }),
   }

--- a/storybook/src/_common/buildComponentProps.ts
+++ b/storybook/src/_common/buildComponentProps.ts
@@ -5,13 +5,33 @@
 
 import { clsx } from 'clsx'
 
-import type { BuildComponentPropsParams, VariantMatrixEntry } from './renderComponentVariantTypes'
+import type { BuildComponentPropsParams, VariantMatrixEntry, VariantValue } from './renderComponentVariantTypes'
 
 /**
  * The props the matrix sets from the cell itself, whatever a story’s args hold.
  * Varying one on the prop axis shows nothing: the value below wins over it.
  */
 export const DERIVED_PROP_NAMES = ['accessibleName', 'accessibleNameId']
+
+/**
+ * Names the value a cell varies, for the key below.
+ *
+ * An icon is a component or a React element, and stringifying either gives something
+ * useless: the component’s whole source, over 300 characters of it for a Design System
+ * icon, or `[object Object]` for an element. Take the name instead, which reads as a name
+ * and keeps two different icons apart.
+ */
+const nameOf = (variant: VariantValue | undefined): string => {
+  if (typeof variant === 'function') return variant.name || 'component'
+
+  if (typeof variant === 'object' && variant !== null) {
+    const { type } = variant as { type?: { name?: string } | string }
+
+    return (typeof type === 'string' ? type : type?.name) || 'element'
+  }
+
+  return String(variant)
+}
 
 /**
  * Names a cell of the variant matrix, uniquely among its siblings. Serves as the
@@ -23,7 +43,7 @@ export const variantKeyFor = ({
   state,
   variant,
 }: Pick<VariantMatrixEntry, 'propName' | 'size' | 'state' | 'variant'>): string =>
-  propName ? `${size ?? 'none'}-${propName}-${String(variant)}-${state}` : `${size ?? 'none'}-baseline-${state}`
+  propName ? `${size ?? 'none'}-${propName}-${nameOf(variant)}-${state}` : `${size ?? 'none'}-baseline-${state}`
 
 /**
  * Assembles the props for a single component instance in the variant matrix.

--- a/storybook/src/_common/buildVariantMatrix.test.ts
+++ b/storybook/src/_common/buildVariantMatrix.test.ts
@@ -1,0 +1,211 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta } from '@storybook/react-vite'
+import type { StrictArgTypes, StrictInputType } from 'storybook/internal/csf'
+
+import { ChevronDownIcon } from '@amsterdam/design-system-react-icons'
+import { describe, expect, it } from 'vitest'
+
+import type { VariantState } from './renderComponentVariantTypes'
+
+import { buildComponentProps, DERIVED_PROP_NAMES } from './buildComponentProps'
+import { buildVariantMatrix, SIZE_PROP_NAME } from './buildVariantMatrix'
+import { HEADING_SAMPLE } from './variantFixtures'
+
+const argType = (overrides: { name: string } & Partial<StrictInputType>): StrictInputType => ({ ...overrides })
+
+const argTypes = (entries: StrictInputType[]): StrictArgTypes =>
+  Object.fromEntries(entries.map((entry) => [entry.name, entry])) as StrictArgTypes
+
+const booleanProp = (name: string) => argType({ name, type: { name: 'boolean' } })
+
+const enumProp = (name: string, values: string[], defaultValue?: string) =>
+  argType({
+    name,
+    ...(defaultValue && { table: { defaultValue: { summary: defaultValue } } }),
+    type: { name: 'enum', value: values },
+  })
+
+/**
+ * The props a cell hands the component, as a comparable string. The derived props are
+ * left out: buildComponentProps builds those from the cell itself, so with them in,
+ * no two cells could ever compare equal.
+ */
+const propsKey = (entry: Parameters<typeof buildComponentProps>[0]): string => {
+  const props = buildComponentProps(entry) as Record<string, unknown>
+
+  return JSON.stringify(
+    Object.keys(props)
+      .filter((name) => !DERIVED_PROP_NAMES.includes(name))
+      .sort()
+      .map((name) => [name, props[name]]),
+    (_key, value) => (typeof value === 'function' ? `function ${value.name}` : value),
+  )
+}
+
+// Mirrors how renderComponentVariants turns the matrix into component instances.
+const renderedKeys = (types: StrictArgTypes, variants: VariantState[], args: Meta['args']) =>
+  buildVariantMatrix(types, { args, variants }).map((entry) =>
+    propsKey({
+      ...entry,
+      acceptsAccessibleName: 'accessibleName' in types,
+      acceptsAccessibleNameId: 'accessibleNameId' in types,
+      args,
+      sizePropName: SIZE_PROP_NAME,
+    }),
+  )
+
+const duplicatesIn = (keys: string[]) => keys.filter((key, index) => keys.indexOf(key) !== index)
+
+// Every shape a test story’s arg types can take, so that the sweep below covers the
+// prop kinds the matrix has to combine rather than a handful of examples.
+const propShapes = [
+  booleanProp('checked'),
+  booleanProp('disabled'),
+  booleanProp('invalid'),
+  enumProp('variant', ['primary', 'secondary', 'tertiary'], 'primary'),
+  enumProp('color', ['default', 'inverse']),
+  enumProp(SIZE_PROP_NAME, ['large', 'small']),
+  argType({ name: 'accessibleName', type: { name: 'string' } }),
+  argType({ name: 'icon', table: { defaultValue: { summary: 'CheckboxIcon' } } }),
+  argType({ name: 'iconOnly', type: { name: 'boolean' } }),
+  argType({ name: 'heading', type: { name: 'string' } }),
+]
+
+const stateAxes: VariantState[][] = [[], ['disabled'], ['hovered'], ['disabled', 'hovered']]
+
+// Metas set args freely: values the prop axis offers as well, and bare `undefined`
+// to put a row in the controls table without choosing a value for it.
+const argSets: Meta['args'][] = [
+  undefined,
+  {},
+  { checked: false, disabled: false, invalid: false },
+  { color: 'inverse', heading: HEADING_SAMPLE, iconOnly: true, variant: 'secondary' },
+  { checked: undefined, color: undefined, variant: undefined },
+]
+
+describe('buildVariantMatrix', () => {
+  it('renders no two identical configurations, whatever the arg types and args hold', () => {
+    const offenders: string[] = []
+
+    // Every subset of the prop shapes, against every state axis and every set of args.
+    for (let subset = 0; subset < 2 ** propShapes.length; subset += 1) {
+      const types = argTypes(propShapes.filter((_shape, index) => subset & (1 << index)))
+
+      for (const variants of stateAxes) {
+        for (const args of argSets) {
+          const duplicates = duplicatesIn(renderedKeys(types, variants, args))
+
+          if (duplicates.length > 0) {
+            offenders.push(
+              `[${Object.keys(types).join(', ')}] × [${variants.join(', ')}] × ${JSON.stringify(args)}: ${duplicates[0]}`,
+            )
+          }
+        }
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  it('leaves out a value the story’s own args already show', () => {
+    const types = argTypes([enumProp('variant', ['primary', 'secondary', 'tertiary'], 'primary')])
+    const matrix = buildVariantMatrix(types, { args: { variant: 'secondary' } })
+
+    // The baseline shows secondary, so the prop axis shows the other two — primary included.
+    expect(matrix.map(({ variant }) => variant)).toEqual([undefined, 'primary', 'tertiary'])
+  })
+
+  it('falls back to the declared default for an arg a meta spells out as undefined', () => {
+    const types = argTypes([
+      argType({ name: 'markers', table: { defaultValue: { summary: 'true' } }, type: { name: 'boolean' } }),
+    ])
+    const matrix = buildVariantMatrix(types, { args: { markers: undefined } })
+
+    // Passing no value leaves the component on its default of true, which the baseline shows.
+    expect(matrix.map(({ variant }) => variant)).toEqual([undefined, false])
+  })
+
+  it('opens every state with the baseline, exactly once', () => {
+    const matrix = buildVariantMatrix(argTypes([booleanProp('invalid')]), { variants: ['disabled', 'hovered'] })
+
+    expect(matrix.filter(({ propName }) => !propName)).toEqual([
+      { hasIcon: null, size: undefined, state: 'default' },
+      { hasIcon: null, size: undefined, state: 'disabled' },
+      { hasIcon: null, size: undefined, state: 'hovered' },
+    ])
+  })
+
+  it('keeps a prop the props builder derives off the prop axis', () => {
+    const matrix = buildVariantMatrix(
+      argTypes([argType({ name: 'accessibleName', type: { name: 'string' } }), booleanProp('invalid')]),
+    )
+
+    expect(matrix.map(({ propName }) => propName)).toEqual([undefined, 'invalid'])
+  })
+
+  it('keeps a prop that is also a state off the prop axis', () => {
+    const matrix = buildVariantMatrix(argTypes([booleanProp('checked'), booleanProp('disabled')]), {
+      variants: ['disabled'],
+    })
+
+    expect(matrix.map(({ propName }) => propName)).toEqual([undefined, 'checked', undefined, 'checked'])
+  })
+
+  it('crosses the states that have tokens of their own, such as disabled and checked', () => {
+    const matrix = buildVariantMatrix(argTypes([booleanProp('checked'), booleanProp('disabled')]), {
+      variants: ['disabled'],
+    })
+
+    expect(matrix).toContainEqual({
+      hasIcon: null,
+      propName: 'checked',
+      size: undefined,
+      state: 'disabled',
+      variant: true,
+    })
+  })
+
+  it('leaves a value equal to the default out, the baseline having shown it', () => {
+    const matrix = buildVariantMatrix(argTypes([enumProp('variant', ['primary', 'secondary', 'tertiary'], 'primary')]))
+
+    expect(matrix.map(({ variant }) => variant)).toEqual([undefined, 'secondary', 'tertiary'])
+  })
+
+  it('drops the false value of a boolean prop, which is its default', () => {
+    const matrix = buildVariantMatrix(argTypes([booleanProp('invalid')]))
+
+    expect(matrix.map(({ variant }) => variant)).toEqual([undefined, true])
+  })
+
+  it('keeps a value that merely shares a name with the default of another prop', () => {
+    const matrix = buildVariantMatrix(
+      argTypes([argType({ name: 'icon', table: { defaultValue: { summary: 'CheckboxIcon' } } })]),
+    )
+
+    expect(matrix.map(({ variant }) => variant)).toEqual([undefined, ChevronDownIcon])
+  })
+
+  it('crosses every state with every size', () => {
+    const matrix = buildVariantMatrix(argTypes([enumProp(SIZE_PROP_NAME, ['large', 'small'])]), {
+      variants: ['disabled'],
+    })
+
+    expect(matrix.map(({ size, state }) => `${state}/${size}`)).toEqual([
+      'default/large',
+      'default/small',
+      'disabled/large',
+      'disabled/small',
+    ])
+  })
+
+  it('yields one baseline per state for a component with nothing to vary', () => {
+    expect(buildVariantMatrix({} as StrictArgTypes, { variants: ['disabled'] })).toEqual([
+      { hasIcon: null, size: undefined, state: 'default' },
+      { hasIcon: null, size: undefined, state: 'disabled' },
+    ])
+  })
+})

--- a/storybook/src/_common/buildVariantMatrix.ts
+++ b/storybook/src/_common/buildVariantMatrix.ts
@@ -7,6 +7,7 @@ import type { StrictArgTypes } from 'storybook/internal/csf'
 
 import type {
   BuildVariantMatrixParams,
+  CellState,
   PropWithValues,
   VariantMatrixEntry,
   VariantValue,
@@ -65,7 +66,9 @@ export const buildVariantMatrix = (
   const baselineValueOf = ({ defaultValue, name }: PropWithValues): VariantValue | undefined =>
     (args?.[name] as VariantValue | undefined) ?? defaultValue
 
-  return ['default', ...variants].flatMap((state) =>
+  const states: CellState[] = ['default', ...variants]
+
+  return states.flatMap((state) =>
     sizes.flatMap((size) => [
       { hasIcon: null, size, state },
       ...matrixProps.flatMap((prop) =>

--- a/storybook/src/_common/buildVariantMatrix.ts
+++ b/storybook/src/_common/buildVariantMatrix.ts
@@ -1,0 +1,78 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { StrictArgTypes } from 'storybook/internal/csf'
+
+import type {
+  BuildVariantMatrixParams,
+  PropWithValues,
+  VariantMatrixEntry,
+  VariantValue,
+} from './renderComponentVariantTypes'
+
+import { DERIVED_PROP_NAMES } from './buildComponentProps'
+import { extractVariantsFromArgTypes } from './extractVariantsFromArgTypes'
+
+/** The prop that drives the size axis, rather than a row of its own on the prop axis. */
+export const SIZE_PROP_NAME = 'size'
+
+const sizesOf = (propsWithValues: PropWithValues[]): (string | undefined)[] => {
+  const sizeProp = propsWithValues.find((prop) => prop.name === SIZE_PROP_NAME)
+
+  if (!sizeProp || sizeProp.values.length === 0) {
+    return [undefined]
+  }
+
+  // Every size the component doesn’t name in words comes down to the same rendering: its own default.
+  return [...new Set(sizeProp.values.map((value) => (typeof value === 'string' ? value : undefined)))]
+}
+
+/**
+ * Lays out the matrix of component instances a test story renders for Chromatic:
+ * every prop value the arg types offer, in every size, in every state.
+ *
+ * Each axis has exactly one job, so that no two cells describe the same component:
+ *
+ * • The state axis carries the modifiers a story asks for through `variants`,
+ *   being `disabled` and `hovered`. A prop that is also a state therefore leaves
+ *   the prop axis: `disabled` would otherwise vary against the state that already
+ *   sets it, rendering both values twice over.
+ * • The prop axis carries every other prop, bar the ones the props builder derives
+ *   from the cell, and shows only the values the baseline doesn’t already show.
+ * • Each state opens with the baseline, so the component as a story’s own args
+ *   leave it is snapshotted once per state rather than once per prop.
+ *
+ * The crosses that matter survive: `disabled` still meets `checked` and
+ * `indeterminate`, which have disabled fills of their own, and an enum still shows
+ * its non-default members in every state.
+ */
+export const buildVariantMatrix = (
+  argTypes: StrictArgTypes,
+  { args, variants = [] }: BuildVariantMatrixParams = {},
+): VariantMatrixEntry[] => {
+  const propsWithValues = extractVariantsFromArgTypes(argTypes)
+  const sizes = sizesOf(propsWithValues)
+  const matrixProps = propsWithValues.filter(
+    ({ name }) =>
+      name !== SIZE_PROP_NAME && !DERIVED_PROP_NAMES.includes(name) && !variants.some((variant) => variant === name),
+  )
+
+  // What the baseline cell already shows for a prop: the story’s own arg where it holds
+  // a value, and the value the arg types declare where it doesn’t. A meta that spells out
+  // `markers: undefined` leaves the choice to the component, so the default still stands.
+  const baselineValueOf = ({ defaultValue, name }: PropWithValues): VariantValue | undefined =>
+    (args?.[name] as VariantValue | undefined) ?? defaultValue
+
+  return ['default', ...variants].flatMap((state) =>
+    sizes.flatMap((size) => [
+      { hasIcon: null, size, state },
+      ...matrixProps.flatMap((prop) =>
+        prop.values
+          .filter((value) => value !== baselineValueOf(prop))
+          .map((variant) => ({ hasIcon: prop.hasIcon, propName: prop.name, size, state, variant })),
+      ),
+    ]),
+  )
+}

--- a/storybook/src/_common/extractVariantsFromArgTypes.test.ts
+++ b/storybook/src/_common/extractVariantsFromArgTypes.test.ts
@@ -26,10 +26,48 @@ describe('extractVariantsFromArgTypes', () => {
     expect(result).toEqual([{ hasIcon: null, name: 'variant', values: ['primary', 'secondary'] }])
   })
 
-  it('expands a boolean prop to [true, false]', () => {
+  it('expands a boolean prop to [true, false], defaulting to false', () => {
     const result = extractVariantsFromArgTypes(argTypes([argType({ name: 'disabled', type: { name: 'boolean' } })]))
 
-    expect(result).toEqual([{ hasIcon: null, name: 'disabled', values: [true, false] }])
+    expect(result).toEqual([{ defaultValue: false, hasIcon: null, name: 'disabled', values: [true, false] }])
+  })
+
+  it('reads the declared default of a boolean prop over the false fallback', () => {
+    const result = extractVariantsFromArgTypes(
+      argTypes([
+        argType({ name: 'expanded', table: { defaultValue: { summary: 'true' } }, type: { name: 'boolean' } }),
+      ]),
+    )
+
+    expect(result[0]?.defaultValue).toBe(true)
+  })
+
+  it('reads the declared default of an enum prop', () => {
+    const result = extractVariantsFromArgTypes(
+      argTypes([
+        argType({
+          name: 'variant',
+          table: { defaultValue: { summary: 'primary' } },
+          type: { name: 'enum', value: ['primary', 'secondary'] },
+        }),
+      ]),
+    )
+
+    expect(result[0]?.defaultValue).toBe('primary')
+  })
+
+  it('strips the quotes docgen may put around a default value', () => {
+    const result = extractVariantsFromArgTypes(
+      argTypes([argType({ name: 'variant', table: { defaultValue: { summary: "'primary'" } } })]),
+    )
+
+    expect(result[0]?.defaultValue).toBe('primary')
+  })
+
+  it('leaves a prop that declares no default and is not a boolean without one', () => {
+    const result = extractVariantsFromArgTypes(argTypes([argType({ name: 'label', type: { name: 'string' } })]))
+
+    expect(result[0]?.defaultValue).toBeUndefined()
   })
 
   it('substitutes the number fixture for a number prop', () => {

--- a/storybook/src/_common/extractVariantsFromArgTypes.ts
+++ b/storybook/src/_common/extractVariantsFromArgTypes.ts
@@ -25,8 +25,31 @@ const valuesFromType = (argType: StrictInputType): VariantValue[] | undefined =>
 }
 
 /**
+ * The value a prop falls back to when a story doesn’t set it, so the matrix can
+ * leave that value out: the baseline instance already shows it.
+ *
+ * The docgen analyzer reports the default as a display string — the source text of
+ * the destructured default, so `'primary'` arrives as `primary` and `CheckboxIcon`
+ * as the identifier. Booleans rarely declare one, since a component reads them
+ * straight from the rest props; an absent boolean is `false`.
+ */
+const defaultValueOf = (argType: StrictInputType): VariantValue | undefined => {
+  const summary = argType.table?.defaultValue?.summary
+
+  if (summary === undefined) {
+    return argType.type?.name === 'boolean' ? false : undefined
+  }
+
+  const unquoted = summary.replace(/^(['"])(.*)\1$/, '$2')
+
+  if (unquoted === 'true' || unquoted === 'false') return unquoted === 'true'
+
+  return unquoted
+}
+
+/**
  * Pure parser: turns Storybook's normalized argTypes into the
- * { name, values, hasIcon } shape consumed by renderComponentVariants.
+ * { name, values, hasIcon, defaultValue } shape consumed by buildVariantMatrix.
  *
  * Props disabled in the controls table (e.g. children, className, style)
  * are skipped — they're noise in the visual matrix. `children` is also
@@ -40,8 +63,9 @@ export const extractVariantsFromArgTypes = (argTypes: StrictArgTypes): PropWithV
     .filter(isMatrixProp)
     .sort((a, b) => a.name.localeCompare(b.name))
     .map((argType) => {
+      const defaultValue = defaultValueOf(argType)
       const fixture = fixtureValuesFor(argType)
-      if (fixture) return { ...fixture, name: argType.name }
+      if (fixture) return { ...fixture, defaultValue, name: argType.name }
 
-      return { hasIcon: null, name: argType.name, values: valuesFromType(argType) ?? [] }
+      return { defaultValue, hasIcon: null, name: argType.name, values: valuesFromType(argType) ?? [] }
     })

--- a/storybook/src/_common/renderComponentVariantTypes.ts
+++ b/storybook/src/_common/renderComponentVariantTypes.ts
@@ -8,16 +8,44 @@ import type { Meta } from '@storybook/react-vite'
 
 export type VariantValue = string | number | boolean | IconProps['svg']
 
+/**
+ * The modifiers the matrix can put on its state axis. Closed on purpose: each one
+ * needs buildComponentProps to apply it, and a prop named here leaves the prop axis,
+ * so a name the props builder ignores would drop that prop from the matrix instead
+ * of varying it.
+ */
+export type VariantState = 'disabled' | 'hovered'
+
 export type PropWithValues = {
+  /** The value the prop takes when a story leaves it out, as far as the arg types declare one. */
+  defaultValue: VariantValue | undefined
   hasIcon: { icon: IconProps['svg'] } | null
   name: string
   values: VariantValue[]
 }
 
+/**
+ * One cell of the variant matrix, holding everything that sets a single component
+ * instance apart from the others. A cell without a `propName` is the baseline: the
+ * component as the story’s own args leave it, with no prop varied.
+ */
+export type VariantMatrixEntry = {
+  hasIcon: { icon: IconProps['svg'] } | null
+  propName?: string
+  size: string | undefined
+  state: string
+  variant?: VariantValue
+}
+
 export type renderComponentVariantsParams = {
   args: Meta['args']
   layout?: 'flex' | 'grid'
-  variants?: string[]
+  variants?: VariantState[]
+}
+
+export type BuildVariantMatrixParams = {
+  args?: Meta['args']
+  variants?: VariantState[]
 }
 
 export type BuildComponentPropsParams = {
@@ -25,9 +53,9 @@ export type BuildComponentPropsParams = {
   acceptsAccessibleNameId?: boolean
   args: Meta['args']
   hasIcon?: { icon: IconProps['svg'] } | null
-  propName: string
+  propName?: string
   size?: string | undefined
   sizePropName: string
   state: string
-  variant: VariantValue
+  variant?: VariantValue
 }

--- a/storybook/src/_common/renderComponentVariantTypes.ts
+++ b/storybook/src/_common/renderComponentVariantTypes.ts
@@ -16,6 +16,9 @@ export type VariantValue = string | number | boolean | IconProps['svg']
  */
 export type VariantState = 'disabled' | 'hovered'
 
+/** The state a cell renders in: the component as it stands, or under one modifier. */
+export type CellState = 'default' | VariantState
+
 export type PropWithValues = {
   /** The value the prop takes when a story leaves it out, as far as the arg types declare one. */
   defaultValue: VariantValue | undefined
@@ -33,7 +36,7 @@ export type VariantMatrixEntry = {
   hasIcon: { icon: IconProps['svg'] } | null
   propName?: string
   size: string | undefined
-  state: string
+  state: CellState
   variant?: VariantValue
 }
 
@@ -56,6 +59,6 @@ export type BuildComponentPropsParams = {
   propName?: string
   size?: string | undefined
   sizePropName: string
-  state: string
+  state: CellState
   variant?: VariantValue
 }

--- a/storybook/src/_common/renderComponentVariants.tsx
+++ b/storybook/src/_common/renderComponentVariants.tsx
@@ -4,106 +4,60 @@
  */
 
 import type { StoryContext } from '@storybook/react-vite'
-import type { ElementType } from 'react'
+import type { CSSProperties, ElementType } from 'react'
 
 import { createElement } from 'react'
 
-import type { PropWithValues, renderComponentVariantsParams, VariantValue } from './renderComponentVariantTypes'
+import type { renderComponentVariantsParams } from './renderComponentVariantTypes'
 
-import { buildComponentProps } from './buildComponentProps'
-import { extractVariantsFromArgTypes } from './extractVariantsFromArgTypes'
+import { buildComponentProps, variantKeyFor } from './buildComponentProps'
+import { buildVariantMatrix, SIZE_PROP_NAME } from './buildVariantMatrix'
 
-const extractSize = (propsWithValues: PropWithValues[]): { propName: string; values: (string | undefined)[] } => {
-  const sizeProp = propsWithValues.find((prop) => prop.name === 'size')
-  if (!sizeProp || sizeProp.values.length === 0) {
-    return { propName: 'size', values: [undefined] }
-  }
-  return {
-    propName: 'size',
-    values: sizeProp.values.map((value) => (typeof value === 'string' ? value : undefined)),
-  }
+const gridCell: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
+  minHeight: '100px',
 }
 
+const propAxisRow: CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: 'var(--ams-space-l)' }
+
 /**
- * Renders all combinations of a component's prop values × variant states
- * (hovered, disabled, ...). Used by *.test.stories.tsx for Chromatic
- * visual diffing.
+ * Renders a component in every configuration worth a snapshot: its prop values in
+ * every size, in every state (hovered, disabled, ...). Used by *.test.stories.tsx
+ * for Chromatic visual diffing.
  *
  * Prop values come from `context.argTypes` — Storybook's normalized
  * manifest, populated by whichever docgen analyzer is configured.
+ * buildVariantMatrix turns those into the cells to render, and owns which
+ * combinations those are. A component with nothing to vary yields its states
+ * alone, which stack instead of flowing in a row because each takes the full width.
  */
 export const renderComponentVariants = (
   component: ElementType,
   { args, layout = 'flex', variants = [] }: renderComponentVariantsParams,
   context: StoryContext,
 ) => {
-  const propsWithValues = extractVariantsFromArgTypes(context.argTypes)
-  const allVariants = [...variants, 'default']
-  const sizes = extractSize(propsWithValues)
+  const matrix = buildVariantMatrix(context.argTypes, { args, variants })
   const acceptsAccessibleName = 'accessibleName' in context.argTypes
   const acceptsAccessibleNameId = 'accessibleNameId' in context.argTypes
-
-  if (propsWithValues.length === 0) {
-    return (
-      <div>
-        {allVariants.map((state) => (
-          <div key={state}>
-            {createElement(component, {
-              ...args,
-              ...(state === 'disabled' ? { disabled: true } : {}),
-              ...(acceptsAccessibleName && { accessibleName: state }),
-              ...(acceptsAccessibleNameId && { accessibleNameId: `variant-${state}` }),
-              className: state === 'hovered' ? 'hover' : undefined,
-            })}
-          </div>
-        ))}
-      </div>
-    )
-  }
+  const hasPropAxis = matrix.some(({ propName }) => propName)
 
   return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--ams-space-l)' }}>
-      {propsWithValues
-        .filter(({ name }) => name !== sizes.propName)
-        .flatMap(({ hasIcon, name, values }) =>
-          sizes.values.flatMap((size) =>
-            allVariants.flatMap((state) =>
-              values.map((variant: VariantValue) => {
-                const key = `${size ?? 'none'}-${name}-${String(variant)}-${state}`
-
-                return (
-                  <div
-                    key={key}
-                    style={
-                      layout === 'flex'
-                        ? undefined
-                        : {
-                            display: 'grid',
-                            gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
-                            minHeight: '100px',
-                          }
-                    }
-                  >
-                    {createElement(
-                      component,
-                      buildComponentProps({
-                        acceptsAccessibleName,
-                        acceptsAccessibleNameId,
-                        args,
-                        hasIcon,
-                        propName: name,
-                        size,
-                        sizePropName: sizes.propName,
-                        state,
-                        variant,
-                      }),
-                    )}
-                  </div>
-                )
-              }),
-            ),
-          ),
-        )}
+    <div style={hasPropAxis ? propAxisRow : undefined}>
+      {matrix.map((entry) => (
+        <div key={variantKeyFor(entry)} style={layout === 'flex' ? undefined : gridCell}>
+          {createElement(
+            component,
+            buildComponentProps({
+              ...entry,
+              acceptsAccessibleName,
+              acceptsAccessibleNameId,
+              args,
+              sizePropName: SIZE_PROP_NAME,
+            }),
+          )}
+        </div>
+      ))}
     </div>
   )
 }

--- a/storybook/src/_common/variantFixtures.ts
+++ b/storybook/src/_common/variantFixtures.ts
@@ -9,13 +9,16 @@ import { ChevronDownIcon } from '@amsterdam/design-system-react-icons'
 
 import type { PropWithValues, VariantValue } from './renderComponentVariantTypes'
 
+/** A fixture supplies the values to render, never the default: that comes from the arg types. */
+type PropFixture = Omit<PropWithValues, 'defaultValue' | 'name'>
+
 const hasIconFixture = { icon: ChevronDownIcon }
 
 export const HEADING_SAMPLE = 'Gemeente Amsterdam'
 export const STRING_SAMPLE = 'Heldhaftig, vastberaden, barmhartig'
 export const NUMBER_SAMPLE = 20
 
-const byPropName: Record<string, Omit<PropWithValues, 'name'>> = {
+const byPropName: Record<string, PropFixture> = {
   color: {
     hasIcon: null,
     values: ['default'],
@@ -46,12 +49,12 @@ const byPropName: Record<string, Omit<PropWithValues, 'name'>> = {
   },
 }
 
-const mergeEnumWithFixture = (fixture: Omit<PropWithValues, 'name'>, enumValues: VariantValue[]) => ({
+const mergeEnumWithFixture = (fixture: PropFixture, enumValues: VariantValue[]) => ({
   hasIcon: fixture.hasIcon,
   values: [...new Set([...enumValues, ...fixture.values])].sort(),
 })
 
-const primitiveFixture = (scalarName: string): Omit<PropWithValues, 'name'> | undefined => {
+const primitiveFixture = (scalarName: string): PropFixture | undefined => {
   if (scalarName === 'number') return { hasIcon: null, values: [NUMBER_SAMPLE] }
   if (scalarName === 'string') return { hasIcon: null, values: [STRING_SAMPLE] }
   return undefined
@@ -72,7 +75,7 @@ const primitiveFixture = (scalarName: string): Omit<PropWithValues, 'name'> | un
  *     Pattern-match the raw string to recover the same behaviour the old
  *     `__docgenInfo`-based parser had.
  */
-export const fixtureValuesFor = (argType: StrictInputType): Omit<PropWithValues, 'name'> | undefined => {
+export const fixtureValuesFor = (argType: StrictInputType): PropFixture | undefined => {
   const fixture = byPropName[argType.name]
 
   if (fixture) {

--- a/storybook/src/components/Accordion/Accordion.test.stories.tsx
+++ b/storybook/src/components/Accordion/Accordion.test.stories.tsx
@@ -50,6 +50,10 @@ export const Test: Story = {
       </Accordion.Section>,
     ],
   },
+  parameters: {
+    // The matrix shows heading levels side by side, not as a document outline.
+    a11y: { config: { rules: [{ enabled: false, id: 'heading-order' }] } },
+  },
   play: async ({ canvas, userEvent }) => {
     const accordionLabel = canvas.getByTestId('test-label')
     const accordionParagraph = canvas.getByTestId('test-paragraph')

--- a/storybook/src/components/Alert/Alert.test.stories.tsx
+++ b/storybook/src/components/Alert/Alert.test.stories.tsx
@@ -21,6 +21,10 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
+  parameters: {
+    // The matrix shows heading levels side by side, not as a document outline.
+    a11y: { config: { rules: [{ enabled: false, id: 'heading-order' }] } },
+  },
   render: (args, context) => renderComponentVariants(Alert, { args }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/components/FileInput/FileInput.test.stories.tsx
+++ b/storybook/src/components/FileInput/FileInput.test.stories.tsx
@@ -21,6 +21,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
-  render: (args, context) => renderComponentVariants(FileInput, { args, variants: ['disabled', 'multiple'] }, context),
+  // `multiple` belongs on the prop axis: only `disabled` and `hovered` are states the matrix applies.
+  render: (args, context) => renderComponentVariants(FileInput, { args, variants: ['disabled'] }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/components/InvalidFormAlert/InvalidFormAlert.test.stories.tsx
+++ b/storybook/src/components/InvalidFormAlert/InvalidFormAlert.test.stories.tsx
@@ -21,6 +21,10 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
+  parameters: {
+    // The matrix shows heading levels side by side, not as a document outline.
+    a11y: { config: { rules: [{ enabled: false, id: 'heading-order' }] } },
+  },
   render: (args, context) => renderComponentVariants(InvalidFormAlert, { args }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/components/Tabs/Tabs.test.stories.tsx
+++ b/storybook/src/components/Tabs/Tabs.test.stories.tsx
@@ -63,13 +63,15 @@ export const Test: Story = {
   play: async ({ canvas, userEvent }) => {
     await new Promise((resolve) => setTimeout(resolve, 500)) // This delay is required to finish the first tab opening
 
-    const gegevensParagraph = canvas.getByTestId('gegevens-panel')
-    const aanslagenTab = canvas.getByTestId('aanslagen')
+    // The matrix renders these children once per configuration, so every test id repeats.
+    // Take the first of each, which keeps the interaction within one set of tabs.
+    const [gegevensParagraph] = canvas.getAllByTestId('gegevens-panel')
+    const [aanslagenTab] = canvas.getAllByTestId('aanslagen')
 
     await expect(gegevensParagraph).toBeVisible()
     await userEvent.click(aanslagenTab)
     await new Promise((resolve) => setTimeout(resolve, 500)) // This delay is required to finish the second tab opening
-    await expect(canvas.getByTestId('aanslagen-panel')).toBeVisible()
+    await expect(canvas.getAllByTestId('aanslagen-panel')[0]).toBeVisible()
     await expect(gegevensParagraph).not.toBeVisible()
   },
   render: (args, context) => renderComponentVariants(Tabs, { args }, context),


### PR DESCRIPTION
# Render no duplicate configurations in the test story matrix

## Links

- [This branch’s deploy](https://designsystem.amsterdam/)
- The change is not browsable in the deploy: the test stories are tagged `!dev`, so the Chromatic build is where it is visible.
- Follows #2891, which grew the Field Set matrix, and #2892, which took the args that carry a default out of the metas.

## What

`renderComponentVariants` no longer renders the same component configuration twice. Across the 48 test stories that use it, the matrix goes from **572 cells to 483**, and where the 572 held 498 distinct configurations, the 483 hold 483.

Nineteen stories shrink, fourteen grow by a cell or two because they gain a baseline they never snapshotted, and fifteen were already minimal. The biggest movers:

| Story | Before | After |
| --- | --- | --- |
| Icon Button | 126 | 105 |
| Text Input | 27 | 18 |
| Field Set | 24 | 14 |
| Button, Text Area | 24 | 18 |
| Checkbox | 18 | 10 |
| Radio | 14 | 8 |
| Date Input, Select, Time Input | 12 | 6 |
| File Input | 12 | 4 |
| Password Input | 8 | 4 |

## Why

The matrix varied one prop at a time against every state, which rendered the same component twice over in two ways.

A prop that is also a state sat on both axes. `disabled` is the case that mattered: its row rendered `true, false, true, false`, four snapshots for two configurations, both of which other cells already covered.

And the default value of a prop renders the component’s baseline appearance, so every boolean row re-rendered what the row beside it had already shown. Chromatic paid for all of it on every run.

## How

Each axis now has one job. The state axis owns the modifiers a story asks for, and a prop named there leaves the prop axis. The prop axis shows only the values the baseline does not already show, judged against the story’s own arg where it holds one and the declared default where it does not. Each state opens with the baseline once, rather than arriving at it again through every boolean.

The crosses that matter are all still there. `disabled` meets `checked` and `indeterminate`, which have disabled fills of their own in `--ams-checkbox-rectangle-checked-disabled-fill` and `--ams-checkbox-rectangle-indeterminate-disabled-fill`, and nothing else snapshots those. An enum still shows its non-default members in every state, so Button covers primary, secondary and tertiary as before.

The matrix used to be computed inline in the JSX, where nothing could assert anything about it. It now lives in `buildVariantMatrix`, a pure function over the arg types, which `renderComponentVariants` maps over. A test sweeps every subset of the prop shapes a story can have against every state axis and every set of args, and checks that no two cells hand the component the same props. Reverting any one of the rules that keep the matrix minimal makes the suite fail.

The Test stories section of `documentation/storybook.md` credited argTypes alone for the matrix; it now names the args as well, since the prop axis compares each value against what the baseline already shows.

`variants` is typed to the states the props builder implements, being `disabled` and `hovered`, so a prop can no longer be listed as a state by mistake. File Input did exactly that with `multiple`: the state applied nothing, so the value never rendered, and the prop axis would have dropped it as well. It goes back on the prop axis, where `disabled` still crosses it.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

**Every baseline needs re-accepting, in one go.** This changes the snapshot of all 48 test stories that use the helper, so every component, utility and mode baseline will come back changed. The diff is expected and it is large: cells are removed, and the cells that remain are reordered, because the matrix now groups by state rather than by prop. There is no subset of stories to review in isolation.

The figures above were measured on the tip of `develop`. An earlier count of 558 cells and 486 distinct configurations was taken before #2891 landed, which grew the Field Set matrix from 10 cells to 24; 558 + 14 = 572 reconciles the two.

Both totals were verified against the rendered DOM rather than predicted: serving the built Storybook and counting the instances each test story renders gives 483, matching the function cell for cell across all 48 stories.
