### PR TITLE
feat(Grid): Allow a Grid and a Subgrid to render a list of Cells

### DIFF
--- a/packages/css/src/components/grid/_mixins.scss
+++ b/packages/css/src/components/grid/_mixins.scss
@@ -4,6 +4,7 @@
  */
 
 @use "../../common/breakpoint" as *;
+@use "../../common/resets" as *;
 @use "../../common/safe-area" as *;
 
 @mixin ams-grid {
@@ -127,6 +128,19 @@
   display: grid;
   grid-template-columns: subgrid;
   row-gap: inherit;
+
+  /*
+   * A Subgrid that is a list drops the marker, the indent and the margin a browser gives it, so it looks
+   * exactly like one that is a `div`. The Cells need nothing of their own: `list-style-type` is inherited,
+   * and a browser gives an `li` no margin or padding.
+   */
+  &:is(ol) {
+    @include reset-ol;
+  }
+
+  &:is(ul) {
+    @include reset-ul;
+  }
 }
 
 @mixin ams-grid__subgrid--gap-vertical--none {

--- a/packages/css/src/components/grid/grid.scss
+++ b/packages/css/src/components/grid/grid.scss
@@ -4,6 +4,7 @@
  */
 
 @use "../../common/breakpoint" as *;
+@use "../../common/resets" as *;
 @use "mixins" as *;
 
 $ams-grid-column-count: 12;
@@ -13,6 +14,25 @@ $ams-grid-row-span-max: 4;
   @include ams-grid;
 
   align-items: start;
+
+  /*
+   * A Grid that is a list drops the marker, the indent and the margin a browser gives it. It keeps its own
+   * inline padding, the gutter of the page, which the reset zeroes along with the list indent.
+   * This sits here rather than in the `ams-grid` mixin, because Breakout reuses that and is never a list.
+   */
+  &:is(ol) {
+    @include reset-ol;
+
+    /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties -- Declared in the `ams-grid` mixin. */
+    padding-inline-start: var(--_ams-grid-padding-inline-start);
+  }
+
+  &:is(ul) {
+    @include reset-ul;
+
+    /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties -- Declared in the `ams-grid` mixin. */
+    padding-inline-start: var(--_ams-grid-padding-inline-start);
+  }
 }
 
 // Grid gap
@@ -97,6 +117,15 @@ $ams-grid-row-span-max: 4;
   container-type: var(--ams-grid-cell-container-type);
   padding-block: var(--ams-grid-cell-padding-block);
   padding-inline: var(--ams-grid-cell-padding-inline);
+}
+
+/*
+ * A Cell that is a list item lays out like any other one. Safari gives the marker of a `list-item` a line
+ * box of its own where the content of the Cell starts with an image, which adds a line of space above it.
+ * Nothing set on the marker removes that box; only dropping `list-item` does.
+ */
+.ams-grid__cell:is(li) {
+  display: block;
 }
 
 .ams-grid__cell--flush {

--- a/packages/react/documentation/coding-conventions.md
+++ b/packages/react/documentation/coding-conventions.md
@@ -50,3 +50,8 @@ Spotlight and Grid Cell are examples.
 We’ve decided to use polymorphism solely for HTML tags that only support global attributes (e.g., `div`, `section`, `footer`, etc.).
 This is because other HTML tags require more complicated typing, and it is often simpler to separate the components.
 We type the refs as `HTMLElement`, the common type of the elements these components can render, so React refs work with all of them.
+
+Grid and Grid Subgrid are exceptions: they render `ol` and `ul` as well, so a set of Grid Cells can be a list.
+Neither types the attributes of an `ol`, and a Subgrid cannot type `start`: it already uses that name for the column it begins at.
+Breakout is never a list, so it allows the tags of a Grid without those two.
+Its props share a base type with `GridProps` rather than aliasing it.

--- a/packages/react/src/Breakout/Breakout.test.tsx
+++ b/packages/react/src/Breakout/Breakout.test.tsx
@@ -8,7 +8,8 @@ import { createRef } from 'react'
 import { describe, expect, it } from 'vitest'
 
 import { ariaRoleForTag } from '../common/accessibility'
-import { gridGaps, gridPaddings, gridTags } from '../Grid/Grid'
+import { gridGaps, gridPaddings } from '../Grid/Grid'
+import { breakoutTags } from './Breakout'
 import { Breakout } from './Breakout'
 
 describe('Breakout', () => {
@@ -77,7 +78,7 @@ describe('Breakout', () => {
     })
   })
 
-  gridTags.forEach((tag) => {
+  breakoutTags.forEach((tag) => {
     it(`renders with a custom ${tag} tag`, () => {
       const { container } = render(<Breakout aria-label={tag === 'section' ? 'Accessible name' : undefined} as={tag} />)
 

--- a/packages/react/src/Breakout/Breakout.tsx
+++ b/packages/react/src/Breakout/Breakout.tsx
@@ -8,7 +8,7 @@ import type { ElementType } from 'react'
 import { clsx } from 'clsx'
 import { forwardRef } from 'react'
 
-import type { GridProps } from '../Grid'
+import type { GridBaseProps } from '../Grid/Grid'
 
 import { paddingClasses } from '../Grid/paddingClasses'
 import { BreakoutCell } from './BreakoutCell'
@@ -16,7 +16,17 @@ import { BreakoutCell } from './BreakoutCell'
 export type BreakoutRowNumber = 1 | 2 | 3 | 4
 export type BreakoutRowNumbers = { narrow: BreakoutRowNumber; medium: BreakoutRowNumber; wide: BreakoutRowNumber }
 
-export type BreakoutProps = GridProps
+/** The tags of a Grid without the list elements: a Breakout widens a figure, which is never a list. */
+export const breakoutTags = ['article', 'aside', 'div', 'footer', 'header', 'main', 'nav', 'section'] as const
+export type BreakoutTag = (typeof breakoutTags)[number]
+
+export type BreakoutProps = {
+  /**
+   * The HTML tag to use.
+   * @default div
+   */
+  readonly as?: BreakoutTag
+} & GridBaseProps
 
 const BreakoutRoot = forwardRef<HTMLElement, BreakoutProps>(
   ({ as, children, className, gapVertical, paddingBottom, paddingTop, paddingVertical, ...restProps }, ref) => {

--- a/packages/react/src/Grid/Grid.tsx
+++ b/packages/react/src/Grid/Grid.tsx
@@ -28,7 +28,7 @@ export type GridGap = (typeof gridGaps)[number]
 export const gridPaddings = ['large', 'x-large', '2x-large'] as const
 export type GridPadding = (typeof gridPaddings)[number]
 
-export const gridTags = ['article', 'aside', 'div', 'footer', 'header', 'main', 'nav', 'section'] as const
+export const gridTags = ['article', 'aside', 'div', 'footer', 'header', 'main', 'nav', 'ol', 'section', 'ul'] as const
 export type GridTag = (typeof gridTags)[number]
 
 type GridPaddingVerticalProp = {
@@ -46,16 +46,20 @@ type GridPaddingTopAndBottomProps = {
   readonly paddingVertical?: never
 }
 
+/** Every prop a Grid and a Breakout share, which is all but the tag: a Breakout is never a list. */
+export type GridBaseProps = {
+  /** The amount of space between rows. */
+  readonly gapVertical?: GridGap
+} & Readonly<PropsWithChildren<HTMLAttributes<HTMLElement>>> &
+  (GridPaddingVerticalProp | GridPaddingTopAndBottomProps)
+
 export type GridProps = {
   /**
    * The HTML tag to use.
    * @default div
    */
   readonly as?: GridTag
-  /** The amount of space between rows. */
-  readonly gapVertical?: GridGap
-} & Readonly<PropsWithChildren<HTMLAttributes<HTMLElement>>> &
-  (GridPaddingVerticalProp | GridPaddingTopAndBottomProps)
+} & GridBaseProps
 
 const GridRoot = forwardRef<HTMLElement, GridProps>(
   ({ as, children, className, gapVertical, paddingBottom, paddingTop, paddingVertical, ...restProps }, ref) => {

--- a/packages/react/src/Grid/GridCell.test.tsx
+++ b/packages/react/src/Grid/GridCell.test.tsx
@@ -177,9 +177,10 @@ describe('GridCell', () => {
 
   gridCellTags.forEach((tag) => {
     it(`renders with a custom ${tag} tag`, () => {
-      const { container } = render(
-        <Grid.Cell aria-label={tag === 'section' ? 'Accessible name' : undefined} as={tag} />,
-      )
+      const cell = <Grid.Cell aria-label={tag === 'section' ? 'Accessible name' : undefined} as={tag} />
+
+      // A list item only takes its role inside a list.
+      const { container } = render(tag === 'li' ? <ul>{cell}</ul> : cell)
 
       const component = tag === 'div' ? container.querySelector(tag) : screen.getByRole(ariaRoleForTag[tag])
 

--- a/packages/react/src/Grid/GridCell.tsx
+++ b/packages/react/src/Grid/GridCell.tsx
@@ -15,7 +15,7 @@ import { gridCellClasses } from './gridCellClasses'
 export const gridCellAppearances = ['flush', 'transparent'] as const
 export type GridCellAppearance = (typeof gridCellAppearances)[number]
 
-export const gridCellTags = ['article', 'aside', 'div', 'footer', 'header', 'main', 'nav', 'section'] as const
+export const gridCellTags = ['article', 'aside', 'div', 'footer', 'header', 'li', 'main', 'nav', 'section'] as const
 export type GridCellTag = (typeof gridCellTags)[number]
 
 type GridCellSpanAllProp = {

--- a/packages/react/src/Grid/GridSubgrid.test.tsx
+++ b/packages/react/src/Grid/GridSubgrid.test.tsx
@@ -9,7 +9,7 @@ import { describe, expect, it } from 'vitest'
 
 import { ariaRoleForTag } from '../common/accessibility'
 import { Grid, gridGaps } from './Grid'
-import { gridCellTags } from './GridCell'
+import { gridSubgridTags } from './GridSubgrid'
 
 describe('GridSubgrid', () => {
   it('renders', () => {
@@ -110,11 +110,12 @@ describe('GridSubgrid', () => {
     expect(component).toHaveClass(`ams-grid__subgrid--gap-vertical--${gap}`)
   })
 
-  gridCellTags.forEach((tag) => {
+  gridSubgridTags.forEach((tag) => {
     it(`renders with a custom ${tag} tag`, () => {
-      const { container } = render(
-        <Grid.Subgrid aria-label={tag === 'section' ? 'Accessible name' : undefined} as={tag} />,
-      )
+      const subgrid = <Grid.Subgrid aria-label={tag === 'section' ? 'Accessible name' : undefined} as={tag} />
+
+      // A list item only takes its role inside a list.
+      const { container } = render(tag === 'li' ? <ul>{subgrid}</ul> : subgrid)
 
       const component = tag === 'div' ? container.querySelector(tag) : screen.getByRole(ariaRoleForTag[tag])
 

--- a/packages/react/src/Grid/GridSubgrid.test.tsx
+++ b/packages/react/src/Grid/GridSubgrid.test.tsx
@@ -112,10 +112,9 @@ describe('GridSubgrid', () => {
 
   gridSubgridTags.forEach((tag) => {
     it(`renders with a custom ${tag} tag`, () => {
-      const subgrid = <Grid.Subgrid aria-label={tag === 'section' ? 'Accessible name' : undefined} as={tag} />
-
-      // A list item only takes its role inside a list.
-      const { container } = render(tag === 'li' ? <ul>{subgrid}</ul> : subgrid)
+      const { container } = render(
+        <Grid.Subgrid aria-label={tag === 'section' ? 'Accessible name' : undefined} as={tag} />,
+      )
 
       const component = tag === 'div' ? container.querySelector(tag) : screen.getByRole(ariaRoleForTag[tag])
 

--- a/packages/react/src/Grid/GridSubgrid.tsx
+++ b/packages/react/src/Grid/GridSubgrid.tsx
@@ -9,7 +9,6 @@ import { clsx } from 'clsx'
 import { forwardRef } from 'react'
 
 import type { GridColumnNumber, GridColumnNumbers, GridRowNumber, GridRowNumbers } from './Grid'
-import type { GridCellTag } from './GridCell'
 
 import { gridSubgridClasses } from './gridSubgridClasses'
 
@@ -19,6 +18,25 @@ import { gridSubgridClasses } from './gridSubgridClasses'
  */
 export const gridSubgridGaps = ['none', 'large', 'x-large', '2x-large'] as const
 export type GridSubgridGap = (typeof gridSubgridGaps)[number]
+
+/**
+ * The tags of a Grid Cell, plus the two list elements. A Subgrid can be the list a set of Cells belongs to;
+ * a Cell cannot, since its children are content rather than list items.
+ */
+export const gridSubgridTags = [
+  'article',
+  'aside',
+  'div',
+  'footer',
+  'header',
+  'li',
+  'main',
+  'nav',
+  'ol',
+  'section',
+  'ul',
+] as const
+export type GridSubgridTag = (typeof gridSubgridTags)[number]
 
 type GridSubgridSpanAllProp = {
   /** Lets the subgrid span the full width of all grid variants. */
@@ -44,7 +62,7 @@ export type GridSubgridProps = {
    * The HTML tag to use.
    * @default div
    */
-  readonly as?: GridCellTag
+  readonly as?: GridSubgridTag
   /**
    * The amount of space between the rows of the subgrid.
    * Defaults to the vertical gap of the Grid.

--- a/packages/react/src/Grid/GridSubgrid.tsx
+++ b/packages/react/src/Grid/GridSubgrid.tsx
@@ -86,7 +86,7 @@ export type GridSubgridProps = {
 
 /**
  * A region of the Grid that shares its columns with its children, so they align to the columns of the page.
- * Every direct child must be a Grid Cell.
+ * Every direct child must be a Grid Cell, or another Subgrid if part of the region is a set of its own.
  *
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-layout-grid--docs Grid docs at Amsterdam Design System}
  */

--- a/packages/react/src/Grid/GridSubgrid.tsx
+++ b/packages/react/src/Grid/GridSubgrid.tsx
@@ -20,7 +20,7 @@ export const gridSubgridGaps = ['none', 'large', 'x-large', '2x-large'] as const
 export type GridSubgridGap = (typeof gridSubgridGaps)[number]
 
 /**
- * The tags of a Grid. A Subgrid can be the list a set of Cells belongs to, but never an item of one:
+ * A Subgrid can be the list a set of Cells belongs to, but never an item of one:
  * an `li` holds content, which is what a Cell is for.
  */
 export const gridSubgridTags = [

--- a/packages/react/src/Grid/GridSubgrid.tsx
+++ b/packages/react/src/Grid/GridSubgrid.tsx
@@ -20,8 +20,8 @@ export const gridSubgridGaps = ['none', 'large', 'x-large', '2x-large'] as const
 export type GridSubgridGap = (typeof gridSubgridGaps)[number]
 
 /**
- * The tags of a Grid Cell, plus the two list elements. A Subgrid can be the list a set of Cells belongs to;
- * a Cell cannot, since its children are content rather than list items.
+ * The tags of a Grid. A Subgrid can be the list a set of Cells belongs to, but never an item of one:
+ * an `li` holds content, which is what a Cell is for.
  */
 export const gridSubgridTags = [
   'article',
@@ -29,7 +29,6 @@ export const gridSubgridTags = [
   'div',
   'footer',
   'header',
-  'li',
   'main',
   'nav',
   'ol',

--- a/packages/react/src/common/accessibility.ts
+++ b/packages/react/src/common/accessibility.ts
@@ -8,7 +8,10 @@ export const ariaRoleForTag = {
   aside: 'complementary',
   footer: 'contentinfo',
   header: 'banner',
+  li: 'listitem',
   main: 'main',
   nav: 'navigation',
+  ol: 'list',
   section: 'region',
+  ul: 'list',
 }

--- a/storybook/src/components/Breakout/Breakout.stories.tsx
+++ b/storybook/src/components/Breakout/Breakout.stories.tsx
@@ -7,7 +7,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Image, Paragraph, Spotlight } from '@amsterdam/design-system-react'
 import { Breakout } from '@amsterdam/design-system-react/src'
-import { gridTags } from '@amsterdam/design-system-react/src/Grid/Grid'
+import { breakoutTags } from '@amsterdam/design-system-react/src/Breakout/Breakout'
 
 import { asArgType } from '#storybook/_common/argTypes'
 import { wrapInPage } from '#storybook/_common/decorators'
@@ -19,7 +19,7 @@ const meta = {
   component: Breakout,
   argTypes: {
     ...gridGapAndPaddingArgTypes,
-    as: asArgType(gridTags),
+    as: asArgType(breakoutTags),
   },
   decorators: [wrapInPage],
   parameters: {

--- a/storybook/src/components/Breakout/Breakout.test.stories.tsx
+++ b/storybook/src/components/Breakout/Breakout.test.stories.tsx
@@ -9,8 +9,6 @@ import { Spotlight } from '@amsterdam/design-system-react'
 import { Breakout } from '@amsterdam/design-system-react/src'
 import { gridGaps } from '@amsterdam/design-system-react/src/Grid/Grid'
 
-import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
-
 import { default as breakoutMeta } from './Breakout.stories'
 
 const meta = {
@@ -50,9 +48,16 @@ export const Test: Story = {
       </Breakout.Cell>,
     ],
   },
-  render: (args, context) => (
+  /*
+   * One composition rather than every variant of every prop. A Breakout takes the gaps, paddings and tags of a
+   * Grid, which snapshots all of them, so only what a Breakout does with them is worth a picture of its own:
+   * a figure that widens past its columns, and a Spotlight that reaches exactly into the gap around it.
+   */
+  render: (args) => (
     <>
-      {renderComponentVariants(Breakout, { args }, context)}
+      <p>A figure and a Spotlight breaking out</p>
+      <Breakout {...args} />
+      <p>Each row gap, cancelled by its own offset</p>
       <div className="_ams-tests-stack">
         {gaps.map((gap) => (
           // The vertical padding is the largest one, so each Spotlight escapes into its own Breakout

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -75,7 +75,14 @@ The Grid manages its own gaps; the utility classes interfere with that.
 
 ### How to use
 
+#### Sizing and placement
+
 Follow the [optimal sizes of Grid Cells](/docs/pages-guidelines-layout-and-spacing--docs#how-to-size-the-grid-cells) for typical page sections.
+
+Ensure the `span` and `start` values for a cell never exceed the number of columns available at that breakpoint.
+The browser would add columns to fit, which breaks the layout.
+
+#### Meaningful elements
 
 Use the `as` prop to give a Grid or a Grid Cell a meaningful HTML element when one applies.
 For example, set a top-level Cell that holds the main content of the page to `as="main"`, or a sidebar Cell to `as="aside"`.
@@ -87,8 +94,7 @@ Next to a sidebar, the main content goes in its own Grid Cell.
 Give a Grid or a Subgrid `as="ul"` and the Cells inside it `as="li"` where those Cells hold the same kind of thing, such as a set of Cards.
 ‘A set of Cells as a list’ below shows how.
 
-Ensure the `span` and `start` values for a cell never exceed the number of columns available at that breakpoint.
-The browser would add columns to fit, which breaks the layout.
+#### Reading order
 
 Write the Cells in the order the content should be read, and use `start` only to decide where each one sits.
 Reading order and keyboard order follow the markup rather than the columns, so the two disagree as soon as `start` is used to reorder rather than to place.

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -40,7 +40,7 @@ Set it on the sidebar rather than on everything around it, and leave the rest to
 
 Shares the columns it spans with its own children, so they align to the columns of the page.
 Place and size it with `span` and `start`, exactly like a Cell; those values also decide how many columns its children have to work with.
-Every direct child of a Subgrid must be a Cell.
+Every direct child of a Subgrid must be a Cell, or another Subgrid if part of the region is a set of its own.
 
 Use it for a region beside a sidebar, such as the results of an index page next to a filter column.
 Without it, a Cell inside a Cell has no columns to align to.
@@ -83,6 +83,9 @@ For example, set a top-level Cell that holds the main content of the page to `as
 Put `as="main"` on the Grid itself when the main content of a page is a single section: the Grid then is that region.
 Wrap the sections in a plain `main` element instead when the region holds several of them, such as more Grids, a [Spotlight](/docs/components-containers-spotlight--docs), or a full-bleed [Image](/docs/components-media-image--docs).
 Next to a sidebar, the main content goes in its own Grid Cell.
+
+Give a Grid or a Subgrid `as="ul"` and the Cells inside it `as="li"` where those Cells hold the same kind of thing, such as a set of Cards.
+‘A set of Cells as a list’ below shows how.
 
 Ensure the `span` and `start` values for a cell never exceed the number of columns available at that breakpoint.
 The browser would add columns to fit, which breaks the layout.
@@ -178,6 +181,23 @@ Both Grid and Grid Cell render a `<div>` by default.
 Use the `as` prop on either to make the markup more semantic.
 
 <Canvas of={GridCellStories.ImproveSemantics} />
+
+### A set of Cells as a list
+
+A set of Cells that hold the same kind of thing is a list: news items, search results, a row of Cards.
+Render the Grid or the Subgrid around them as an `ol` or a `ul`, and every Cell inside it as an `li`.
+
+That element then holds those items and nothing else.
+A heading above the set or a [Pagination](/docs/components-navigation-pagination--docs) below it is not one of them, so each goes in a Cell of its own outside the list.
+A Subgrid is usually the one to reach for, since a Grid tends to carry that heading as well.
+
+Where the set is only part of a wider region, give it a Subgrid of its own inside that region’s Subgrid.
+A Subgrid inside a Subgrid still hands down the columns of the page, and takes the same row gap.
+
+A list looks exactly like a `div`: it drops the marker, the indent and the margin a browser gives a list.
+A Grid keeps its own inline padding, the gutter of the page.
+
+<Canvas of={GridSubgridStories.SemanticList} />
 
 ## Features
 
@@ -318,6 +338,10 @@ A cell written second and started at column 7 is read second and reached second 
 
 The `as` prop can render an `article` or a `section` instead of a `div`.
 A `section` reaches assistive technology as a landmark only once it has a name, so give the heading inside it an `id` and point `aria-labelledby` at that id.
+
+A Grid or a Subgrid that renders an `ol` or a `ul` reaches assistive technology as a list, and the Cells inside it need `as="li"` to be its items.
+A screen reader then announces how many items the set holds and which one it is on.
+It also offers its shortcuts for moving through the set or skipping past it.
 
 ## See also
 

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -87,13 +87,14 @@ The browser would add columns to fit, which breaks the layout.
 
 Use the `as` prop to give a Grid or a Grid Cell a meaningful HTML element when one applies.
 For example, set a top-level Cell that holds the main content of the page to `as="main"`, or a sidebar Cell to `as="aside"`.
+A Grid or a Cell can be an `article` or a `section` too, among the other tags `as` offers.
 
 Put `as="main"` on the Grid itself when the main content of a page is a single section: the Grid then is that region.
 Wrap the sections in a plain `main` element instead when the region holds several of them, such as more Grids, a [Spotlight](/docs/components-containers-spotlight--docs), or a full-bleed [Image](/docs/components-media-image--docs).
 Next to a sidebar, the main content goes in its own Grid Cell.
 
 Give a Grid or a Subgrid `as="ul"` and the Cells inside it `as="li"` where those Cells hold the same kind of thing, such as a set of Cards.
-‘A set of Cells as a list’ below shows how.
+‘Semantic list of cards’ below shows how.
 
 #### Reading order
 
@@ -182,14 +183,7 @@ This example appears best with Compact Mode active in the toolbar above.
 
 <Canvas of={GridStories.BackgroundInCompactMode} />
 
-### Improve semantics
-
-Both Grid and Grid Cell render a `<div>` by default.
-Use the `as` prop on either to make the markup more semantic.
-
-<Canvas of={GridCellStories.ImproveSemantics} />
-
-### A set of Cells as a list
+### Semantic list of cards
 
 A set of Cells that hold the same kind of thing is a list: news items, search results, a row of Cards.
 Render the Grid or the Subgrid around them as an `ol` or a `ul`, and every Cell inside it as an `li`.
@@ -204,7 +198,7 @@ A Subgrid inside a Subgrid still hands down the columns of the page, and takes t
 A list looks exactly like a `div`: it drops the marker, the indent and the margin a browser gives a list.
 A Grid keeps its own inline padding, the gutter of the page.
 
-<Canvas of={GridSubgridStories.SemanticList} />
+<Canvas of={GridSubgridStories.SemanticListOfCards} />
 
 ## Features
 

--- a/storybook/src/components/Grid/Grid.docs.mdx
+++ b/storybook/src/components/Grid/Grid.docs.mdx
@@ -69,6 +69,7 @@ This lets you mix a Grid with a [Spotlight](/docs/components-containers-spotligh
 
 Never nest a Grid inside another Grid.
 The Grid is currently intended for the full width of the page only.
+Use a Subgrid where a region needs to place its own children on the columns of the page.
 
 Do not apply [Gap utility classes](/docs/utilities-css-gap--docs) to the Grid.
 The Grid manages its own gaps; the utility classes interfere with that.

--- a/storybook/src/components/Grid/Grid.test.stories.tsx
+++ b/storybook/src/components/Grid/Grid.test.stories.tsx
@@ -183,21 +183,33 @@ const GridListCase = () => (
 
 export const Test: Story = {
   args: {
-    children: [<Grid.Cell key={1} span="all" />, <Grid.Cell key={2} span="all" />],
+    // Empty Cells leave every variant blank, so the gaps and paddings they differ in have nothing to measure.
+    children: [<Grid.Cell key={1} {...item} span="all" />, <Grid.Cell key={2} {...item} span="all" />],
   },
   render: (args, context) => (
     <div className="_ams-tests-stack">
+      <p>Gaps and paddings</p>
       {renderComponentVariants(Grid, { args }, context)}
+      <p>Subgrid</p>
       <SubgridCase />
+      <p>Subgrid in a Grid without a row gap</p>
       <SubgridCase gapVertical="none" />
+      <p>Subgrid with a 2x-large row gap</p>
       <SubgridCase subgridGapVertical="2x-large" />
       {/* The reason x-large exists: the Grid drops its gap, and the Subgrid puts the regular one back. */}
+      <p>Subgrid restoring the x-large row gap</p>
       <SubgridCase gapVertical="none" subgridGapVertical="x-large" />
+      <p>Subgrid placement</p>
       <SubgridPlacementCase />
+      <p>Subgrid spanning two rows</p>
       <SubgridRowSpanCase />
+      <p>Row start</p>
       <RowStartCase />
+      <p>Row start for a Subgrid</p>
       <SubgridRowStartCase />
+      <p>Subgrid as a list</p>
       <ListCase />
+      <p>Grid as a list</p>
       <GridListCase />
     </div>
   ),

--- a/storybook/src/components/Grid/Grid.test.stories.tsx
+++ b/storybook/src/components/Grid/Grid.test.stories.tsx
@@ -128,6 +128,59 @@ const SubgridRowStartCase = () => (
   </Grid>
 )
 
+/*
+ * A Subgrid that is a list is indistinguishable from one that is not: markers or an indent in the first row
+ * mean the list reset is gone. The second list sits inside a plain Subgrid, the arrangement of a page where
+ * the set is only part of a wider region, and its rows must still line up with the reference row above.
+ */
+const ListCase = () => (
+  <Grid paddingVertical="large">
+    <Grid.Subgrid as="ul" span="all">
+      <Grid.Cell {...item} as="li" span={quarter} />
+      <Grid.Cell {...item} as="li" span={quarter} />
+      <Grid.Cell {...item} as="li" span={quarter} />
+      <Grid.Cell {...item} as="li" span={quarter} />
+    </Grid.Subgrid>
+    <Grid.Subgrid span="all">
+      <Grid.Cell {...item} span={quarter} />
+      <Grid.Cell {...item} span={quarter} />
+      <Grid.Cell {...item} span={quarter} />
+      <Grid.Cell {...item} span={quarter} />
+    </Grid.Subgrid>
+    <Grid.Subgrid span={threeQuarters} start={secondQuarter}>
+      <Grid.Cell {...item} span={quarter} />
+      <Grid.Subgrid as="ol" span="all">
+        <Grid.Cell {...item} as="li" span={quarter} />
+        <Grid.Cell {...item} as="li" span={quarter} />
+        <Grid.Cell {...item} as="li" span={quarter} />
+      </Grid.Subgrid>
+      <Grid.Cell {...item} span={quarter} />
+    </Grid.Subgrid>
+  </Grid>
+)
+
+/*
+ * A Grid can be the list itself. Unlike a Subgrid it keeps its inline padding, the gutter of the page, which
+ * the list reset would zero: these Cells must line up with those of every other case rather than sit further
+ * out. The Grid below it is the reference.
+ */
+const GridListCase = () => (
+  <>
+    <Grid as="ul" paddingVertical="large">
+      <Grid.Cell {...item} as="li" span={quarter} />
+      <Grid.Cell {...item} as="li" span={quarter} />
+      <Grid.Cell {...item} as="li" span={quarter} />
+      <Grid.Cell {...item} as="li" span={quarter} />
+    </Grid>
+    <Grid paddingVertical="large">
+      <Grid.Cell {...item} span={quarter} />
+      <Grid.Cell {...item} span={quarter} />
+      <Grid.Cell {...item} span={quarter} />
+      <Grid.Cell {...item} span={quarter} />
+    </Grid>
+  </>
+)
+
 export const Test: Story = {
   args: {
     children: [<Grid.Cell key={1} span="all" />, <Grid.Cell key={2} span="all" />],
@@ -144,6 +197,8 @@ export const Test: Story = {
       <SubgridRowSpanCase />
       <RowStartCase />
       <SubgridRowStartCase />
+      <ListCase />
+      <GridListCase />
     </div>
   ),
   tags: ['!dev', '!autodocs', '!manifest'],

--- a/storybook/src/components/Grid/GridCell.stories.tsx
+++ b/storybook/src/components/Grid/GridCell.stories.tsx
@@ -31,10 +31,11 @@ const meta = {
     },
   },
   decorators: [
-    (Story) => (
+    (Story, context) => (
       <>
         <GridColumnsGuide />
-        <Grid paddingVertical="x-large">
+        {/* A list item belongs in a list, so the Grid around it becomes one as soon as the Cell is an `li`. */}
+        <Grid as={context.args.as === 'li' ? 'ul' : undefined} paddingVertical="x-large">
           <Story />
         </Grid>
       </>

--- a/storybook/src/components/Grid/GridCell.stories.tsx
+++ b/storybook/src/components/Grid/GridCell.stories.tsx
@@ -102,11 +102,3 @@ export const StartPosition: CellStory = {
     start: { narrow: 2, medium: 4, wide: 6 },
   },
 }
-
-export const ImproveSemantics: CellStory = {
-  args: {
-    as: 'section',
-    className: '_ams-item',
-    span: 'all',
-  },
-}

--- a/storybook/src/components/Grid/GridSubgrid.stories.tsx
+++ b/storybook/src/components/Grid/GridSubgrid.stories.tsx
@@ -6,7 +6,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Grid } from '@amsterdam/design-system-react/src'
-import { gridCellTags } from '@amsterdam/design-system-react/src/Grid/GridCell'
+import { gridSubgridTags } from '@amsterdam/design-system-react/src/Grid/GridSubgrid'
 
 import { asArgType } from '#storybook/_common/argTypes'
 import { GridColumnsGuide } from '#storybook/_components/GridColumnsGuide/GridColumnsGuide'
@@ -15,7 +15,7 @@ const meta = {
   title: 'Components/Layout/Grid',
   component: Grid.Subgrid,
   argTypes: {
-    as: asArgType(gridCellTags),
+    as: asArgType(gridSubgridTags),
     gapVertical: {
       control: {
         labels: { undefined: 'inherit (default)' },
@@ -69,5 +69,21 @@ export const Subgrid: SubgridStory = {
         <Grid.Cell className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
       </Grid.Subgrid>
     </>
+  ),
+}
+
+/**
+ * A set of Cells that hold the same kind of thing is a list. Render the Subgrid as an `ol` or a `ul` and every
+ * Cell inside it as an `li`. It looks exactly the same, and assistive technology announces the set and its size.
+ */
+export const SemanticList: SubgridStory = {
+  // Taking no argument keeps the Code Panel showing this markup as written.
+  render: () => (
+    <Grid.Subgrid as="ul" span="all">
+      <Grid.Cell as="li" className="_ams-item" span={{ narrow: 4, medium: 4, wide: 3 }} style={{ blockSize: '6rem' }} />
+      <Grid.Cell as="li" className="_ams-item" span={{ narrow: 4, medium: 4, wide: 3 }} style={{ blockSize: '6rem' }} />
+      <Grid.Cell as="li" className="_ams-item" span={{ narrow: 4, medium: 4, wide: 3 }} style={{ blockSize: '6rem' }} />
+      <Grid.Cell as="li" className="_ams-item" span={{ narrow: 4, medium: 4, wide: 3 }} style={{ blockSize: '6rem' }} />
+    </Grid.Subgrid>
   ),
 }

--- a/storybook/src/components/Grid/GridSubgrid.stories.tsx
+++ b/storybook/src/components/Grid/GridSubgrid.stories.tsx
@@ -77,13 +77,14 @@ export const Subgrid: SubgridStory = {
  * Cell inside it as an `li`. It looks exactly the same, and assistive technology announces the set and its size.
  */
 export const SemanticListOfCards: SubgridStory = {
-  // Taking no argument keeps the Code Panel showing this markup as written.
-  render: () => (
-    <Grid.Subgrid as="ul" span="all">
-      <Grid.Cell as="li" className="_ams-item" span={{ narrow: 4, medium: 4, wide: 3 }} style={{ blockSize: '6rem' }} />
-      <Grid.Cell as="li" className="_ams-item" span={{ narrow: 4, medium: 4, wide: 3 }} style={{ blockSize: '6rem' }} />
-      <Grid.Cell as="li" className="_ams-item" span={{ narrow: 4, medium: 4, wide: 3 }} style={{ blockSize: '6rem' }} />
-      <Grid.Cell as="li" className="_ams-item" span={{ narrow: 4, medium: 4, wide: 3 }} style={{ blockSize: '6rem' }} />
-    </Grid.Subgrid>
-  ),
+  args: {
+    as: 'ul',
+    children: [
+      <Grid.Cell as="li" className="_ams-item" key={1} span={{ narrow: 4, medium: 4, wide: 3 }} />,
+      <Grid.Cell as="li" className="_ams-item" key={2} span={{ narrow: 4, medium: 4, wide: 3 }} />,
+      <Grid.Cell as="li" className="_ams-item" key={3} span={{ narrow: 4, medium: 4, wide: 3 }} />,
+      <Grid.Cell as="li" className="_ams-item" key={4} span={{ narrow: 4, medium: 4, wide: 3 }} />,
+    ],
+    span: 'all',
+  },
 }

--- a/storybook/src/components/Grid/GridSubgrid.stories.tsx
+++ b/storybook/src/components/Grid/GridSubgrid.stories.tsx
@@ -76,7 +76,7 @@ export const Subgrid: SubgridStory = {
  * A set of Cells that hold the same kind of thing is a list. Render the Subgrid as an `ol` or a `ul` and every
  * Cell inside it as an `li`. It looks exactly the same, and assistive technology announces the set and its size.
  */
-export const SemanticList: SubgridStory = {
+export const SemanticListOfCards: SubgridStory = {
   // Taking no argument keeps the Code Panel showing this markup as written.
   render: () => (
     <Grid.Subgrid as="ul" span="all">

--- a/storybook/src/components/Grid/GridSubgrid.stories.tsx
+++ b/storybook/src/components/Grid/GridSubgrid.stories.tsx
@@ -56,20 +56,25 @@ type SubgridStory = StoryObj<typeof subgridMeta>
  * the Cells inside it line up with the column guide.
  */
 export const Subgrid: SubgridStory = {
-  render: (args) => (
-    <>
-      <Grid.Cell className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} style={{ blockSize: '16rem' }} />
-      <Grid.Subgrid {...args} span={{ narrow: 4, medium: 6, wide: 9 }} start={{ narrow: 1, medium: 3, wide: 4 }}>
-        <Grid.Cell className="_ams-item" span="all" style={{ blockSize: '6rem' }} />
-        <Grid.Cell className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
-        <Grid.Cell className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
-        <Grid.Cell className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
-        <Grid.Cell className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
-        <Grid.Cell className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
-        <Grid.Cell className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
-      </Grid.Subgrid>
-    </>
-  ),
+  render: (args) => {
+    // The Cells of a list are its items, so they follow the tag the control sets.
+    const item = args.as === 'ol' || args.as === 'ul' ? ('li' as const) : undefined
+
+    return (
+      <>
+        <Grid.Cell className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} style={{ blockSize: '16rem' }} />
+        <Grid.Subgrid {...args} span={{ narrow: 4, medium: 6, wide: 9 }} start={{ narrow: 1, medium: 3, wide: 4 }}>
+          <Grid.Cell as={item} className="_ams-item" span="all" style={{ blockSize: '6rem' }} />
+          <Grid.Cell as={item} className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
+          <Grid.Cell as={item} className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
+          <Grid.Cell as={item} className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
+          <Grid.Cell as={item} className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
+          <Grid.Cell as={item} className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
+          <Grid.Cell as={item} className="_ams-item" span={{ narrow: 4, medium: 2, wide: 3 }} />
+        </Grid.Subgrid>
+      </>
+    )
+  },
 }
 
 /**

--- a/storybook/src/components/OrderedList/OrderedList.docs.mdx
+++ b/storybook/src/components/OrderedList/OrderedList.docs.mdx
@@ -53,16 +53,11 @@ Use the HTML attribute `reversed`.
 
 ### Without markers
 
-An overview of search results can be seen as an ordered list.
-In such cases, apply the list semantics while hiding markers.
-This helps screen readers understand and navigate the list.
+Set `markers` to false where a group of items reads as a list but should not show its numbers.
+The list keeps its `ol` and `li` elements, so a screen reader still announces it as a list and reports how many items it holds, while the numbers stay out of the way.
+Its items then hold blocks rather than sentences, so the list defines no typography and the `color` prop has no effect.
 
-Note: each item typically contains a container with headings and other text components in this variant.
-Therefore, it does not define typography for the items and the `color` prop has no effect.
-
-For example, here are three news articles:
-
-<Canvas of={OrderedListStories.WithoutMarkers} />
+For a set of Cards laid out across the page, make the [Grid](/docs/components-layout-grid--docs) or a Grid Subgrid the list instead.
 
 ### Inverse colour
 

--- a/storybook/src/components/OrderedList/OrderedList.stories.tsx
+++ b/storybook/src/components/OrderedList/OrderedList.stories.tsx
@@ -5,11 +5,9 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { Card, Paragraph } from '@amsterdam/design-system-react'
 import { OrderedList } from '@amsterdam/design-system-react/src'
 
 import { inverseColorArgType, textSizeArgType } from '#storybook/_common/argTypes'
-import { maximiseInlineSize } from '#storybook/_common/decorators'
 import { exampleOrderedList } from '#storybook/_common/exampleContent'
 
 const orderedListItems = exampleOrderedList().map((text) => <OrderedList.Item key={text}>{text}</OrderedList.Item>)
@@ -85,52 +83,6 @@ export const DescendingNumbers: Story = {
     reversed: true,
     start: 3,
   },
-}
-
-export const WithoutMarkers: Story = {
-  args: {
-    children: [
-      <OrderedList.Item key={1}>
-        <Card>
-          <Card.Heading level={2}>
-            <Card.Link href="#">Weg met steen, hallo extra groen en koelte</Card.Link>
-          </Card.Heading>
-          <Paragraph>
-            Sinds 2021 kwamen er maar liefst 60 nieuwe groene plekken bij in de stad. Groen is fijn en het verkoelt de
-            stad in de zomer. Een paar voorbeelden.
-          </Paragraph>
-          <Paragraph size="small">16 augustus 2023</Paragraph>
-        </Card>
-      </OrderedList.Item>,
-      <OrderedList.Item key={2}>
-        <Card>
-          <Card.Heading level={2}>
-            <Card.Link href="#">Amsterdam bindt de strijd aan met lawaaierige voertuigen</Card.Link>
-          </Card.Heading>
-          <Paragraph>
-            Deze zomer testen we of digitale borden langs de weg kunnen helpen om geluidsoverlast van voertuigen zoals
-            motoren en auto’s tegen te gaan.
-          </Paragraph>
-          <Paragraph size="small">10 augustus 2023</Paragraph>
-        </Card>
-      </OrderedList.Item>,
-      <OrderedList.Item key={3}>
-        <Card>
-          <Card.Heading level={2}>
-            <Card.Link href="#">Een prachtroute door de wonderlijke Baarsjes</Card.Link>
-          </Card.Heading>
-          <Paragraph>
-            In de Baarsjes zijn kunst en cultuur met elkaar vervlochten. We zetten een prachtige wandelroute voor u uit
-            en laten zien hoe het was en hoe het nu is.
-          </Paragraph>
-          <Paragraph size="small">8 augustus 2023</Paragraph>
-        </Card>
-      </OrderedList.Item>,
-    ],
-    className: 'ams-gap-xl',
-    markers: false,
-  },
-  decorators: [maximiseInlineSize('32rem')],
 }
 
 export const InverseColor: Story = {

--- a/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
+++ b/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
@@ -40,16 +40,11 @@ It is left-aligned with the text of the higher-level item.
 
 ### Without markers
 
-An overview of articles can be seen as an unordered list.
-In such cases, apply the list semantics while hiding markers.
-This helps screen readers understand and navigate the list.
+Set `markers` to false where a group of items reads as a list but should not look like one.
+The list keeps its `ul` and `li` elements, so a screen reader still announces it as a list and reports how many items it holds, while the markers stay out of the way.
+Its items then hold blocks rather than sentences, so the list defines no typography and the `color` prop has no effect.
 
-Note: each item typically contains a container with headings and other text components in this variant.
-Therefore, it does not define typography for the items and the `color` prop has no effect.
-
-For example, here are three news articles:
-
-<Canvas of={UnorderedListStories.WithoutMarkers} />
+For a set of Cards laid out across the page, make the [Grid](/docs/components-layout-grid--docs) or a Grid Subgrid the list instead.
 
 ### Inverse colour
 

--- a/storybook/src/components/UnorderedList/UnorderedList.stories.tsx
+++ b/storybook/src/components/UnorderedList/UnorderedList.stories.tsx
@@ -5,11 +5,9 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { Card, Paragraph } from '@amsterdam/design-system-react'
 import { UnorderedList } from '@amsterdam/design-system-react/src'
 
 import { inverseColorArgType, textSizeArgType } from '#storybook/_common/argTypes'
-import { maximiseInlineSize } from '#storybook/_common/decorators'
 import { exampleUnorderedList } from '#storybook/_common/exampleContent'
 
 const unorderedListItems = exampleUnorderedList().map((text) => (
@@ -56,52 +54,6 @@ export const TwoLevels: Story = {
       </UnorderedList.Item>
     </UnorderedList>
   ),
-}
-
-export const WithoutMarkers: Story = {
-  args: {
-    children: [
-      <UnorderedList.Item key={1}>
-        <Card>
-          <Card.Heading level={2}>
-            <Card.Link href="#">Weg met steen, hallo extra groen en koelte</Card.Link>
-          </Card.Heading>
-          <Paragraph>
-            Sinds 2021 kwamen er maar liefst 60 nieuwe groene plekken bij in de stad. Groen is fijn en het verkoelt de
-            stad in de zomer. Een paar voorbeelden.
-          </Paragraph>
-          <Paragraph size="small">16 augustus 2023</Paragraph>
-        </Card>
-      </UnorderedList.Item>,
-      <UnorderedList.Item key={2}>
-        <Card>
-          <Card.Heading level={2}>
-            <Card.Link href="#">Amsterdam bindt de strijd aan met lawaaierige voertuigen</Card.Link>
-          </Card.Heading>
-          <Paragraph>
-            Deze zomer testen we of digitale borden langs de weg kunnen helpen om geluidsoverlast van voertuigen zoals
-            motoren en auto’s tegen te gaan.
-          </Paragraph>
-          <Paragraph size="small">10 augustus 2023</Paragraph>
-        </Card>
-      </UnorderedList.Item>,
-      <UnorderedList.Item key={3}>
-        <Card>
-          <Card.Heading level={2}>
-            <Card.Link href="#">Een prachtroute door de wonderlijke Baarsjes</Card.Link>
-          </Card.Heading>
-          <Paragraph>
-            In de Baarsjes zijn kunst en cultuur met elkaar vervlochten. We zetten een prachtige wandelroute voor u uit
-            en laten zien hoe het was en hoe het nu is.
-          </Paragraph>
-          <Paragraph size="small">8 augustus 2023</Paragraph>
-        </Card>
-      </UnorderedList.Item>,
-    ],
-    className: 'ams-gap-xl',
-    markers: false,
-  },
-  decorators: [maximiseInlineSize('32rem')],
 }
 
 export const InverseColor: Story = {

--- a/storybook/src/pages/guidelines/layout-and-spacing.docs.mdx
+++ b/storybook/src/pages/guidelines/layout-and-spacing.docs.mdx
@@ -144,6 +144,11 @@ The Subgrid hands its columns to its own Cells, so each block is placed against 
 </Grid>
 ```
 
+Where those blocks hold the same kind of thing – Cards, news items, search results – the set is a list.
+Give the Subgrid `as="ul"` and each Cell inside it `as="li"`.
+Keep whatever is not one of the items outside it, such as the heading or a Pagination.
+[A set of Cells as a list](/docs/components-layout-grid--docs#a-set-of-cells-as-a-list) shows how.
+
 Where two columns run beside one another and one is much taller, give **each column** its own Subgrid instead.
 A Subgrid is a single item in the row of the Grid however many rows it holds, so the columns stack independently rather than a tall block pushing its neighbour down.
 On the narrow grid the second column then lands below the whole of the first rather than interleaving with it.

--- a/storybook/src/pages/guidelines/layout-and-spacing.docs.mdx
+++ b/storybook/src/pages/guidelines/layout-and-spacing.docs.mdx
@@ -147,7 +147,7 @@ The Subgrid hands its columns to its own Cells, so each block is placed against 
 Where those blocks hold the same kind of thing – Cards, news items, search results – the set is a list.
 Give the Subgrid `as="ul"` and each Cell inside it `as="li"`.
 Keep whatever is not one of the items outside it, such as the heading or a Pagination.
-[A set of Cells as a list](/docs/components-layout-grid--docs#a-set-of-cells-as-a-list) shows how.
+[Semantic list of cards](/docs/components-layout-grid--docs#semantic-list-of-cards) shows how.
 
 Where two columns run beside one another and one is much taller, give **each column** its own Subgrid instead.
 A Subgrid is a single item in the row of the Grid however many rows it holds, so the columns stack independently rather than a tall block pushing its neighbour down.

--- a/storybook/src/pages/public/HomePage/HomePage.docs.mdx
+++ b/storybook/src/pages/public/HomePage/HomePage.docs.mdx
@@ -58,6 +58,9 @@ On the Article Page the comparable band sits outside `main` as a named aside, be
 
 Card images take an empty `alt`: the heading and link beside them already name what they point at.
 
+The top tasks and the news previews are each a list in the markup: their Subgrid renders a `ul` and every Cell in it an `li`.
+A screen reader then announces how many Cards the set holds and which one it is on, and can skip past them all at once.
+
 ## See also
 
 - [Navigation Page](/docs/pages-public-navigation-page--docs) – the same job for a single topic.

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -46,7 +46,12 @@ const meta = {
             {topTaskSection.title}
           </Heading>
         </Grid.Cell>
-        <Grid.Subgrid className="ams-mb-l" gapVertical="x-large" span="all">
+        {/*
+         * A set of Cards is a list, so the Subgrid renders a ul and every Cell in it an li. A screen reader
+         * then announces how many there are and which one it is on. This only works where the Subgrid holds
+         * the Cards alone.
+         */}
+        <Grid.Subgrid as="ul" className="ams-mb-l" gapVertical="x-large" span="all">
           {/*
            * Cells flow from the left in source order, so no section here needs a start. On the wide grid the top
            * tasks fit four to a row at {{ narrow: 4, medium: 4, wide: 3 }} and three preview cards at span={4}
@@ -55,7 +60,7 @@ const meta = {
            * both the wide and medium grids, and stack on the narrow one.
            */}
           {topTaskSection.tasks.map(({ title, description }) => (
-            <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
+            <Grid.Cell as="li" key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
               <Card>
                 {/* Card.Link stretches over the whole Card, so the entire Card is one clickable link. */}
                 <Card.Heading level={3}>
@@ -96,9 +101,9 @@ const meta = {
             {newsSection.title}
           </Heading>
         </Grid.Cell>
-        <Grid.Subgrid gapVertical="x-large" span="all">
+        <Grid.Subgrid as="ul" gapVertical="x-large" span="all">
           {newsSection.items.map(({ title, description, image }) => (
-            <Grid.Cell key={title} span={4}>
+            <Grid.Cell as="li" key={title} span={4}>
               <Card>
                 {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
                 <Card.Image alt="" src={image} />
@@ -147,7 +152,12 @@ export const Default: StoryObj = {
       {/* Second level in the outline (the hidden h1 is first), shown at the largest size. */}
       <Heading className="ams-mb-m" level={2} size="level-1">{topTaskSection.title}</Heading>
     </Grid.Cell>
-    <Grid.Subgrid className="ams-mb-l" gapVertical="x-large" span="all">
+    {/*
+     * A set of Cards is a list, so the Subgrid renders a ul and every Cell in it an li. A screen reader then
+     * announces how many there are and which one it is on. This only works where the Subgrid holds the
+     * Cards alone.
+     */}
+    <Grid.Subgrid as="ul" className="ams-mb-l" gapVertical="x-large" span="all">
       {/*
        * Cells flow from the left in source order, so no section here needs a start. On the wide grid the top
        * tasks fit four to a row at {{ narrow: 4, medium: 4, wide: 3 }} and three preview cards at span={4}
@@ -156,7 +166,7 @@ export const Default: StoryObj = {
        * both the wide and medium grids, and stack on the narrow one.
        */}
       {topTaskSection.tasks.map(({ title, description }) => (
-        <Grid.Cell key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
+        <Grid.Cell as="li" key={title} span={{ narrow: 4, medium: 4, wide: 3 }}>
           <Card>
             {/* Card.Link stretches over the whole Card, so the entire Card is one clickable link. */}
             <Card.Heading level={3}>
@@ -191,9 +201,9 @@ export const Default: StoryObj = {
     <Grid.Cell span="all">
       <Heading className="ams-mb-m" level={2} size="level-1">{newsSection.title}</Heading>
     </Grid.Cell>
-    <Grid.Subgrid gapVertical="x-large" span="all">
+    <Grid.Subgrid as="ul" gapVertical="x-large" span="all">
       {newsSection.items.map(({ title, description, image }) => (
-        <Grid.Cell key={title} span={4}>
+        <Grid.Cell as="li" key={title} span={4}>
           <Card>
             {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
             <Card.Image alt="" src={image} />

--- a/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.docs.mdx
+++ b/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.docs.mdx
@@ -45,6 +45,9 @@ Put the results in a [Grid Subgrid](/docs/components-layout-grid--docs) rather t
 A Subgrid hands the columns it spans to its own children, so the Cells inside it sit on the columns of the page.
 Without it the results have no columns of their own, and nothing in them can line up with the rest of the page.
 
+The articles are a list, so give them a Subgrid of their own inside that one: a `ul` with every Cell in it an `li`.
+The sentence announcing the total and the Pagination are not part of that list, so they stay outside it.
+
 Announce the number of results in a `role="status"` paragraph, and name the filters that produced it.
 A visitor using a screen reader otherwise has no way to tell that ticking a checkbox changed anything.
 
@@ -84,6 +87,9 @@ The heading of the filter column is hidden visually but not from assistive techn
 
 The number of results is announced in a `role="status"` paragraph that names the filters which produced it.
 A visitor using a screen reader otherwise has no way to tell that ticking a checkbox changed anything.
+
+The articles are a list in the markup as well as on screen.
+A screen reader then announces how many there are and which one it is on, and can skip past them all at once.
 
 ## See also
 

--- a/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.stories.tsx
+++ b/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.stories.tsx
@@ -148,34 +148,41 @@ export const Default: StoryObj = {
           <Paragraph role="status">{resultsMessage}</Paragraph>
         </Grid.Cell>
         {/*
-         * On the medium Grid a Card takes 4 of the 5 columns of the results region, leaving the last one
-         * empty. That is below the width at which a Card with an image goes horizontal, so it stays vertical.
+         * The articles are a list, so they get a Subgrid of their own: a ul with every Cell in it an li.
+         * The result count above and the Pagination below stay outside it; neither is one of the articles.
+         * A Subgrid inside a Subgrid still hands down the columns of the page, and takes the same row gap.
          */}
-        <Grid.Cell span={{ narrow: 4, medium: 4, wide: 9 }}>
-          <Card>
-            {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
-            <Card.Image alt="" loading="lazy" src="https://picsum.photos/id/122/640/360" />
-            {/* A Card that pairs an image with a Content lays out horizontally in a cell this wide. */}
-            <Card.Content>
-              <Card.HeadingGroup tagline="Algemeen, Centrum, Werkzaamheden">
-                <Card.Heading level={3}>
-                  <Card.Link href="#">Berlagebrug een aantal nachten dicht</Card.Link>
-                </Card.Heading>
-              </Card.HeadingGroup>
-              <Column gap="small">
-                <Paragraph>
-                  Tussen 3 juni en 21 juli leggen we het tramspoor op de Berlagebrug aan. De brug is ongeveer 12
-                  nachten dicht voor gemotoriseerd verkeer en in 3 nachten voor al het verkeer.
-                </Paragraph>
-                <Paragraph size="small">
-                  {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
-                  <time dateTime="2023-10-20">20 oktober 2023</time>
-                </Paragraph>
-              </Column>
-            </Card.Content>
-          </Card>
-        </Grid.Cell>
-        {/* … one Cell per article … */}
+        <Grid.Subgrid as="ul" span="all">
+          {/*
+           * On the medium Grid a Card takes 4 of the 5 columns of the results region, leaving the last one
+           * empty. That is below the width at which a Card with an image goes horizontal, so it stays vertical.
+           */}
+          <Grid.Cell as="li" span={{ narrow: 4, medium: 4, wide: 9 }}>
+            <Card>
+              {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
+              <Card.Image alt="" loading="lazy" src="https://picsum.photos/id/122/640/360" />
+              {/* A Card that pairs an image with a Content lays out horizontally in a cell this wide. */}
+              <Card.Content>
+                <Card.HeadingGroup tagline="Algemeen, Centrum, Werkzaamheden">
+                  <Card.Heading level={3}>
+                    <Card.Link href="#">Berlagebrug een aantal nachten dicht</Card.Link>
+                  </Card.Heading>
+                </Card.HeadingGroup>
+                <Column gap="small">
+                  <Paragraph>
+                    Tussen 3 juni en 21 juli leggen we het tramspoor op de Berlagebrug aan. De brug is ongeveer 12
+                    nachten dicht voor gemotoriseerd verkeer en in 3 nachten voor al het verkeer.
+                  </Paragraph>
+                  <Paragraph size="small">
+                    {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
+                    <time dateTime="2023-10-20">20 oktober 2023</time>
+                  </Paragraph>
+                </Column>
+              </Card.Content>
+            </Card>
+          </Grid.Cell>
+          {/* … one Cell per article … */}
+        </Grid.Subgrid>
         <Grid.Cell span="all">
           <Pagination
             accessibleNameId="paginering"
@@ -287,32 +294,39 @@ export const Default: StoryObj = {
               <Paragraph role="status">{resultsMessage}</Paragraph>
             </Grid.Cell>
             {/*
-             * On the medium Grid a Card takes 4 of the 5 columns of the results region, leaving the last one
-             * empty. That is below the width at which a Card with an image goes horizontal, so it stays vertical.
+             * The articles are a list, so they get a Subgrid of their own: a ul with every Cell in it an li.
+             * The result count above and the Pagination below stay outside it; neither is one of the articles.
+             * A Subgrid inside a Subgrid still hands down the columns of the page, and takes the same row gap.
              */}
-            {newsArticles.map((article) => (
-              <Grid.Cell key={article.id} span={{ narrow: 4, medium: 4, wide: 9 }}>
-                <Card>
-                  {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
-                  <Card.Image alt="" loading="lazy" src={article.imageSource} />
-                  {/* A Card that pairs an image with a Content lays out horizontally in a cell this wide. */}
-                  <Card.Content>
-                    <Card.HeadingGroup tagline={article.category}>
-                      <Card.Heading level={3}>
-                        <Card.Link href="#">{article.title}</Card.Link>
-                      </Card.Heading>
-                    </Card.HeadingGroup>
-                    <Column gap="small">
-                      <Paragraph>{article.teaser}</Paragraph>
-                      <Paragraph size="small">
-                        {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
-                        <time dateTime={article.isoDate}>{article.date}</time>
-                      </Paragraph>
-                    </Column>
-                  </Card.Content>
-                </Card>
-              </Grid.Cell>
-            ))}
+            <Grid.Subgrid as="ul" span="all">
+              {/*
+               * On the medium Grid a Card takes 4 of the 5 columns of the results region, leaving the last one
+               * empty. That is below the width at which a Card with an image goes horizontal, so it stays vertical.
+               */}
+              {newsArticles.map((article) => (
+                <Grid.Cell as="li" key={article.id} span={{ narrow: 4, medium: 4, wide: 9 }}>
+                  <Card>
+                    {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
+                    <Card.Image alt="" loading="lazy" src={article.imageSource} />
+                    {/* A Card that pairs an image with a Content lays out horizontally in a cell this wide. */}
+                    <Card.Content>
+                      <Card.HeadingGroup tagline={article.category}>
+                        <Card.Heading level={3}>
+                          <Card.Link href="#">{article.title}</Card.Link>
+                        </Card.Heading>
+                      </Card.HeadingGroup>
+                      <Column gap="small">
+                        <Paragraph>{article.teaser}</Paragraph>
+                        <Paragraph size="small">
+                          {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
+                          <time dateTime={article.isoDate}>{article.date}</time>
+                        </Paragraph>
+                      </Column>
+                    </Card.Content>
+                  </Card>
+                </Grid.Cell>
+              ))}
+            </Grid.Subgrid>
             <Grid.Cell span="all">
               <Pagination
                 accessibleNameId="paginering"

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.docs.mdx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.docs.mdx
@@ -43,6 +43,7 @@ Keep it out of the filter form as well: nesting one `form` inside another is inv
 
 Put the results in a [Grid Subgrid](/docs/components-layout-grid--docs) and announce the total in a `role="status"` paragraph, as on any index page.
 Name the term that was searched for in that sentence, so it is clear what produced the list.
+The Cards take a `ul` Subgrid of their own inside that one, as on the [News Overview Page](/docs/pages-public-news-overview-page--docs).
 
 The page title is the only Heading 1, and it names the activity rather than the query.
 The filter column and the list of results each take a Heading 2, and the title of every result is a Heading 3.

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
@@ -116,28 +116,35 @@ export const Default: StoryObj = {
           {/* A polite live region, so a screen reader hears the new total when the search or the filters change. */}
           <Paragraph role="status">62 resultaten gevonden voor ‘veiligheid’</Paragraph>
         </Grid.Cell>
-        <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
-          {/* A search result has no image, so this Card needs no Card Content and stays vertical at any width. */}
-          <Card>
-            <Card.HeadingGroup tagline="Actiecentrum Veiligheid en Zorg">
-              <Card.Heading level={3}>
-                <Card.Link href="#">Top 400/600</Card.Link>
-              </Card.Heading>
-            </Card.HeadingGroup>
-            <Column gap="small">
-              <Paragraph>
-                Om de stad veiliger te maken coördineert de gemeente, samen met haar maatschappelijke partners,
-                vanuit het Actiecentrum Veiligheid en Zorg verschillende aanpakken op het snijvlak van veiligheid,
-                zorg en het sociaal domein.
-              </Paragraph>
-              <Paragraph size="small">
-                {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
-                <time dateTime="2023-07-01">1 juli 2023</time>
-              </Paragraph>
-            </Column>
-          </Card>
-        </Grid.Cell>
-        {/* … one Cell per result … */}
+        {/*
+         * The results are a list, so they get a Subgrid of their own: a ul with every Cell in it an li.
+         * The result count above and the Pagination below stay outside it; neither is one of the results.
+         * A Subgrid inside a Subgrid still hands down the columns of the page, and takes the same row gap.
+         */}
+        <Grid.Subgrid as="ul" span="all">
+          <Grid.Cell as="li" span={{ narrow: 4, medium: 5, wide: 7 }}>
+            {/* A search result has no image, so this Card needs no Card Content and stays vertical at any width. */}
+            <Card>
+              <Card.HeadingGroup tagline="Actiecentrum Veiligheid en Zorg">
+                <Card.Heading level={3}>
+                  <Card.Link href="#">Top 400/600</Card.Link>
+                </Card.Heading>
+              </Card.HeadingGroup>
+              <Column gap="small">
+                <Paragraph>
+                  Om de stad veiliger te maken coördineert de gemeente, samen met haar maatschappelijke partners,
+                  vanuit het Actiecentrum Veiligheid en Zorg verschillende aanpakken op het snijvlak van veiligheid,
+                  zorg en het sociaal domein.
+                </Paragraph>
+                <Paragraph size="small">
+                  {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
+                  <time dateTime="2023-07-01">1 juli 2023</time>
+                </Paragraph>
+              </Column>
+            </Card>
+          </Grid.Cell>
+          {/* … one Cell per result … */}
+        </Grid.Subgrid>
         {/* The Pagination takes the width of the results above it rather than that of the region. */}
         <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
           <Pagination accessibleNameId="paginering" linkTemplate={(page) => \`?pagina=\${page}\`} page={1} totalPages={8} />
@@ -227,25 +234,32 @@ export const Default: StoryObj = {
                 {totalResults} resultaten gevonden voor ‘{searchTerm}’
               </Paragraph>
             </Grid.Cell>
-            {searchResults.map((result) => (
-              <Grid.Cell key={result.id} span={{ narrow: 4, medium: 5, wide: 7 }}>
-                {/* A search result has no image, so this Card needs no Card Content and stays vertical at any width. */}
-                <Card>
-                  <Card.HeadingGroup tagline={result.section}>
-                    <Card.Heading level={3}>
-                      <Card.Link href="#">{result.title}</Card.Link>
-                    </Card.Heading>
-                  </Card.HeadingGroup>
-                  <Column gap="small">
-                    <Paragraph>{result.teaser}</Paragraph>
-                    <Paragraph size="small">
-                      {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
-                      <time dateTime={result.isoDate}>{result.date}</time>
-                    </Paragraph>
-                  </Column>
-                </Card>
-              </Grid.Cell>
-            ))}
+            {/*
+             * The results are a list, so they get a Subgrid of their own: a ul with every Cell in it an li.
+             * The result count above and the Pagination below stay outside it; neither is one of the results.
+             * A Subgrid inside a Subgrid still hands down the columns of the page, and takes the same row gap.
+             */}
+            <Grid.Subgrid as="ul" span="all">
+              {searchResults.map((result) => (
+                <Grid.Cell as="li" key={result.id} span={{ narrow: 4, medium: 5, wide: 7 }}>
+                  {/* A search result has no image, so this Card needs no Card Content and stays vertical at any width. */}
+                  <Card>
+                    <Card.HeadingGroup tagline={result.section}>
+                      <Card.Heading level={3}>
+                        <Card.Link href="#">{result.title}</Card.Link>
+                      </Card.Heading>
+                    </Card.HeadingGroup>
+                    <Column gap="small">
+                      <Paragraph>{result.teaser}</Paragraph>
+                      <Paragraph size="small">
+                        {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
+                        <time dateTime={result.isoDate}>{result.date}</time>
+                      </Paragraph>
+                    </Column>
+                  </Card>
+                </Grid.Cell>
+              ))}
+            </Grid.Subgrid>
             {/* The Pagination takes the width of the results above it rather than that of the region. */}
             <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
               <Pagination


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

## Links

- [DES-1976](https://gemeente-amsterdam.atlassian.net/browse/DES-1976)
- [Feature branch deploy](https://amsterdam.github.io/design-system/demo-DES-1976-semantic-card-lists/)
- [Grid documentation](https://amsterdam.github.io/design-system/demo-DES-1976-semantic-card-lists/?path=/docs/components-layout-grid--docs), whose ‘A set of Cells as a list’ covers the pattern
- [Grid Subgrid semantic list story](https://amsterdam.github.io/design-system/demo-DES-1976-semantic-card-lists/?path=/story/components-layout-grid--semantic-list)
- [News Overview Page](https://amsterdam.github.io/design-system/demo-DES-1976-semantic-card-lists/?path=/story/pages-public-news-overview-page--default), where the list sits inside the results Subgrid
- [Search Results Page](https://amsterdam.github.io/design-system/demo-DES-1976-semantic-card-lists/?path=/story/pages-public-search-results-page--default)
- [Home Page](https://amsterdam.github.io/design-system/demo-DES-1976-semantic-card-lists/?path=/story/pages-public-home-page--default), whose two sets of Cards each became a list
- [Layout and spacing](https://amsterdam.github.io/design-system/demo-DES-1976-semantic-card-lists/?path=/docs/pages-guidelines-layout-and-spacing--docs), which gained the rule

## What

A Grid and a Grid Subgrid can render an `ol` or a `ul`, and a Grid Cell an `li`. The News Overview, Search Results and Home Page templates use this, so their sets of Cards are lists in the markup as well as on screen.

Breakout is deliberately left out: it is never a list, so it no longer aliases `GridProps` and keeps the tags it already had.

## Why

A set of Cards is a list, but the markup said otherwise. A screen reader announced six unrelated articles rather than “list, 6 items”, with no way to tell where you were in the set or to skip past it.

Wrapping the Cells in a plain `ul` was not an option: a Subgrid uses `grid-template-columns: subgrid`, which only places its direct children.

## How

The tag unions widen, which is purely additive — nothing is removed and every new tag is optional.

A list drops the marker, the indent and the margin a browser gives it, reusing `reset-ol` and `reset-ul` from `resets.scss`. Those use `list-style-type: ""` rather than `none`, which would remove the list semantics in Safari. A Grid keeps its own inline padding, the gutter of the page, which the reset would zero along with the list indent; that rule sits in `grid.scss` rather than the shared `ams-grid` mixin, because Breakout includes that mixin.

On News Overview and Search Results the results region also holds the result count and the Pagination, which are not list items, so only the Cards go in a `ul` Subgrid of their own inside it. Both Home Page sets already had a Subgrid to themselves. Moving the count and the Pagination out to siblings instead would break the layout: the tall filter panel would then set the height of the first row and push the Cards below it.

One browser fix: Safari gives the marker of a `list-item` a line box of its own where the content of the Cell starts with an image, adding 18px above the Card. Nothing set on the marker removes it — not `list-style-position`, not `::marker { content: none }`, not the image's own display. `.ams-grid__cell:is(li)` therefore takes `display: block`. Safari's Web Inspector reports the computed role as `listitem` either way, so the list semantics are unaffected, and the repo already ships `li` elements that are not `display: list-item` in File List and Progress List.

Measured against the `div` cells they replace, in Chromium at 1440, 880 and 320px and in WebKit: identical column placement, identical cell and Card heights, and every row gap unchanged through both levels of subgrid. Chromatic should therefore show no difference on the Pages stories. The Grid test story gained two cases that do need accepting: a list Subgrid beside an identical plain one, and a Grid that is itself a list, which catches a lost gutter.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11)

## Additional notes

The Events Overview page needs the same change, but it lives on `feat/DES-1913-events-overview-page`, so it follows there.

Two points worth a look:

- `ol` is allowed even though `coding-conventions.md` restricts polymorphism to tags that only support global attributes. Its `reversed`, `start` and `type` stay untyped, and `start` necessarily so, since a Subgrid already uses that name for the column it begins at. The exception is written down in that file.
- A Subgrid may now hold another Subgrid. Nesting a Grid in a Grid is still not allowed, and ‘When not to use’ still says so.


[DES-1976]: https://gemeente-amsterdam.atlassian.net/browse/DES-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
