### PR TITLE
feat(React): Export the types that were missing from the barrel files

### DIFF
--- a/packages/react/documentation/coding-conventions.md
+++ b/packages/react/documentation/coding-conventions.md
@@ -37,8 +37,9 @@ Instead of this:
 
 Subcomponents (e.g. `Grid.Cell`) are kept in separate files (e.g. `GridCell.tsx`) and they have their own test files (e.g. `GridCell.test.tsx`). Subcomponents are imported in the main component file. We do not directly expose subcomponents to consumers, so a consumer can only import `Grid`, not `GridCell`.
 
-Their prop types are different: the barrel file does re-export those, so consumers can type a wrapper around a subcomponent.
-Subcomponents that a consumer cannot reach, such as `CalendarHeader`, do not need their prop type in the barrel file.
+Prop types are the exception: the barrel file does export the prop type of a subcomponent, so a consumer can type a wrapper around it.
+This covers every subcomponent a consumer can reach through the main component, such as `Table.Cell`.
+Internal subcomponents that a consumer cannot reach, such as `CalendarHeader`, keep their prop type out of the barrel file.
 
 ## Text for screen readers only
 

--- a/packages/react/documentation/coding-conventions.md
+++ b/packages/react/documentation/coding-conventions.md
@@ -37,6 +37,9 @@ Instead of this:
 
 Subcomponents (e.g. `Grid.Cell`) are kept in separate files (e.g. `GridCell.tsx`) and they have their own test files (e.g. `GridCell.test.tsx`). Subcomponents are imported in the main component file. We do not directly expose subcomponents to consumers, so a consumer can only import `Grid`, not `GridCell`.
 
+Their prop types are different: the barrel file does re-export those, so consumers can type a wrapper around a subcomponent.
+Subcomponents that a consumer cannot reach, such as `CalendarHeader`, do not need their prop type in the barrel file.
+
 ## Text for screen readers only
 
 Use the `ams-visually-hidden` [utility class](https://designsystem.amsterdam/?path=/docs/utilities-css-visually-hidden--docs) to hide content from sighted users but keep it accessible to non-visual user agents, such as screen readers.

--- a/packages/react/src/DescriptionList/index.ts
+++ b/packages/react/src/DescriptionList/index.ts
@@ -6,4 +6,5 @@
 export { DescriptionList } from './DescriptionList'
 export type { DescriptionListProps } from './DescriptionList'
 export type { DescriptionListDescriptionProps } from './DescriptionListDescription'
+export type { DescriptionListSectionProps } from './DescriptionListSection'
 export type { DescriptionListTermProps } from './DescriptionListTerm'

--- a/packages/react/src/Figure/index.ts
+++ b/packages/react/src/Figure/index.ts
@@ -5,3 +5,4 @@
 
 export { Figure } from './Figure'
 export type { FigureProps } from './Figure'
+export type { FigureCaptionProps } from './FigureCaption'

--- a/packages/react/src/FileList/index.ts
+++ b/packages/react/src/FileList/index.ts
@@ -5,3 +5,4 @@
 
 export { FileList } from './FileList'
 export type { FileListProps } from './FileList'
+export type { FileListItemProps } from './FileListItem'

--- a/packages/react/src/ImageSlider/index.ts
+++ b/packages/react/src/ImageSlider/index.ts
@@ -4,4 +4,4 @@
  */
 
 export { ImageSlider } from './ImageSlider'
-export type { ImageSliderProps } from './ImageSlider'
+export type { ImageSliderImageProps, ImageSliderProps } from './ImageSlider'

--- a/packages/react/src/Label/index.ts
+++ b/packages/react/src/Label/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { Label } from './Label'
+export type { LabelProps } from './Label'

--- a/packages/react/src/Logo/index.ts
+++ b/packages/react/src/Logo/index.ts
@@ -4,4 +4,4 @@
  */
 
 export { Logo } from './Logo'
-export type { LogoBrand, LogoProps } from './Logo'
+export type { LogoBrand, LogoBrandConfig, LogoProps } from './Logo'

--- a/packages/react/src/Select/index.ts
+++ b/packages/react/src/Select/index.ts
@@ -6,3 +6,4 @@
 export { Select } from './Select'
 export type { SelectProps } from './Select'
 export type { SelectOptionProps } from './SelectOption'
+export type { SelectOptionGroupProps } from './SelectOptionGroup'

--- a/packages/react/src/Table/index.ts
+++ b/packages/react/src/Table/index.ts
@@ -5,3 +5,10 @@
 
 export { Table } from './Table'
 export type { TableProps } from './Table'
+export type { TableBodyProps } from './TableBody'
+export type { TableCaptionProps } from './TableCaption'
+export type { TableCellProps } from './TableCell'
+export type { TableFooterProps } from './TableFooter'
+export type { TableHeaderProps } from './TableHeader'
+export type { TableHeaderCellProps } from './TableHeaderCell'
+export type { TableRowProps } from './TableRow'


### PR DESCRIPTION
# Describe the pull request

## Links

- Requested in #2901, which came from https://github.com/Amsterdam/ee-ads-rhf/issues/65.
- [Coding conventions](https://github.com/Amsterdam/design-system/blob/main/packages/react/documentation/coding-conventions.md#subcomponents), the section this PR extends.

There is no feature branch deploy link. This PR only adds type exports, so nothing renders differently.

## What

Fourteen types were declared in a component file but never re-exported from its barrel file, which put them out of reach of anyone importing from the package root.

`Label` never exported `LabelProps`. The subcomponents of Description List, Figure, File List, Select and Table exported some or none of their prop types, with Table missing all seven. Image Slider did not export `ImageSliderImageProps`, the type of an entry in its `images` prop. Logo did not export `LogoBrandConfig`, the object a consumer constructs to pass a custom logo to the `brand` prop.

The Subcomponents section of the coding conventions gains two sentences, because it stated that we do not expose subcomponents without saying that we do expose their prop types.

## Why

Consumers cannot type a wrapper component without the prop type of the component they are wrapping. That is what prompted the issue: `ee-ads-rhf` wraps `Label` and could not reach `LabelProps` to pass `inFieldSet` through.

Rather than add only that one type, I audited every barrel file in the React package so the same request does not have to be made once per component.

## How

The additions are re-exports in eight barrel files. No component source changed, so there is no behavioural or visual change and nothing to deprecate.

I limited the audit to types a consumer can actually reach. Prop types of subcomponents that are not attached to a compound component, such as `CalendarHeader` and `ImageSliderThumbnails`, stay out of the barrel files.

Beyond prop types, I only added `LogoBrandConfig`. The other unexported types are string or number unions behind a single prop, such as `GridGap` and `IconButtonColor`, or internal React context values. Those are reachable through an indexed access type like `GridProps['gap']`, so exporting them would widen the public surface without adding capability. This leaves one known inconsistency: Grid exports `GridColumnNumbers` and `GridRowNumbers` while Breakout does not export its equivalent `BreakoutRowNumbers`. Removing the Grid ones would be breaking, so they stay as they are.

Verified with `tsc`, the unit tests, and by checking that all fourteen types appear in the public `export type` statement of the built `dist/index.d.ts`.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

Unit tests, stories and Chromatic are marked as not necessary: the diff is barrel files and one documentation paragraph, with no runtime code.

## Additional notes

Nothing here enforces that a barrel file stays complete, so this can drift again. A test that compares each barrel file against its component's compound members would catch that. Happy to add it here or in a follow-up.
