### PR TITLE
chore(Storybook): Remove the view transition from the Page Anatomy drawings

### DIFF
--- a/storybook/src/_components/PageAnatomy/PageAnatomy.tsx
+++ b/storybook/src/_components/PageAnatomy/PageAnatomy.tsx
@@ -6,8 +6,7 @@
 import type { CSSProperties, HTMLAttributes } from 'react'
 
 import { clsx } from 'clsx'
-import { useId, useState } from 'react'
-import { flushSync } from 'react-dom'
+import { useState } from 'react'
 
 import type {
   AnatomyBlock,
@@ -324,9 +323,7 @@ const Drawing = ({
  * Grid variants side by side. The geometry comes from the story, so the drawing follows the page it documents.
  *
  * Where there is no width for three drawings beside one another, they would take three pages of scrolling one under
- * the other, so one is drawn at a time and the buttons above choose which. Switching between them at one width is
- * also the closest look at what the Grid does that the drawing gives: the frame stays put while the page inside it
- * lays itself out again.
+ * the other, so one is drawn at a time and the buttons above choose which.
  */
 export const PageAnatomy = ({
   className,
@@ -339,26 +336,10 @@ export const PageAnatomy = ({
   ...restProps
 }: PageAnatomyProps) => {
   const [selected, setSelected] = useState<Breakpoint>('narrow')
-  // A view transition names the elements it carries across, and a documentation page may hold more than one drawing.
-  const transitionName = `ams-page-anatomy-${useId().replace(/[^a-z\d]/gi, '')}`
   const { problems, sections } = readPageAnatomy(readStoryTree(of, story), labels)
   const viewports = anatomyViewports({ menu, mode })
   const widest = viewports[viewports.length - 1]?.width ?? 0
   const drawings = viewports.map((viewport) => ({ drawn: drawnSections(sections, viewport, mode), viewport }))
-
-  /**
-   * Swaps one drawing for another. The two are of different heights, so a view transition carries the page across
-   * rather than cutting to it. React would batch the state change past the transition, which `flushSync` prevents.
-   */
-  const select = (key: Breakpoint) => {
-    if (key === selected) return
-
-    if ('startViewTransition' in document && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      document.startViewTransition(() => flushSync(() => setSelected(key)))
-    } else {
-      setSelected(key)
-    }
-  }
 
   return (
     <div
@@ -377,7 +358,6 @@ export const PageAnatomy = ({
             )
             .join(' '),
           '--_ams-page-anatomy-single-row': viewports.map((viewport) => `minmax(0, ${viewport.width}fr)`).join(' '),
-          '--_ams-page-anatomy-transition': transitionName,
         } as CSSProperties
       }
     >
@@ -392,7 +372,7 @@ export const PageAnatomy = ({
             aria-pressed={viewport.key === selected}
             className="_ams-page-anatomy__switch"
             key={viewport.key}
-            onClick={() => select(viewport.key)}
+            onClick={() => setSelected(viewport.key)}
             type="button"
           >
             {viewport.label}

--- a/storybook/src/_components/PageAnatomy/page-anatomy.css
+++ b/storybook/src/_components/PageAnatomy/page-anatomy.css
@@ -25,9 +25,6 @@
   --_ams-page-anatomy-row: minmax(0, 320fr) minmax(0, 880fr) minmax(0, 240fr);
   --_ams-page-anatomy-single-row: minmax(0, 320fr) minmax(0, 880fr) minmax(0, 1440fr);
 
-  /* The name a view transition carries the drawing across under. Each set of drawings sets one of its own. */
-  --_ams-page-anatomy-transition: ams-page-anatomy;
-
   /* One colour stands for a Spotlight, whatever colour that Spotlight is: the drawing keeps its own palette.
    * Purple is far more saturated than the azure of the space bands, so it takes a much smaller share to weigh
    * the same. The second value darkens the space inside the band, which the first one already covers. */
@@ -115,15 +112,6 @@
 
   ._ams-page-anatomy__viewport:not(._ams-page-anatomy__viewport--selected) {
     display: none;
-  }
-
-  /* The drawing that is on its way out and the one coming in are the same thing at another width, so a view
-   * transition moves between the two rather than cutting. Each set of drawings names its own. */
-  @media (prefers-reduced-motion: no-preference) {
-    ._ams-page-anatomy__viewport--selected {
-      /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
-      view-transition-name: var(--_ams-page-anatomy-transition);
-    }
   }
 
   ._ams-page-anatomy__switcher {


### PR DESCRIPTION
## Links

- [Feature branch deploy](https://amsterdam.github.io/design-system/demo-page-anatomy-view-transition)
- [Reading the anatomy](https://amsterdam.github.io/design-system/demo-page-anatomy-view-transition/?path=/docs/pages-guidelines-reading-the-anatomy--docs)
- [Article Page, whose docs page draws an anatomy](https://amsterdam.github.io/design-system/demo-page-anatomy-view-transition/?path=/docs/pages-public-article-page--docs)

## What

The Page Anatomy component no longer animates between the three Grid variants. In a container too narrow to show all three drawings side by side, the buttons above the drawing now cut straight to the one you pick.

## Why

The transition flickered in Storybook.

## How

The component wrapped its state change in `document.startViewTransition`, with a `flushSync` so React would not batch the change past the transition, and gave the selected drawing a `view-transition-name` under a per-instance name built from `useId`. That name travelled from the component to the stylesheet through a custom property, because a documentation page may hold more than one drawing and two drawings may not share a name. All of that is gone, and the buttons call `setSelected` directly.

The `stylelint-disable` for `plugin/use-baseline` went with the rule it covered, and `--report-needless-disables` confirms nothing else needed it. The reduced-motion guard around the rule is gone too, since there is no motion left to guard.

Nothing about the drawing itself changes, so the Chromatic snapshots should be identical: the animation only ever ran between two states, and a snapshot catches neither.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

No documentation mentioned the transition, so none needed editing. ESLint, Stylelint, `tsc --noEmit` and the 62 Page Anatomy tests all pass.

This has no DES ticket yet. Happy to add one to the title if you would rather it carried one.
