### PR TITLE
chore: Update unreleased deprecation dates to six months from today

### DIFF
--- a/packages-proprietary/tokens/lint/allowlist.json
+++ b/packages-proprietary/tokens/lint/allowlist.json
@@ -1,7 +1,7 @@
 {
-  "--ams-avatar-forced-colors-border-width": "Deprecated, removable on or after 2027-01-21. Consumed until #1998 replaced the border with a box shadow.",
+  "--ams-avatar-forced-colors-border-width": "Deprecated, removable on or after 2027-02-08. Consumed until #1998 replaced the border with a box shadow.",
   "--ams-field-gap": "Deprecated in favour of the ams.field-set.child.* tokens, and no longer referenced since #2358. Its removal date has passed, so it goes in the next major release.",
   "--ams-field-set-legend-margin-block-end": "Deprecated in favour of the ams.field-set.child.* tokens, and no longer referenced since #2358. Its removal date has passed, so it goes in the next major release.",
-  "--ams-page-header-menu-item-font-family": "Deprecated, removable on or after 2027-01-21. Redundant since page-header.scss sets the font family on the root, which the menu items inherit.",
-  "--ams-search-field-input-cancel-button-color": "Deprecated, removable on or after 2027-01-21. Never referenced in the history of search-field.scss; the cancel button carries its colour in a data URI, which cannot reference a token."
+  "--ams-page-header-menu-item-font-family": "Deprecated, removable on or after 2027-02-08. Redundant since page-header.scss sets the font family on the root, which the menu items inherit.",
+  "--ams-search-field-input-cancel-button-color": "Deprecated, removable on or after 2027-02-08. Never referenced in the history of search-field.scss; the cancel button carries its colour in a data URI, which cannot reference a token."
 }

--- a/packages-proprietary/tokens/src/components/ams/avatar.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/avatar.tokens.json
@@ -81,7 +81,7 @@
       },
       "forced-colors": {
         "border-width": {
-          "$deprecated": "The Avatar no longer draws a border in forced colours mode, so this token has no effect. Will be removed on or after 2027-01-21.",
+          "$deprecated": "The Avatar no longer draws a border in forced colours mode, so this token has no effect. Will be removed on or after 2027-02-08.",
           "$value": "{ams.border.width.m}",
           "$extensions": {
             "nl.amsterdam.type": "borderWidth"

--- a/packages-proprietary/tokens/src/components/ams/page-header.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/page-header.tokens.json
@@ -220,7 +220,7 @@
             }
           },
           "font-family": {
-            "$deprecated": "Use `ams.page-header.font-family` instead, which the menu items inherit. Will be removed on or after 2027-01-21.",
+            "$deprecated": "Use `ams.page-header.font-family` instead, which the menu items inherit. Will be removed on or after 2027-02-08.",
             "$value": "{ams.typography.font-family}",
             "$extensions": {
               "nl.amsterdam.type": "fontFamily"

--- a/packages-proprietary/tokens/src/components/ams/search-field.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/search-field.tokens.json
@@ -148,7 +148,7 @@
             }
           },
           "color": {
-            "$deprecated": "Use `ams.search-field.input.cancel-button.background-image` instead, which carries the colour, because a data URI cannot reference a token. Will be removed on or after 2027-01-21.",
+            "$deprecated": "Use `ams.search-field.input.cancel-button.background-image` instead, which carries the colour, because a data URI cannot reference a token. Will be removed on or after 2027-02-08.",
             "$value": "{ams.color.interactive.default}",
             "$extensions": {
               "nl.amsterdam.type": "color"

--- a/packages/react/src/Card/CardHeadingGroup.tsx
+++ b/packages/react/src/Card/CardHeadingGroup.tsx
@@ -16,7 +16,7 @@ const hasMetadataChild = (children: ReactNode) =>
 export type CardHeadingGroupProps = {
   /**
    * A short phrase of text, e.g. to categorise the card. Displayed above the card heading.
-   * @deprecated Add a Metadata as a child instead. Will be removed on or after 2027-02-10.
+   * @deprecated Add a Metadata as a child instead. Will be removed on or after 2027-02-08.
    */
   readonly tagline?: string
 } & Readonly<PropsWithChildren<HTMLAttributes<HTMLElement>>>


### PR DESCRIPTION
# Update unreleased deprecation dates to six months from today

## Links

- [Storybook on main](https://designsystem.amsterdam/)
- [Unused-token check that introduced the token deprecations](https://github.com/Amsterdam/design-system/pull/2820)
- [Metadata change that deprecated the Card Heading Group tagline](https://github.com/Amsterdam/design-system/pull/2913)

## What

This PR moves the removal date of every deprecation notice that has not shipped yet to 2027-02-08, six months from today. That covers the tokens `ams.avatar.forced-colors.border-width`, `ams.page-header.menu.item.font-family`, and `ams.search-field.input.cancel-button.color`, their entries in the unused-token allowlist, and the `tagline` prop of Card Heading Group.

## Why

A deprecation promises consumers a migration window, and that window only starts once a release lets them see the notice. These dates were written when the work was done, at 2027-01-21 and 2027-02-10, so they would quietly shorten the window the longer the release took. Aligning them just before the release keeps the six-month promise accurate.

## How

Each package was compared against its latest release tag to find every removal date added since, and only those change. Dates that already shipped, such as the 2026-10-20 dialog tokens and the 2027-01-10 Progress List Step props, are commitments and stay untouched.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

These dates assume the release follows soon; if it slips by more than a few weeks, they should shift along with it.
