### PR TITLE
chore: Downgrade publiccode.yml to version 0.5

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -4,7 +4,9 @@
 # metadata file that makes public software easily discoverable.
 # More info at https://github.com/publiccodeyml/publiccode.yml
 
-publiccodeYmlVersion: "0.7"
+# Version 0.7 is the latest, but the Dutch open source register can’t read it yet:
+# https://github.com/developer-overheid-nl/don-checker/issues/59
+publiccodeYmlVersion: "0.5"
 
 name: Amsterdam Design System
 url: https://github.com/Amsterdam/design-system.git
@@ -93,8 +95,9 @@ localisation:
     - nl
   localisationReady: true
 
-supports:
-  - id: https://www.digitoegankelijk.nl/
+# Version 0.7 adds this key; restore it once we upgrade:
+# supports:
+#   - id: https://www.digitoegankelijk.nl/
 
 maintenance:
   type: internal


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Describe the pull request

## Links

- [Our page in the open source register](https://oss.developer.overheid.nl/repositories/235bba28-3fe0-4e55-9660-0c68a720743a)
- [don-checker#59: repositories with publiccode.yml version 0.7 get undefined](https://github.com/developer-overheid-nl/don-checker/issues/59)
- [The publiccode.yml standard, version 0.5](https://github.com/publiccodeyml/publiccode.yml/blob/v0.5.0/docs/standard/schema.core.rst)

## What

This sets `publiccodeYmlVersion` to `0.5` and moves the `supports` key into a comment.

## Why

The open source register at oss.developer.overheid.nl can’t read version 0.7. Our page there shows no data at all, which defeats the point of publishing the file. The fix on their side is blocked upstream, with no date, so we meet the register where it is and go back up later.

## How

There is no version 0.6: the entire difference between 0.5 and 0.7 is [one change to the standard](https://github.com/publiccodeyml/publiccode.yml/pull/318) that adds the `supports` key and deprecates the country-specific sections. So `supports` is the only key in our file that version 0.5 does not have. It waits in a comment, right where it was, together with a note above the version number that explains why we are not on the latest version.

Everything else stays as it is. All remaining keys exist unchanged in 0.5, `library`, `stable`, `internal`, `government` and uppercase `NL` are valid values there, and both short descriptions fit within 150 characters. The version string `"0.5"` is one of the versions [publiccode-parser-go](https://github.com/italia/publiccode-parser-go/blob/main/publiccode.go) accepts, which is the parser the register uses.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Once the register reads version 0.7, restoring this is a matter of uncommenting three lines and removing two comments.
