### PR TITLE
chore(Storybook): Disable the page-level axe checks that test stories break

### DIFF
--- a/documentation/storybook.md
+++ b/documentation/storybook.md
@@ -169,8 +169,13 @@ The matrix holds each configuration once: it opens every state with the componen
 A `play` function has to allow for that matrix rendering the component more than once, since `args.children` repeat with it: a query for a single element throws where a test id or a role occurs once per configuration.
 Either take the first match, as Tabs and Image Slider do, or give the interaction its own instance outside the matrix, as Accordion does.
 
-The same goes for axe’s `heading-order` rule, which describes a document outline where the matrix shows heading levels side by side and leaves out the level the baseline already shows.
-A test story whose component takes a heading level therefore disables that rule, and only that rule: checks that hold per component, such as colour contrast, stay on.
+Some axe rules check a whole page rather than a single component, and the matrix breaks those on purpose.
+`heading-order` wants headings to form an outline, but the matrix shows all levels side by side.
+`label` and `select-name` want every form control to have a label, but the matrix shows the bare control.
+`landmark-unique` wants a landmark to appear once, but the matrix repeats it for every configuration.
+When a test story fails such a rule, disable that rule alone with `disablePageLevelChecks`.
+Rules that pass stay on, and the helper only accepts these four ids, so a component check such as colour contrast cannot be disabled by mistake.
+Presentation stories and page templates keep all rules, because they show how components should be used.
 
 CSS utilities under `Utilities/` have test stories as well, but cannot use `renderComponentVariants`.
 The component next to each utility is a mock that renders a bare element; the utility class comes from the story’s `render`, so a generated matrix would show elements without the class on them.

--- a/storybook/src/_common/disablePageLevelChecks.test.ts
+++ b/storybook/src/_common/disablePageLevelChecks.test.ts
@@ -1,0 +1,23 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { disablePageLevelChecks } from './disablePageLevelChecks'
+
+describe('disablePageLevelChecks', () => {
+  it('disables the named rules and nothing else', () => {
+    expect(disablePageLevelChecks('label', 'select-name')).toEqual({
+      a11y: {
+        config: {
+          rules: [
+            { enabled: false, id: 'label' },
+            { enabled: false, id: 'select-name' },
+          ],
+        },
+      },
+    })
+  })
+})

--- a/storybook/src/_common/disablePageLevelChecks.ts
+++ b/storybook/src/_common/disablePageLevelChecks.ts
@@ -1,0 +1,21 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+/**
+ * The axe rules that describe the page a story pretends to be, not the component
+ * itself. The closed list is the point: a component-level check, such as colour
+ * contrast, cannot be disabled through this helper.
+ */
+type PageLevelRuleId = 'heading-order' | 'label' | 'landmark-unique' | 'select-name'
+
+/**
+ * Story parameters that turn off the named page-level axe checks, and only those.
+ * For test stories whose matrix of bare component instances breaks a rule that
+ * documented usage satisfies — see the Test stories section of the Storybook
+ * documentation for which rule fails where, and why.
+ */
+export const disablePageLevelChecks = (...ids: [PageLevelRuleId, ...PageLevelRuleId[]]) => ({
+  a11y: { config: { rules: ids.map((id) => ({ enabled: false, id })) } },
+})

--- a/storybook/src/components/Accordion/Accordion.test.stories.tsx
+++ b/storybook/src/components/Accordion/Accordion.test.stories.tsx
@@ -8,6 +8,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { Accordion } from '@amsterdam/design-system-react/src'
 import { expect } from 'storybook/test'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as accordionMeta } from './Accordion.stories'
@@ -50,10 +51,7 @@ export const Test: Story = {
       </Accordion.Section>,
     ],
   },
-  parameters: {
-    // The matrix shows heading levels side by side, not as a document outline.
-    a11y: { config: { rules: [{ enabled: false, id: 'heading-order' }] } },
-  },
+  parameters: disablePageLevelChecks('heading-order'),
   play: async ({ canvas, userEvent }) => {
     const accordionLabel = canvas.getByTestId('test-label')
     const accordionParagraph = canvas.getByTestId('test-paragraph')

--- a/storybook/src/components/Alert/Alert.test.stories.tsx
+++ b/storybook/src/components/Alert/Alert.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Alert } from '@amsterdam/design-system-react/src'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as alertMeta } from './Alert.stories'
@@ -21,10 +22,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
-  parameters: {
-    // The matrix shows heading levels side by side, not as a document outline.
-    a11y: { config: { rules: [{ enabled: false, id: 'heading-order' }] } },
-  },
+  parameters: disablePageLevelChecks('heading-order', 'landmark-unique'),
   render: (args, context) => renderComponentVariants(Alert, { args }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/components/DateInput/DateInput.test.stories.tsx
+++ b/storybook/src/components/DateInput/DateInput.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { DateInput } from '@amsterdam/design-system-react/src'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as dateInputMeta } from './DateInput.stories'
@@ -21,6 +22,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
+  parameters: disablePageLevelChecks('label'),
   render: (args, context) => renderComponentVariants(DateInput, { args, variants: ['disabled'] }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/components/FileInput/FileInput.test.stories.tsx
+++ b/storybook/src/components/FileInput/FileInput.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { FileInput } from '@amsterdam/design-system-react/src'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as fileInputMeta } from './FileInput.stories'
@@ -21,6 +22,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
+  parameters: disablePageLevelChecks('label'),
   // `multiple` belongs on the prop axis: only `disabled` and `hovered` are states the matrix applies.
   render: (args, context) => renderComponentVariants(FileInput, { args, variants: ['disabled'] }, context),
   tags: ['!dev', '!autodocs', '!manifest'],

--- a/storybook/src/components/InvalidFormAlert/InvalidFormAlert.test.stories.tsx
+++ b/storybook/src/components/InvalidFormAlert/InvalidFormAlert.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { InvalidFormAlert } from '@amsterdam/design-system-react/src'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as invalidFormAlertMeta } from './InvalidFormAlert.stories'
@@ -21,10 +22,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
-  parameters: {
-    // The matrix shows heading levels side by side, not as a document outline.
-    a11y: { config: { rules: [{ enabled: false, id: 'heading-order' }] } },
-  },
+  parameters: disablePageLevelChecks('heading-order'),
   render: (args, context) => renderComponentVariants(InvalidFormAlert, { args }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/components/Pagination/Pagination.test.stories.tsx
+++ b/storybook/src/components/Pagination/Pagination.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Pagination } from '@amsterdam/design-system-react/src'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as paginationMeta } from './Pagination.stories'
@@ -21,6 +22,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
+  parameters: disablePageLevelChecks('landmark-unique'),
   render: (args, context) => renderComponentVariants(Pagination, { args }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/components/PasswordInput/PasswordInput.test.stories.tsx
+++ b/storybook/src/components/PasswordInput/PasswordInput.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { PasswordInput } from '@amsterdam/design-system-react/src'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as passwordInputMeta } from './PasswordInput.stories'
@@ -21,6 +22,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
+  parameters: disablePageLevelChecks('label'),
   render: (args, context) => renderComponentVariants(PasswordInput, { args, variants: ['disabled'] }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/components/Select/Select.test.stories.tsx
+++ b/storybook/src/components/Select/Select.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Select } from '@amsterdam/design-system-react/src'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as selectMeta } from './Select.stories'
@@ -21,6 +22,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
+  parameters: disablePageLevelChecks('select-name'),
   render: (args, context) => renderComponentVariants(Select, { args, variants: ['hovered', 'disabled'] }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/components/Switch/Switch.test.stories.tsx
+++ b/storybook/src/components/Switch/Switch.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Switch } from '@amsterdam/design-system-react/src'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as switchMeta } from './Switch.stories'
@@ -21,6 +22,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
+  parameters: disablePageLevelChecks('label'),
   render: (args, context) => renderComponentVariants(Switch, { args }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/components/TextArea/TextArea.test.stories.tsx
+++ b/storybook/src/components/TextArea/TextArea.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { TextArea } from '@amsterdam/design-system-react/src'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as textAreaMeta } from './TextArea.stories'
@@ -25,6 +26,7 @@ export const Test: Story = {
     defaultValue:
       'Het waterrijke achterland van de provincie Holland was een paradijs voor vissers. Maar terwijl de visserij floreerde in Holland, was Amsterdam eigenlijk helemaal geen visserijstad. Toch maakten Amsterdammers naam in de vishandel. Zij speelden namelijk een cruciale rol bij het klaarmaken en vervoeren van haring.',
   },
+  parameters: disablePageLevelChecks('label'),
   render: (args, context) => renderComponentVariants(TextArea, { args, variants: ['disabled', 'hovered'] }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/components/TextInput/TextInput.test.stories.tsx
+++ b/storybook/src/components/TextInput/TextInput.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { TextInput } from '@amsterdam/design-system-react/src'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as textInputMeta } from './TextInput.stories'
@@ -21,6 +22,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
+  parameters: disablePageLevelChecks('label'),
   render: (args, context) => renderComponentVariants(TextInput, { args, variants: ['disabled', 'hovered'] }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/components/TimeInput/TimeInput.test.stories.tsx
+++ b/storybook/src/components/TimeInput/TimeInput.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { TimeInput } from '@amsterdam/design-system-react/src'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as timeInputMeta } from './TimeInput.stories'
@@ -21,6 +22,7 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
+  parameters: disablePageLevelChecks('label'),
   render: (args, context) => renderComponentVariants(TimeInput, { args, variants: ['disabled', 'hovered'] }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }


### PR DESCRIPTION
# Disable the page-level axe checks that test stories break

## Links

- [This branch’s deploy](https://designsystem.amsterdam/)
- The change is not visible in the deploy: it only affects the accessibility results of the Test stories, which show in Chromatic.
- Follows #2894, which introduced the first of these disables for `heading-order`.

## What

Test stories no longer report accessibility violations for rules they break on purpose. A new helper, `disablePageLevelChecks`, turns off a named axe rule for a single story, and the twelve test stories that fail such a rule use it: `label` on the seven bare form controls, `select-name` on Select, `landmark-unique` on Alert and Pagination, and `heading-order` on Accordion, Alert and Invalid Form Alert, migrated from the inline blocks #2894 added.

This takes the axe violations across all 48 test stories from 68 nodes to 1. The one that remains is real: the contrast of Avatar’s initials on the azure background is 3.01:1, which awaits the updated colour palette rather than a story change.

## Why

Some axe rules check a whole page rather than a single component, and the variant matrix breaks those by design. `heading-order` wants headings to form an outline, but the matrix shows all levels side by side. `label` and `select-name` want every form control to have a label, but the matrix shows the bare control, where documented usage adds a Label through a Field. `landmark-unique` wants a landmark to appear once, but the matrix repeats it for every configuration.

Leaving these as accepted flags in Chromatic has two costs. The flags come back whenever a matrix changes shape, since acceptance is tied to the result set, and the knowledge of which flags are fake lives outside the repository. Meanwhile the noise buries the signal: the one real finding above sat indistinguishable among 68 nodes. With the fake ones off, a flagged accessibility result means something again.

## How

The helper builds the story parameters the a11y addon and Chromatic both read: `parameters.a11y.config.rules` with `enabled: false` for the named rules. #2894’s Chromatic run confirmed end to end that Chromatic honours this. Its argument type is a closed union of exactly these four rule ids, so a component-level check, such as colour contrast, cannot be disabled through it — that is a type error.

Each story disables only the rules it fails today, so a page-level rule that passes stays armed and a new failure still surfaces. Presentation stories and page templates keep all rules, because they show how components should be used. The Test stories section of `documentation/storybook.md` explains which rule fails where, and why.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

There are no visual changes: story parameters do not render, and counting the rendered instances of all 48 test stories gives the same 483 cells before and after, matching per story. Only the accessibility results of the twelve stories come back changed in Chromatic, reporting fewer violations, and need accepting once.
