### PR TITLE
feat(Storybook): Highlight the search term on the Search Results Page

### DIFF
--- a/storybook/src/components/Mark/Mark.docs.mdx
+++ b/storybook/src/components/Mark/Mark.docs.mdx
@@ -37,21 +37,30 @@ An [Alert](/docs/components-feedback-alert--docs) carries that meaning and annou
 
 Never let the highlight carry information by itself.
 The text around it has to make sense without it, so that what the highlight shows reaches everyone, as [WCAG 1.3.1](https://www.w3.org/TR/WCAG22/#info-and-relationships) requires.
-A list of search results already satisfies this: each result is meaningful on its own, and the highlight only speeds up scanning.
+
+#### Search terms
+
+A list of search results meets that on its own: each result is meaningful without the highlight, which only speeds up scanning.
+
+A highlight here follows the query rather than an editorial choice, so no limit applies to how many appear.
+Mark every match on the page, including matches inside the heading of a result.
+Ignore capitalisation and include partial matches.
+
+Leave the labels around a result alone, such as the category it is filed under.
+A full-text search does not match those, so a word that looks like a match there is not one.
+
+#### Editorial highlights
 
 Keep an editorial highlight to one fragment per page, and to at most one sentence.
 Marking a whole paragraph, or several passages at once, leaves nothing standing out.
 Rewrite a heading that needs emphasis rather than highlighting part of it.
-
-Highlighted search terms follow the search instead of an editorial choice, so those limits do not apply to them.
-Mark every match on the page, including matches inside the heading of a result.
-Ignore capitalisation and include partial matches.
 
 ## Examples
 
 ### Search results
 
 Every match of every keyword is highlighted, in the heading of a result as well as in its summary.
+The category above each heading stays unmarked, so the third result shows an unmarked ‘Vergunningen’ above a heading that marks the same word.
 
 <Canvas of={MarkStories.SearchResults} />
 

--- a/storybook/src/components/Mark/Mark.docs.mdx
+++ b/storybook/src/components/Mark/Mark.docs.mdx
@@ -59,8 +59,10 @@ Rewrite a heading that needs emphasis rather than highlighting part of it.
 
 ### Search results
 
-Every match of every keyword is highlighted, in the heading of a result as well as in its summary.
-The category above each heading stays unmarked, so the third result shows an unmarked ‘Vergunningen’ above a heading that marks the same word.
+One result of a search for ‘vergunning’, with every match highlighted in the heading as well as in the summary.
+The category above the heading is a label rather than text the search matched, so the word stays unmarked there.
+
+The [Search Results Page](/docs/pages-public-search-results-page--docs) puts this to work on a whole list of results.
 
 <Canvas of={MarkStories.SearchResults} />
 

--- a/storybook/src/components/Mark/Mark.stories.tsx
+++ b/storybook/src/components/Mark/Mark.stories.tsx
@@ -5,11 +5,12 @@
 
 import type { Args, Meta, StoryObj } from '@storybook/react-vite'
 
-import { Card, Grid, Heading, Paragraph, SearchField, UnorderedList } from '@amsterdam/design-system-react'
+import { Card, Heading, Paragraph, SearchField, UnorderedList } from '@amsterdam/design-system-react'
 import { Mark } from '@amsterdam/design-system-react/src'
 import { useState } from 'react'
 
 import { childrenArgType } from '#storybook/_common/argTypes'
+import { maximiseInlineSize } from '#storybook/_common/decorators'
 
 const meta = {
   title: 'Components/Text/Mark',
@@ -98,6 +99,7 @@ const mark = (text: string, query: string, args: Args) => {
 }
 
 export const SearchResults = {
+  decorators: [maximiseInlineSize('7-of-12-columns')],
   render: (args: Args) => {
     const [query, setQuery] = useState('horeca vergunning')
 
@@ -111,34 +113,32 @@ export const SearchResults = {
     )
 
     return (
-      <Grid>
-        <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
-          <SearchField className="ams-mb-m">
-            <SearchField.Input label="Zoeken" onChange={(e) => setQuery(e.target.value)} value={query} />
-            <SearchField.Button />
-          </SearchField>
-          <Paragraph className="ams-mb-xl">
-            <strong>{searchResults.length}</strong> artikelen gaan over ‘{query}’.
-          </Paragraph>
-          <UnorderedList className="ams-gap-xl" markers={false}>
-            {searchResults.map(({ category, date, fragment, heading }) => (
-              <UnorderedList.Item key={heading}>
-                <Card>
-                  <Card.HeadingGroup tagline={category}>
-                    <Heading level={2} size="level-4">
-                      <Card.Link href="#">{mark(heading, query, args)}</Card.Link>
-                    </Heading>
-                  </Card.HeadingGroup>
-                  <Paragraph className="ams-mb-xs">{mark(fragment, query, args)}</Paragraph>
-                  <Paragraph size="small">
-                    <time dateTime={date.toISOString()}>{dateFormat.format(date)}</time>
-                  </Paragraph>
-                </Card>
-              </UnorderedList.Item>
-            ))}
-          </UnorderedList>
-        </Grid.Cell>
-      </Grid>
+      <>
+        <SearchField className="ams-mb-m">
+          <SearchField.Input label="Zoeken" onChange={(e) => setQuery(e.target.value)} value={query} />
+          <SearchField.Button />
+        </SearchField>
+        <Paragraph className="ams-mb-xl">
+          <strong>{searchResults.length}</strong> artikelen gaan over ‘{query}’.
+        </Paragraph>
+        <UnorderedList className="ams-gap-xl" markers={false}>
+          {searchResults.map(({ category, date, fragment, heading }) => (
+            <UnorderedList.Item key={heading}>
+              <Card>
+                <Card.HeadingGroup tagline={category}>
+                  <Heading level={2} size="level-4">
+                    <Card.Link href="#">{mark(heading, query, args)}</Card.Link>
+                  </Heading>
+                </Card.HeadingGroup>
+                <Paragraph className="ams-mb-xs">{mark(fragment, query, args)}</Paragraph>
+                <Paragraph size="small">
+                  <time dateTime={date.toISOString()}>{dateFormat.format(date)}</time>
+                </Paragraph>
+              </Card>
+            </UnorderedList.Item>
+          ))}
+        </UnorderedList>
+      </>
     )
   },
 }

--- a/storybook/src/components/Mark/Mark.stories.tsx
+++ b/storybook/src/components/Mark/Mark.stories.tsx
@@ -3,11 +3,10 @@
  * Copyright Gemeente Amsterdam
  */
 
-import type { Args, Meta, StoryObj } from '@storybook/react-vite'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { Card, Heading, Paragraph, SearchField, UnorderedList } from '@amsterdam/design-system-react'
+import { Card, Heading, Paragraph } from '@amsterdam/design-system-react'
 import { Mark } from '@amsterdam/design-system-react/src'
-import { useState } from 'react'
 
 import { childrenArgType } from '#storybook/_common/argTypes'
 import { maximiseInlineSize } from '#storybook/_common/decorators'
@@ -25,7 +24,7 @@ export const Default: Story = {
   args: {
     children: 'Wat vinden Amsterdammers belangrijk?',
   },
-  // Only this story renders a single Mark whose text the control drives – the other story composes many instances.
+  // Only this story renders a single Mark whose text the control drives – the other story writes its highlights out.
   argTypes: {
     children: childrenArgType('The text to mark.'),
   },
@@ -38,107 +37,25 @@ export const Default: Story = {
   ),
 }
 
-type Article = {
-  category: string
-  date: Date
-  fragment: string
-  heading: string
-}
-
-const articles: Article[] = [
-  {
-    category: 'Kansspelen',
-    date: new Date('2025-10-27'),
-    fragment:
-      'Op dit moment zijn alle vergunning voor speelautomatenhallen verleend. Als u kansspelautomaten wilt plaatsen in uw horecabedrijf dan heeft u de …',
-    heading: 'Vergunning speelautomatenhal of kansspelautomaten aanvragen',
-  },
-  {
-    category: 'Veelgevraagd',
-    date: new Date('2024-09-15'),
-    fragment:
-      'U heeft een ontheffing nodig als u de geldende geluidsgrenzen van uw horecagelegenheid wil overschrijden. Kijk hier hoe het werkt en hoe u de …',
-    heading: 'Ontheffing geluidsvoorschriften',
-  },
-  {
-    category: 'Vergunningen',
-    date: new Date('2023-08-03'),
-    fragment: `Voor de organisatie van grootschalige vechtsportgala’s in Amsterdam moet u een vergunning aanvragen bij de gemeente. Vooraf moet u een Bibobformulier …`,
-    heading: 'Vergunning vechtsportevenementen',
-  },
-]
-
-const dateFormat = new Intl.DateTimeFormat('nl', {
-  day: 'numeric',
-  month: 'long',
-  year: 'numeric',
-})
-
-const mark = (text: string, query: string, args: Args) => {
-  if (!query) return text
-
-  const words = query
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-
-  if (words.length === 0) return text
-
-  const regex = new RegExp(`(${words.join('|')})`, 'gi')
-  const parts = text.split(regex)
-
-  return parts.map((part) =>
-    part.match(regex) ? (
-      <Mark key={part} {...args}>
-        {part}
-      </Mark>
-    ) : (
-      part
-    ),
-  )
-}
-
 export const SearchResults = {
   decorators: [maximiseInlineSize('7-of-12-columns')],
-  render: (args: Args) => {
-    const [query, setQuery] = useState('horeca vergunning')
-
-    const searchResults = articles.filter(({ fragment, heading }) =>
-      [fragment, heading].some((text) =>
-        query
-          .split(/\s+/)
-          .filter(Boolean)
-          .some((word) => text.toLowerCase().includes(word.toLowerCase())),
-      ),
-    )
-
-    return (
-      <>
-        <SearchField className="ams-mb-m">
-          <SearchField.Input label="Zoeken" onChange={(e) => setQuery(e.target.value)} value={query} />
-          <SearchField.Button />
-        </SearchField>
-        <Paragraph className="ams-mb-xl">
-          <strong>{searchResults.length}</strong> artikelen gaan over ‘{query}’.
-        </Paragraph>
-        <UnorderedList className="ams-gap-xl" markers={false}>
-          {searchResults.map(({ category, date, fragment, heading }) => (
-            <UnorderedList.Item key={heading}>
-              <Card>
-                <Card.HeadingGroup tagline={category}>
-                  <Heading level={2} size="level-4">
-                    <Card.Link href="#">{mark(heading, query, args)}</Card.Link>
-                  </Heading>
-                </Card.HeadingGroup>
-                <Paragraph className="ams-mb-xs">{mark(fragment, query, args)}</Paragraph>
-                <Paragraph size="small">
-                  <time dateTime={date.toISOString()}>{dateFormat.format(date)}</time>
-                </Paragraph>
-              </Card>
-            </UnorderedList.Item>
-          ))}
-        </UnorderedList>
-      </>
-    )
-  },
+  render: () => (
+    <Card>
+      {/* The category is a label rather than text the search matched, so the word in it stays unmarked. */}
+      <Card.HeadingGroup tagline="Vergunningen">
+        <Heading level={2} size="level-4">
+          <Card.Link href="#">
+            <Mark>Vergunning</Mark> vechtsportevenementen
+          </Card.Link>
+        </Heading>
+      </Card.HeadingGroup>
+      <Paragraph className="ams-mb-xs">
+        Voor de organisatie van grootschalige vechtsportgala’s in Amsterdam moet u een <Mark>vergunning</Mark> aanvragen
+        bij de gemeente. Vooraf moet u een Bibobformulier …
+      </Paragraph>
+      <Paragraph size="small">
+        <time dateTime="2023-08-03">3 augustus 2023</time>
+      </Paragraph>
+    </Card>
+  ),
 }

--- a/storybook/src/pages/public/LoadingPage/LoadingPage.docs.mdx
+++ b/storybook/src/pages/public/LoadingPage/LoadingPage.docs.mdx
@@ -29,7 +29,8 @@ Use this page where the content arrives after the first render, so the reader se
 
 ### When not to use
 
-Where the server renders the results with the page, use the [Search Results Page](/docs/pages-public-search-results-page--docs), which has no loading state to manage.
+Where the results are in the response that renders the page, there is nothing to wait for, so show them straight away, as the [Search Results Page](/docs/pages-public-search-results-page--docs) does.
+Which of the two a search needs follows from where its results come from, not from the kind of page it is.
 
 ## Variants
 
@@ -80,5 +81,5 @@ No component wraps this pattern yet, so the Grid carries the busy state and the 
 ## See also
 
 - [Skeleton](/docs/components-feedback-skeleton--docs) – what stands in for a result while it loads.
-- [Search Results Page](/docs/pages-public-search-results-page--docs) – the same page without a loading state.
+- [Search Results Page](/docs/pages-public-search-results-page--docs) – search results beside a column of filters.
 - [News Overview Page](/docs/pages-public-news-overview-page--docs) – the filter-and-results layout these share.

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.docs.mdx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.docs.mdx
@@ -27,6 +27,9 @@ This schematic shows the default sections for this page type and how the grids a
 
 Use this page for the results of a site-wide search, where a result can be any kind of content.
 
+The results may come with the page or be fetched after it has rendered.
+Where they arrive later, show [Skeletons](/docs/components-feedback-skeleton--docs) in their place while they load, as the [Loading Page](/docs/pages-public-loading-page--docs) does.
+
 ### When not to use
 
 Use a [News Overview Page](/docs/pages-public-news-overview-page--docs) for an index of one content type, where every item has an image.
@@ -79,7 +82,7 @@ Highlighting the term inside it leaves the name the link is announced with uncha
 ## See also
 
 - [News Overview Page](/docs/pages-public-news-overview-page--docs) – the same layout for one content type.
-- [Loading Page](/docs/pages-public-loading-page--docs) – this page while its results are on their way, a state the results here do not use yet.
+- [Loading Page](/docs/pages-public-loading-page--docs) – the loading state to show while results are on their way.
 - [Search Field](/docs/components-forms-search-field--docs) – the field this page repeats.
 - [Mark](/docs/components-text-mark--docs) – the highlight on a matched word, and the rules it follows.
 - [Semantic list of cards](/docs/components-layout-grid--docs#semantic-list-of-cards) – the `ul` Subgrid the results sit in.

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.docs.mdx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.docs.mdx
@@ -79,5 +79,7 @@ Highlighting the term inside it leaves the name the link is announced with uncha
 ## See also
 
 - [News Overview Page](/docs/pages-public-news-overview-page--docs) – the same layout for one content type.
-- [Loading Page](/docs/pages-public-loading-page--docs) – this page while its results are on their way.
+- [Loading Page](/docs/pages-public-loading-page--docs) – this page while its results are on their way, a state the results here do not use yet.
 - [Search Field](/docs/components-forms-search-field--docs) – the field this page repeats.
+- [Mark](/docs/components-text-mark--docs) – the highlight on a matched word, and the rules it follows.
+- [Semantic list of cards](/docs/components-layout-grid--docs#semantic-list-of-cards) – the `ul` Subgrid the results sit in.

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.docs.mdx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.docs.mdx
@@ -44,6 +44,10 @@ Keep it out of the filter form as well: nesting one `form` inside another is inv
 Put the results in a [Grid Subgrid](/docs/components-layout-grid--docs) and announce the total in a `role="status"` paragraph, as on any index page.
 Name the term that was searched for in that sentence, so it is clear what produced the list.
 
+Highlight the term in the teaser of a result with [Mark](/docs/components-text-mark--docs), so a visitor sees at a glance why a result is in the list.
+Match it whatever its casing, and keep the casing the teaser uses.
+A result can match on text the teaser does not show, so not every teaser has something to highlight.
+
 The page title is the only Heading 1, and it names the activity rather than the query.
 The filter column and the list of results each take a Heading 2, and the title of every result is a Heading 3.
 Neither Heading 2 has a place in the design, so both are visually hidden, as on the News Overview Page.
@@ -66,9 +70,11 @@ Leave the row gap of the Subgrid at the vertical gap of the Grid.
 The heading of the filter column is hidden visually but not from assistive technology, so it still names the landmark that `aria-labelledby` points at.
 
 The total is announced in a `role="status"` paragraph that names the term searched for, so it is clear what produced the list.
+Leave the term unhighlighted there: a highlight adds nothing to a sentence that is read out in full anyway.
 
 A result title is the title of the page it links to, neither shortened to fit nor marked up to highlight the matched words.
 A highlight inside a link makes the link harder to read out.
+The teaser below it carries the highlights instead.
 
 ## See also
 

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.docs.mdx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.docs.mdx
@@ -44,9 +44,9 @@ Keep it out of the filter form as well: nesting one `form` inside another is inv
 Put the results in a [Grid Subgrid](/docs/components-layout-grid--docs) and announce the total in a `role="status"` paragraph, as on any index page.
 Name the term that was searched for in that sentence, so it is clear what produced the list.
 
-Highlight the term in the teaser of a result with [Mark](/docs/components-text-mark--docs), so a visitor sees at a glance why a result is in the list.
-Match it whatever its casing, and keep the casing the teaser uses.
-A result can match on text the teaser does not show, so not every teaser has something to highlight.
+Highlight the term with [Mark](/docs/components-text-mark--docs), in the title of a result as well as in its teaser, so a visitor sees at a glance why a result is in the list.
+Match it whatever its casing, and keep the casing of the text.
+A result can match on text that neither the title nor the teaser shows, so not every result has something to highlight.
 
 The page title is the only Heading 1, and it names the activity rather than the query.
 The filter column and the list of results each take a Heading 2, and the title of every result is a Heading 3.
@@ -72,9 +72,8 @@ The heading of the filter column is hidden visually but not from assistive techn
 The total is announced in a `role="status"` paragraph that names the term searched for, so it is clear what produced the list.
 Leave the term unhighlighted there: a highlight adds nothing to a sentence that is read out in full anyway.
 
-A result title is the title of the page it links to, neither shortened to fit nor marked up to highlight the matched words.
-A highlight inside a link makes the link harder to read out.
-The teaser below it carries the highlights instead.
+A result title is the title of the page it links to, not shortened to fit.
+Highlighting the term inside it leaves the name the link is announced with unchanged.
 
 ## See also
 

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
@@ -134,7 +134,10 @@ export const Default: StoryObj = {
           <Grid.Cell as="li" span={{ narrow: 4, medium: 5, wide: 7 }}>
             {/* A search result has no image, so this Card needs no Card Content and stays vertical at any width. */}
             <Card>
-              {/* Every match is marked, in the title of a result as well as in its teaser. This title holds none. */}
+              {/*
+               * Every match is marked, in the title of a result as well as in its teaser; this title holds none.
+               * The tagline names the category rather than text the search matched, so nothing in it is marked.
+               */}
               <Card.HeadingGroup tagline="Actiecentrum Veiligheid en Zorg">
                 <Card.Heading level={3}>
                   <Card.Link href="#">Top 400/600</Card.Link>
@@ -254,7 +257,10 @@ export const Default: StoryObj = {
                 <Grid.Cell as="li" key={result.id} span={{ narrow: 4, medium: 5, wide: 7 }}>
                   {/* A search result has no image, so this Card needs no Card Content and stays vertical at any width. */}
                   <Card>
-                    {/* Every match is marked, in the title of a result as well as in its teaser. */}
+                    {/*
+                     * Every match is marked, in the title of a result as well as in its teaser.
+                     * The tagline names the category rather than text the search matched, so nothing in it is marked.
+                     */}
                     <Card.HeadingGroup tagline={result.section}>
                       <Card.Heading level={3}>
                         <Card.Link href="#">{markSearchTerm(result.title)}</Card.Link>

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
@@ -128,13 +128,13 @@ export const Default: StoryObj = {
         <Grid.Cell span={{ narrow: 4, medium: 5, wide: 7 }}>
           {/* A search result has no image, so this Card needs no Card Content and stays vertical at any width. */}
           <Card>
+            {/* Every match is marked, in the title of a result as well as in its teaser. This title holds none. */}
             <Card.HeadingGroup tagline="Actiecentrum Veiligheid en Zorg">
               <Card.Heading level={3}>
                 <Card.Link href="#">Top 400/600</Card.Link>
               </Card.Heading>
             </Card.HeadingGroup>
             <Column gap="small">
-              {/* Only the teaser marks the term: a highlight inside the title would make that link harder to read out. */}
               <Paragraph>
                 Om de stad veiliger te maken coördineert de gemeente, samen met haar maatschappelijke partners,
                 vanuit het Actiecentrum <Mark>Veiligheid</Mark> en Zorg verschillende aanpakken op het snijvlak
@@ -241,13 +241,13 @@ export const Default: StoryObj = {
               <Grid.Cell key={result.id} span={{ narrow: 4, medium: 5, wide: 7 }}>
                 {/* A search result has no image, so this Card needs no Card Content and stays vertical at any width. */}
                 <Card>
+                  {/* Every match is marked, in the title of a result as well as in its teaser. */}
                   <Card.HeadingGroup tagline={result.section}>
                     <Card.Heading level={3}>
-                      <Card.Link href="#">{result.title}</Card.Link>
+                      <Card.Link href="#">{markSearchTerm(result.title)}</Card.Link>
                     </Card.Heading>
                   </Card.HeadingGroup>
                   <Column gap="small">
-                    {/* Only the teaser marks the term: a highlight inside the title would make that link harder to read out. */}
                     <Paragraph>{markSearchTerm(result.teaser)}</Paragraph>
                     <Paragraph size="small">
                       {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
@@ -16,6 +16,7 @@ import {
   Grid,
   Heading,
   Label,
+  Mark,
   Pagination,
   Paragraph,
   SearchField,
@@ -28,6 +29,13 @@ import { searchResults, searchTopics } from './data'
 const searchTerm = 'veiligheid'
 const totalResults = 62
 const totalPages = 8
+
+// Splitting on the term itself keeps the casing of each occurrence, so a sentence still starts with a capital.
+const markSearchTerm = (text: string) => {
+  const regex = new RegExp(`(${searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi')
+
+  return text.split(regex).map((part, index) => (part.match(regex) ? <Mark key={index}>{part}</Mark> : part))
+}
 
 const meta = {
   ...commonMeta,
@@ -125,10 +133,11 @@ export const Default: StoryObj = {
               </Card.Heading>
             </Card.HeadingGroup>
             <Column gap="small">
+              {/* Only the teaser marks the term: a highlight inside the title would make that link harder to read out. */}
               <Paragraph>
                 Om de stad veiliger te maken coördineert de gemeente, samen met haar maatschappelijke partners,
-                vanuit het Actiecentrum Veiligheid en Zorg verschillende aanpakken op het snijvlak van veiligheid,
-                zorg en het sociaal domein.
+                vanuit het Actiecentrum <Mark>Veiligheid</Mark> en Zorg verschillende aanpakken op het snijvlak
+                van <Mark>veiligheid</Mark>, zorg en het sociaal domein.
               </Paragraph>
               <Paragraph size="small">
                 {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
@@ -237,7 +246,8 @@ export const Default: StoryObj = {
                     </Card.Heading>
                   </Card.HeadingGroup>
                   <Column gap="small">
-                    <Paragraph>{result.teaser}</Paragraph>
+                    {/* Only the teaser marks the term: a highlight inside the title would make that link harder to read out. */}
+                    <Paragraph>{markSearchTerm(result.teaser)}</Paragraph>
                     <Paragraph size="small">
                       {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
                       <time dateTime={result.isoDate}>{result.date}</time>

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
@@ -31,10 +31,11 @@ const totalResults = 62
 const totalPages = 8
 
 // Splitting on the term itself keeps the casing of each occurrence, so a sentence still starts with a capital.
+// The capturing group puts every match at an odd position in the split.
 const markSearchTerm = (text: string) => {
   const regex = new RegExp(`(${searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi')
 
-  return text.split(regex).map((part, index) => (part.match(regex) ? <Mark key={index}>{part}</Mark> : part))
+  return text.split(regex).map((part, index) => (index % 2 === 1 ? <Mark key={index}>{part}</Mark> : part))
 }
 
 const meta = {

--- a/storybook/src/pages/public/SearchResultsPage/data.ts
+++ b/storybook/src/pages/public/SearchResultsPage/data.ts
@@ -31,7 +31,7 @@ export const searchResults: ReadonlyArray<SearchResult> = [
     isoDate: '2023-06-24',
     section: 'Actiecentrum Veiligheid en Zorg',
     teaser:
-      'Bewoners die stelselmatig worden lastiggevallen door buurtgenoten kunnen een melding doen. De gemeente, de politie en de woningcorporatie bekijken samen welke maatregelen nodig zijn.',
+      'Bewoners die stelselmatig worden lastiggevallen door buurtgenoten kunnen een melding doen. De gemeente, de politie en de woningcorporatie bekijken samen welke maatregelen nodig zijn om de veiligheid te herstellen.',
   },
   {
     title: 'Keurmerk Veilig Ondernemen aanvragen',
@@ -49,7 +49,7 @@ export const searchResults: ReadonlyArray<SearchResult> = [
     isoDate: '2023-06-12',
     section: 'Wonen en leefomgeving',
     teaser:
-      'Een buurtpreventieteam bestaat uit bewoners die samen met de wijkagent letten op wat er in de straat gebeurt. De gemeente ondersteunt nieuwe teams met training en materiaal.',
+      'Een buurtpreventieteam bestaat uit bewoners die samen met de wijkagent letten op de veiligheid in hun straat. De gemeente ondersteunt nieuwe teams met training en materiaal.',
   },
   {
     title: 'Cameratoezicht in de openbare ruimte',
@@ -58,7 +58,7 @@ export const searchResults: ReadonlyArray<SearchResult> = [
     isoDate: '2023-06-05',
     section: 'Beleid en regels',
     teaser:
-      'De burgemeester kan cameratoezicht instellen op plekken waar de openbare orde structureel onder druk staat. De beelden worden na 28 dagen verwijderd.',
+      'Veiligheid en openbare orde staan op sommige plekken structureel onder druk. Daar kan de burgemeester cameratoezicht instellen. De beelden worden na 28 dagen verwijderd.',
   },
   {
     title: 'Meldpunt Zorg en Woonoverlast',

--- a/storybook/src/pages/public/SearchResultsPage/data.ts
+++ b/storybook/src/pages/public/SearchResultsPage/data.ts
@@ -43,7 +43,7 @@ export const searchResults: ReadonlyArray<SearchResult> = [
       'Ondernemers in winkelgebieden kunnen meedoen aan het Keurmerk Veilig Ondernemen. Deelnemers maken samen met de politie en de brandweer afspraken over veiligheid op straat.',
   },
   {
-    title: 'Een buurtpreventieteam beginnen',
+    title: 'Veiligheid in de straat met een buurtpreventieteam',
     date: '12 juni 2023',
     id: 'buurtpreventie',
     isoDate: '2023-06-12',
@@ -52,7 +52,7 @@ export const searchResults: ReadonlyArray<SearchResult> = [
       'Een buurtpreventieteam bestaat uit bewoners die samen met de wijkagent letten op de veiligheid in hun straat. De gemeente ondersteunt nieuwe teams met training en materiaal.',
   },
   {
-    title: 'Cameratoezicht in de openbare ruimte',
+    title: 'Cameratoezicht en veiligheid in de openbare ruimte',
     date: '5 juni 2023',
     id: 'cameratoezicht',
     isoDate: '2023-06-05',


### PR DESCRIPTION
# Highlight the search term on the Search Results Page

## Links

- [Search Results Page](https://designsystem.amsterdam/?path=/story/pages-public-search-results-page--default) in Storybook on main, and its [documentation page](https://designsystem.amsterdam/?path=/docs/pages-public-search-results-page--docs).
- [Storybook on main](https://designsystem.amsterdam/).
- [Mark](https://designsystem.amsterdam/?path=/docs/components-text-mark--docs), the component this page now uses.

## What

Every occurrence of the searched-for term in the title and the teaser of a result is now wrapped in `Mark`. Matching is case insensitive, and each occurrence keeps the casing of the text it sits in: a title that opens with ‘Veiligheid’ keeps its capital, a teaser that mentions ‘veiligheid’ mid-sentence stays lowercase.

The taglines, the dates and the `role="status"` sentence that announces the total are left alone.

The example copy was adjusted so the page shows the behaviour: three teasers and two titles now mention the term, giving eight highlights across five of the six results. The sixth result shows none, on purpose.

Mark's own documentation changed alongside it. Its How to use section now separates the two uses under their own subheadings, since a highlighted search term and an editorial highlight follow different rules, and it records that the labels around a result are left alone.

The Loading Page is touched as well. It said the Search Results Page “has no loading state to manage”, which assumed the results always arrive with the page. An application may just as well render this page and fetch the results afterwards. Both pages now say that whether a search needs a loading state follows from where its results come from rather than from the kind of page it is, so neither rules the other approach out, and this page's When to use points at Skeletons for the case where the results arrive later.

Its Search results example is down to a single result card. That example used to build a small search page of its own, with a field, a query in React state, a filter and a list of three articles. The page template covers all of that now, so the component example only shows what a highlight looks like inside a result, and the docs link the template for the full list. The highlights there are written out as `Mark` elements rather than computed, so the Code Panel shows the markup itself.

## Why

A highlight shows a visitor at a glance why a result is in the list, which is what a result summary is there for.

Mark's usage guidelines already say to mark every match on the page, the heading of a result included, and its own Search results example does exactly that. The Accessibility section of this page said the opposite: that a result title is never marked up to highlight the matched words, because a highlight inside a link makes that link harder to read out. Mark's own Accessibility section undercuts that reason, since most screen readers do not announce highlighted text by default, and marking a title leaves the name its link is announced with unchanged either way. The page now follows the component, and those two sentences are gone.

The announcement of the total stays unmarked. It is read out in full when it changes, so a highlight adds nothing there.

The sixth result keeps no highlight because a search matches a whole page, not only the title and the sentence a result shows. One result without a highlight keeps the template honest about that, and the docs give the reason.

## How

A helper in the story escapes the term, builds a `RegExp` with the `gi` flags, splits the text on a capturing group and wraps the parts that land on an odd position. It follows the `mark` helper in Mark's own Search Results story, without the `args` a page template has no use for. Title and teaser both go through it.

The story hand-writes its Code Panel source, so the same `Mark` elements appear there too, in the one card the panel shows in full.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

Expect a visual difference on this page. Eight `mark` elements appear, and three teasers and two titles changed their wording, so the Chromatic diff is real and intended.

The card in the Code Panel is the first result, whose title holds no match, so the marked title only shows in the story itself. A comment in the panel names the rule.

The tagline of a result names its category, which a full-text search does not match, so it is never marked. Both documentation pages say so now, and Mark's example was chosen to show it: the card is filed under ‘Vergunningen’, above a heading that marks the same word.

The See also of the page names Mark and the semantic list of cards, both new here.

Both See also entries also stopped calling the other page “the same page”. The Loading Page has no filter column and lays its results out as 4 column Cards, against the single 7 column column beside a filter aside here, so they are two layouts rather than one page in two states. That wording predates this branch. If they are meant to be one page in two states, that is a change to the templates rather than to the text, and worth its own ticket.
