### PR TITLE
chore(docs): Clarify what the Baseline linter cannot check in token values

### DIFF
--- a/storybook/src/docs/developer-guide/browser-support.docs.mdx
+++ b/storybook/src/docs/developer-guide/browser-support.docs.mdx
@@ -13,9 +13,14 @@ We use linters for CSS and JavaScript to enforce this.
 These tools help us catch most usages of unsupported features early in the development process, allowing us to maintain our commitment to browser compatibility.
 
 However, there is a limitation: we use a lot of CSS custom properties (CSS variables) in our design system.
-Linters cannot check whether the combination of a CSS property that has a CSS variable as its value adheres to the Baseline standard.
-For example, a linter can verify that the `grid-template-columns` property is widely supported,
-but it cannot determine whether the value assigned to it via a CSS variable is also widely supported.
+The Baseline linter judges each declaration by the value written next to it, and does not follow a `var()` reference to the value behind it.
+It does check the declaration of a custom property itself, so the ones a component defines for its own use are covered.
+Our design tokens are generated into a stylesheet that we exclude from linting, so the values they carry are the ones that go unchecked.
+For example, `color` is widely available and `light-dark()` is not, but `color: var(--ams-alert-background-color)` gives the linter no way to tell which one it ends up with.
+
+Where the value behind a token matters, we resolve it ourselves.
+Our own Stylelint rules follow a token reference through as many aliases as it takes and judge the value it ends at, which is how we check grid tracks, font stacks, font sizes, and list markers today.
+The same approach could be applied to Baseline if we find we need it.
 
 We carefully test and review our code to minimize the risk of using unsupported values.
 If you find any issues related to browser support, please [report them](https://github.com/Amsterdam/design-system/issues) so we can address them promptly.


### PR DESCRIPTION
# Clarify what the Baseline linter cannot check in token values

## Links

- [Storybook on main](https://designsystem.amsterdam/)
- [The Browser support page in this branch’s deploy](https://designsystem.amsterdam/demo-browser-support-baseline-limitations/?path=/docs/docs-developer-guide-browser-support--docs)

## What

This rewrites the paragraph on the Browser support page that describes the limitation of Baseline linting in combination with CSS custom properties.

## Why

The old text said that linters cannot check whether a property with a CSS variable as its value adheres to Baseline, which was both too broad and incomplete. The page now pins the limitation down: the linter judges each declaration by the value written next to it and does not follow a `var()` reference, the declarations of custom properties themselves are checked, and it is the generated token stylesheet — excluded from linting — whose values go unchecked.

It also records what we already do where the value behind a token matters: our own Stylelint rules resolve a token reference through its aliases and judge the value it ends at, as they do for grid tracks, font stacks, font sizes and list markers. That same approach could serve Baseline if we ever need it to.

## How

A documentation-only change to a single page.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix
