### PR TITLE
chore(Grid, Breakout): Stop generating column classes beyond the medium column count

### DIFF
--- a/packages/css/src/components/breakout/breakout.scss
+++ b/packages/css/src/components/breakout/breakout.scss
@@ -83,7 +83,7 @@ $ams-breakout-row-span-max: 4;
 }
 
 @media (min-width: $ams-breakpoint-medium) {
-  @for $i from 1 through $ams-grid-column-count {
+  @for $i from 1 through $ams-grid-medium-column-count {
     .ams-breakout__cell--col-span-#{$i}-medium {
       @include ams-grid__cell--span-medium($i);
     }

--- a/packages/css/src/components/grid/grid.scss
+++ b/packages/css/src/components/grid/grid.scss
@@ -7,7 +7,10 @@
 @use "../../common/resets" as *;
 @use "mixins" as *;
 
+// The Grid has 12 columns at the wide breakpoint, and 8 at the medium one.
+// Classes that name a column beyond the count of the breakpoint they apply to have no use.
 $ams-grid-column-count: 12;
+$ams-grid-medium-column-count: 8;
 $ams-grid-row-span-max: 4;
 
 .ams-grid {
@@ -161,7 +164,7 @@ $ams-grid-row-span-max: 4;
 }
 
 @media (min-width: $ams-breakpoint-medium) {
-  @for $i from 1 through $ams-grid-column-count {
+  @for $i from 1 through $ams-grid-medium-column-count {
     .ams-grid__cell--span-#{$i}-medium,
     .ams-grid__subgrid--span-#{$i}-medium {
       @include ams-grid__cell--span-medium($i);


### PR DESCRIPTION
# Stop generating column classes beyond the medium column count

## Links

- [Storybook on main](https://designsystem.amsterdam/)
- [The Grid documentation in the main deploy](https://designsystem.amsterdam/?path=/docs/components-layout-grid--docs)

## What

This introduces `$ams-grid-medium-column-count: 8` and uses it in the loops that generate the medium-breakpoint classes of Grid and Breakout. The classes `ams-grid__cell--span-9-medium` through `--span-12-medium`, the matching `--start-` classes, and their Subgrid and Breakout counterparts are no longer generated.

## Why

The grid has 8 columns at the medium breakpoint. A cell that spans or starts beyond that count makes the browser create implicit columns, which breaks the layout, so these classes had no valid use. The React types already cap the medium value at 8, so the stylesheet now matches that contract, and it gets a little smaller in the process.

## How

A second Sass variable sits next to the existing `$ams-grid-column-count`, with a comment naming both column counts. The unsuffixed classes still run to 12: they apply at every width, so a plain `span={12}` keeps working on the wide grid. Nothing in the repository or the documentation references the removed classes.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

Strictly speaking the removed class names were part of the published stylesheet, but they could never produce a working layout, and the typed React API has never emitted them. Only hand-written markup that named one of them would notice, and it was broken already.
