### PR TITLE
feat(Storybook): Add a link to all topics below the top tasks on the Home Page

### DIFF
--- a/storybook/src/_components/PageAnatomy/model.test.ts
+++ b/storybook/src/_components/PageAnatomy/model.test.ts
@@ -6,7 +6,7 @@
 import type { ImageProps } from '@amsterdam/design-system-react'
 import type { ReactNode } from 'react'
 
-import { Grid, Image, Overlap, Spotlight } from '@amsterdam/design-system-react'
+import { Grid, Heading, Image, Overlap, Spotlight } from '@amsterdam/design-system-react'
 import { createElement, Fragment } from 'react'
 import { describe, expect, it } from 'vitest'
 
@@ -111,6 +111,30 @@ describe('readPageAnatomy', () => {
 
     expect(block?.span).toEqual({ narrow: 1, medium: 1, wide: 1 })
     expect(block?.start).toEqual({ narrow: undefined, medium: undefined, wide: undefined })
+  })
+
+  it('reads the margin utility on the content of a Cell, which spaces it where the Grid has no row gap', () => {
+    const story = createElement(
+      Grid,
+      { gapVertical: 'none' },
+      cell({ children: createElement(Heading, { className: 'ams-mb-m', level: 2 }), span: 'all' }),
+    )
+
+    const [block] = readPageAnatomy(story, [['Section heading']]).sections[0]?.blocks ?? []
+
+    expect(block?.spaceAfter).toBe('m')
+  })
+
+  it('reads the margin utility on a Subgrid itself, which holds Cells rather than content', () => {
+    const story = createElement(
+      Grid,
+      { gapVertical: 'none' },
+      createElement(Grid.Subgrid, { className: 'ams-mb-l', span: 'all' }, cell({ span: 3 })),
+    )
+
+    const [block] = readPageAnatomy(story, [['Top task']]).sections[0]?.blocks ?? []
+
+    expect(block?.spaceAfter).toBe('l')
   })
 
   it('looks past wrappers such as fragments and landmark elements', () => {

--- a/storybook/src/_components/PageAnatomy/model.ts
+++ b/storybook/src/_components/PageAnatomy/model.ts
@@ -325,20 +325,25 @@ const readCellRatio = (children: ReactNode): number | undefined => {
 /** The space tokens of the margin utilities, longest first so that `xs` is not read as an `s`. */
 const spaceAfterPattern = /(?:^|\s)ams-mb-(2xl|xl|xs|s|m|l)(?:\s|$)/
 
+/** The space token of the `ams-mb-*` utility a `className` carries, where it holds one. */
+const spaceOf = (className: unknown): SpaceToken | undefined =>
+  typeof className === 'string' ? (spaceAfterPattern.exec(className)?.[1] as SpaceToken | undefined) : undefined
+
 /**
- * The space the content of a Cell puts below itself with an `ams-mb-*` utility.
+ * The space a Grid Cell or a Grid Subgrid puts below itself with an `ams-mb-*` utility.
  *
  * A Grid that gives up its row gap leaves the spacing to that margin, so a drawing that ignored it would show a
- * heading sitting against the section it introduces. The utility goes on the content rather than on the Cell,
- * which only ever takes the props of the Grid, so this reads the last thing the Cell holds: a grid item opens an
- * independent formatting context, so the margin of that last child adds to the height of the Cell rather than
- * collapsing through it.
+ * heading sitting against the section it introduces. On a Cell the utility goes on the content rather than on the
+ * Cell, which only ever takes the props of the Grid, so this reads the last thing the Cell holds: a grid item opens
+ * an independent formatting context, so the margin of that last child adds to the height of the Cell rather than
+ * collapsing through it. A Subgrid holds Cells rather than content, so there the utility sits on the Subgrid itself.
  */
-const readSpaceAfter = (children: ReactNode): SpaceToken | undefined => {
-  const last = Children.toArray(children).filter(isValidElement).at(-1)
-  const className = last ? propsOf(last)['className'] : undefined
+const readSpaceAfter = (element: ReactElement): SpaceToken | undefined => {
+  const last = Children.toArray(propsOf(element)['children'] as ReactNode)
+    .filter(isValidElement)
+    .at(-1)
 
-  return typeof className === 'string' ? (spaceAfterPattern.exec(className)?.[1] as SpaceToken | undefined) : undefined
+  return spaceOf(propsOf(element)['className']) ?? (last ? spaceOf(propsOf(last)['className']) : undefined)
 }
 
 /**
@@ -359,7 +364,7 @@ const readCell = (element: ReactElement, columns?: Record<Breakpoint, number>): 
     height: perViewport(() => defaultBlockHeight),
     label: '',
     rowSpan: perViewport((viewport) => readColumns(rowSpan, viewport)),
-    spaceAfter: readSpaceAfter(children as ReactNode),
+    spaceAfter: readSpaceAfter(element),
     // A cell without a `span` spans a single column, as `grid-column-end: auto` does.
     span: perViewport((viewport) => readColumns(span, viewport, available(viewport)) ?? 1),
     start: perViewport((viewport) => readColumns(start, viewport, available(viewport))),

--- a/storybook/src/pages/guidelines/choosing-a-page-type.docs.mdx
+++ b/storybook/src/pages/guidelines/choosing-a-page-type.docs.mdx
@@ -12,7 +12,7 @@ Two questions settle most of it: is the site public or internal, and does the pa
 ## Public pages that carry content
 
 The [Article Page](/docs/pages-public-article-page--docs) presents a single news item, from its headline and lead to the related reading that follows.
-The [Information Page](/docs/pages-public-information-page--docs) explains a subject that is neither a product nor a news article, for a reader who wants to understand something rather than arrange it.
+The [Information Page](/docs/pages-public-information-page--docs) explains a topic that is neither a product nor a news article, for a reader who wants to understand something rather than arrange it.
 The [Product Page](/docs/pages-public-product-page--docs) brings together everything a resident needs to know about a product or service of the City, and guides them toward the next step.
 The [Project Page](/docs/pages-public-project-page--docs) keeps residents and stakeholders informed about a construction or traffic project.
 The [Profile Page](/docs/pages-public-profile-page--docs) presents a single person, group of people, or place.
@@ -20,7 +20,7 @@ The [Handbook Page](/docs/pages-public-handbook-page--docs) presents long-form r
 
 ## Public pages that help people find content
 
-The [Home Page](/docs/pages-public-home-page--docs) is the entry point of a website, offering a broad overview of its main subjects, common tasks, and recent news.
+The [Home Page](/docs/pages-public-home-page--docs) is the entry point of a website, offering a broad overview of its main topics, common tasks, and recent news.
 The [Navigation Page](/docs/pages-public-navigation-page--docs) is a signpost with little content of its own, grouping links to related pages.
 The [News Overview Page](/docs/pages-public-news-overview-page--docs) lists content items that a visitor narrows down with filters.
 The [Search Results Page](/docs/pages-public-search-results-page--docs) presents what a visitor finds after searching the site, in that same filter-and-results layout.

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.docs.mdx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.docs.mdx
@@ -28,7 +28,7 @@ Use this page for a single dated article: a news item, a press release, or a blo
 ### When not to use
 
 Use a [News Overview Page](/docs/pages-public-news-overview-page--docs) to list several of them.
-Use an [Information Page](/docs/pages-public-information-page--docs) for a subject that stays true rather than one that happened on a date.
+Use an [Information Page](/docs/pages-public-information-page--docs) for a topic that stays true rather than one that happened on a date.
 
 ## Structure
 

--- a/storybook/src/pages/public/HandbookPage/HandbookPage.docs.mdx
+++ b/storybook/src/pages/public/HandbookPage/HandbookPage.docs.mdx
@@ -27,7 +27,7 @@ Use this page for reference material long enough to need splitting: a personnel 
 
 ### When not to use
 
-Use an [Information Page](/docs/pages-public-information-page--docs) where a single page carries the whole subject.
+Use an [Information Page](/docs/pages-public-information-page--docs) where a single page carries the whole topic.
 
 ## Structure
 
@@ -58,4 +58,4 @@ The link they just activated therefore keeps focus, where a navigation rebuilt p
 
 - [Table of Contents](/docs/components-navigation-table-of-contents--docs) – the navigation column, and how to control it.
 - [Skip Link](/docs/components-navigation-skip-link--docs) – why this page needs two.
-- [Information Page](/docs/pages-public-information-page--docs) – for a subject that fits on one page.
+- [Information Page](/docs/pages-public-information-page--docs) – for a topic that fits on one page.

--- a/storybook/src/pages/public/HomePage/HomePage.docs.mdx
+++ b/storybook/src/pages/public/HomePage/HomePage.docs.mdx
@@ -46,6 +46,8 @@ A home page has no single most prominent topic, so it usually has no visible lev
 ## Layout and spacing
 
 - In Grids of Cards, use a large vertical gap.
+- Space a Standalone Link below such a Grid a large from the Cards.
+  That is less than the gap between the rows of Cards, so the link reads as part of the section above it.
 
 ## Accessibility
 

--- a/storybook/src/pages/public/HomePage/HomePage.docs.mdx
+++ b/storybook/src/pages/public/HomePage/HomePage.docs.mdx
@@ -23,11 +23,11 @@ This schematic shows the default sections for this page type and how the grids a
 
 ### When to use
 
-Use this page as the entry point of a website, where a visitor arrives without a subject in mind.
+Use this page as the entry point of a website, where a visitor arrives without a topic in mind.
 
 ### When not to use
 
-Use a [Navigation Page](/docs/pages-public-navigation-page--docs) for the entry point of one subject within the site.
+Use a [Navigation Page](/docs/pages-public-navigation-page--docs) for the entry point of one topic within the site.
 
 ## Structure
 
@@ -36,7 +36,7 @@ An Overlap runs to the full width of the page, so it is a sibling of the Grids r
 Everything below it sits on a Grid again.
 See [Page structure](/docs/pages-guidelines-page-structure--docs) for the shell around it.
 
-A home page has no single most prominent subject, so it usually has no visible level 1 [Heading](/docs/components-text-heading--docs).
+A home page has no single most prominent topic, so it usually has no visible level 1 [Heading](/docs/components-text-heading--docs).
 
 - Add a visually hidden level 1 heading with a text like ‘Homepage van (name of the organisation)’.
   Assign level 2 and a size of ‘level-1’ to the visible headings.
@@ -58,6 +58,6 @@ Card images take an empty `alt`: the heading and link beside them already name w
 
 ## See also
 
-- [Navigation Page](/docs/pages-public-navigation-page--docs) – the same job for a single subject.
+- [Navigation Page](/docs/pages-public-navigation-page--docs) – the same job for a single topic.
 - [Overlap](/docs/components-layout-overlap--docs) – the full-width opening section.
 - [Page structure](/docs/pages-guidelines-page-structure--docs) – the shell every page shares.

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
   ...commonMeta,
   title: 'Pages/Public/Home Page',
   parameters: pageParameters(
-    'The entry point of a public website, offering a broad overview of its main subjects, ' +
+    'The entry point of a public website, offering a broad overview of its main topics, ' +
       'common tasks, and recent news.',
   ),
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -36,7 +36,8 @@ const meta = {
       {/*
        * The row gap would put an x-large below the heading, where the guidance asks for a medium at this size.
        * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
-       * between the Cells.
+       * between the Cells. The Subgrid also sets a large below itself, since the Grid no longer spaces the
+       * link that follows it.
        */}
       <Grid gapVertical="none" paddingVertical="x-large">
         <Grid.Cell span="all">
@@ -45,7 +46,7 @@ const meta = {
             {topTaskSection.title}
           </Heading>
         </Grid.Cell>
-        <Grid.Subgrid gapVertical="x-large" span="all">
+        <Grid.Subgrid className="ams-mb-l" gapVertical="x-large" span="all">
           {/*
            * Cells flow from the left in source order, so no section here needs a start. On the wide grid the top
            * tasks fit four to a row at {{ narrow: 4, medium: 4, wide: 3 }} and three preview cards at span={4}
@@ -65,6 +66,9 @@ const meta = {
             </Grid.Cell>
           ))}
         </Grid.Subgrid>
+        <Grid.Cell span="all">
+          <StandaloneLink href="#">{topTaskSection.link}</StandaloneLink>
+        </Grid.Cell>
       </Grid>
       {/*
        * These highlights are part of the homepage’s own content, so the Spotlight stays a plain band inside <main>.
@@ -135,14 +139,15 @@ export const Default: StoryObj = {
   {/*
    * The row gap would put an x-large below the heading, where the guidance asks for a medium at this size.
    * So the Grid gives up its gap, the heading sets the space itself, and the Subgrid puts the gap back
-   * between the Cells.
+   * between the Cells. The Subgrid also sets a large below itself, since the Grid no longer spaces the
+   * link that follows it.
    */}
   <Grid gapVertical="none" paddingVertical="x-large">
     <Grid.Cell span="all">
       {/* Second level in the outline (the hidden h1 is first), shown at the largest size. */}
       <Heading className="ams-mb-m" level={2} size="level-1">{topTaskSection.title}</Heading>
     </Grid.Cell>
-    <Grid.Subgrid gapVertical="x-large" span="all">
+    <Grid.Subgrid className="ams-mb-l" gapVertical="x-large" span="all">
       {/*
        * Cells flow from the left in source order, so no section here needs a start. On the wide grid the top
        * tasks fit four to a row at {{ narrow: 4, medium: 4, wide: 3 }} and three preview cards at span={4}
@@ -162,6 +167,9 @@ export const Default: StoryObj = {
         </Grid.Cell>
       ))}
     </Grid.Subgrid>
+    <Grid.Cell span="all">
+      <StandaloneLink href="#">{topTaskSection.link}</StandaloneLink>
+    </Grid.Cell>
   </Grid>
   {/*
    * These highlights are part of the homepage’s own content, so the Spotlight stays a plain band inside <main>.

--- a/storybook/src/pages/public/HomePage/anatomyLabels.ts
+++ b/storybook/src/pages/public/HomePage/anatomyLabels.ts
@@ -15,6 +15,7 @@ export const anatomyLabels: AnatomyLabels = [
   [
     { height: 'heading', label: 'Section heading' },
     ...Array.from({ length: 8 }, (): AnatomyLabel => ({ height: 'tile', label: 'Top task' })),
+    { height: 'line', label: 'Link to all topics' },
   ],
   [
     { height: 'card', label: 'Link section' },

--- a/storybook/src/pages/public/HomePage/data.ts
+++ b/storybook/src/pages/public/HomePage/data.ts
@@ -7,6 +7,7 @@ import { exampleImageSource } from '#storybook/_common/exampleContent'
 
 export const topTaskSection = {
   title: 'Direct naar',
+  link: 'Naar alle onderwerpen',
   tasks: [
     {
       title: 'Gemeentebelastingen',

--- a/storybook/src/pages/public/InformationPage/InformationPage.docs.mdx
+++ b/storybook/src/pages/public/InformationPage/InformationPage.docs.mdx
@@ -23,7 +23,7 @@ This schematic shows the default sections for this page type and how the grids a
 
 ### When to use
 
-Use this page to explain a subject a reader wants to understand: its background, the rules, and what they mean.
+Use this page to explain a topic a reader wants to understand: its background, the rules, and what they mean.
 
 ### When not to use
 
@@ -95,7 +95,7 @@ What a Table and a Figure each take their accessible name from is the part of th
 
 ## See also
 
-- [Product Page](/docs/pages-public-product-page--docs) – for a subject that ends in an application.
+- [Product Page](/docs/pages-public-product-page--docs) – for a topic that ends in an application.
 - [Accordion](/docs/components-containers-accordion--docs) – groups the detail questions.
 - [Table](/docs/components-containers-table--docs) – for reference data, and what its Caption is for.
 - [Figure](/docs/components-media-figure--docs) – pairs the table with its sources.

--- a/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
+++ b/storybook/src/pages/public/InformationPage/InformationPage.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
   ...commonMeta,
   title: 'Pages/Public/Information Page',
   parameters: pageParameters(
-    'Explains a subject in full: its background, the rules that apply, ' +
+    'Explains a topic in full: its background, the rules that apply, ' +
       'and what they mean for a reader who wants to understand something rather than arrange it.',
   ),
 } satisfies Meta

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.docs.mdx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.docs.mdx
@@ -23,7 +23,7 @@ This schematic shows the default sections for this page type and how the grids a
 
 ### When to use
 
-Use this page as the entry point of one subject, where the page itself carries little content and mostly points onward.
+Use this page as the entry point of one topic, where the page itself carries little content and mostly points onward.
 
 ### When not to use
 
@@ -43,12 +43,12 @@ The Cards carry a heading and a link and no image, so they take 3 columns each o
 
 ### With an interactive element
 
-Adds a [Spotlight](/docs/components-containers-spotlight--docs) holding a [Search Field](/docs/components-forms-search-field--docs) and the links around it, for a subject where a visitor looks something up rather than browses to it.
+Adds a [Spotlight](/docs/components-containers-spotlight--docs) holding a [Search Field](/docs/components-forms-search-field--docs) and the links around it, for a topic where a visitor looks something up rather than browses to it.
 A full-width [Image](/docs/components-media-image--docs) closes the page.
 
 ### With an image gallery
 
-Opens with a full-width Image at a 16:5 ratio and introduces the people behind the subject as Cards that each carry a portrait.
+Opens with a full-width Image at a 16:5 ratio and introduces the people behind the topic as Cards that each carry a portrait.
 Those Card Headings are level 3, because the heading above the set is the level 2.
 A gallery of images closes the page, below the contact details.
 

--- a/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
+++ b/storybook/src/pages/public/NavigationPage/NavigationPage.stories.tsx
@@ -37,7 +37,7 @@ const meta = {
   title: 'Pages/Public/Navigation Page',
   parameters: pageParameters(
     'A signpost with little content of its own, grouping links to related pages ' +
-      'so visitors can find their way around a subject.',
+      'so visitors can find their way around a topic.',
   ),
 } satisfies Meta
 

--- a/storybook/src/pages/public/ProductPage/ProductPage.docs.mdx
+++ b/storybook/src/pages/public/ProductPage/ProductPage.docs.mdx
@@ -27,7 +27,7 @@ Use this page for a product or service a resident can arrange, where the page ha
 
 ### When not to use
 
-Use an [Information Page](/docs/pages-public-information-page--docs) for a subject a reader wants to understand rather than arrange.
+Use an [Information Page](/docs/pages-public-information-page--docs) for a topic a reader wants to understand rather than arrange.
 
 ## Structure
 
@@ -40,6 +40,6 @@ The body ends in a [Call to Action Link](/docs/components-navigation-call-to-act
 
 ## See also
 
-- [Information Page](/docs/pages-public-information-page--docs) – for a subject with no action attached.
+- [Information Page](/docs/pages-public-information-page--docs) – for a topic with no action attached.
 - [Call to Action Link](/docs/components-navigation-call-to-action-link--docs) – the next step this page leads to.
 - [Form Flow](/docs/pages-public-form-flow--docs) – where that next step usually goes.


### PR DESCRIPTION
## Links

- [Home Page story in this branch’s deploy](https://amsterdam.github.io/design-system/demo-home-page-topics-link/?path=/story/pages-public-home-page--default)
- [Home Page documentation page](https://amsterdam.github.io/design-system/demo-home-page-topics-link/?path=/docs/pages-public-home-page--docs), with the anatomy drawing
- [Layout and spacing](https://amsterdam.github.io/design-system/demo-home-page-topics-link/?path=/docs/pages-guidelines-layout-and-spacing--docs)

## What

The top task section of the Home Page ends in a Standalone Link to all topics, ‘Naar alle onderwerpen’, as amsterdam.nl has it. The page anatomy drawing shows the space above that link, which it could not read before. And the page templates now call the subject matter of a page a topic rather than a subject.

## Why

A visitor who finds none of the eight top tasks needs a way on to the full list, and the template should show where that link goes and how much space it takes.

The drawing derives its geometry from the story. It read a margin utility only from the content inside a Grid Cell, so the margin that spaces this link sat where it could not see it, and the schematic showed the link straight against the Cards.

‘Topic’ is the word amsterdam.nl uses for what these pages are about, and it now reads the same way in the label, the documentation pages and the guidelines.

## How

The Grid has given up its row gap so the heading can set its own space, so the Subgrid carries the `ams-mb-l` that spaces the link from the Cards. That is one step less than the gap between the rows of Cards, so the link reads as part of the section above it rather than as the next one. No table in the vertical space guide covers a Card followed by a Standalone Link, so the Home Page records the value under Layout and spacing. Both the story and its hand-written Code Panel source carry the change, and `anatomyLabels.ts` names the new Cell.

In the page anatomy model, `readSpaceAfter` now reads the `className` of the element itself before falling back to the last child inside a Cell. A Cell only ever takes the props of the Grid, so there the utility goes on its content; a Subgrid holds Cells rather than content, so there it goes on the Subgrid. Two unit tests cover both paths.

The terminology change keeps ‘subject’ in the nine places where it means something else: the person, body or place a Profile Page describes, and the subject of an image in the Project Page comments. With ‘topic’ carrying the subject matter, the two words now read as distinct rather than as the same word used loosely.

The three concerns are three commits, so they can be read apart.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Chromatic will show the new link on the Home Page snapshot, and the anatomy drawing is not snapshotted, so the space above the link is worth checking on the documentation page itself.
