### PR TITLE
fix(Storybook): Show the example for values that reference a default token

### DIFF
--- a/storybook/src/_common/formatCustomPropertyName.test.ts
+++ b/storybook/src/_common/formatCustomPropertyName.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { formatCustomPropertyName } from './formatCustomPropertyName'
+
+describe('formatCustomPropertyName', () => {
+  it('joins the path segments with hyphens', () => {
+    expect(formatCustomPropertyName(['ams', 'color', 'highlight', 'orange'])).toBe('--ams-color-highlight-orange')
+  })
+
+  it('drops a trailing "default" segment', () => {
+    expect(formatCustomPropertyName(['ams', 'color', 'interactive', 'default'])).toBe('--ams-color-interactive')
+  })
+
+  it('keeps a "default" segment that is not the last one', () => {
+    expect(formatCustomPropertyName(['ams', 'default', 'color'])).toBe('--ams-default-color')
+  })
+
+  it('drops only the last of two consecutive "default" segments', () => {
+    expect(formatCustomPropertyName(['ams', 'default', 'default'])).toBe('--ams-default')
+  })
+})

--- a/storybook/src/_common/formatCustomPropertyName.ts
+++ b/storybook/src/_common/formatCustomPropertyName.ts
@@ -5,7 +5,10 @@
 
 /**
  * Converts a token path to the name of the CSS custom property that the build pipeline ships for it.
- * A trailing `default` segment is dropped, mirroring the `name/customKebab` transform in the tokens package.
+ * A trailing `default` segment is dropped, as the `name/customKebab` and `name/customCamel` transforms in the tokens
+ * package do.
+ * Those transforms also run the path through `kebabCase` and this does not, which holds only while every path segment
+ * is lower case and hyphenated already, as all of them currently are.
  *
  * @param path - The token path segments, e.g. `['ams', 'color', 'interactive', 'default']`.
  * @returns The custom property name, including the leading double hyphen.

--- a/storybook/src/_common/formatCustomPropertyName.ts
+++ b/storybook/src/_common/formatCustomPropertyName.ts
@@ -1,0 +1,22 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+/**
+ * Converts a token path to the name of the CSS custom property that the build pipeline ships for it.
+ * A trailing `default` segment is dropped, mirroring the `name/customKebab` transform in the tokens package.
+ *
+ * @param path - The token path segments, e.g. `['ams', 'color', 'interactive', 'default']`.
+ * @returns The custom property name, including the leading double hyphen.
+ *
+ * @example
+ * formatCustomPropertyName(['ams', 'color', 'interactive'])            // "--ams-color-interactive"
+ * formatCustomPropertyName(['ams', 'color', 'interactive', 'default']) // "--ams-color-interactive"
+ * formatCustomPropertyName(['ams', 'color', 'interactive', 'hover'])   // "--ams-color-interactive-hover"
+ */
+export function formatCustomPropertyName(path: string[]): string {
+  const segments = path[path.length - 1] === 'default' ? path.slice(0, -1) : path
+
+  return `--${segments.join('-')}`
+}

--- a/storybook/src/_common/formatTokenValue.test.ts
+++ b/storybook/src/_common/formatTokenValue.test.ts
@@ -24,6 +24,16 @@ describe('formatTokenValue', () => {
     expect(formatTokenValue('{ams.color.highlight.orange}')).toBe('var(--ams-color-highlight-orange)')
   })
 
+  it('drops a trailing "default" segment from the reference', () => {
+    expect(formatTokenValue('{ams.color.interactive.default}')).toBe('var(--ams-color-interactive)')
+  })
+
+  it('drops a trailing "default" segment from every reference in a string', () => {
+    expect(formatTokenValue('inset 0rem {ams.border.width.m} 0rem 0rem {ams.color.interactive.invalid.default}')).toBe(
+      'inset 0rem var(--ams-border-width-m) 0rem 0rem var(--ams-color-interactive-invalid)',
+    )
+  })
+
   it('converts multiple token references in a single string', () => {
     expect(formatTokenValue('inset 0rem {ams.border.width.m} 0rem 0rem {ams.color.separator}')).toBe(
       'inset 0rem var(--ams-border-width-m) 0rem 0rem var(--ams-color-separator)',

--- a/storybook/src/_common/formatTokenValue.ts
+++ b/storybook/src/_common/formatTokenValue.ts
@@ -3,6 +3,8 @@
  * Copyright Gemeente Amsterdam
  */
 
+import { formatCustomPropertyName } from './formatCustomPropertyName'
+
 /**
  * Converts design token references in a string to CSS custom properties.
  * Supports both single references and strings containing multiple references.
@@ -13,12 +15,16 @@
  * @example
  * formatTokenValue("{border.width.sm}")                          // "var(--border-width-sm)"
  * formatTokenValue("{spacing.md}")                               // "var(--spacing-md)"
+ * formatTokenValue("{color.text.default}")                       // "var(--color-text)"
  * formatTokenValue("2px")                                        // "2px"
  * formatTokenValue("inset 0rem {border.width.m} 0rem {color.x}") // "inset 0rem var(--border-width-m) 0rem var(--color-x)"
  */
 export function formatTokenValue<T = string>(value: string): T {
   if (value.includes('{')) {
-    return value.replace(/\{([^}]+)\}/g, (_, ref: string) => `var(--${ref.replace(/\./g, '-')})`) as unknown as T
+    return value.replace(
+      /\{([^}]+)\}/g,
+      (_, ref: string) => `var(${formatCustomPropertyName(ref.split('.'))})`,
+    ) as unknown as T
   }
 
   return value as unknown as T

--- a/storybook/src/_common/formatTokenValue.ts
+++ b/storybook/src/_common/formatTokenValue.ts
@@ -9,15 +9,16 @@ import { formatCustomPropertyName } from './formatCustomPropertyName'
  * Converts design token references in a string to CSS custom properties.
  * Supports both single references and strings containing multiple references.
  *
- * @param value - A token value that may contain variable references (e.g., "{spacing.md}") or be a literal value (e.g., "2px")
+ * @param value - A token value that may contain variable references (e.g., "{ams.space.m}") or be a literal value (e.g., "2px")
  * @returns String with all token references replaced by CSS custom properties
  *
  * @example
- * formatTokenValue("{border.width.sm}")                          // "var(--border-width-sm)"
- * formatTokenValue("{spacing.md}")                               // "var(--spacing-md)"
- * formatTokenValue("{color.text.default}")                       // "var(--color-text)"
- * formatTokenValue("2px")                                        // "2px"
- * formatTokenValue("inset 0rem {border.width.m} 0rem {color.x}") // "inset 0rem var(--border-width-m) 0rem var(--color-x)"
+ * formatTokenValue("{ams.border.width.s}")                                  // "var(--ams-border-width-s)"
+ * formatTokenValue("{ams.space.m}")                                         // "var(--ams-space-m)"
+ * formatTokenValue("{ams.color.text.default}")                              // "var(--ams-color-text)"
+ * formatTokenValue("2px")                                                   // "2px"
+ * formatTokenValue("inset 0rem {ams.border.width.m} 0rem {ams.color.separator}")
+ * // "inset 0rem var(--ams-border-width-m) 0rem var(--ams-color-separator)"
  */
 export function formatTokenValue<T = string>(value: string): T {
   if (value.includes('{')) {

--- a/storybook/src/_components/DesignTokensTable/flattenTokens.ts
+++ b/storybook/src/_components/DesignTokensTable/flattenTokens.ts
@@ -3,6 +3,8 @@
  * Copyright Gemeente Amsterdam
  */
 
+import { formatCustomPropertyName } from '#storybook/_common/formatCustomPropertyName'
+
 import type { ShadowValue, TokenEntry, Tokens } from './DesignTokensTable.types'
 
 import { formatShadowValue } from './formatShadowValue'
@@ -22,8 +24,7 @@ import { isTokenValue } from './isTokenValue'
 export const flattenTokens = (tokens: Tokens, scope: string[] = [], inheritedType?: string): TokenEntry[] => {
   // A group-level $type overrides any inherited type for this group and its descendants.
   const groupType = ('$type' in tokens && typeof tokens['$type'] === 'string' ? tokens['$type'] : inheritedType) as
-    | string
-    | undefined
+    string | undefined
 
   return Object.entries(tokens).flatMap(([key, node]) => {
     if (key.startsWith('$')) return []
@@ -50,14 +51,11 @@ export const flattenTokens = (tokens: Tokens, scope: string[] = [], inheritedTyp
         normalizedValue = formatShadowValue($value as ShadowValue)
       }
 
-      // Drop a trailing 'default' segment to match the CSS custom property names shipped by the build pipeline.
-      const cssPath = currentPath[currentPath.length - 1] === 'default' ? currentPath.slice(0, -1) : currentPath
-
       return [
         {
           deprecated: $deprecated,
           description: $description,
-          path: `--${cssPath.join('-')}`,
+          path: formatCustomPropertyName(currentPath),
           type,
           value: normalizedValue,
         },


### PR DESCRIPTION
# Show the example for values that reference a default token

## Links

- [This branch’s deploy](https://designsystem.amsterdam/)
- [Date Picker on this branch](https://designsystem.amsterdam/?path=/docs/components-forms-date-picker--docs), the component the bug was reported on, and [Checkbox on this branch](https://designsystem.amsterdam/?path=/docs/components-forms-checkbox--docs), the one it affected most.
- [Date Picker on the current site](https://designsystem.amsterdam/?path=/docs/components-forms-date-picker--docs), for the before: its Design tokens table still draws two empty swatches.

## What

The Example column of the Design Tokens Table drew nothing for a token whose value references another token whose path ends in `default`. `{ams.color.interactive.default}` gave an empty swatch where `{ams.color.interactive.hover}` gave blue.

It was reported on the Date Picker, but it was never confined to it. Resolving every reference in the token sources against the set of custom properties the build actually emits turns up **70 broken references across 37 token files**: `color.text.default` (23), `color.background.default` (16), `color.interactive.default` (25) and `color.interactive.invalid.default` (6). Checkbox, Progress List, Radio and Button carried the most; Date Picker carried two.

The components themselves were always right. Only the table was wrong.

## Why

The tokens build strips a trailing `default` segment from a token path, in both `name/customKebab` and `name/customCamel`. So `ams.color.interactive.default` ships as `--ams-color-interactive`, and `--ams-color-interactive-default` does not exist.

`formatTokenValue`, which turns a token value into something a sample component can render, only replaced dots with hyphens. It built `var(--ams-color-interactive-default)`, which resolves to nothing, and a `background-color` of nothing is no swatch at all.

The two columns of the table disagreed with each other. `flattenTokens` already stripped the trailing `default` when it built the CSS variable name, so the left column named `--ams-color-interactive` while the right column looked up `--ams-color-interactive-default` for the same row. The rule existed in one column and not the other, and nothing held them together.

## How

The rule now lives in one place. `formatCustomPropertyName` takes a token path and returns the custom property name the build pipeline ships for it, and both `flattenTokens` and `formatTokenValue` go through it. Neither carries its own copy any more, so the name and the example cannot drift apart again.

`formatTokenValue` splits each reference on its dots and hands the segments over, rather than treating the reference as a string to search and replace. That is what makes the trailing segment visible to it at all.

The audit was mechanical rather than eyeballed: every `{…}` reference in `packages-proprietary/tokens/src` resolved against the names the build emits for every token path. 70 of 1050 references failed before, 0 fail after. Nothing else in the repository converts a token path to a variable name, and the other artefacts are consistent already — the SCSS, `.mjs` and `.d.ts` outputs use the custom transforms, and the nested `index.json` keeps `default` as a key, which is right for that format.

Verified by rendering the Date Picker table headlessly against the built stylesheets: the two `{ams.color.interactive.default}` rows draw the blue, and no other row changed.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

The commit carries a two-line reformat in `flattenTokens.ts` that is not part of the fix. That file was on `develop` in a state the pinned Prettier rejects, and the pre-commit hook blocks any commit touching it until it is reformatted. It was the only such file — the rest of `storybook/src` and `packages/react/src` pass.

No Chromatic diff is expected. The Design Tokens Table test story builds its own fixtures, and all of them are literal values rather than references, so nothing in the snapshot exercises the path this fixes. That is also why the bug survived: the unit tests now pin the rule at the point where it failed. Say the word if you would rather have a reference fixture in the test story as a visual guard as well, and I will add one.
