### PR TITLE
chore(Storybook): Remove the test stories' axe workarounds

### DIFF
--- a/storybook/src/_common/buildComponentProps.test.ts
+++ b/storybook/src/_common/buildComponentProps.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { BuildComponentPropsParams } from './renderComponentVariantTypes'
 
-import { buildComponentProps } from './buildComponentProps'
+import { buildComponentProps, variantKeyFor } from './buildComponentProps'
 
 const baseParams = {
   args: { label: 'Click' },
@@ -78,39 +78,19 @@ describe('buildComponentProps', () => {
     expect(result).toMatchObject({ icon: ChevronDownIcon, iconBefore: true })
   })
 
-  it('omits accessibleName and accessibleNameId when the flags are not set', () => {
-    const result = buildComponentProps(baseParams)
-    expect(result).not.toHaveProperty('accessibleName')
-    expect(result).not.toHaveProperty('accessibleNameId')
+  it('hands the component only the props of the cell', () => {
+    expect(Object.keys(buildComponentProps(baseParams)).sort()).toEqual(['className', 'color', 'label', 'size'])
   })
+})
 
-  it('injects a unique accessibleName derived from the variant when the flag is set', () => {
-    const result = buildComponentProps({ ...baseParams, acceptsAccessibleName: true })
-    expect(result).toMatchObject({ accessibleName: 'none-color-primary-default' })
-  })
-
-  it('injects a unique accessibleNameId derived from the variant when the flag is set', () => {
-    const result = buildComponentProps({ ...baseParams, acceptsAccessibleNameId: true })
-    expect(result).toMatchObject({ accessibleNameId: 'variant-none-color-primary-default' })
-  })
-
+describe('variantKeyFor', () => {
   it('names an icon variant by its component rather than stringifying its source', () => {
-    const result = buildComponentProps({
-      ...baseParams,
-      acceptsAccessibleName: true,
-      propName: 'icon',
-      variant: ChevronDownIcon,
-    })
-    expect(result).toMatchObject({ accessibleName: `none-icon-${ChevronDownIcon.name}-default` })
+    const key = variantKeyFor({ propName: 'icon', size: undefined, state: 'default', variant: ChevronDownIcon })
+    expect(key).toBe(`none-icon-${ChevronDownIcon.name}-default`)
   })
 
   it('names an icon variant passed as an element by its element type', () => {
-    const result = buildComponentProps({
-      ...baseParams,
-      acceptsAccessibleName: true,
-      propName: 'icon',
-      variant: createElement('svg'),
-    })
-    expect(result).toMatchObject({ accessibleName: 'none-icon-svg-default' })
+    const key = variantKeyFor({ propName: 'icon', size: undefined, state: 'default', variant: createElement('svg') })
+    expect(key).toBe('none-icon-svg-default')
   })
 })

--- a/storybook/src/_common/buildComponentProps.ts
+++ b/storybook/src/_common/buildComponentProps.ts
@@ -8,12 +8,6 @@ import { clsx } from 'clsx'
 import type { BuildComponentPropsParams, VariantMatrixEntry, VariantValue } from './renderComponentVariantTypes'
 
 /**
- * The props the matrix sets from the cell itself, whatever a story’s args hold.
- * Varying one on the prop axis shows nothing: the value below wins over it.
- */
-export const DERIVED_PROP_NAMES = ['accessibleName', 'accessibleNameId']
-
-/**
  * Names the value a cell varies, for the key below.
  *
  * An icon is a component or a React element, and stringifying either gives something
@@ -34,8 +28,8 @@ const nameOf = (variant: VariantValue | undefined): string => {
 }
 
 /**
- * Names a cell of the variant matrix, uniquely among its siblings. Serves as the
- * React key and as the accessible name for the components that take one.
+ * Names a cell of the variant matrix, uniquely among its siblings, to serve as its
+ * React key.
  */
 export const variantKeyFor = ({
   propName,
@@ -52,15 +46,8 @@ export const variantKeyFor = ({
  *
  * A cell without a `propName` is the baseline, which varies no prop at all and so
  * shows the component as the story's own args leave it, in this state and size.
- *
- * For components that render an ARIA landmark and expose `accessibleName`
- * / `accessibleNameId` props, a per-variant value is injected so each
- * landmark in the matrix has a unique accessible name and id. This avoids
- * axe's `landmark-unique` and duplicate-id violations in Chromatic.
  */
 export const buildComponentProps = ({
-  acceptsAccessibleName,
-  acceptsAccessibleNameId,
   args,
   hasIcon,
   propName,
@@ -68,20 +55,14 @@ export const buildComponentProps = ({
   sizePropName,
   state,
   variant,
-}: BuildComponentPropsParams) => {
-  const variantKey = variantKeyFor({ propName, size, state, variant })
-
-  return {
-    ...args,
-    ...(state === 'disabled' && { [state]: true }),
-    ...(hasIcon ?? {}),
-    ...(sizePropName && { [sizePropName]: size }),
-    className: clsx(
-      state === 'hovered' && 'hover',
-      typeof variant === 'string' && variant === 'inverse' && state !== 'disabled' && '_ams-page-background--dark',
-    ),
-    ...(propName && propName !== sizePropName && { [propName]: variant }),
-    ...(acceptsAccessibleName && { accessibleName: variantKey }),
-    ...(acceptsAccessibleNameId && { accessibleNameId: `variant-${variantKey}` }),
-  }
-}
+}: BuildComponentPropsParams) => ({
+  ...args,
+  ...(state === 'disabled' && { [state]: true }),
+  ...(hasIcon ?? {}),
+  ...(sizePropName && { [sizePropName]: size }),
+  className: clsx(
+    state === 'hovered' && 'hover',
+    typeof variant === 'string' && variant === 'inverse' && state !== 'disabled' && '_ams-page-background--dark',
+  ),
+  ...(propName && propName !== sizePropName && { [propName]: variant }),
+})

--- a/storybook/src/_common/buildVariantMatrix.test.ts
+++ b/storybook/src/_common/buildVariantMatrix.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { VariantState } from './renderComponentVariantTypes'
 
-import { buildComponentProps, DERIVED_PROP_NAMES } from './buildComponentProps'
+import { buildComponentProps } from './buildComponentProps'
 import { buildVariantMatrix, SIZE_PROP_NAME } from './buildVariantMatrix'
 import { HEADING_SAMPLE } from './variantFixtures'
 
@@ -29,17 +29,12 @@ const enumProp = (name: string, values: string[], defaultValue?: string) =>
     type: { name: 'enum', value: values },
   })
 
-/**
- * The props a cell hands the component, as a comparable string. The derived props are
- * left out: buildComponentProps builds those from the cell itself, so with them in,
- * no two cells could ever compare equal.
- */
+/** The props a cell hands the component, as a comparable string. */
 const propsKey = (entry: Parameters<typeof buildComponentProps>[0]): string => {
   const props = buildComponentProps(entry) as Record<string, unknown>
 
   return JSON.stringify(
     Object.keys(props)
-      .filter((name) => !DERIVED_PROP_NAMES.includes(name))
       .sort()
       .map((name) => [name, props[name]]),
     (_key, value) => (typeof value === 'function' ? `function ${value.name}` : value),
@@ -49,13 +44,7 @@ const propsKey = (entry: Parameters<typeof buildComponentProps>[0]): string => {
 // Mirrors how renderComponentVariants turns the matrix into component instances.
 const renderedKeys = (types: StrictArgTypes, variants: VariantState[], args: Meta['args']) =>
   buildVariantMatrix(types, { args, variants }).map((entry) =>
-    propsKey({
-      ...entry,
-      acceptsAccessibleName: 'accessibleName' in types,
-      acceptsAccessibleNameId: 'accessibleNameId' in types,
-      args,
-      sizePropName: SIZE_PROP_NAME,
-    }),
+    propsKey({ ...entry, args, sizePropName: SIZE_PROP_NAME }),
   )
 
 const duplicatesIn = (keys: string[]) => keys.filter((key, index) => keys.indexOf(key) !== index)
@@ -139,7 +128,7 @@ describe('buildVariantMatrix', () => {
     ])
   })
 
-  it('keeps a prop the props builder derives off the prop axis', () => {
+  it('keeps an aria-only prop off the prop axis', () => {
     const matrix = buildVariantMatrix(
       argTypes([argType({ name: 'accessibleName', type: { name: 'string' } }), booleanProp('invalid')]),
     )

--- a/storybook/src/_common/buildVariantMatrix.ts
+++ b/storybook/src/_common/buildVariantMatrix.ts
@@ -13,11 +13,16 @@ import type {
   VariantValue,
 } from './renderComponentVariantTypes'
 
-import { DERIVED_PROP_NAMES } from './buildComponentProps'
 import { extractVariantsFromArgTypes } from './extractVariantsFromArgTypes'
 
 /** The prop that drives the size axis, rather than a row of its own on the prop axis. */
 export const SIZE_PROP_NAME = 'size'
+
+/**
+ * Props that only set an accessible name. Varying one produces a cell that looks
+ * identical to the baseline, so they stay off the prop axis.
+ */
+export const ARIA_ONLY_PROP_NAMES = ['accessibleName', 'accessibleNameId']
 
 const sizesOf = (propsWithValues: PropWithValues[]): (string | undefined)[] => {
   const sizeProp = propsWithValues.find((prop) => prop.name === SIZE_PROP_NAME)
@@ -40,8 +45,8 @@ const sizesOf = (propsWithValues: PropWithValues[]): (string | undefined)[] => {
  *   being `disabled` and `hovered`. A prop that is also a state therefore leaves
  *   the prop axis: `disabled` would otherwise vary against the state that already
  *   sets it, rendering both values twice over.
- * • The prop axis carries every other prop, bar the ones the props builder derives
- *   from the cell, and shows only the values the baseline doesn’t already show.
+ * • The prop axis carries every other prop, bar the aria-only ones, and shows only
+ *   the values the baseline doesn’t already show.
  * • Each state opens with the baseline, so the component as a story’s own args
  *   leave it is snapshotted once per state rather than once per prop.
  *
@@ -57,7 +62,7 @@ export const buildVariantMatrix = (
   const sizes = sizesOf(propsWithValues)
   const matrixProps = propsWithValues.filter(
     ({ name }) =>
-      name !== SIZE_PROP_NAME && !DERIVED_PROP_NAMES.includes(name) && !variants.some((variant) => variant === name),
+      name !== SIZE_PROP_NAME && !ARIA_ONLY_PROP_NAMES.includes(name) && !variants.some((variant) => variant === name),
   )
 
   // What the baseline cell already shows for a prop: the story’s own arg where it holds

--- a/storybook/src/_common/renderComponentVariantTypes.ts
+++ b/storybook/src/_common/renderComponentVariantTypes.ts
@@ -52,8 +52,6 @@ export type BuildVariantMatrixParams = {
 }
 
 export type BuildComponentPropsParams = {
-  acceptsAccessibleName?: boolean
-  acceptsAccessibleNameId?: boolean
   args: Meta['args']
   hasIcon?: { icon: IconProps['svg'] } | null
   propName?: string

--- a/storybook/src/_common/renderComponentVariants.tsx
+++ b/storybook/src/_common/renderComponentVariants.tsx
@@ -38,24 +38,13 @@ export const renderComponentVariants = (
   context: StoryContext,
 ) => {
   const matrix = buildVariantMatrix(context.argTypes, { args, variants })
-  const acceptsAccessibleName = 'accessibleName' in context.argTypes
-  const acceptsAccessibleNameId = 'accessibleNameId' in context.argTypes
   const hasPropAxis = matrix.some(({ propName }) => propName)
 
   return (
     <div style={hasPropAxis ? propAxisRow : undefined}>
       {matrix.map((entry) => (
         <div key={variantKeyFor(entry)} style={layout === 'flex' ? undefined : gridCell}>
-          {createElement(
-            component,
-            buildComponentProps({
-              ...entry,
-              acceptsAccessibleName,
-              acceptsAccessibleNameId,
-              args,
-              sizePropName: SIZE_PROP_NAME,
-            }),
-          )}
+          {createElement(component, buildComponentProps({ ...entry, args, sizePropName: SIZE_PROP_NAME }))}
         </div>
       ))}
     </div>

--- a/storybook/src/components/FieldSet/FieldSet.test.stories.tsx
+++ b/storybook/src/components/FieldSet/FieldSet.test.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { FieldSet } from '@amsterdam/design-system-react/src'
 
+import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as fieldSetMeta } from './FieldSet.stories'
@@ -22,16 +23,9 @@ type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
   args: {
-    children: (
-      // The label names the input, which Chromatic needs, and wraps it so that no id repeats across the variants.
-      <div>
-        <label>
-          Voornaam
-          <input readOnly value="Yassine" />
-        </label>
-      </div>
-    ),
+    children: <input readOnly value="Yassine" />,
   },
+  parameters: disablePageLevelChecks('label'),
   render: (args, context) => renderComponentVariants(FieldSet, { args, variants: ['disabled'] }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }


### PR DESCRIPTION
# Remove the test stories’ axe workarounds

## Links

- [This branch’s deploy](https://designsystem.amsterdam/)
- The only visible change is in the Field Set test story, which is tagged `!dev`, so Chromatic is where it shows.
- Follows #2894 and #2895, which made these workarounds redundant.

## What

An inventory of all test stories found two places where something existed only to keep axe quiet, and both now use the page-level rule disables instead.

The Field Set test story wrapped its input in a label, with a comment saying the label names the input “which Chromatic needs”. It now renders a bare input and disables the `label` check, like the seven bare form controls already do. This is the branch’s one visual change: the word ‘Voornaam’ leaves all fourteen cells.

The variant matrix injected a unique `accessibleName` and `accessibleNameId` into every cell to keep `landmark-unique` quiet. That injection is gone. Exactly one test story has a component accepting those props, Pagination, and its story already disables `landmark-unique`.

## Why

The injection did not work where it applied. The injected id contained spaces, and `aria-labelledby` parses as a space-separated list of ids, so Pagination’s cells that vary a name string referenced ids that cannot exist and their navs had no accessible name at all. With the injection gone, every nav takes the component’s own fallback: `aria-labelledby` points at the generated id of the visually hidden span reading ‘Paginering’. The names all being equal is exactly what `landmark-unique` flags, and exactly what the story disables.

The rest of the inventory checked out as legitimate: Field’s Label is the margin its story tests, Table’s `aria-labelledby` demonstrates naming a table after its caption, the Lo-fi Mode form sheet shows documented usage, and Tabs, Skeleton and Accordion use their components’ own APIs.

## How

Field Set follows the pattern from #2895: bare markup plus `disablePageLevelChecks('label')`. The injection’s removal simplifies `buildComponentProps` to just assembling the cell’s props. The two aria-only props stay off the prop axis — varying one produces a cell that looks identical to the baseline — under the honest name `ARIA_ONLY_PROP_NAMES`. As a side effect the duplicate-configuration sweep gets stricter: with nothing injected, it now compares every prop a cell hands the component.

Verified against the rendered build: all 48 test stories render the same 483 cells as before, matching per story; Field Set contains no label element and no ‘Voornaam’; and axe with each story’s own configuration applied still reports exactly one violation in the whole suite, the Avatar contrast that awaits the updated colour palette.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

Two results change in Chromatic: Field Set comes back with a visual diff in all fourteen cells and needs one re-accept, and Pagination’s accessibility result changes because its `landmark-unique` finding disappears. Nothing else moves.
