### PR TITLE
feat(Image): Show a placeholder background while the image loads

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/image.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/image.tokens.json
@@ -8,7 +8,8 @@
         }
       },
       "background-color": {
-        "$value": "transparent",
+        "$value": "#e8e8e8",
+        "$description": "A neutral tint that marks the reserved space until the image has loaded. Set as a literal because the brand layer has no matching grey yet.",
         "$extensions": {
           "nl.amsterdam.type": "color"
         }

--- a/packages/css/src/components/image/image.scss
+++ b/packages/css/src/components/image/image.scss
@@ -6,14 +6,14 @@
 .ams-image {
   aspect-ratio: var(--ams-image-aspect-ratio);
   background-color: var(--ams-image-background-color); /* [5] */
-  background-image: var(--ams-image-background-image); /* [5] */
-  background-repeat: no-repeat; /* [5] */
-  background-size: 100% 100%; /* [5] */
+  background-image: var(--ams-image-background-image); /* [6] */
+  background-repeat: no-repeat; /* [6] */
+  background-size: 100% 100%; /* [6] */
   block-size: auto; /* [1] */
   font-style: var(--ams-typography-italic-font-style); /* [3] */
   inline-size: 100%; /* [1] */
   object-fit: cover; /* [4] */
-  object-position: var(--ams-image-object-position); /* [5] */
+  object-position: var(--ams-image-object-position); /* [6] */
   vertical-align: middle; /* [2] */
 }
 
@@ -22,4 +22,5 @@
 // [3] Italicise alt text to visually offset it from surrounding copy
 // Source: https://x.com/csswizardry/status/1717841334462005661
 // [4] Crop the image to maintain a supported aspect ratio
-// [5] Invisible by default: modes can move the image out of view and show a placeholder background instead
+// [5] Marks the reserved space as a placeholder until the image loads
+// [6] Invisible by default: modes can move the image out of view and show a placeholder background instead

--- a/packages/css/src/components/image/image.scss
+++ b/packages/css/src/components/image/image.scss
@@ -23,4 +23,4 @@
 // Source: https://x.com/csswizardry/status/1717841334462005661
 // [4] Crop the image to maintain a supported aspect ratio
 // [5] Marks the reserved space as a placeholder until the image loads
-// [6] Invisible by default: modes can move the image out of view and show a placeholder background instead
+// [6] Paints nothing by default: modes can move the image out of view and show a placeholder background instead

--- a/storybook/src/components/Image/Image.docs.mdx
+++ b/storybook/src/components/Image/Image.docs.mdx
@@ -77,8 +77,9 @@ When a file fails to load, its description then reads as a stand-in rather than 
 The component sets a width of 600 pixels in the markup, which the stylesheet immediately overrides.
 It only takes effect when that stylesheet does not arrive, and it keeps a missing image from rendering at whatever size the file happens to be.
 
-An Image carries a background colour and a background image that are both switched off by default.
-This is what lets a mode move the picture out of view and show a placeholder in the space it reserved, without the component knowing anything about that mode.
+An Image carries a light grey background colour, so the space it reserves reads as a placeholder rather than a hole in the page until the file arrives.
+It also carries a background image that is switched off by default.
+Together they let a mode move the picture out of view and show its own placeholder in the space it reserved, without the component knowing anything about that mode.
 
 ## Accessibility
 


### PR DESCRIPTION
# Show a placeholder background while the image loads

## Links

- [Storybook on main](https://designsystem.amsterdam/)
- [The Image documentation in the main deploy](https://designsystem.amsterdam/?path=/docs/components-media-image--docs)

## What

The `ams.image.background-color` token now holds a light grey (`#e8e8e8`) instead of `transparent`, so an Image marks the space it reserves until its file has loaded. The code notes in the stylesheet and the paragraph about backgrounds on the docs page follow suit.

## Why

An Image reserves its box through an aspect ratio, but that box was invisible while the file loaded. Especially on overview pages, which show many images at once, the page appeared to have holes in it until they arrived. A neutral tint makes the reserved space read as a placeholder instead.

## How

The value is set as a literal with a description, following the example of `ams.inputs.disabled.background-color`, because the brand layer has no matching grey to reference. The stylesheet already applied the token to `background-color`, so no rule changed — only its code note, which claimed the background colour was invisible by default. Modes keep working unchanged, as they override the custom properties either way.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

The grey is only visible while a file is loading or when it fails, so a fast connection hides this change entirely — throttle the network in devtools to see it. A loaded image covers its box completely, so no visual regressions are expected. Note that a browser draws its own broken-image decoration on top of the background when a file fails; that hairline is not ours.
