### PR TITLE
feat(Pagination): Add accessible name props for the page links

### DIFF
--- a/packages/react/src/Pagination/LinkItem.tsx
+++ b/packages/react/src/Pagination/LinkItem.tsx
@@ -8,12 +8,24 @@ import type { PaginationProps } from './Pagination'
 type LinkItemProps = {
   readonly currentPage: PaginationProps['page']
   readonly pageNumber: number
-} & Readonly<Pick<PaginationProps, 'linkComponent' | 'linkTemplate'>>
+} & Readonly<
+  Pick<PaginationProps, 'currentPageAccessibleName' | 'linkComponent' | 'linkTemplate' | 'pageAccessibleName'>
+>
 
-export const LinkItem = ({ currentPage, linkComponent, linkTemplate, pageNumber }: LinkItemProps) => {
+export const LinkItem = ({
+  currentPage,
+  currentPageAccessibleName,
+  linkComponent,
+  linkTemplate,
+  pageAccessibleName,
+  pageNumber,
+}: LinkItemProps) => {
   if (!linkComponent) return null
 
   const Link = linkComponent
+
+  const accessibleNamePrefix =
+    pageNumber === currentPage ? currentPageAccessibleName || 'Pagina' : pageAccessibleName || 'Ga naar pagina'
 
   return (
     <li>
@@ -22,7 +34,7 @@ export const LinkItem = ({ currentPage, linkComponent, linkTemplate, pageNumber 
         className="ams-pagination__link"
         href={linkTemplate(pageNumber)}
       >
-        <span className="ams-visually-hidden">{pageNumber === currentPage ? 'Pagina ' : 'Ga naar pagina '}</span>
+        <span className="ams-visually-hidden">{`${accessibleNamePrefix} `}</span>
         {pageNumber}
       </Link>
     </li>

--- a/packages/react/src/Pagination/Pagination.test.tsx
+++ b/packages/react/src/Pagination/Pagination.test.tsx
@@ -206,6 +206,34 @@ describe('Pagination', () => {
     expect(nextLink).toBeInTheDocument()
   })
 
+  it('renders accessible names for the page links', () => {
+    render(<Pagination linkTemplate={linkTemplate} page={4} totalPages={10} />)
+
+    const currentPageLink = screen.getByRole('link', { name: 'Pagina 4' })
+    const otherPageLink = screen.getByRole('link', { name: 'Ga naar pagina 5' })
+
+    expect(currentPageLink).toBeInTheDocument()
+    expect(otherPageLink).toBeInTheDocument()
+  })
+
+  it('renders custom accessible names for the page links', () => {
+    render(
+      <Pagination
+        currentPageAccessibleName="Page"
+        linkTemplate={linkTemplate}
+        page={4}
+        pageAccessibleName="Go to page"
+        totalPages={10}
+      />,
+    )
+
+    const currentPageLink = screen.getByRole('link', { name: 'Page 4' })
+    const otherPageLink = screen.getByRole('link', { name: 'Go to page 5' })
+
+    expect(currentPageLink).toBeInTheDocument()
+    expect(otherPageLink).toBeInTheDocument()
+  })
+
   it('renders a custom link component', () => {
     const CustomLink = (props: AnchorHTMLAttributes<HTMLAnchorElement>) => <a data-test {...props} />
 

--- a/packages/react/src/Pagination/Pagination.tsx
+++ b/packages/react/src/Pagination/Pagination.tsx
@@ -24,6 +24,8 @@ export type PaginationProps = {
    * Note: must be unique for the page.
    */
   readonly accessibleNameId?: string
+  /** The accessible name for the link to the current page. The page number is appended. */
+  readonly currentPageAccessibleName?: string
   /** The React component or intrinsic element to use for the links. */
   readonly linkComponent?: ElementType
   /** The template used to construct the link hrefs. */
@@ -36,6 +38,8 @@ export type PaginationProps = {
   readonly nextLabel?: string
   /** The current page number. */
   readonly page?: number
+  /** The accessible name for the links to the other pages. The page number is appended. */
+  readonly pageAccessibleName?: string
   /** The accessible name for the link to the previous page. */
   readonly previousAccessibleName?: string
   /** The visible label for the link to the previous page. */
@@ -55,12 +59,14 @@ export const Pagination = forwardRef(
       accessibleName,
       accessibleNameId,
       className,
+      currentPageAccessibleName,
       linkComponent = DefaultLink,
       linkTemplate,
       maxVisiblePages = 7,
       nextAccessibleName,
       nextLabel = 'volgende',
       page = 1,
+      pageAccessibleName,
       previousAccessibleName,
       previousLabel = 'vorige',
       totalPages,
@@ -101,9 +107,11 @@ export const Pagination = forwardRef(
             typeof pageNumberOrEllipsis === 'number' ? (
               <LinkItem
                 currentPage={page}
+                currentPageAccessibleName={currentPageAccessibleName}
                 key={pageNumberOrEllipsis}
                 linkComponent={linkComponent}
                 linkTemplate={linkTemplate}
+                pageAccessibleName={pageAccessibleName}
                 pageNumber={pageNumberOrEllipsis}
               />
             ) : (

--- a/storybook/src/components/Pagination/Pagination.docs.mdx
+++ b/storybook/src/components/Pagination/Pagination.docs.mdx
@@ -34,6 +34,9 @@ Pagination should not be displayed if there is only one page.
 
 Make sure that the visible and accessible labels for the 'previous' and 'next' buttons convey the same meaning at all times – e.g. don't update one and forget the other.
 
+All texts in the component default to Dutch: the landmark name, the previous and next links, and the hidden prefixes that name the numbered links.
+On a page in another language, set each of them through its prop – translating some but not all makes screen readers announce a mix of languages.
+
 Start a page with an overview list at the top after changing the page.
 Redirect users to the first page if they enter a URL with a page number that doesn’t exist.
 
@@ -90,6 +93,9 @@ Pagination renders a `nav` around an ordered list, so it is a navigation landmar
 The landmark is named by text that is in the markup and hidden visually.
 
 The current page is marked as such, so assistive technology reports which link is the page you are on rather than leaving it to be inferred from the styling.
+
+The numbered links are also named by hidden text, placed before the visible number: ‘Ga naar pagina 3’ tells a screen reader user what the link does where a bare ‘3’ would not.
+The current page reads ‘Pagina 4’ instead – naming where you are, not where you can go.
 
 The previous and next links are named by hidden text that says which page they lead to, while their visible label stays short.
 That visible label is hidden from assistive technology, so the link is announced once rather than twice — and it is why ‘How to use’ asks that the two labels keep saying the same thing.


### PR DESCRIPTION
# Add accessible name props for the page links

## Links

- [Pagination documentation](https://designsystem.amsterdam/?path=/docs/components-navigation-pagination--docs)
- [Deploy on main](https://designsystem.amsterdam/) and its [Pagination page](https://designsystem.amsterdam/?path=/docs/components-navigation-pagination--docs)

## What

Pagination names its numbered links with visually hidden prefixes before the page number: ‘Ga naar pagina’ for the pages you can move to and ‘Pagina’ for the current page. These strings were hardcoded Dutch. This PR turns them into the props `pageAccessibleName` and `currentPageAccessibleName`, keeping the current strings as defaults. The page number is appended as before.

## Why

The landmark name and the names of the previous and next links are already configurable, which made these prefixes the only texts of the component that could not be translated. With these two props, a page in another language can name every part of Pagination in that language.

## How

`LinkItem` receives the props through a `Pick` of `PaginationProps` and falls back to the Dutch strings with `||`, matching how the component resolves its other names. The rendered markup is unchanged when the props are not set, so no visual changes are expected.

The Accessibility section of the documentation now describes how the numbered links get their names, and ‘How to use’ notes that all texts of the component default to Dutch and should be set together on a page in another language. Unit tests cover the default and the custom names.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix.
