### PR TITLE
chore: Apply the full package.json lint rule set to the proprietary packages

### DIFF
--- a/.npmpackagejsonlintrc.json
+++ b/.npmpackagejsonlintrc.json
@@ -42,9 +42,15 @@
   },
   "overrides": [
     {
-      "patterns": ["packages/*/package.json"],
+      "patterns": ["packages/*/package.json", "packages-proprietary/*/package.json"],
       "rules": {
         "require-files": "error"
+      }
+    },
+    {
+      "patterns": ["packages-proprietary/*/package.json"],
+      "rules": {
+        "valid-values-license": ["error", ["SEE LICENSE IN LICENSE.md"]]
       }
     }
   ]

--- a/documentation/publishing.md
+++ b/documentation/publishing.md
@@ -139,7 +139,8 @@ Measure with `npm pack --dry-run` on a clean build before changing a `files` fie
 
 ### Linting the package manifests
 
-`pnpm run lint:package-json` checks every `package.json` against `.npmpackagejsonlintrc.json`, which is where `require-files` is switched on.
+`pnpm run lint:package-json` checks every `package.json` against `.npmpackagejsonlintrc.json`.
+An entry in its `overrides` block switches `require-files` on for the published packages only, since the private manifests publish no tarball whose contents need allowlisting.
 
 Keep that single config file at the root.
 `npmPkgJsonLint` loads the **nearest** config file and never merges it with the ones above it, so a config in a subdirectory replaces the root rule set instead of extending it.

--- a/documentation/publishing.md
+++ b/documentation/publishing.md
@@ -127,6 +127,28 @@ To fix this, check whether any closed PRs still have the `autorelease: pending` 
 
 [See the Release Please docs for more information](https://github.com/googleapis/release-please?tab=readme-ov-file#release-please-bot-does-not-create-a-release-pr-why).
 
+## What each package publishes
+
+Every published package declares a `files` field, the allowlist of what npm puts in the tarball.
+Without one, a package publishes whatever happens to be tracked in git inside its directory, plus the gitignored `dist/` that CI builds.
+Nothing then records what a package is meant to contain, so its contents drift silently whenever someone adds a file.
+
+We declared these explicitly in [pull request 2821](https://github.com/Amsterdam/design-system/pull/2821), which cut the Tokens tarball from 113 files to 15 by dropping the token sources, the Style Dictionary transforms and its build tooling.
+CSS deliberately keeps `src/` next to `dist/`: our developer guide documents importing breakpoint variables from `src/common/breakpoint.scss`, which have to be Sass variables because custom properties can’t be used in media queries.
+Measure with `npm pack --dry-run` on a clean build before changing a `files` field, and check that every documented entry point still resolves.
+
+### Linting the package manifests
+
+`pnpm run lint:package-json` checks every `package.json` against `.npmpackagejsonlintrc.json`, which is where `require-files` is switched on.
+
+Keep that single config file at the root.
+`npmPkgJsonLint` loads the **nearest** config file and never merges it with the ones above it, so a config in a subdirectory replaces the root rule set instead of extending it.
+A second config in `packages-proprietary` did precisely that, from the first commit of this repository until July 2026: Tokens, Assets and React Icons were checked against only the rules it listed, never the root ones, and the build stayed green the whole time.
+Rules that apply to only some packages belong in the `overrides` block of the root config, where a path pattern selects them.
+
+Verify any change to these rules by deleting a required field from a `package.json` and confirming that the rule fires.
+A lint that passes proves nothing on its own, because a shadowed rule is silently absent rather than failing.
+
 ## Dependencies between packages
 
 We’ve established dependencies between our packages to avoid version mismatches.

--- a/packages-proprietary/.npmpackagejsonlintrc.json
+++ b/packages-proprietary/.npmpackagejsonlintrc.json
@@ -1,6 +1,0 @@
-{
-  "rules": {
-    "require-files": "error",
-    "valid-values-license": ["error", ["SEE LICENSE IN LICENSE.md"]]
-  }
-}


### PR DESCRIPTION
# Apply the full package.json lint rule set to the proprietary packages

## Links

- [The publishing guide on this branch](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md)
- #2821, which introduced the `files` fields this lint enforces

## What

This moves the two rules from `packages-proprietary/.npmpackagejsonlintrc.json` into the `overrides` block of the root config and deletes that nested file. It also extends the publishing guide with a section on what each package publishes to npm and how the manifest linting keeps it that way.

## Why

npm-package-json-lint loads the nearest config file only and never merges it with configs higher up the tree. The nested config therefore replaced the root rule set entirely for the Tokens, Assets and React Icons packages: they were checked against two rules instead of forty, from the first commit of this repository onwards, while the build stayed green. Rules that apply to only some packages belong in the `overrides` block of the root config, where a path pattern selects them.

## How

The `require-files` override now covers `packages-proprietary/*/package.json` as well, and a second override keeps the proprietary licence value of “SEE LICENSE IN LICENSE.md”. All three packages already satisfied the full rule set, so no package.json needed changing — `pnpm run lint:package-json` passes on this branch. The new documentation also records how to verify that a rule actually fires, since a shadowed rule is silently absent rather than failing.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix
