### PR TITLE
feat(Alert Dialog): Add Alert Dialog component

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/alert-dialog.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/alert-dialog.tokens.json
@@ -1,0 +1,241 @@
+{
+  "ams": {
+    "alert-dialog": {
+      "background-color": {
+        "$value": "{ams.color.background.default}",
+        "$extensions": {
+          "nl.amsterdam.type": "color"
+        }
+      },
+      "border-color": {
+        "$value": "{ams.alert-dialog.background-color}",
+        "$extensions": {
+          "nl.amsterdam.type": "color"
+        }
+      },
+      "border-radius": {
+        "$value": "0",
+        "$extensions": {
+          "nl.amsterdam.type": "borderRadius"
+        }
+      },
+      "border-style": {
+        "$value": "solid",
+        "$extensions": {
+          "nl.amsterdam.type": "borderStyle"
+        }
+      },
+      "border-width": {
+        "$value": "{ams.border.width.m}",
+        "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
+          "nl.amsterdam.type": "borderWidth"
+        }
+      },
+      "box-shadow": {
+        "$value": "none",
+        "$extensions": {
+          "nl.amsterdam.type": "shadow"
+        }
+      },
+      "container-name": {
+        "$value": "{ams.query-containers.inline-size.container-name}"
+      },
+      "container-type": {
+        "$value": "inline-size"
+      },
+      "inline-size": {
+        "$value": "calc(100% - 2 * {ams.space.l})",
+        "$extensions": {
+          "nl.amsterdam.type": "dimension"
+        }
+      },
+      "max-block-size": {
+        "$value": "calc(100dvh - 2 * {ams.space.l})",
+        "$extensions": {
+          "nl.amsterdam.type": "dimension"
+        }
+      },
+      "max-inline-size": {
+        "$value": {
+          "value": 48,
+          "unit": "rem"
+        },
+        "$type": "dimension"
+      },
+      "vi-medium": {
+        "inline-size": {
+          "$value": "calc(100% - 2 * {ams.space.xl})",
+          "$extensions": {
+            "nl.amsterdam.type": "dimension"
+          }
+        },
+        "max-block-size": {
+          "$value": "calc(100dvh - 2 * {ams.space.xl})",
+          "$extensions": {
+            "nl.amsterdam.type": "dimension"
+          }
+        }
+      },
+      "backdrop": {
+        "background-color": {
+          "$value": "rgb(24 24 24 / 62.5%)",
+          "$type": "color"
+        }
+      },
+      "header": {
+        "column-gap": {
+          "$value": "{ams.space.m}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        },
+        "padding-block": {
+          "$value": "{ams.space.l}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        },
+        "padding-inline": {
+          "$value": "{ams.space.l}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        },
+        "row-gap": {
+          "$value": "{ams.space.xs}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        },
+        "vi-medium": {
+          "padding-block": {
+            "$value": "{ams.space.xl}",
+            "$extensions": {
+              "nl.amsterdam.subtype": "space",
+              "nl.amsterdam.type": "dimension"
+            }
+          },
+          "padding-inline": {
+            "$value": "{ams.space.xl}",
+            "$extensions": {
+              "nl.amsterdam.subtype": "space",
+              "nl.amsterdam.type": "dimension"
+            }
+          }
+        }
+      },
+      "body": {
+        "min-block-size": {
+          "$value": "calc(2 * {ams.typography.body-text.font-size} * {ams.typography.body-text.line-height})",
+          "$extensions": {
+            "nl.amsterdam.type": "dimension"
+          }
+        },
+        "outline-offset": {
+          "$value": "{ams.focus.outline-offset}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        },
+        "padding-block": {
+          "$value": "0 {ams.space.l}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        },
+        "padding-inline": {
+          "$value": "{ams.space.l}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        },
+        "vi-medium": {
+          "padding-block": {
+            "$value": "0 {ams.space.xl}",
+            "$extensions": {
+              "nl.amsterdam.subtype": "space",
+              "nl.amsterdam.type": "dimension"
+            }
+          },
+          "padding-inline": {
+            "$value": "{ams.space.xl}",
+            "$extensions": {
+              "nl.amsterdam.subtype": "space",
+              "nl.amsterdam.type": "dimension"
+            }
+          }
+        }
+      },
+      "footer": {
+        "padding-block": {
+          "$value": "0 {ams.space.l}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        },
+        "padding-inline": {
+          "$value": "{ams.space.l}",
+          "$extensions": {
+            "nl.amsterdam.subtype": "space",
+            "nl.amsterdam.type": "dimension"
+          }
+        },
+        "vi-medium": {
+          "padding-block": {
+            "$value": "0 {ams.space.xl}",
+            "$extensions": {
+              "nl.amsterdam.subtype": "space",
+              "nl.amsterdam.type": "dimension"
+            }
+          },
+          "padding-inline": {
+            "$value": "{ams.space.xl}",
+            "$extensions": {
+              "nl.amsterdam.subtype": "space",
+              "nl.amsterdam.type": "dimension"
+            }
+          }
+        }
+      },
+      "error": {
+        "header": {
+          "background-color": {
+            "$value": "{ams.color.feedback.error}",
+            "$extensions": {
+              "nl.amsterdam.type": "color"
+            }
+          }
+        }
+      },
+      "success": {
+        "header": {
+          "background-color": {
+            "$value": "{ams.color.feedback.success}",
+            "$extensions": {
+              "nl.amsterdam.type": "color"
+            }
+          }
+        }
+      },
+      "warning": {
+        "header": {
+          "background-color": {
+            "$value": "{ams.color.feedback.warning}",
+            "$extensions": {
+              "nl.amsterdam.type": "color"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/css/src/components/alert-dialog/alert-dialog.scss
+++ b/packages/css/src/components/alert-dialog/alert-dialog.scss
@@ -1,0 +1,166 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+@use "../../common/breakpoint" as *;
+@use "../../common/resets" as *;
+
+/* A dialog must have `display: none` until the `open` attribute is set,
+so do not apply these styles without an `open` attribute. */
+.ams-alert-dialog:not(dialog:not([open])) {
+  @include reset-dialog;
+
+  background-color: var(--ams-alert-dialog-background-color);
+  border-color: var(--ams-alert-dialog-border-color);
+  border-radius: var(--ams-alert-dialog-border-radius);
+  border-style: var(--ams-alert-dialog-border-style);
+  border-width: var(--ams-alert-dialog-border-width);
+  box-shadow: var(--ams-alert-dialog-box-shadow);
+  box-sizing: border-box;
+  container-name: var(--ams-alert-dialog-container-name);
+  container-type: var(--ams-alert-dialog-container-type);
+  display: flex; // We’d like to use CSS Grid here, but that doesn’t work as expected in Safari.
+  flex-direction: column;
+  inline-size: var(--ams-alert-dialog-inline-size);
+  max-block-size: var(--ams-alert-dialog-max-block-size);
+  max-inline-size: var(--ams-alert-dialog-max-inline-size);
+
+  /* Let the dialog itself scroll when the header, the body at its minimum height,
+  and the footer together exceed the available height. This keeps all content
+  reachable in vertically short windows and with strongly enlarged text. */
+  /* stylelint-disable-next-line defensive-css/require-scrollbar-gutter -- A gutter would uncentre the content. */
+  overflow-y: auto;
+
+  /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
+  overscroll-behavior-y: contain;
+
+  // Ensure there always is a border in forced colors mode.
+  @media (forced-colors: active) {
+    background-color: Canvas;
+    border-color: currentColor;
+    border-style: solid;
+
+    // Keep at least 1px so a token set to 0 can’t hide the border.
+    border-width: max(1px, var(--ams-alert-dialog-border-width));
+  }
+
+  @media (min-width: $ams-breakpoint-medium) {
+    inline-size: var(--ams-alert-dialog-vi-medium-inline-size);
+    max-block-size: var(--ams-alert-dialog-vi-medium-max-block-size);
+  }
+
+  /*
+   * The fallback value is for browsers where ::backdrop does not inherit from its originating element.
+   * @see https://caniuse.com/mdn-css_selectors_backdrop_inherit_from_originating_element
+   */
+  &::backdrop {
+    background-color: var(--ams-alert-dialog-backdrop-background-color, rgb(24 24 24 / 62.5%));
+  }
+}
+
+/*
+ * showModal() makes content inert but doesn’t lock scrolling: gestures over
+ * the ::backdrop still scroll the page. overflow: hidden on the body (not
+ * html) suppresses this because body overflow propagates to the viewport.
+ * iOS Safari still needs JS for a hard guarantee on touch.
+ */
+.ams-body:has(.ams-alert-dialog:modal) {
+  overflow: hidden;
+}
+
+/* A grid so that a heading and a subtitle stack without needing a wrapper.
+The Alert Dialog has no close button; instead it can show a leading icon. */
+.ams-alert-dialog__header {
+  align-items: start;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  padding-block: var(--ams-alert-dialog-header-padding-block);
+  padding-inline: var(--ams-alert-dialog-header-padding-inline);
+  row-gap: var(--ams-alert-dialog-header-row-gap);
+
+  /* Use a border in forced colors mode for visual hierarchy and demarcating the scrollable body */
+  @media (forced-colors: active) {
+    border-block-end-color: currentColor;
+    border-block-end-style: solid;
+    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- A hairline separator. */
+    border-block-end-width: 1px;
+  }
+
+  @media (min-width: $ams-breakpoint-medium) {
+    padding-block: var(--ams-alert-dialog-header-vi-medium-padding-block);
+    padding-inline: var(--ams-alert-dialog-header-vi-medium-padding-inline);
+  }
+}
+
+/* With a leading icon, add a first column for it; content moves to the second. */
+.ams-alert-dialog__header--with-icon {
+  column-gap: var(--ams-alert-dialog-header-column-gap);
+  grid-template-columns: auto minmax(0, 1fr);
+
+  > :not(.ams-alert-dialog__icon) {
+    grid-column: 2;
+  }
+}
+
+/* Pin the icon to the first column, next to the first line of content. */
+.ams-alert-dialog__icon {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+/* A severity fills the whole header with its colour. The heading and icon stay the default
+dark text colour: it keeps a sufficient contrast on all severity colours, where white would
+fail on warning and info. In forced colors mode the fill drops out and the icon shape
+carries the meaning. */
+.ams-alert-dialog__header--error {
+  background-color: var(--ams-alert-dialog-error-header-background-color);
+}
+
+.ams-alert-dialog__header--success {
+  background-color: var(--ams-alert-dialog-success-header-background-color);
+}
+
+.ams-alert-dialog__header--warning {
+  background-color: var(--ams-alert-dialog-warning-header-background-color);
+}
+
+.ams-alert-dialog__body {
+  /* Keep a minimum height so the header and footer can never crowd out the body entirely.
+  If less space is available, the dialog itself scrolls. */
+  min-block-size: var(--ams-alert-dialog-body-min-block-size);
+  outline-offset: var(--ams-alert-dialog-body-outline-offset);
+
+  /* Let wide content scroll horizontally instead of clipping it. */
+  overflow-x: auto;
+  overflow-y: auto;
+  /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
+  overscroll-behavior: contain;
+  padding-block: var(--ams-alert-dialog-body-padding-block);
+  padding-inline: var(--ams-alert-dialog-body-padding-inline);
+  /* stylelint-disable-next-line plugin/use-baseline -- Progressive enhancement. */
+  scrollbar-gutter: stable;
+
+  @media (min-width: $ams-breakpoint-medium) {
+    padding-block: var(--ams-alert-dialog-body-vi-medium-padding-block);
+    padding-inline: var(--ams-alert-dialog-body-vi-medium-padding-inline);
+  }
+}
+
+.ams-alert-dialog__footer {
+  padding-block: var(--ams-alert-dialog-footer-padding-block);
+  padding-inline: var(--ams-alert-dialog-footer-padding-inline);
+
+  /* Use a border in forced colors mode for visual hierarchy and demarcating the scrollable body */
+  @media (forced-colors: active) {
+    border-block-start-color: currentColor;
+    border-block-start-style: solid;
+    /* stylelint-disable-next-line defensive-css/no-fixed-sizes -- A hairline separator. */
+    border-block-start-width: 1px;
+  }
+
+  @media (min-width: $ams-breakpoint-medium) {
+    padding-block: var(--ams-alert-dialog-footer-vi-medium-padding-block);
+    padding-inline: var(--ams-alert-dialog-footer-vi-medium-padding-inline);
+  }
+}

--- a/packages/css/src/components/index.scss
+++ b/packages/css/src/components/index.scss
@@ -7,6 +7,7 @@
 @use "accordion/accordion";
 @use "action-group/action-group";
 @use "alert/alert";
+@use "alert-dialog/alert-dialog";
 @use "aspect-ratio/aspect-ratio";
 @use "avatar/avatar";
 @use "badge/badge";

--- a/packages/react/src/AlertDialog/AlertDialog.test.tsx
+++ b/packages/react/src/AlertDialog/AlertDialog.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { renderToString } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AlertDialog } from './AlertDialog'
+
+/* jsdom does not implement `showModal` and `close` – https://github.com/jsdom/jsdom/issues/3294.
+These mocks reflect their effect on the `open` attribute so the component logic can be tested. */
+const showModalMock = vi.fn(function showModal(this: HTMLDialogElement) {
+  this.setAttribute('open', '')
+})
+
+const closeMock = vi.fn(function close(this: HTMLDialogElement) {
+  this.removeAttribute('open')
+})
+
+const originalClose = HTMLDialogElement.prototype.close
+const originalShowModal = HTMLDialogElement.prototype.showModal
+
+describe('AlertDialog', () => {
+  beforeEach(() => {
+    HTMLDialogElement.prototype.close = closeMock
+    HTMLDialogElement.prototype.showModal = showModalMock
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    HTMLDialogElement.prototype.close = originalClose
+    HTMLDialogElement.prototype.showModal = originalShowModal
+    closeMock.mockClear()
+    showModalMock.mockClear()
+    vi.restoreAllMocks()
+  })
+
+  it('renders', () => {
+    render(<AlertDialog open />)
+
+    const component = screen.getByRole('alertdialog')
+
+    expect(component).toBeInTheDocument()
+    expect(component).toBeVisible()
+  })
+
+  it('is not visible without open', () => {
+    render(<AlertDialog />)
+
+    const component = screen.getByRole('alertdialog', { hidden: true })
+
+    expect(component).not.toBeVisible()
+  })
+
+  it('has the alertdialog role', () => {
+    render(<AlertDialog open />)
+
+    expect(screen.getByRole('alertdialog')).toHaveAttribute('role', 'alertdialog')
+  })
+
+  it('renders a design system BEM class name', () => {
+    render(<AlertDialog open />)
+
+    const component = screen.getByRole('alertdialog')
+
+    expect(component).toHaveClass('ams-alert-dialog')
+  })
+
+  it('renders an extra class name', () => {
+    render(<AlertDialog className="extra" open />)
+
+    const component = screen.getByRole('alertdialog')
+
+    expect(component).toHaveClass('ams-alert-dialog extra')
+  })
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLDialogElement>()
+
+    render(<AlertDialog open ref={ref} />)
+
+    const component = screen.getByRole('alertdialog')
+
+    expect(ref.current).toBe(component)
+  })
+
+  it('passes additional props', () => {
+    render(<AlertDialog data-test="data-test" id="id" open />)
+
+    const component = screen.getByRole('alertdialog')
+
+    expect(component).toHaveAttribute('id', 'id')
+    expect(component).toHaveAttribute('data-test', 'data-test')
+  })
+
+  it('renders children directly, without a wrapper', () => {
+    const { container } = render(
+      <AlertDialog open>
+        <p>Content</p>
+      </AlertDialog>,
+    )
+
+    expect(screen.getByText('Content')).toBeInTheDocument()
+    expect(container.querySelector('.ams-alert-dialog__body')).not.toBeInTheDocument()
+  })
+
+  describe('controlled open state', () => {
+    it('opens as a modal on mount when `open` is true', () => {
+      render(<AlertDialog open />)
+
+      expect(showModalMock).toHaveBeenCalledOnce()
+    })
+
+    it('opens as a modal when `open` becomes true', () => {
+      const { rerender } = render(<AlertDialog open={false} />)
+
+      expect(showModalMock).not.toHaveBeenCalled()
+
+      rerender(<AlertDialog open />)
+
+      expect(showModalMock).toHaveBeenCalledOnce()
+    })
+
+    it('closes when `open` becomes false', () => {
+      const { rerender } = render(<AlertDialog open />)
+
+      rerender(<AlertDialog open={false} />)
+
+      expect(closeMock).toHaveBeenCalledOnce()
+    })
+
+    it('does not open or close the dialog when `open` is undefined', () => {
+      render(<AlertDialog />)
+
+      expect(showModalMock).not.toHaveBeenCalled()
+      expect(closeMock).not.toHaveBeenCalled()
+    })
+
+    it('does not render the `open` attribute on the server', () => {
+      const html = renderToString(<AlertDialog open />)
+
+      expect(html).toContain('<dialog')
+      expect(html).not.toContain('open=""')
+    })
+  })
+
+  describe('accessible name', () => {
+    it('warns when no accessible name is provided', () => {
+      const warnSpy = vi.spyOn(console, 'warn')
+
+      render(<AlertDialog />)
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('provide an accessible name'))
+    })
+
+    it('does not warn when `aria-label` is provided', () => {
+      const warnSpy = vi.spyOn(console, 'warn')
+
+      render(<AlertDialog aria-label="Titel" />)
+
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('does not warn when `aria-labelledby` is provided', () => {
+      const warnSpy = vi.spyOn(console, 'warn')
+
+      render(<AlertDialog aria-labelledby="heading-id" />)
+
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('static methods', () => {
+    it('opens the dialog matching the selector with AlertDialog.open', () => {
+      render(<AlertDialog id="alert-dialog-id" />)
+
+      AlertDialog.open('#alert-dialog-id')
+
+      expect(showModalMock).toHaveBeenCalledOnce()
+    })
+
+    it('does not throw when the selector matches nothing', () => {
+      expect(() => AlertDialog.open('#does-not-exist')).not.toThrow()
+    })
+
+    it('closes the dialog containing the button with AlertDialog.close', async () => {
+      render(
+        <AlertDialog open>
+          <button onClick={AlertDialog.close}>Stoppen</button>
+        </AlertDialog>,
+      )
+
+      screen.getByRole('button', { name: 'Stoppen' }).click()
+
+      expect(closeMock).toHaveBeenCalledOnce()
+    })
+
+    it('does not throw when the button is not inside a dialog', () => {
+      render(<button onClick={AlertDialog.close}>Stoppen</button>)
+
+      expect(() => screen.getByRole('button', { name: 'Stoppen' }).click()).not.toThrow()
+      expect(closeMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/react/src/AlertDialog/AlertDialog.tsx
+++ b/packages/react/src/AlertDialog/AlertDialog.tsx
@@ -1,0 +1,77 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { DialogHTMLAttributes, ForwardedRef, PropsWithChildren } from 'react'
+
+import { clsx } from 'clsx'
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react'
+
+import { closeAlertDialog, openAlertDialog } from './alertDialogActions'
+import { AlertDialogBody } from './AlertDialogBody'
+import { AlertDialogFooter } from './AlertDialogFooter'
+import { AlertDialogHeader } from './AlertDialogHeader'
+
+export type AlertDialogProps = {
+  /**
+   * Whether the Alert Dialog is open, to control it from your application’s state.
+   * Leave undefined to open it imperatively with `AlertDialog.open`.
+   */
+  readonly open?: boolean
+} & Readonly<PropsWithChildren<Omit<DialogHTMLAttributes<HTMLDialogElement>, 'open'>>>
+
+const AlertDialogRoot = forwardRef(
+  ({ children, className, open, ...restProps }: AlertDialogProps, ref: ForwardedRef<HTMLDialogElement>) => {
+    const innerRef = useRef<HTMLDialogElement>(null)
+
+    useImperativeHandle(ref, () => innerRef.current as HTMLDialogElement)
+
+    useEffect(() => {
+      const dialog = innerRef.current
+
+      if (!dialog || open === undefined) {
+        return
+      }
+
+      if (open && !dialog.open) {
+        dialog.showModal()
+      } else if (!open && dialog.open) {
+        dialog.close()
+      }
+    }, [open])
+
+    const ariaLabel = restProps['aria-label']
+    const ariaLabelledBy = restProps['aria-labelledby']
+
+    useEffect(() => {
+      if (!ariaLabel && !ariaLabelledBy) {
+        console.warn(
+          'AlertDialog: provide an accessible name. Pass `aria-labelledby` referencing the `id` of the heading in `AlertDialog.Header`.',
+        )
+      }
+    }, [ariaLabel, ariaLabelledBy])
+
+    return (
+      // Override the native dialog’s implicit `dialog` role: an Alert Dialog interrupts the user and requires a response.
+      <dialog {...restProps} className={clsx('ams-alert-dialog', className)} ref={innerRef} role="alertdialog">
+        {children}
+      </dialog>
+    )
+  },
+)
+
+AlertDialogRoot.displayName = 'AlertDialog'
+
+/**
+ * A window over the page that requires the user to respond before continuing. It blocks interaction with the underlying page and has no close button.
+ *
+ * @see {@link https://designsystem.amsterdam/?path=/docs/components-containers-alert-dialog--docs Alert Dialog docs at Amsterdam Design System}
+ */
+export const AlertDialog = Object.assign(AlertDialogRoot, {
+  Body: AlertDialogBody,
+  close: closeAlertDialog,
+  Footer: AlertDialogFooter,
+  Header: AlertDialogHeader,
+  open: openAlertDialog,
+})

--- a/packages/react/src/AlertDialog/AlertDialogBody.test.tsx
+++ b/packages/react/src/AlertDialog/AlertDialogBody.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { act, render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AlertDialogBody } from './AlertDialogBody'
+
+describe('AlertDialogBody', () => {
+  it('renders', () => {
+    const { container } = render(<AlertDialogBody>Body content</AlertDialogBody>)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toBeInTheDocument()
+    expect(component).toHaveTextContent('Body content')
+  })
+
+  it('renders a design system BEM class name', () => {
+    const { container } = render(<AlertDialogBody />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('ams-alert-dialog__body')
+  })
+
+  it('renders an extra class name', () => {
+    const { container } = render(<AlertDialogBody className="extra" />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveClass('ams-alert-dialog__body extra')
+  })
+
+  it('renders children', () => {
+    render(
+      <AlertDialogBody>
+        <p>Inside body</p>
+      </AlertDialogBody>,
+    )
+
+    expect(screen.getByText('Inside body')).toBeInTheDocument()
+  })
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLDivElement>()
+
+    const { container } = render(<AlertDialogBody ref={ref} />)
+
+    expect(ref.current).toBe(container.querySelector(':only-child'))
+  })
+
+  it('passes additional props', () => {
+    const { container } = render(<AlertDialogBody data-test="data-test" id="id" />)
+
+    const component = container.querySelector(':only-child')
+
+    expect(component).toHaveAttribute('id', 'id')
+    expect(component).toHaveAttribute('data-test', 'data-test')
+  })
+
+  describe('keyboard focusability', () => {
+    let resizeCallback: () => void = () => {}
+
+    const defineSizes = (
+      element: Element,
+      sizes: Partial<Record<'clientHeight' | 'clientWidth' | 'scrollHeight' | 'scrollWidth', number>>,
+    ) => {
+      for (const [property, value] of Object.entries(sizes)) {
+        Object.defineProperty(element, property, { configurable: true, value })
+      }
+    }
+
+    beforeEach(() => {
+      vi.stubGlobal(
+        'ResizeObserver',
+        class {
+          constructor(callback: () => void) {
+            resizeCallback = callback
+          }
+          disconnect() {}
+          observe() {}
+          unobserve() {}
+        },
+      )
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('is not focusable by default', () => {
+      const { container } = render(<AlertDialogBody />)
+
+      expect(container.querySelector(':only-child')).not.toHaveAttribute('tabindex')
+    })
+
+    it('becomes focusable when its content overflows vertically', () => {
+      const { container } = render(<AlertDialogBody />)
+
+      const component = container.querySelector(':only-child') as HTMLDivElement
+      defineSizes(component, { clientHeight: 48, scrollHeight: 200 })
+
+      act(() => resizeCallback())
+
+      expect(component).toHaveAttribute('tabindex', '0')
+    })
+
+    it('becomes focusable when its content overflows horizontally', () => {
+      const { container } = render(<AlertDialogBody />)
+
+      const component = container.querySelector(':only-child') as HTMLDivElement
+      defineSizes(component, { clientWidth: 320, scrollWidth: 640 })
+
+      act(() => resizeCallback())
+
+      expect(component).toHaveAttribute('tabindex', '0')
+    })
+
+    it('keeps a provided tabIndex', () => {
+      const { container } = render(<AlertDialogBody tabIndex={-1} />)
+
+      const component = container.querySelector(':only-child') as HTMLDivElement
+      defineSizes(component, { clientHeight: 48, scrollHeight: 200 })
+
+      act(() => resizeCallback())
+
+      expect(component).toHaveAttribute('tabindex', '-1')
+    })
+  })
+})

--- a/packages/react/src/AlertDialog/AlertDialogBody.tsx
+++ b/packages/react/src/AlertDialog/AlertDialogBody.tsx
@@ -1,0 +1,57 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
+
+import { clsx } from 'clsx'
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+
+export type AlertDialogBodyProps = Readonly<PropsWithChildren<HTMLAttributes<HTMLDivElement>>>
+
+/**
+ * The main content of an Alert Dialog. It scrolls if it is taller than the available space.
+ *
+ * @see {@link https://designsystem.amsterdam/?path=/docs/components-containers-alert-dialog--docs Alert Dialog docs at Amsterdam Design System}
+ */
+export const AlertDialogBody = forwardRef(
+  ({ children, className, tabIndex, ...restProps }: AlertDialogBodyProps, ref: ForwardedRef<HTMLDivElement>) => {
+    const innerRef = useRef<HTMLDivElement>(null)
+    const [isScrollable, setIsScrollable] = useState(false)
+
+    useImperativeHandle(ref, () => innerRef.current as HTMLDivElement)
+
+    /* Chromium and Firefox make a scroll container without focusable content focusable,
+    so that it can always be scrolled with the keyboard. Safari does not yet –
+    add a tabindex when the body scrolls to guarantee keyboard access to its content. */
+    useEffect(() => {
+      const element = innerRef.current
+
+      if (!element || typeof ResizeObserver === 'undefined') {
+        return undefined
+      }
+
+      const observer = new ResizeObserver(() =>
+        setIsScrollable(element.scrollHeight > element.clientHeight || element.scrollWidth > element.clientWidth),
+      )
+
+      observer.observe(element)
+
+      return () => observer.disconnect()
+    }, [])
+
+    return (
+      <div
+        {...restProps}
+        className={clsx('ams-alert-dialog__body', className)}
+        ref={innerRef}
+        tabIndex={tabIndex ?? (isScrollable ? 0 : undefined)}
+      >
+        {children}
+      </div>
+    )
+  },
+)
+
+AlertDialogBody.displayName = 'AlertDialog.Body'

--- a/packages/react/src/AlertDialog/AlertDialogFooter.test.tsx
+++ b/packages/react/src/AlertDialog/AlertDialogFooter.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { AlertDialogFooter } from './AlertDialogFooter'
+
+describe('AlertDialogFooter', () => {
+  it('renders', () => {
+    render(<AlertDialogFooter>Footer content</AlertDialogFooter>)
+
+    const component = screen.getByRole('contentinfo')
+
+    expect(component).toBeInTheDocument()
+    expect(component).toHaveTextContent('Footer content')
+  })
+
+  it('renders a design system BEM class name', () => {
+    render(<AlertDialogFooter />)
+
+    const component = screen.getByRole('contentinfo')
+
+    expect(component).toHaveClass('ams-alert-dialog__footer')
+  })
+
+  it('renders an extra class name', () => {
+    render(<AlertDialogFooter className="extra" />)
+
+    const component = screen.getByRole('contentinfo')
+
+    expect(component).toHaveClass('ams-alert-dialog__footer extra')
+  })
+
+  it('renders children', () => {
+    render(
+      <AlertDialogFooter>
+        <button>Click Me</button>
+      </AlertDialogFooter>,
+    )
+
+    expect(screen.getByRole('button', { name: 'Click Me' })).toBeInTheDocument()
+  })
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLElement>()
+
+    render(<AlertDialogFooter ref={ref} />)
+
+    expect(ref.current).toBe(screen.getByRole('contentinfo'))
+  })
+
+  it('passes additional props', () => {
+    render(<AlertDialogFooter data-test="data-test" id="id" />)
+
+    const component = screen.getByRole('contentinfo')
+
+    expect(component).toHaveAttribute('id', 'id')
+    expect(component).toHaveAttribute('data-test', 'data-test')
+  })
+})

--- a/packages/react/src/AlertDialog/AlertDialogFooter.tsx
+++ b/packages/react/src/AlertDialog/AlertDialogFooter.tsx
@@ -1,0 +1,27 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
+
+import { clsx } from 'clsx'
+import { forwardRef } from 'react'
+
+export type AlertDialogFooterProps = Readonly<PropsWithChildren<HTMLAttributes<HTMLElement>>>
+
+/**
+ * The footer of an Alert Dialog. It holds the buttons that respond to the message and dismiss the dialog.
+ * An Alert Dialog needs at least one action here, as it has no close button.
+ *
+ * @see {@link https://designsystem.amsterdam/?path=/docs/components-containers-alert-dialog--docs Alert Dialog docs at Amsterdam Design System}
+ */
+export const AlertDialogFooter = forwardRef(
+  ({ children, className, ...restProps }: AlertDialogFooterProps, ref: ForwardedRef<HTMLElement>) => (
+    <footer {...restProps} className={clsx('ams-alert-dialog__footer', className)} ref={ref}>
+      {children}
+    </footer>
+  ),
+)
+
+AlertDialogFooter.displayName = 'AlertDialog.Footer'

--- a/packages/react/src/AlertDialog/AlertDialogHeader.test.tsx
+++ b/packages/react/src/AlertDialog/AlertDialogHeader.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { AlertDialogHeader } from './AlertDialogHeader'
+
+describe('AlertDialogHeader', () => {
+  it('renders', () => {
+    render(<AlertDialogHeader>Header content</AlertDialogHeader>)
+
+    const component = screen.getByRole('banner')
+
+    expect(component).toBeInTheDocument()
+    expect(component).toHaveTextContent('Header content')
+  })
+
+  it('renders a design system BEM class name', () => {
+    render(<AlertDialogHeader />)
+
+    const component = screen.getByRole('banner')
+
+    expect(component).toHaveClass('ams-alert-dialog__header')
+  })
+
+  it('renders an extra class name', () => {
+    render(<AlertDialogHeader className="extra" />)
+
+    const component = screen.getByRole('banner')
+
+    expect(component).toHaveClass('ams-alert-dialog__header extra')
+  })
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLElement>()
+
+    render(<AlertDialogHeader ref={ref} />)
+
+    expect(ref.current).toBe(screen.getByRole('banner'))
+  })
+
+  it('passes additional props', () => {
+    render(<AlertDialogHeader data-test="data-test" id="id" />)
+
+    const component = screen.getByRole('banner')
+
+    expect(component).toHaveAttribute('id', 'id')
+    expect(component).toHaveAttribute('data-test', 'data-test')
+  })
+
+  it('does not render a close button', () => {
+    render(<AlertDialogHeader />)
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  describe('severity', () => {
+    it('renders no icon or severity class by default', () => {
+      render(<AlertDialogHeader />)
+
+      const component = screen.getByRole('banner')
+
+      expect(component).not.toHaveClass('ams-alert-dialog__header--with-icon')
+      expect(component.querySelector('.ams-alert-dialog__icon')).not.toBeInTheDocument()
+    })
+
+    it('renders the severity icon before the content', () => {
+      render(
+        <AlertDialogHeader severity="warning">
+          <h1>Titel</h1>
+        </AlertDialogHeader>,
+      )
+
+      const component = screen.getByRole('banner')
+      const icon = component.querySelector('.ams-alert-dialog__icon')
+
+      expect(icon).toBeInTheDocument()
+      expect(component.firstElementChild).toBe(icon)
+    })
+
+    it('adds the layout and severity modifier classes', () => {
+      render(<AlertDialogHeader severity="error" />)
+
+      const component = screen.getByRole('banner')
+
+      expect(component).toHaveClass('ams-alert-dialog__header--with-icon')
+      expect(component).toHaveClass('ams-alert-dialog__header--error')
+    })
+
+    it('applies the requested severity', () => {
+      render(<AlertDialogHeader severity="success" />)
+
+      expect(screen.getByRole('banner')).toHaveClass('ams-alert-dialog__header--success')
+    })
+  })
+})

--- a/packages/react/src/AlertDialog/AlertDialogHeader.tsx
+++ b/packages/react/src/AlertDialog/AlertDialogHeader.tsx
@@ -1,0 +1,55 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { ForwardedRef, HTMLAttributes, PropsWithChildren } from 'react'
+
+import { ErrorFillIcon, SuccessFillIcon, WarningFillIcon } from '@amsterdam/design-system-react-icons'
+import { clsx } from 'clsx'
+import { forwardRef } from 'react'
+
+import type { IconProps } from '../Icon'
+
+import { Icon } from '../Icon'
+
+type Severity = 'error' | 'success' | 'warning'
+
+export type AlertDialogHeaderProps = {
+  /**
+   * The significance of the message.
+   * Displays a matching icon and fills the header with the corresponding colour.
+   */
+  readonly severity?: Severity
+} & Readonly<PropsWithChildren<HTMLAttributes<HTMLElement>>>
+
+const iconSvgBySeverity: Record<Severity, IconProps['svg']> = {
+  error: ErrorFillIcon,
+  success: SuccessFillIcon,
+  warning: WarningFillIcon,
+}
+
+/**
+ * The header of an Alert Dialog. It contains the title and, when a severity is set, a matching icon and fill colour.
+ * Unlike a Modal Dialog, it has no close button: an Alert Dialog is dismissed through an action in its Footer.
+ *
+ * @see {@link https://designsystem.amsterdam/?path=/docs/components-containers-alert-dialog--docs Alert Dialog docs at Amsterdam Design System}
+ */
+export const AlertDialogHeader = forwardRef(
+  ({ children, className, severity, ...restProps }: AlertDialogHeaderProps, ref: ForwardedRef<HTMLElement>) => (
+    <header
+      {...restProps}
+      className={clsx(
+        'ams-alert-dialog__header',
+        severity && ['ams-alert-dialog__header--with-icon', `ams-alert-dialog__header--${severity}`],
+        className,
+      )}
+      ref={ref}
+    >
+      {severity && <Icon className="ams-alert-dialog__icon" size="heading-3" svg={iconSvgBySeverity[severity]} />}
+      {children}
+    </header>
+  ),
+)
+
+AlertDialogHeader.displayName = 'AlertDialog.Header'

--- a/packages/react/src/AlertDialog/alertDialogActions.ts
+++ b/packages/react/src/AlertDialog/alertDialogActions.ts
@@ -1,0 +1,13 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { MouseEvent } from 'react'
+
+/** Closes the dialog that contains the clicked element, e.g. a Button in the footer of an Alert Dialog. */
+export const closeAlertDialog = (event: MouseEvent<HTMLButtonElement>) => event.currentTarget.closest('dialog')?.close()
+
+/** Opens the dialog that the CSS selector matches – e.g. `'#my-dialog'` – as a modal. */
+export const openAlertDialog = (selector: string) =>
+  (document.querySelector(selector) as HTMLDialogElement)?.showModal()

--- a/packages/react/src/AlertDialog/index.ts
+++ b/packages/react/src/AlertDialog/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+export { AlertDialog } from './AlertDialog'
+export type { AlertDialogProps } from './AlertDialog'
+export type { AlertDialogBodyProps } from './AlertDialogBody'
+export type { AlertDialogFooterProps } from './AlertDialogFooter'
+export type { AlertDialogHeaderProps } from './AlertDialogHeader'

--- a/packages/react/src/Dialog/Dialog.tsx
+++ b/packages/react/src/Dialog/Dialog.tsx
@@ -48,6 +48,7 @@ DialogRoot.displayName = 'Dialog'
 /**
  * A small window over the page that asks the user to confirm an action, answer a short question, or acknowledge a brief message.
  *
+ * @deprecated Use Alert Dialog instead. Will be removed on or after 2027-08-08.
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-containers-dialog--docs Dialog docs at Amsterdam Design System}
  */
 export const Dialog = Object.assign(DialogRoot, {

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,7 @@
 export * from './Accordion'
 export * from './ActionGroup'
 export * from './Alert'
+export * from './AlertDialog'
 export * from './Avatar'
 export * from './Badge'
 export * from './Blockquote'

--- a/storybook/AGENTS.md
+++ b/storybook/AGENTS.md
@@ -19,7 +19,7 @@ Meta title format: `Components/<Category>/<Component Name>`
 Valid categories (use exactly these):
 
 - `Buttons` — Button, Icon Button
-- `Containers` — Accordion, Dialog, Modal Dialog, Page, Page Footer, Page Header, Progress List, Spotlight, Table, Tabs
+- `Containers` — Accordion, Alert Dialog, Dialog, Modal Dialog, Page, Page Footer, Page Header, Progress List, Spotlight, Table, Tabs
 - `Feedback` — Alert, Avatar, Badge, Skeleton
 - `Forms` — all form-related components (Checkbox, Field, Label, Select, Text Input, etc.)
 - `Layout` — Action Group, Breakout, Column, Grid, Overlap, Row

--- a/storybook/src/components/AlertDialog/AlertDialog.docs.mdx
+++ b/storybook/src/components/AlertDialog/AlertDialog.docs.mdx
@@ -1,0 +1,182 @@
+{/* @license CC0-1.0 */}
+
+import { Canvas, Controls, Description, Meta, Primary, Title } from "@storybook/addon-docs/blocks";
+
+import { DesignTokensTable } from "#storybook/_components/DesignTokensTable/DesignTokensTable";
+import tokens from "#tokens/components/ams/alert-dialog.tokens.json";
+
+import * as AlertDialogStories from "./AlertDialog.stories.tsx";
+import * as AlertDialogHeaderStories from "./AlertDialogHeader.stories.tsx";
+
+<Meta of={AlertDialogStories} />
+
+<Title />
+
+<Description of={AlertDialogStories} />
+
+<Primary />
+
+<Controls />
+
+## Subcomponents
+
+Compose an Alert Dialog from its Header, Body, and Footer subcomponents.
+The Body holds the main content of the dialog and has no props of its own; the examples below show it in place.
+
+### Header
+
+The Header contains the title of the dialog.
+Unlike a [Modal Dialog](/docs/components-containers-modal-dialog--docs), it has no close button: an Alert Dialog is dismissed through an action in its Footer.
+Pass `severity` to signal the significance of the message: it adds a matching icon before the title and fills the Header with the corresponding colour.
+Place a single [Heading](/docs/components-text-heading--docs) in the Header; when a severity fills it, keep the Header to that heading, as smaller text on the fill does not always meet the contrast requirement.
+
+<Canvas of={AlertDialogHeaderStories.Header} />
+
+<Controls of={AlertDialogHeaderStories.Header} />
+
+### Footer
+
+The Footer holds one Button or an [Action Group](/docs/components-layout-action-group--docs) containing more of them.
+It is required: as an Alert Dialog has no close button, the user needs at least one action here to respond and continue.
+
+## Usage guidelines
+
+### When to use
+
+Use an Alert Dialog to interrupt the user with an important message that requires a response before they can continue.
+It typically appears in reaction to a system event, such as an expiring session or a loss of data, rather than as part of the user’s own flow.
+Interaction with the rest of the page is blocked until the user responds.
+
+### When not to use
+
+Use a [Modal Dialog](/docs/components-containers-modal-dialog--docs) for a task or message the user can dismiss without consequence, such as a form or a confirmation the user opened themselves.
+The rule of thumb: if the dialog can be closed without the user making a choice, it is a Modal Dialog; if it demands a decision, it is an Alert Dialog.
+
+Use Alert Dialogs sparingly, as they interrupt the user and demand immediate attention.
+
+### How to use
+
+Compose the dialog from its Header, Body, and Footer subcomponents, in that order.
+Always provide at least one action in the Footer, so the user can respond and continue.
+
+Give the dialog an accessible name and description.
+Add an `id` to the Heading in the Header and pass it to the `aria-labelledby` prop of the dialog.
+Add an `id` to the content in the Body and pass it to the `aria-describedby` prop, so assistive technologies announce the message together with the title.
+Use heading level 1: an Alert Dialog is a new layer that covers the page, so its heading hierarchy starts over.
+
+To open the dialog, use `AlertDialog.open` from the React package.
+It takes a CSS selector, so include the `#` when referencing an id: `AlertDialog.open('#my-dialog')`.
+Alternatively, keep the dialog rendered and control it with the `open` prop and the `onClose` event – see [the ‘Controlled’ example](#controlling-the-dialog-with-state).
+
+To close it, call the `AlertDialog.close` function from a button inside the dialog, or add a `<form method="dialog">` as in [the ‘Asking to confirm’ example](#asking-to-confirm).
+
+#### Focusing a specific element
+
+When an Alert Dialog opens (and no element has `autofocus`), the browser places focus on the first focusable element inside it, which is the first action in the Footer.
+
+To give another element the initial focus instead, add the `autofocus` attribute to it, or the `autoFocus` prop in React.
+Don’t place focus on a destructive or irreversible action: a user confirming by reflex with Enter or Space could lose data.
+When asking to confirm, focus the option that keeps the user’s data safe.
+
+For more information: [MDN: the dialog element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#accessibility).
+
+## Examples
+
+### With a severity
+
+Pass `severity` to the Header to signal the significance of the message.
+The Header shows a matching icon and takes on the severity’s colour.
+
+<Canvas of={AlertDialogStories.WithSeverity} />
+
+### Asking to confirm
+
+Use a `form` when asking the user to confirm an action, e.g. through ‘Delete’ and ‘Cancel’ buttons.
+Add `method="dialog"` to make the browser close the dialog when the form is submitted.
+Add an `id` to the form and use it in the `form` attribute of the buttons in the Footer.
+Set a `value` on each button to identify which one was clicked.
+Consult [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog#handling_the_return_value_from_the_dialog) for more information.
+
+<Canvas of={AlertDialogStories.Confirmation} />
+
+### Reminding the user
+
+Open an Alert Dialog to remind the user of something time-sensitive, such as a session that is about to expire.
+Offer a clear way to continue alongside a way to stop.
+
+<Canvas of={AlertDialogStories.SessionExpiring} />
+
+### Controlling the dialog with state
+
+Keep the dialog rendered and pass a boolean to the `open` prop to open and close it from your application’s state.
+The component calls `showModal()` and `close()` on the dialog element for you.
+Listen to the `onClose` event to synchronise your state when the dialog closes itself, e.g. through the Escape key.
+Don’t render the dialog conditionally: unmounting it while open skips the `close` event and the browser’s focus restoration.
+
+<Canvas of={AlertDialogStories.Controlled} />
+
+## Features
+
+The Alert Dialog is a [query container](/docs/utilities-css-query-container--docs) for inline size, so elements inside it can adapt their appearance to the width of the dialog.
+
+### Scrolling
+
+Both the dialog and its Body can scroll.
+If the content of the Body is taller than the available space, the Body scrolls while the Header and Footer remain visible.
+In vertically short windows, or with strongly enlarged text, the Body keeps a minimum height of two lines of body text and the dialog itself scrolls instead.
+This keeps all content reachable, up to a text size of 400%.
+
+### Keyboard navigation
+
+| Key         | Behaviour                                                              |
+| :---------- | :--------------------------------------------------------------------- |
+| Tab         | Moves focus to the next focusable element inside the Alert Dialog.     |
+| Shift + Tab | Moves focus to the previous focusable element inside the Alert Dialog. |
+| Arrow keys  | Scroll the Body when it has focus and its content overflows.           |
+| Escape      | Closes the Alert Dialog.                                               |
+
+The NL Design System describes an Alert Dialog as not dismissable, to emphasise that the user should make a deliberate choice.
+This component still lets the Escape key close it: that behaviour is built into the browser’s `dialog` element and recommended by the [WAI-ARIA Authoring Practices](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/) for the `alertdialog` role.
+Removing it would trap keyboard users and diverge from the platform.
+Design your flow so that closing the dialog with Escape is always safe, and never rely on the dialog staying open to prevent data loss.
+
+## Design
+
+The Header has no close button: an Alert Dialog asks for a decision, so its only ways out are the actions in the Footer and the Escape key.
+When a severity fills the Header, the heading and icon keep the default dark text colour, which meets the contrast requirement on every severity colour where white text would not.
+
+The dialog is sized against the window rather than against its content, so it opens at a predictable size, and a maximum width caps it on wide screens.
+The Body reserves space for its scrollbar whether or not one appears, so its text does not shift sideways as content loads.
+
+The Header, Body, and Footer are told apart by their padding alone.
+In forced colours mode that is not enough, so the Header and Footer gain hairline separators marking the edges of the part that scrolls, and the dialog’s border keeps a floor of one pixel to hold its edge against the page behind.
+
+## Accessibility
+
+The component renders a native `dialog` element and opens it with `showModal()`.
+The browser then provides the modal behaviour: the rest of the page becomes [inert](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert), Tab stays inside the dialog without a focus trap of our own, the Escape key closes it, and focus returns to the triggering element on close.
+The dialog is given the `alertdialog` role, which tells assistive technologies to announce it immediately and treat it as a message that requires a response.
+
+The dialog does not name or describe itself: it takes its accessible name from the element that `aria-labelledby` references, and announces the message that `aria-describedby` points to along with it.
+It warns in the browser console when it has no accessible name.
+[How to use](#how-to-use) covers providing both.
+
+A `severity` never relies on colour alone: it is always paired with a distinct icon and the heading text, so the meaning survives when the fill drops out, for example in forced colours mode.
+
+A scrolling Body takes keyboard focus in its own right, so someone navigating by keyboard can scroll long content with the arrow keys even when nothing inside it is focusable, as [WCAG 2.1.1](https://www.w3.org/TR/WCAG22/#keyboard) requires.
+Chromium and Firefox already make an overflowing scroll container focusable; Safari does not, so the component makes the Body focusable itself.
+
+Scrolling of the page behind the dialog is suppressed while it is open.
+Opening a modal does not lock scrolling on its own, and iOS Safari still needs JavaScript for a guarantee, so a gesture over the backdrop there can move the page underneath.
+
+Note that an Alert Dialog requires JavaScript: without it, the dialog stays closed and its content stays hidden.
+
+## See also
+
+- [Modal Dialog](/docs/components-containers-modal-dialog--docs) – for a task or message the user can dismiss without consequence.
+- [Alert](/docs/components-feedback-alert--docs) – conveys a message inline, without interrupting the user.
+- [Action Group](/docs/components-layout-action-group--docs) – lays out multiple Buttons.
+
+## Design tokens
+
+<DesignTokensTable tokens={tokens} />

--- a/storybook/src/components/AlertDialog/AlertDialog.stories.tsx
+++ b/storybook/src/components/AlertDialog/AlertDialog.stories.tsx
@@ -21,7 +21,8 @@ const showInlineDecorator: Decorator = (Story) => (
 
       if (dialog && !dialog.open) {
         dialog.style.position = 'static'
-        dialog.show()
+        // Set the open attribute instead of calling show(), which would move focus here and scroll the docs page.
+        dialog.open = true
       }
     }}
   >

--- a/storybook/src/components/AlertDialog/AlertDialog.stories.tsx
+++ b/storybook/src/components/AlertDialog/AlertDialog.stories.tsx
@@ -1,0 +1,258 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Decorator, Meta, StoryObj } from '@storybook/react-vite'
+
+import { ActionGroup, Button, Heading, Paragraph } from '@amsterdam/design-system-react'
+import { AlertDialog } from '@amsterdam/design-system-react/src'
+import { useState } from 'react'
+import { action } from 'storybook/actions'
+
+import { dialogIdArgType } from '#storybook/_common/argTypes'
+
+/* Opens the dialog non-modally and in the document flow, so the example shows inline in the docs
+without a trigger. This lives in a decorator so the code panel shows only the composition. */
+const showInlineDecorator: Decorator = (Story) => (
+  <div
+    ref={(element) => {
+      const dialog = element?.querySelector('dialog')
+
+      if (dialog && !dialog.open) {
+        dialog.style.position = 'static'
+        dialog.show()
+      }
+    }}
+  >
+    <Story />
+  </div>
+)
+
+const openButtonDecorator: Decorator = (Story, { args }) => (
+  <>
+    <Button
+      onClick={() => {
+        action('open')()
+        AlertDialog.open(`#${args['id']}`)
+      }}
+    >
+      Open
+    </Button>
+    <Story />
+  </>
+)
+
+const meta = {
+  title: 'Components/Containers/Alert Dialog',
+  component: AlertDialog,
+  argTypes: {
+    'aria-describedby': {
+      description: 'The id of the message in the Body. Announced together with the accessible name.',
+    },
+    'aria-labelledby': {
+      description: 'The id of the heading that labels the dialog. Provides its accessible name.',
+    },
+    id: dialogIdArgType,
+  },
+  subcomponents: {
+    'AlertDialog.Body': AlertDialog.Body,
+    'AlertDialog.Footer': AlertDialog.Footer,
+    'AlertDialog.Header': AlertDialog.Header,
+  },
+} satisfies Meta<typeof AlertDialog>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  decorators: [showInlineDecorator],
+  render: () => (
+    <AlertDialog aria-describedby="ams-alert-dialog-default-body" aria-labelledby="ams-alert-dialog-default-heading">
+      <AlertDialog.Header>
+        <Heading id="ams-alert-dialog-default-heading" level={1} size="level-3">
+          Uw sessie is verlopen
+        </Heading>
+      </AlertDialog.Header>
+      <AlertDialog.Body>
+        <Paragraph id="ams-alert-dialog-default-body">Log opnieuw in om verder te gaan.</Paragraph>
+      </AlertDialog.Body>
+      <AlertDialog.Footer>
+        <Button onClick={AlertDialog.close}>Opnieuw inloggen</Button>
+      </AlertDialog.Footer>
+    </AlertDialog>
+  ),
+}
+
+export const WithSeverity: Story = {
+  decorators: [showInlineDecorator],
+  render: () => (
+    <AlertDialog
+      aria-describedby="ams-alert-dialog-with-severity-body"
+      aria-labelledby="ams-alert-dialog-with-severity-heading"
+    >
+      <AlertDialog.Header severity="warning">
+        <Heading id="ams-alert-dialog-with-severity-heading" level={1} size="level-3">
+          Er zijn niet-opgeslagen wijzigingen
+        </Heading>
+      </AlertDialog.Header>
+      <AlertDialog.Body>
+        <Paragraph id="ams-alert-dialog-with-severity-body">
+          Als u doorgaat, gaan uw wijzigingen verloren. Wilt u eerst opslaan?
+        </Paragraph>
+      </AlertDialog.Body>
+      <AlertDialog.Footer>
+        <ActionGroup>
+          <Button onClick={AlertDialog.close}>Opslaan</Button>
+          <Button onClick={AlertDialog.close} variant="secondary">
+            Doorgaan zonder opslaan
+          </Button>
+        </ActionGroup>
+      </AlertDialog.Footer>
+    </AlertDialog>
+  ),
+}
+
+export const Confirmation: Story = {
+  args: {
+    id: 'ams-alert-dialog-confirmation',
+  },
+  decorators: [openButtonDecorator],
+  render: (args) => (
+    <AlertDialog
+      {...args}
+      aria-describedby="ams-alert-dialog-confirmation-body"
+      aria-labelledby="ams-alert-dialog-confirmation-heading"
+    >
+      <AlertDialog.Header>
+        <Heading id="ams-alert-dialog-confirmation-heading" level={1} size="level-3">
+          Wilt u dit bestand verwijderen?
+        </Heading>
+      </AlertDialog.Header>
+      <AlertDialog.Body>
+        <form id="ams-alert-dialog-form" method="dialog">
+          <Paragraph id="ams-alert-dialog-confirmation-body">
+            U kunt het bestand ‘Begroting 2026.pdf’ hierna niet meer terughalen.
+          </Paragraph>
+        </form>
+      </AlertDialog.Body>
+      <AlertDialog.Footer>
+        <ActionGroup>
+          <Button form="ams-alert-dialog-form" type="submit" value="delete">
+            Verwijderen
+          </Button>
+          <Button form="ams-alert-dialog-form" type="submit" value="cancel" variant="secondary">
+            Annuleren
+          </Button>
+        </ActionGroup>
+      </AlertDialog.Footer>
+    </AlertDialog>
+  ),
+}
+
+export const SessionExpiring: Story = {
+  args: {
+    id: 'ams-alert-dialog-session-expiring',
+  },
+  decorators: [openButtonDecorator],
+  render: (args) => (
+    <AlertDialog
+      {...args}
+      aria-describedby="ams-alert-dialog-session-expiring-body"
+      aria-labelledby="ams-alert-dialog-session-expiring-heading"
+    >
+      <AlertDialog.Header>
+        <Heading id="ams-alert-dialog-session-expiring-heading" level={1} size="level-3">
+          Uw sessie verloopt bijna
+        </Heading>
+      </AlertDialog.Header>
+      <AlertDialog.Body>
+        <Paragraph id="ams-alert-dialog-session-expiring-body">
+          Zonder activiteit wordt u over 2 minuten automatisch afgemeld.
+        </Paragraph>
+      </AlertDialog.Body>
+      <AlertDialog.Footer>
+        <ActionGroup>
+          <Button
+            onClick={(event) => {
+              action('continue')()
+              return AlertDialog.close(event)
+            }}
+          >
+            Ingelogd blijven
+          </Button>
+          <Button
+            onClick={(event) => {
+              action('sign-out')()
+              return AlertDialog.close(event)
+            }}
+            variant="secondary"
+          >
+            Nu afmelden
+          </Button>
+        </ActionGroup>
+      </AlertDialog.Footer>
+    </AlertDialog>
+  ),
+}
+
+export const Controlled: Story = {
+  parameters: {
+    docs: {
+      source: {
+        code: `const [open, setOpen] = useState(false)
+
+<Button onClick={() => setOpen(true)}>Open</Button>
+<AlertDialog
+  aria-describedby="ams-alert-dialog-controlled-body"
+  aria-labelledby="ams-alert-dialog-controlled-heading"
+  onClose={() => setOpen(false)}
+  open={open}
+>
+  <AlertDialog.Header>
+    <Heading id="ams-alert-dialog-controlled-heading" level={1} size="level-3">
+      Uw sessie verloopt bijna
+    </Heading>
+  </AlertDialog.Header>
+  <AlertDialog.Body>
+    <Paragraph id="ams-alert-dialog-controlled-body">Zonder activiteit wordt u over 2 minuten afgemeld.</Paragraph>
+  </AlertDialog.Body>
+  <AlertDialog.Footer>
+    <Button onClick={() => setOpen(false)}>Doorgaan met mijn sessie</Button>
+  </AlertDialog.Footer>
+</AlertDialog>`,
+        language: 'tsx',
+      },
+    },
+  },
+  render: function Controlled() {
+    const [open, setOpen] = useState(false)
+
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open</Button>
+        <AlertDialog
+          aria-describedby="ams-alert-dialog-controlled-body"
+          aria-labelledby="ams-alert-dialog-controlled-heading"
+          onClose={() => setOpen(false)}
+          open={open}
+        >
+          <AlertDialog.Header>
+            <Heading id="ams-alert-dialog-controlled-heading" level={1} size="level-3">
+              Uw sessie verloopt bijna
+            </Heading>
+          </AlertDialog.Header>
+          <AlertDialog.Body>
+            <Paragraph id="ams-alert-dialog-controlled-body">
+              Zonder activiteit wordt u over 2 minuten afgemeld.
+            </Paragraph>
+          </AlertDialog.Body>
+          <AlertDialog.Footer>
+            <Button onClick={() => setOpen(false)}>Doorgaan met mijn sessie</Button>
+          </AlertDialog.Footer>
+        </AlertDialog>
+      </>
+    )
+  },
+}

--- a/storybook/src/components/AlertDialog/AlertDialog.test.stories.tsx
+++ b/storybook/src/components/AlertDialog/AlertDialog.test.stories.tsx
@@ -1,0 +1,179 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import type { CSSProperties } from 'react'
+
+import { ActionGroup, Button, Heading, Paragraph } from '@amsterdam/design-system-react'
+import { AlertDialog } from '@amsterdam/design-system-react/src'
+import { expect, within } from 'storybook/test'
+
+import { default as alertDialogMeta } from './AlertDialog.stories'
+
+const meta = {
+  ...alertDialogMeta,
+  title: 'Components/Containers/Alert Dialog',
+} satisfies Meta<typeof AlertDialog>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/* Opens the dialogs non-modally, so that multiple variants can be shown and snapshotted together. */
+const showNonModally = (dialog: HTMLDialogElement | null) => {
+  if (dialog && !dialog.open) {
+    dialog.show()
+  }
+}
+
+/* Keeps a non-modal dialog in the document flow instead of overlaying its container. */
+const inFlow: CSSProperties = { position: 'static' }
+
+/* Simulates a vertically short window to test the scrolling of dialog and body. */
+const shortWindow: CSSProperties = {
+  ...inFlow,
+  '--ams-alert-dialog-max-block-size': '12rem',
+  '--ams-alert-dialog-vi-medium-max-block-size': '12rem',
+} as CSSProperties
+
+const longText =
+  'Veel Amsterdammers in de bijstand zijn huiverig om te gaan werken. Ze denken dat ze dan minder geld krijgen, ' +
+  'bijvoorbeeld omdat ze hun toeslagen verliezen. Voor deze mensen ontwikkelen we de ‘garantieknop’. Als mensen in ' +
+  'de bijstand beginnen met werken en binnen 7 maanden hun baan verliezen, kunnen zij met de ‘garantieknop’ meteen ' +
+  'weer bijstand krijgen als dat nodig is. Dit zorgt ervoor dat zij minder stress hebben. Het wordt zo makkelijker ' +
+  'om weer een nieuwe baan te zoeken.'
+
+export const Test: Story = {
+  play: async ({ canvas, userEvent }) => {
+    const openButton = canvas.getByRole('button', { name: 'Open de interactietest' })
+
+    // Opens as a modal, with initial focus on the first action button (there is no close button)
+    await userEvent.click(openButton)
+
+    const dialog = canvas.getByTestId('interaction-dialog')
+
+    await expect(dialog).toBeVisible()
+
+    const confirmButton = within(dialog).getByRole('button', { name: 'Opnieuw inloggen' })
+
+    await expect(confirmButton).toHaveFocus()
+
+    // An action in the footer closes the dialog through AlertDialog.close and returns focus to the trigger
+    await userEvent.click(confirmButton)
+    await expect(dialog).not.toBeVisible()
+    await expect(openButton).toHaveFocus()
+  },
+  render: () => (
+    <>
+      <div className="_ams-tests-stack">
+        <AlertDialog aria-labelledby="test-default-heading" ref={showNonModally} style={inFlow}>
+          <AlertDialog.Header>
+            <Heading id="test-default-heading" level={1} size="level-3">
+              Uw sessie is verlopen
+            </Heading>
+          </AlertDialog.Header>
+          <AlertDialog.Body>
+            <Paragraph>Log opnieuw in om verder te gaan.</Paragraph>
+          </AlertDialog.Body>
+          <AlertDialog.Footer>
+            <Button>Opnieuw inloggen</Button>
+          </AlertDialog.Footer>
+        </AlertDialog>
+        <AlertDialog aria-labelledby="test-warning-heading" ref={showNonModally} style={inFlow}>
+          <AlertDialog.Header severity="warning">
+            <Heading id="test-warning-heading" level={1} size="level-3">
+              Er zijn niet-opgeslagen wijzigingen
+            </Heading>
+          </AlertDialog.Header>
+          <AlertDialog.Body>
+            <Paragraph>Als u doorgaat, gaan uw wijzigingen verloren.</Paragraph>
+          </AlertDialog.Body>
+          <AlertDialog.Footer>
+            <ActionGroup>
+              <Button>Opslaan</Button>
+              <Button variant="secondary">Doorgaan zonder opslaan</Button>
+            </ActionGroup>
+          </AlertDialog.Footer>
+        </AlertDialog>
+        <AlertDialog aria-labelledby="test-error-heading" ref={showNonModally} style={inFlow}>
+          <AlertDialog.Header severity="error">
+            <Heading id="test-error-heading" level={1} size="level-3">
+              Het bestand kon niet worden geüpload
+            </Heading>
+          </AlertDialog.Header>
+          <AlertDialog.Body>
+            <Paragraph>Probeer het later opnieuw.</Paragraph>
+          </AlertDialog.Body>
+          <AlertDialog.Footer>
+            <Button>Oké</Button>
+          </AlertDialog.Footer>
+        </AlertDialog>
+        <AlertDialog aria-labelledby="test-success-heading" ref={showNonModally} style={inFlow}>
+          <AlertDialog.Header severity="success">
+            <Heading id="test-success-heading" level={1} size="level-3">
+              Uw aanvraag is verstuurd
+            </Heading>
+          </AlertDialog.Header>
+          <AlertDialog.Body>
+            <Paragraph>U ontvangt een bevestiging per e-mail.</Paragraph>
+          </AlertDialog.Body>
+          <AlertDialog.Footer>
+            <Button>Oké</Button>
+          </AlertDialog.Footer>
+        </AlertDialog>
+        <AlertDialog
+          aria-labelledby="test-long-heading-heading"
+          ref={showNonModally}
+          style={{ ...inFlow, maxInlineSize: '24rem' }}
+        >
+          <AlertDialog.Header severity="warning">
+            <Heading id="test-long-heading-heading" level={1} size="level-3">
+              Een lange kop die over meerdere regels doorloopt naast het pictogram
+            </Heading>
+          </AlertDialog.Header>
+          <AlertDialog.Body>
+            <Paragraph>Het pictogram hoort naast de eerste regel van de kop te staan.</Paragraph>
+          </AlertDialog.Body>
+          <AlertDialog.Footer>
+            <Button>Oké</Button>
+          </AlertDialog.Footer>
+        </AlertDialog>
+        <AlertDialog aria-labelledby="test-short-window-heading" ref={showNonModally} style={shortWindow}>
+          <AlertDialog.Header>
+            <Heading id="test-short-window-heading" level={1} size="level-3">
+              Een dialoogvenster in een verticaal krap venster
+            </Heading>
+          </AlertDialog.Header>
+          <AlertDialog.Body>
+            <Paragraph>{longText}</Paragraph>
+          </AlertDialog.Body>
+          <AlertDialog.Footer>
+            <Button>Oké</Button>
+          </AlertDialog.Footer>
+        </AlertDialog>
+      </div>
+      <Button onClick={() => AlertDialog.open('#test-interactions')}>Open de interactietest</Button>
+      <AlertDialog
+        aria-describedby="test-interactions-body"
+        aria-labelledby="test-interactions-heading"
+        data-testid="interaction-dialog"
+        id="test-interactions"
+      >
+        <AlertDialog.Header>
+          <Heading id="test-interactions-heading" level={1} size="level-3">
+            Uw sessie is verlopen
+          </Heading>
+        </AlertDialog.Header>
+        <AlertDialog.Body>
+          <Paragraph id="test-interactions-body">Log opnieuw in om verder te gaan.</Paragraph>
+        </AlertDialog.Body>
+        <AlertDialog.Footer>
+          <Button onClick={AlertDialog.close}>Opnieuw inloggen</Button>
+        </AlertDialog.Footer>
+      </AlertDialog>
+    </>
+  ),
+  tags: ['!dev', '!autodocs', '!manifest'],
+}

--- a/storybook/src/components/AlertDialog/AlertDialogHeader.stories.tsx
+++ b/storybook/src/components/AlertDialog/AlertDialogHeader.stories.tsx
@@ -1,0 +1,50 @@
+/**
+ * @license EUPL-1.2+
+ * Copyright Gemeente Amsterdam
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Heading } from '@amsterdam/design-system-react'
+import { AlertDialog } from '@amsterdam/design-system-react/src'
+
+const meta = {
+  title: 'Components/Containers/Alert Dialog',
+  component: AlertDialog.Header,
+  argTypes: {
+    severity: {
+      control: { labels: { undefined: 'none' }, type: 'select' },
+      options: [undefined, 'error', 'warning', 'success'],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <AlertDialog
+        aria-labelledby="ams-alert-dialog-header-heading"
+        ref={(dialog) => {
+          if (dialog && !dialog.open) {
+            dialog.show() // Open the dialog non-modally, in place, to display the Header.
+          }
+        }}
+        style={{ position: 'static' }}
+      >
+        <Story />
+      </AlertDialog>
+    ),
+  ],
+  tags: ['!manifest'],
+} satisfies Meta<typeof AlertDialog.Header>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const Header: Story = {
+  args: {
+    children: (
+      <Heading id="ams-alert-dialog-header-heading" level={1} size="level-3">
+        Titel van het dialoogvenster
+      </Heading>
+    ),
+  },
+}

--- a/storybook/src/components/AlertDialog/AlertDialogHeader.stories.tsx
+++ b/storybook/src/components/AlertDialog/AlertDialogHeader.stories.tsx
@@ -23,7 +23,8 @@ const meta = {
         aria-labelledby="ams-alert-dialog-header-heading"
         ref={(dialog) => {
           if (dialog && !dialog.open) {
-            dialog.show() // Open the dialog non-modally, in place, to display the Header.
+            // Set the open attribute instead of calling show(), which would move focus here and scroll the docs page.
+            dialog.open = true
           }
         }}
         style={{ position: 'static' }}

--- a/storybook/src/components/Dialog/Dialog.docs.mdx
+++ b/storybook/src/components/Dialog/Dialog.docs.mdx
@@ -3,11 +3,17 @@
 import { Canvas, Controls, Description, Meta, Primary, Title } from "@storybook/addon-docs/blocks";
 
 import { DesignTokensTable } from "#storybook/_components/DesignTokensTable/DesignTokensTable";
+import { StatusBadge } from "#storybook/_components/StatusBadge/StatusBadge.tsx";
 import tokens from "#tokens/components/ams/dialog.tokens.json";
 
 import * as DialogStories from "./Dialog.stories.tsx";
 
 <Meta of={DialogStories} />
+
+<StatusBadge
+  description="Use Alert Dialog instead. It covers the same messages and will replace this component in a future major version."
+  status="deprecated"
+/>
 
 <Title />
 
@@ -112,6 +118,7 @@ Opening a modal does not lock scrolling on its own, and iOS Safari still needs J
 
 ## See also
 
+- [Alert Dialog](/docs/components-containers-alert-dialog--docs) – the replacement for this component.
 - [Modal Dialog](/docs/components-containers-modal-dialog--docs) – for a task that needs more room, such as a form.
 - [Action Group](/docs/components-layout-action-group--docs) – lays out multiple Buttons.
 


### PR DESCRIPTION
# Add Alert Dialog component

## Links

- [Storybook for this branch](https://designsystem.amsterdam/demo-DES-1829-alert-dialog/)
- [Alert Dialog documentation in that deploy](https://designsystem.amsterdam/demo-DES-1829-alert-dialog/?path=/docs/components-containers-alert-dialog--docs)
- [WAI-ARIA APG: Alert Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/)
- Related: [Modal Dialog PR](https://github.com/Amsterdam/design-system/pull/2920)

## What

This PR adds the Alert Dialog component, for brief, urgent interruptions that require a choice before the user can continue. It spans all layers: design tokens, CSS, the React component with its Header, Body, and Footer subcomponents, and Storybook stories, interaction tests, and a documentation page.

The Header takes an optional `severity` prop (`error`, `success`, or `warning`) that adds a matching icon before the title and fills the Header with the corresponding feedback colour. Unlike a Modal Dialog, the Header has no close button: the user responds through the actions in the Footer.

Dialog is now marked as deprecated in favour of Alert Dialog, with a status badge on its documentation page and an `@deprecated` tag on the component.

## Why

This is the second part of DES-1829, continuing the dialog split introduced with Modal Dialog: interactions the user may dismiss belong in a Modal Dialog, while messages that require a decision get an Alert Dialog. This follows the WAI-ARIA `alertdialog` pattern and the corresponding NL Design System direction.

## How

The component is a standalone port of Modal Dialog; the duplication is deliberate for now, so both can evolve independently until we know what is worth sharing. It sets `role="alertdialog"` on the native `dialog` element, applied after `restProps` so it always wins, and the docs instruct wiring `aria-labelledby` to the Header and `aria-describedby` to the Body.

Escape still closes the dialog, as the native element and the APG prescribe, even though NL Design System frames an alert dialog as non-dismissable; the Keyboard section of the docs explains this divergence, so flows must make closing through Escape safe. The severity fill uses the existing `ams.color.feedback.*` tokens and keeps text and icon in the default dark colour, which passes the contrast requirements for every severity where white would fail.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

Alert Dialog replaces the current Dialog, which this PR deprecates; removing Dialog itself follows in a future major release.
