### PR TITLE
fix(Ordered List, Unordered List): Only style a list that is directly nested in a list item

### DIFF
--- a/packages/css/src/components/ordered-list/ordered-list.scss
+++ b/packages/css/src/components/ordered-list/ordered-list.scss
@@ -26,7 +26,7 @@
   line-height: var(--ams-ordered-list-line-height);
   list-style-type: var(--ams-ordered-list-list-style-type);
 
-  .ams-ordered-list__item {
+  > .ams-ordered-list__item {
     margin-inline-start: var(--ams-ordered-list-item-margin-inline-start);
     padding-inline-start: var(--ams-ordered-list-item-padding-inline-start);
   }
@@ -41,19 +41,23 @@
   line-height: var(--ams-ordered-list-small-line-height);
 }
 
+/*
+ * A list is nested only when it sits directly inside a list item: one inside a card is a list of its own.
+ * The element in between is not typed, as it should be a list item but the effect is wanted regardless.
+ */
 :is(.ams-ordered-list, .ams-unordered-list) {
-  .ams-ordered-list {
+  > * > .ams-ordered-list:not(.ams-ordered-list--no-markers) {
     gap: var(--ams-ordered-list-ordered-list-gap);
     list-style-type: var(--ams-ordered-list-ordered-list-list-style-type);
     padding-block-start: var(--ams-ordered-list-ordered-list-padding-block-start);
 
-    .ams-ordered-list__item {
+    > .ams-ordered-list__item {
       margin-inline-start: var(--ams-ordered-list-ordered-list-item-margin-inline-start);
       padding-inline-start: var(--ams-ordered-list-ordered-list-item-padding-inline-start);
     }
   }
 
-  > :not(:last-child) > .ams-ordered-list {
+  > :not(:last-child) > .ams-ordered-list:not(.ams-ordered-list--no-markers) {
     padding-block-end: var(--ams-ordered-list-ordered-list-padding-block-end);
   }
 }

--- a/packages/css/src/components/unordered-list/unordered-list.scss
+++ b/packages/css/src/components/unordered-list/unordered-list.scss
@@ -26,7 +26,7 @@
   line-height: var(--ams-unordered-list-line-height);
   list-style-type: var(--ams-unordered-list-list-style-type);
 
-  .ams-unordered-list__item {
+  > .ams-unordered-list__item {
     margin-inline-start: var(--ams-unordered-list-item-margin-inline-start);
     padding-inline-start: var(--ams-unordered-list-item-padding-inline-start);
   }
@@ -41,19 +41,23 @@
   line-height: var(--ams-unordered-list-small-line-height);
 }
 
+/*
+ * A list is nested only when it sits directly inside a list item: one inside a card is a list of its own.
+ * The element in between is not typed, as it should be a list item but the effect is wanted regardless.
+ */
 :is(.ams-ordered-list, .ams-unordered-list) {
-  .ams-unordered-list {
+  > * > .ams-unordered-list:not(.ams-unordered-list--no-markers) {
     gap: var(--ams-unordered-list-unordered-list-gap);
     list-style-type: var(--ams-unordered-list-unordered-list-list-style-type);
     padding-block-start: var(--ams-unordered-list-unordered-list-padding-block-start);
 
-    .ams-unordered-list__item {
+    > .ams-unordered-list__item {
       margin-inline-start: var(--ams-unordered-list-unordered-list-item-margin-inline-start);
       padding-inline-start: var(--ams-unordered-list-unordered-list-item-padding-inline-start);
     }
   }
 
-  > :not(:last-child) > .ams-unordered-list {
+  > :not(:last-child) > .ams-unordered-list:not(.ams-unordered-list--no-markers) {
     padding-block-end: var(--ams-unordered-list-unordered-list-padding-block-end);
   }
 }

--- a/storybook/src/components/OrderedList/OrderedList.docs.mdx
+++ b/storybook/src/components/OrderedList/OrderedList.docs.mdx
@@ -84,6 +84,8 @@ The second and following lines of an item line up with its first line instead of
 
 A nested list is indented less than the top level.
 Its numbers need less room because they are letters, and a smaller step keeps a two-level list from drifting far to the right.
+Only a list that sits directly in a list item counts as nested.
+A list inside a container, such as a card, starts at the first level again.
 
 ## Accessibility
 

--- a/storybook/src/components/OrderedList/OrderedList.test.stories.tsx
+++ b/storybook/src/components/OrderedList/OrderedList.test.stories.tsx
@@ -33,6 +33,26 @@ export const Test: Story = {
       <OrderedList.Item key={5}>
         Er zijn veel mogelijkheden in de bouw, infrastructuur, haven en groenvoorziening.
       </OrderedList.Item>,
+      <OrderedList.Item key={6}>
+        Een lijst in een lijstitem is een niveau dieper.
+        <OrderedList>
+          <OrderedList.Item>Deze krijgt letters en minder inspringing.</OrderedList.Item>
+        </OrderedList>
+      </OrderedList.Item>,
+      <OrderedList.Item key={7}>
+        Een lijst achter een tussenliggend element hoort niet bij deze lijst.
+        <div>
+          <OrderedList>
+            <OrderedList.Item>Deze krijgt de opmaak van een eerste niveau.</OrderedList.Item>
+          </OrderedList>
+        </div>
+      </OrderedList.Item>,
+      <OrderedList.Item key={8}>
+        Een geneste lijst zonder opsommingstekens houdt die weg.
+        <OrderedList markers={false}>
+          <OrderedList.Item>Deze krijgt geen teken en geen inspringing.</OrderedList.Item>
+        </OrderedList>
+      </OrderedList.Item>,
     ],
   },
   render: (args, context) => renderComponentVariants(OrderedList, { args }, context),

--- a/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
+++ b/storybook/src/components/UnorderedList/UnorderedList.docs.mdx
@@ -72,6 +72,8 @@ Markers sit outside the text column.
 The second and following lines of an item line up with its first line instead of running back underneath the marker, which keeps the left edge of the text straight.
 
 A nested list is indented less than the top level, which keeps a two-level list from drifting far to the right.
+Only a list that sits directly in a list item counts as nested.
+A list inside a container, such as a card, starts at the first level again.
 
 ## Accessibility
 

--- a/storybook/src/components/UnorderedList/UnorderedList.test.stories.tsx
+++ b/storybook/src/components/UnorderedList/UnorderedList.test.stories.tsx
@@ -33,6 +33,26 @@ export const Test: Story = {
       <UnorderedList.Item key={5}>
         Er zijn veel mogelijkheden in de bouw, infrastructuur, haven en groenvoorziening.
       </UnorderedList.Item>,
+      <UnorderedList.Item key={6}>
+        Een lijst in een lijstitem is een niveau dieper.
+        <UnorderedList>
+          <UnorderedList.Item>Deze krijgt een half kastlijntje en minder inspringing.</UnorderedList.Item>
+        </UnorderedList>
+      </UnorderedList.Item>,
+      <UnorderedList.Item key={7}>
+        Een lijst achter een tussenliggend element hoort niet bij deze lijst.
+        <div>
+          <UnorderedList>
+            <UnorderedList.Item>Deze krijgt de opmaak van een eerste niveau.</UnorderedList.Item>
+          </UnorderedList>
+        </div>
+      </UnorderedList.Item>,
+      <UnorderedList.Item key={8}>
+        Een geneste lijst zonder opsommingstekens houdt die weg.
+        <UnorderedList markers={false}>
+          <UnorderedList.Item>Deze krijgt geen teken en geen inspringing.</UnorderedList.Item>
+        </UnorderedList>
+      </UnorderedList.Item>,
     ],
   },
   render: (args, context) => renderComponentVariants(UnorderedList, { args }, context),


### PR DESCRIPTION
# Only treat a list directly inside a list item as nested

## Links

- [Unordered List, Two levels](https://designsystem.amsterdam/?path=/story/components-text-unordered-list--two-levels) — unchanged, the case the child combinators must keep matching
- [Unordered List documentation](https://designsystem.amsterdam/?path=/docs/components-text-unordered-list--docs) — the Design section says what counts as nested
- [Ordered List, Two levels](https://designsystem.amsterdam/?path=/story/components-text-ordered-list--two-levels) — also unchanged
- [Ordered List documentation](https://designsystem.amsterdam/?path=/docs/components-text-ordered-list--docs)
- [Storybook root](https://designsystem.amsterdam/) on main
- [DES-1897](https://gemeente-amsterdam.atlassian.net/browse/DES-1897) — the ticket
- [Slack thread](https://codefornl.slack.com/archives/C01DAT4TRPF/p1781859488574359) — the NLDS use case that reported it

## What

The nested-list rules now use child combinators, so only a list that sits directly inside a list item takes the deeper level's marker and indentation. A list of cards holding an unrelated list inside a card renders as a first-level list again.

The same rules now skip a list without markers, as the base rules already do. Until now the deeper level's marker won over the reset, so `markers={false}` had no effect on a nested list.

Both `Test` stories gain three cases: a directly nested list, a list behind an intervening element, and a nested marker-less list. Nesting had no visual-regression coverage at all before this.

## Why

NLDS renders a marker-less Unordered List of cards, each card holding a list of its own. That inner list is unrelated to the outer one, but `:is(.ams-ordered-list, .ams-unordered-list) .ams-unordered-list` reached it through the card and gave it an en dash instead of a square bullet, 1.75rem of indentation instead of 2.5rem, and space above with no matching space below.

The descendant selector was never a decision. It has been there since the first Unordered List commit in #391 and was never discussed. #444 did add child combinators and then remove them again, but those were on `__item`, and removing them was right at the time: with the nested-list rule left as a descendant selector, a `>` on `__item` bought nothing. #2133 then scoped `padding-block-end` with `> :not(:last-child) >`, which left the block half scoped and is why the reported case gets padding above but not below.

## How

The middle step is `*` rather than `li`, for the two reasons #2133 gives: the element in between should be a list item, but the effect is wanted either way, and a type selector would raise specificity for nothing.

The base rules keep their own item selector, scoped to `> .ams-…__item`, which is what makes the fallback work. A list behind an intervening element still matches the base rules on its own merits, so it reads as a first-level list rather than losing its indentation.

Nesting deeper than two levels is unchanged. A third-level list is a child of a second-level item whose list is itself an `:is(.ams-ordered-list, .ams-unordered-list)`, so it still matches, and every level from the second down shares one set of tokens.

The item selector inside the nested block is scoped too. Without that, a list inside a card inside an already nested list would still pick up the second level's indentation.

A list nested in a marker-less list still takes the deeper level's marker. Whether to hide markers is each list's own business, so the ancestor's choice does not reach in.

I checked the compiled selectors and then read `getComputedStyle` in a headless browser across thirteen nesting shapes, before and after. Every properly nested case is identical: two levels, three levels, a `ul` inside an `ol` item, and a nested list with `size="small"`. What changes is the list behind an intervening element, the list inside a card at either depth, and the nested marker-less list.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

Expect Chromatic diffs on the two list `Test` stories only, from the three cases added to each. No other story nests a list behind an intervening element, so nothing else should move. If a diff appears elsewhere, it is worth looking at rather than accepting.

Adding `:not(…--no-markers)` raises the nested rule from `(0,2,0)` to `(0,3,0)`. A consumer overriding the nested marker with a two-class selector would now lose that fight. It is unavoidable if the guard is to work at all, since the reset it has to beat sits at `(0,1,0)`.

`--ams-unordered-list-unordered-list-gap` and `--ams-unordered-list-gap` both resolve to `{ams.space.s}` in every mode, so the `gap` declaration in the nested block currently changes nothing. Left alone here, but it is either a token that wants a different value or a declaration that can go.

`table-of-contents.scss` has the same descendant pattern for its own nested list, and the collapsible variant already has to undo it with `padding-inline-start: 0`. Much lower risk, since nobody nests a Table of Contents inside a Table of Contents item, so it is not touched here.

On the second acceptance criterion: `@scope` is not worth using for this. The boundary that matters lives in consumer markup — NLDS's own card class — so a donut hole cannot be authored from inside the design system, and `to (.ams-unordered-list)` would exclude the very list we want to style. What `@scope` adds over a combinator is proximity beating source order, which this problem does not need. It is also Baseline newly available only since December 2025, so `plugin/use-baseline` flags it at the `widely` level we enforce, and as a progressive enhancement the fallback for other browsers would have to be the current descendant rules, leaving the bug in place there.


[DES-1897]: https://gemeente-amsterdam.atlassian.net/browse/DES-1897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ