### PR TITLE
feat(Card): Use new Metadata component and deprecate tagline property

### DIFF
--- a/packages/react/src/Card/CardHeadingGroup.test.tsx
+++ b/packages/react/src/Card/CardHeadingGroup.test.tsx
@@ -88,6 +88,8 @@ describe('CardHeadingGroup', () => {
 
   describe('the deprecated tagline prop', () => {
     it('renders the tagline as a small Metadata', () => {
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+
       render(<CardHeadingGroup tagline="Nieuws" />)
 
       const tagline = screen.getByText('Nieuws')

--- a/packages/react/src/Card/CardHeadingGroup.test.tsx
+++ b/packages/react/src/Card/CardHeadingGroup.test.tsx
@@ -5,13 +5,18 @@
 
 import { render, screen } from '@testing-library/react'
 import { createRef } from 'react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { Metadata } from '../Metadata/Metadata'
 import { CardHeadingGroup } from './CardHeadingGroup'
 
 describe('CardHeadingGroup', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('renders', () => {
-    const { container } = render(<CardHeadingGroup tagline="test" />)
+    const { container } = render(<CardHeadingGroup />)
 
     const component = container.querySelector(':only-child')
 
@@ -20,7 +25,7 @@ describe('CardHeadingGroup', () => {
   })
 
   it('renders a design system BEM class name', () => {
-    const { container } = render(<CardHeadingGroup tagline="test" />)
+    const { container } = render(<CardHeadingGroup />)
 
     const component = container.querySelector(':only-child')
 
@@ -28,25 +33,43 @@ describe('CardHeadingGroup', () => {
   })
 
   it('renders an extra class name', () => {
-    const { container } = render(<CardHeadingGroup className="extra" tagline="test" />)
+    const { container } = render(<CardHeadingGroup className="extra" />)
 
     const component = container.querySelector(':only-child')
 
     expect(component).toHaveClass('ams-card__heading-group extra')
   })
 
-  it('renders a tagline', () => {
-    render(<CardHeadingGroup tagline="tagline" />)
+  it('renders a Metadata child after the heading, so screen readers reach the heading first', () => {
+    const { container } = render(
+      <CardHeadingGroup>
+        <h3>Berlagebrug dicht</h3>
+        <Metadata size="small">Nieuws</Metadata>
+      </CardHeadingGroup>,
+    )
 
-    const tagline = screen.getByText('tagline')
+    const component = container.querySelector(':only-child')
 
-    expect(tagline).toBeInTheDocument()
+    expect(component?.firstElementChild?.tagName).toBe('H3')
+    expect(component?.lastElementChild).toHaveClass('ams-metadata')
+  })
+
+  it('renders no metadata of its own without a tagline', () => {
+    const { container } = render(
+      <CardHeadingGroup>
+        <h3>Berlagebrug dicht</h3>
+      </CardHeadingGroup>,
+    )
+
+    const component = container.querySelector(':only-child')
+
+    expect(component?.querySelector('.ams-metadata')).not.toBeInTheDocument()
   })
 
   it('supports ForwardRef in React', () => {
     const ref = createRef<HTMLElement>()
 
-    const { container } = render(<CardHeadingGroup ref={ref} tagline="test" />)
+    const { container } = render(<CardHeadingGroup ref={ref} />)
 
     const component = container.querySelector(':only-child')
 
@@ -54,12 +77,55 @@ describe('CardHeadingGroup', () => {
   })
 
   it('passes additional props', () => {
-    const { container } = render(<CardHeadingGroup aria-hidden={false} data-test="data-test" id="id" tagline="test" />)
+    const { container } = render(<CardHeadingGroup aria-hidden={false} data-test="data-test" id="id" />)
 
     const component = container.querySelector(':only-child')
 
     expect(component).toHaveAttribute('aria-hidden', 'false')
     expect(component).toHaveAttribute('id', 'id')
     expect(component).toHaveAttribute('data-test', 'data-test')
+  })
+
+  describe('the deprecated tagline prop', () => {
+    it('renders the tagline as a small Metadata', () => {
+      render(<CardHeadingGroup tagline="Nieuws" />)
+
+      const tagline = screen.getByText('Nieuws')
+
+      expect(tagline).toHaveClass('ams-metadata ams-metadata--small')
+    })
+
+    it('warns that the prop has been replaced', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      render(<CardHeadingGroup tagline="Nieuws" />)
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('has been replaced'))
+    })
+
+    it('warns that it duplicates a Metadata child', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      render(
+        <CardHeadingGroup tagline="Nieuws">
+          <h3>Berlagebrug dicht</h3>
+          <Metadata size="small">Algemeen</Metadata>
+        </CardHeadingGroup>,
+      )
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('renders a second Metadata'))
+    })
+
+    it('does not warn when it is left off', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      render(
+        <CardHeadingGroup>
+          <h3>Berlagebrug dicht</h3>
+        </CardHeadingGroup>,
+      )
+
+      expect(warn).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/react/src/Card/CardHeadingGroup.tsx
+++ b/packages/react/src/Card/CardHeadingGroup.tsx
@@ -3,30 +3,54 @@
  * Copyright Gemeente Amsterdam
  */
 
-import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren, ReactNode } from 'react'
 
 import { clsx } from 'clsx'
-import { forwardRef } from 'react'
+import { Children, forwardRef, isValidElement, useEffect, useRef } from 'react'
 
-import { Paragraph } from '../Paragraph'
+import { Metadata } from '../Metadata/Metadata'
+
+const hasMetadataChild = (children: ReactNode) =>
+  Children.toArray(children).some((child) => isValidElement(child) && child.type === Metadata)
 
 export type CardHeadingGroupProps = {
-  /** A short phrase of text, e.g. to categorise the card. Displayed above the card heading. */
-  readonly tagline: string
+  /**
+   * A short phrase of text, e.g. to categorise the card. Displayed above the card heading.
+   * @deprecated Add a Metadata as a child instead. Will be removed on or after 2027-02-10.
+   */
+  readonly tagline?: string
 } & Readonly<PropsWithChildren<HTMLAttributes<HTMLElement>>>
 
 /**
- * Groups a Card's heading with an optional tagline, ensuring screen readers encounter the heading first.
+ * Groups a Card's heading with its metadata, ensuring screen readers encounter the heading first.
  *
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-navigation-card--docs Card docs at Amsterdam Design System}
  */
 export const CardHeadingGroup = forwardRef(
-  ({ children, className, tagline, ...restProps }: CardHeadingGroupProps, ref: ForwardedRef<HTMLElement>) => (
-    <hgroup {...restProps} className={clsx('ams-card__heading-group', className)} ref={ref}>
-      {children}
-      <Paragraph size="small">{tagline}</Paragraph>
-    </hgroup>
-  ),
+  ({ children, className, tagline, ...restProps }: CardHeadingGroupProps, ref: ForwardedRef<HTMLElement>) => {
+    // The deprecation warning fires once with the values passed on mount, so we read them through refs to keep the effect dependency-free.
+    const initialTaglineRef = useRef(tagline)
+    const initialMetadataChildRef = useRef(hasMetadataChild(children))
+
+    useEffect(() => {
+      if (initialTaglineRef.current === undefined) {
+        return
+      }
+
+      console.warn(
+        initialMetadataChildRef.current
+          ? '@deprecated The `tagline` prop of Card Heading Group renders a second Metadata beside the one you passed as a child. Remove the prop.'
+          : '@deprecated The `tagline` prop of Card Heading Group has been replaced. Add a Metadata as a child instead.',
+      )
+    }, [])
+
+    return (
+      <hgroup {...restProps} className={clsx('ams-card__heading-group', className)} ref={ref}>
+        {children}
+        {tagline !== undefined && <Metadata size="small">{tagline}</Metadata>}
+      </hgroup>
+    )
+  },
 )
 
 CardHeadingGroup.displayName = 'Card.HeadingGroup'

--- a/storybook/src/components/Card/Card.docs.mdx
+++ b/storybook/src/components/Card/Card.docs.mdx
@@ -46,7 +46,8 @@ Set its `level` to fit the document outline.
 
 ### Heading Group
 
-Displays a `tagline` above the heading.
+Displays a [Metadata](/docs/components-text-metadata--docs) above the heading.
+Write it after the Heading; the component reverses the two, so a screen reader reaches the heading first.
 
 <Canvas of={CardHeadingGroupStories.HeadingGroup} />
 
@@ -90,17 +91,16 @@ The Card Link covers the whole Card to make it clickable, so a second link insid
 ### How to write
 
 Place the text in a regular [Paragraph](/docs/components-text-paragraph--docs).
-Use a small Paragraph for a publication date.
+Use a small [Metadata](/docs/components-text-metadata--docs) for a publication date or a category.
 
 ## Examples
 
-### With tagline
+### With metadata
 
-A Card can display metadata in a tagline above the heading, like a category or content type.
-Wrap the Heading in a Heading Group and set its `tagline` property.
-This ensures screen readers read out the heading before the metadata.
+A Card can show a category, a date, or both above its heading.
+Wrap the Heading in a Heading Group and add a [Metadata](/docs/components-text-metadata--docs) after it, at the small size.
 
-<Canvas of={CardStories.WithTagline} />
+<Canvas of={CardStories.WithMetadata} />
 
 ### Horizontal layout
 
@@ -142,8 +142,9 @@ Only the title is the link, and everything else stays plain content, so the targ
 The focus ring is drawn around the entire Card instead of around the title alone, and the link’s own ring is switched off.
 Browsers that cannot express that condition get neither rule, so they still show the ordinary ring on the title rather than nothing at all.
 
-In a Heading Group the tagline is written after the heading and displayed above it.
+In a Heading Group the Metadata is written after the heading and displayed above it.
 The reading order and the visual order differ on purpose, which is what lets the metadata sit on top while the heading is still what gets read first.
+Writing it before the heading undoes both.
 
 Whether a Card is horizontal follows the width of its container rather than the width of the window.
 The same Card is one row in a list of results and one card in a row of three, and which of the two it should be depends on the space it is given, not on the size of the screen.

--- a/storybook/src/components/Card/Card.stories.tsx
+++ b/storybook/src/components/Card/Card.stories.tsx
@@ -30,10 +30,10 @@ type Story = StoryObj<typeof meta>
 
 type DefaultProps = {
   aspectRatio: (typeof aspectRatioOptions)[number]
+  category: string
   date: string
   heading: string
   imageSrc: string
-  tagline: string
   text: string
 } & Readonly<ComponentProps<typeof Card>>
 
@@ -42,10 +42,10 @@ type DefaultStory = StoryObj<DefaultProps>
 export const Default: DefaultStory = {
   args: {
     aspectRatio: '16:9',
+    category: 'Nieuws',
     date: formatDate(Date.now()),
     heading: 'Nederlands eerste houten woonwijk komt in Zuidoost',
     imageSrc: 'https://picsum.photos/480/360',
-    tagline: 'Nieuws',
     text: 'We bouwen een levendige, groene en duurzame woonbuurt tussen de Gooiseweg en het Nelson Mandelapark.',
   },
   // These argTypes describe flattened args specific to this composed story; the meta cannot provide them.
@@ -54,22 +54,24 @@ export const Default: DefaultStory = {
       control: { type: 'select' },
       options: aspectRatioOptions,
     },
+    category: { control: 'text' },
     date: { control: 'text' },
     heading: { control: 'text' },
     imageSrc: { control: 'text' },
-    tagline: { control: 'text' },
     text: { control: 'text' },
   },
   // The query container keeps this Card below the width at which it would switch to a horizontal layout.
   decorators: [wrapInInlineSizeQueryContainer(), maximiseInlineSize('24rem')],
-  render: ({ aspectRatio, date, heading, imageSrc, tagline, text, ...args }) => (
+  render: ({ aspectRatio, category, date, heading, imageSrc, text, ...args }) => (
     <Card {...args}>
       <Card.Image alt="" aspectRatio={aspectRatio} src={imageSrc} />
       <Card.Content>
-        <Card.HeadingGroup tagline={tagline}>
+        <Card.HeadingGroup>
           <Card.Heading level={3}>
             <Card.Link href="/">{heading}</Card.Link>
           </Card.Heading>
+          {/* The Metadata is written after the heading and displayed above it, so the heading is read first. */}
+          <Metadata size="small">{category}</Metadata>
         </Card.HeadingGroup>
         <Column gap="small">
           <Paragraph>{text}</Paragraph>
@@ -80,13 +82,14 @@ export const Default: DefaultStory = {
   ),
 }
 
-export const WithTagline: Story = {
+export const WithMetadata: Story = {
   args: {
     children: [
-      <Card.HeadingGroup key={1} tagline="Dossier">
+      <Card.HeadingGroup key={1}>
         <Card.Heading level={2}>
           <Card.Link href="/">Monitor Attracties MRA</Card.Link>
         </Card.Heading>
+        <Metadata size="small">Dossier</Metadata>
       </Card.HeadingGroup>,
       <Paragraph key={2}>
         Ontwikkeling van het aantal attracties en bezoekers in de metropoolregio Amsterdam.

--- a/storybook/src/components/Card/Card.stories.tsx
+++ b/storybook/src/components/Card/Card.stories.tsx
@@ -6,8 +6,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { ComponentProps } from 'react'
 
-import { Column, Grid, Metadata, Paragraph } from '@amsterdam/design-system-react'
-import { Card } from '@amsterdam/design-system-react/src'
+import { Column, Grid, Paragraph } from '@amsterdam/design-system-react'
+import { Card, Metadata } from '@amsterdam/design-system-react/src'
 import { aspectRatioOptions } from '@amsterdam/design-system-react/src/common/types'
 
 import { maximiseInlineSize, wrapInInlineSizeQueryContainer } from '#storybook/_common/decorators'

--- a/storybook/src/components/Card/Card.test.stories.tsx
+++ b/storybook/src/components/Card/Card.test.stories.tsx
@@ -5,6 +5,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
+import { Metadata } from '@amsterdam/design-system-react'
 import { Card } from '@amsterdam/design-system-react/src'
 
 import { default as cardMeta } from './Card.stories'
@@ -22,13 +23,14 @@ const NewsCard = () => (
   <Card>
     <Card.Image alt="" aspectRatio="4:3" src="https://picsum.photos/id/122/1280/720" />
     <Card.Content>
-      <Card.HeadingGroup tagline="Nieuws">
+      <Card.HeadingGroup>
         <Card.Heading level={3}>
           <Card.Link href="/">Nederlands eerste houten woonwijk komt in Zuidoost</Card.Link>
           <Card.Link className="hover" href="/">
             Nederlands eerste houten woonwijk komt in Zuidoost
           </Card.Link>
         </Card.Heading>
+        <Metadata size="small">Nieuws</Metadata>
       </Card.HeadingGroup>
       <div>
         <p>We bouwen een levendige, groene en duurzame woonbuurt tussen de Gooiseweg en het Nelson Mandelapark.</p>

--- a/storybook/src/components/Card/Card.test.stories.tsx
+++ b/storybook/src/components/Card/Card.test.stories.tsx
@@ -5,8 +5,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { Metadata } from '@amsterdam/design-system-react'
-import { Card } from '@amsterdam/design-system-react/src'
+import { Card, Metadata } from '@amsterdam/design-system-react/src'
 
 import { default as cardMeta } from './Card.stories'
 

--- a/storybook/src/components/Card/CardHeadingGroup.stories.tsx
+++ b/storybook/src/components/Card/CardHeadingGroup.stories.tsx
@@ -5,11 +5,16 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
+import { Metadata } from '@amsterdam/design-system-react'
 import { Card } from '@amsterdam/design-system-react/src'
 
 const meta = {
   title: 'Components/Navigation/Card',
   component: Card.HeadingGroup,
+  // The render wires a Metadata child rather than the deprecated prop, so its control would do nothing.
+  argTypes: {
+    tagline: { control: false },
+  },
   decorators: [
     (Story) => (
       <Card>
@@ -26,11 +31,13 @@ type Story = StoryObj<typeof meta>
 
 export const HeadingGroup: Story = {
   args: {
-    children: (
-      <Card.Heading level={3}>
+    children: [
+      <Card.Heading key={1} level={3}>
         <Card.Link href="#">Meer plekken voor kunst en cultuur, verspreid over de stad</Card.Link>
-      </Card.Heading>
-    ),
-    tagline: 'Nieuws',
+      </Card.Heading>,
+      <Metadata key={2} size="small">
+        Nieuws
+      </Metadata>,
+    ],
   },
 }

--- a/storybook/src/components/Card/CardHeadingGroup.stories.tsx
+++ b/storybook/src/components/Card/CardHeadingGroup.stories.tsx
@@ -5,8 +5,7 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { Metadata } from '@amsterdam/design-system-react'
-import { Card } from '@amsterdam/design-system-react/src'
+import { Card, Metadata } from '@amsterdam/design-system-react/src'
 
 const meta = {
   title: 'Components/Navigation/Card',

--- a/storybook/src/components/Mark/Mark.stories.tsx
+++ b/storybook/src/components/Mark/Mark.stories.tsx
@@ -41,13 +41,14 @@ export const SearchResults = {
   decorators: [maximiseInlineSize('7-of-12-columns')],
   render: () => (
     <Card>
-      {/* The category is a label rather than text the search matched, so the word in it stays unmarked. */}
-      <Card.HeadingGroup tagline="Vergunningen">
+      <Card.HeadingGroup>
         <Heading level={2} size="level-4">
           <Card.Link href="#">
             <Mark>Vergunning</Mark> vechtsportevenementen
           </Card.Link>
         </Heading>
+        {/* The category is a label rather than text the search matched, so the word in it stays unmarked. */}
+        <Metadata size="small">Vergunningen</Metadata>
       </Card.HeadingGroup>
       <Paragraph className="ams-mb-xs">
         Voor de organisatie van grootschalige vechtsportgala’s in Amsterdam moet u een <Mark>vergunning</Mark> aanvragen

--- a/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
+++ b/storybook/src/pages/public/ArticlePage/ArticlePage.stories.tsx
@@ -185,10 +185,11 @@ const meta = {
             <Card>
               {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
               <Card.Image alt="" src={exampleImageSource(640, 360, 1)} />
-              <Card.HeadingGroup tagline="Nieuws">
+              <Card.HeadingGroup>
                 <Card.Heading level={3}>
                   <Card.Link href="#">Waarom we op zoek zijn naar vleermuizen</Card.Link>
                 </Card.Heading>
+                <Metadata size="small">Nieuws</Metadata>
               </Card.HeadingGroup>
               <Paragraph>
                 U kunt &apos;s avonds ecologen in oranje hesjes tegenkomen. Zij zijn op zoek naar vleermuizen. Dat heeft
@@ -199,10 +200,11 @@ const meta = {
           <Grid.Cell span={4}>
             <Card>
               <Card.Image alt="" src={exampleImageSource(640, 360, 2)} />
-              <Card.HeadingGroup tagline="Nieuws">
+              <Card.HeadingGroup>
                 <Card.Heading level={3}>
                   <Card.Link href="#">Meer aandacht voor voetgangers, een jaar lang</Card.Link>
                 </Card.Heading>
+                <Metadata size="small">Nieuws</Metadata>
               </Card.HeadingGroup>
               <Paragraph>
                 We gaan de veiligheid voor voetgangers verbeteren, meer ruimte maken, en lopen en wandelen stimuleren.
@@ -212,10 +214,11 @@ const meta = {
           <Grid.Cell span={4}>
             <Card>
               <Card.Image alt="" src={exampleImageSource(640, 360, 3)} />
-              <Card.HeadingGroup tagline="Nieuws">
+              <Card.HeadingGroup>
                 <Card.Heading level={3}>
                   <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>
                 </Card.Heading>
+                <Metadata size="small">Nieuws</Metadata>
               </Card.HeadingGroup>
               <Paragraph>
                 Afvalboten, bakfietsen en ondergrondse containers. We experimenteren met nieuwe manieren om afval op te
@@ -359,10 +362,11 @@ export const Default: StoryObj = {
         <Card>
           {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
           <Card.Image alt="" src="https://picsum.photos/640/360?random=1" />
-          <Card.HeadingGroup tagline="Nieuws">
+          <Card.HeadingGroup>
             <Card.Heading level={3}>
               <Card.Link href="#">Waarom we op zoek zijn naar vleermuizen</Card.Link>
             </Card.Heading>
+            <Metadata size="small">Nieuws</Metadata>
           </Card.HeadingGroup>
           <Paragraph>
             U kunt 's avonds ecologen in oranje hesjes tegenkomen. Zij zijn op zoek naar vleermuizen.
@@ -372,10 +376,11 @@ export const Default: StoryObj = {
       <Grid.Cell span={4}>
         <Card>
           <Card.Image alt="" src="https://picsum.photos/640/360?random=2" />
-          <Card.HeadingGroup tagline="Nieuws">
+          <Card.HeadingGroup>
             <Card.Heading level={3}>
               <Card.Link href="#">Meer aandacht voor voetgangers, een jaar lang</Card.Link>
             </Card.Heading>
+            <Metadata size="small">Nieuws</Metadata>
           </Card.HeadingGroup>
           <Paragraph>We gaan de veiligheid voor voetgangers verbeteren en meer ruimte maken.</Paragraph>
         </Card>
@@ -383,10 +388,11 @@ export const Default: StoryObj = {
       <Grid.Cell span={4}>
         <Card>
           <Card.Image alt="" src="https://picsum.photos/640/360?random=3" />
-          <Card.HeadingGroup tagline="Nieuws">
+          <Card.HeadingGroup>
             <Card.Heading level={3}>
               <Card.Link href="#">Nieuwe manieren om afval op te halen</Card.Link>
             </Card.Heading>
+            <Metadata size="small">Nieuws</Metadata>
           </Card.HeadingGroup>
           <Paragraph>Afvalboten, bakfietsen en ondergrondse containers in het centrum.</Paragraph>
         </Card>

--- a/storybook/src/pages/public/HomePage/HomePage.stories.tsx
+++ b/storybook/src/pages/public/HomePage/HomePage.stories.tsx
@@ -5,7 +5,16 @@
 
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { Card, Grid, Heading, Overlap, Paragraph, Spotlight, StandaloneLink } from '@amsterdam/design-system-react'
+import {
+  Card,
+  Grid,
+  Heading,
+  Metadata,
+  Overlap,
+  Paragraph,
+  Spotlight,
+  StandaloneLink,
+} from '@amsterdam/design-system-react'
 
 import { Default as OverlapStory } from '../../../components/Overlap/Overlap.stories'
 import { commonMeta, pageParameters } from '../common/commonMeta'
@@ -107,11 +116,12 @@ const meta = {
               <Card>
                 {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
                 <Card.Image alt="" src={image} />
-                {/* Card.HeadingGroup adds a short tagline above the Card’s heading. */}
-                <Card.HeadingGroup tagline="Nieuws">
+                <Card.HeadingGroup>
                   <Card.Heading level={3}>
                     <Card.Link href="#">{title}</Card.Link>
                   </Card.Heading>
+                  {/* Written after the heading and displayed above it, so the heading is read first. */}
+                  <Metadata size="small">Nieuws</Metadata>
                 </Card.HeadingGroup>
                 <Paragraph>{description}</Paragraph>
               </Card>
@@ -207,11 +217,12 @@ export const Default: StoryObj = {
           <Card>
             {/* Screen readers skip a Card’s image, so only use a decorative one with an empty alt. */}
             <Card.Image alt="" src={image} />
-            {/* Card.HeadingGroup adds a short tagline above the Card’s heading. */}
-            <Card.HeadingGroup tagline="Nieuws">
+            <Card.HeadingGroup>
               <Card.Heading level={3}>
                 <Card.Link href="#">{title}</Card.Link>
               </Card.Heading>
+              {/* Written after the heading and displayed above it, so the heading is read first. */}
+              <Metadata size="small">Nieuws</Metadata>
             </Card.HeadingGroup>
             <Paragraph>{description}</Paragraph>
           </Card>

--- a/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.stories.tsx
+++ b/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.stories.tsx
@@ -164,10 +164,11 @@ export const Default: StoryObj = {
               <Card.Image alt="" loading="lazy" src="https://picsum.photos/id/122/640/360" />
               {/* A Card that pairs an image with a Content lays out horizontally in a cell this wide. */}
               <Card.Content>
-                <Card.HeadingGroup tagline="Algemeen, Centrum, Werkzaamheden">
+                <Card.HeadingGroup>
                   <Card.Heading level={3}>
                     <Card.Link href="#">Berlagebrug een aantal nachten dicht</Card.Link>
                   </Card.Heading>
+                  <Metadata size="small">Algemeen, Centrum, Werkzaamheden</Metadata>
                 </Card.HeadingGroup>
                 <Column gap="small">
                   <Paragraph>
@@ -312,10 +313,11 @@ export const Default: StoryObj = {
                     <Card.Image alt="" loading="lazy" src={article.imageSource} />
                     {/* A Card that pairs an image with a Content lays out horizontally in a cell this wide. */}
                     <Card.Content>
-                      <Card.HeadingGroup tagline={article.category}>
+                      <Card.HeadingGroup>
                         <Card.Heading level={3}>
                           <Card.Link href="#">{article.title}</Card.Link>
                         </Card.Heading>
+                        <Metadata size="small">{article.category}</Metadata>
                       </Card.HeadingGroup>
                       <Column gap="small">
                         <Paragraph>{article.teaser}</Paragraph>

--- a/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
+++ b/storybook/src/pages/public/SearchResultsPage/SearchResultsPage.stories.tsx
@@ -137,12 +137,13 @@ export const Default: StoryObj = {
             <Card>
               {/*
                * Every match is marked, in the title of a result as well as in its teaser; this title holds none.
-               * The tagline names the category rather than text the search matched, so nothing in it is marked.
+               * The Metadata names the category rather than text the search matched, so nothing in it is marked.
                */}
-              <Card.HeadingGroup tagline="Actiecentrum Veiligheid en Zorg">
+              <Card.HeadingGroup>
                 <Card.Heading level={3}>
                   <Card.Link href="#">Top 400/600</Card.Link>
                 </Card.Heading>
+                <Metadata size="small">Actiecentrum Veiligheid en Zorg</Metadata>
               </Card.HeadingGroup>
               <Column gap="small">
                 <Paragraph>
@@ -261,12 +262,13 @@ export const Default: StoryObj = {
                   <Card>
                     {/*
                      * Every match is marked, in the title of a result as well as in its teaser.
-                     * The tagline names the category rather than text the search matched, so nothing in it is marked.
+                     * The Metadata names the category rather than text the search matched, so nothing in it is marked.
                      */}
-                    <Card.HeadingGroup tagline={result.section}>
+                    <Card.HeadingGroup>
                       <Card.Heading level={3}>
                         <Card.Link href="#">{markSearchTerm(result.title)}</Card.Link>
                       </Card.Heading>
+                      <Metadata size="small">{result.section}</Metadata>
                     </Card.HeadingGroup>
                     <Column gap="small">
                       <Paragraph>{markSearchTerm(result.teaser)}</Paragraph>


### PR DESCRIPTION
# Let a Heading Group take a Metadata child

## Links

- [Card, Default](https://designsystem.amsterdam/?path=/story/components-navigation-card--default) — the tagline above the heading, now in the secondary colour
- [Card, With metadata](https://designsystem.amsterdam/?path=/story/components-navigation-card--with-metadata) — the new composition
- [Card documentation](https://designsystem.amsterdam/?path=/docs/components-navigation-card--docs) — Heading Group and the deprecated prop
- [News Overview Page](https://designsystem.amsterdam/?path=/story/pages-public-news-overview-page--default) — a page of Cards carrying it
- [Storybook root](https://designsystem.amsterdam/) on main
- [DES-1948](https://gemeente-amsterdam.atlassian.net/browse/DES-1948) — the design ticket, which asks for the tagline to become flexible
- [DES-1981](https://gemeente-amsterdam.atlassian.net/browse/DES-1981) — the code ticket for Metadata, merged as #2912

## What

`Card.HeadingGroup` now takes a [Metadata](https://designsystem.amsterdam/?path=/docs/components-text-metadata--docs) as a child, written after the Heading. Its `tagline` prop becomes optional and deprecated, and every Card in the stories and page templates moves to the new form, so nothing in the repository still uses it.

While the prop lives on, it renders a Metadata rather than a Paragraph. That gives the tagline the secondary text colour, which is the visible change in this pull request.

## Why

`tagline` holds a single string, so a Card could show a category or a date but never both on one line. DES-1948 asks for exactly that. A Metadata child can carry as many kinds as the content needs, and it is the same markup a content page already uses under its title.

The colour follows from the same change rather than from a token. The tagline rendered a plain small Paragraph with no Card class on it, so the Card owned no selector and no colour token that could reach it; `ams.card.heading-group` has only `gap` and `margin-block-end`. Rendering the component that owns the concept is what makes it grey.

## How

Widening a required prop to optional accepts more input than before, so no existing call breaks. The prop keeps working until at least 10 February 2027, announced through an `@deprecated` tag and a `console.warn` on mount, following Accordion and Progress List.

Passing both the prop and a Metadata child warns with a message of its own, because the two would stack above the heading. The check reads the children once on mount, the way `TableOfContents` finds a nested list.

A child rather than a slot prop, because the two slot props in the package — `Dialog.footer` and `PageHeader.menuItems` — exist for content that cannot be a child. A tagline can: it already renders as a plain sibling inside the same `hgroup`. Every other compound in the package composes with children.

The Metadata is written after the Heading and displayed above it. That inversion is what lets a screen reader reach the heading first, and it is why the order matters; the Card documentation says so where a reader will meet it.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

Every Card in the design system holds one kind of metadata, so each call site is a single Metadata with no Separator. The two-kind case that DES-1948 describes — a category and a date on one line — is not built here, because where that line belongs in a Card is still a question for UX. Merging them below the teaser would also free the component from the `hgroup`, whose content model allows only a heading and paragraphs.

`tagline` is no longer exercised by any story, so Chromatic does not snapshot the deprecated path. It renders markup identical to the Metadata child, so there is nothing to see, but a story could be kept until the removal date if reviewers would rather have one.


[DES-1948]: https://gemeente-amsterdam.atlassian.net/browse/DES-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DES-1981]: https://gemeente-amsterdam.atlassian.net/browse/DES-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
