### PR TITLE
feat(Pages): Separate facets from different filter fields with a Metadata Separator

### DIFF
--- a/storybook/src/_common/exampleContent.ts
+++ b/storybook/src/_common/exampleContent.ts
@@ -298,10 +298,12 @@ export const exampleUnorderedList = () =>
 // take that list from `districts` above rather than keeping a copy of their own.
 
 export type NewsArticle = {
-  /** The facets of the article, comma separated, as one Metadata line. */
+  /** The kind of news, shown in the Card Metadata and used by the ‘Soort nieuws’ filter. */
   readonly category: string
   /** The human-readable date, e.g. ‘20 oktober 2023’. */
   readonly date: string
+  /** The city district (stadsdeel) the article is about; news that concerns the whole city has none. */
+  readonly district?: string
   readonly id: string
   /** A decorative image; its `alt` is intentionally empty as the title beside it conveys the same meaning. */
   readonly imageSource: string
@@ -367,8 +369,9 @@ export const searchTopics: ReadonlyArray<string> = ['Nieuwsbericht', 'Beleid en 
 export const newsArticles: ReadonlyArray<NewsArticle> = [
   {
     title: 'Berlagebrug een aantal nachten dicht',
-    category: 'Algemeen, Centrum, Werkzaamheden',
+    category: 'Algemeen',
     date: '20 oktober 2023',
+    district: 'Centrum',
     id: 'berlagebrug',
     imageSource: exampleImageSource(640, 360, 0),
     isoDate: '2023-10-20',
@@ -387,8 +390,9 @@ export const newsArticles: ReadonlyArray<NewsArticle> = [
   },
   {
     title: 'Noorderpark wordt groener en beter toegankelijk',
-    category: 'Algemeen, Noord',
+    category: 'Algemeen',
     date: '16 oktober 2023',
+    district: 'Noord',
     id: 'noorderpark',
     imageSource: exampleImageSource(640, 360, 2),
     isoDate: '2023-10-16',
@@ -397,8 +401,9 @@ export const newsArticles: ReadonlyArray<NewsArticle> = [
   },
   {
     title: 'Zuidoost viert 750 jaar Amsterdam: vraag subsidie aan voor uw initiatief',
-    category: 'Algemeen, Zuidoost',
+    category: 'Algemeen',
     date: '13 oktober 2023',
+    district: 'Zuidoost',
     id: 'zuidoost-subsidie',
     imageSource: exampleImageSource(640, 360, 3),
     isoDate: '2023-10-13',
@@ -417,8 +422,9 @@ export const newsArticles: ReadonlyArray<NewsArticle> = [
   },
   {
     title: 'Erfgoed van de week: het wonderkind van de Amsterdamse School',
-    category: 'Achtergrond, West',
+    category: 'Achtergrond',
     date: '9 oktober 2023',
+    district: 'West',
     id: 'amsterdamse-school',
     imageSource: exampleImageSource(640, 360, 5),
     isoDate: '2023-10-09',

--- a/storybook/src/pages/public/EventsOverviewPage/EventsOverviewPage.docs.mdx
+++ b/storybook/src/pages/public/EventsOverviewPage/EventsOverviewPage.docs.mdx
@@ -95,13 +95,16 @@ Close the list with [Pagination](/docs/components-navigation-pagination--docs) i
 The medium grid is where the two part company: the results leave a column spare there, and Pagination spanning the whole region would reach past the Cards it belongs to.
 
 Give each activity the facets it was filtered by at the top of the Card.
-A [Metadata](/docs/components-text-metadata--docs) in the Card Heading Group carries those values comma separated: here the category and the district, which are the two facets the filter column offers.
+A [Metadata](/docs/components-text-metadata--docs) in the Card Heading Group carries those values: here the category and the district, which are the two facets the filter column offers.
+
+Set the two apart with a Metadata Separator rather than with punctuation of your own.
+They come from different filter fields, so they are two kinds of metadata rather than two values of one kind, and that is what a comma between them would say instead.
+Keep the comma for the values within one kind, as in ‘Kunst en cultuur, Sport en spel’.
 
 Close the Card with when and where it happens, below the description, as a second Metadata: the day, the time, and the venue.
 Those three answer a different question from the facets above — not what kind of activity this is, but whether the visitor can be there — so they read better as a footnote to the description than beside the heading.
 
-Set each of the three apart with a Metadata Separator rather than with punctuation of your own.
-They are three kinds of metadata rather than one sentence, and a comma between them would imply the sentence continues.
+Those are three kinds again, so two Separators divide them.
 Leave the Separator out where an activity has no time, so two never meet.
 
 List the categories alphabetically.

--- a/storybook/src/pages/public/EventsOverviewPage/EventsOverviewPage.stories.tsx
+++ b/storybook/src/pages/public/EventsOverviewPage/EventsOverviewPage.stories.tsx
@@ -206,8 +206,15 @@ export const Default: StoryObj = {
                   <Card.Heading level={3}>
                     <Card.Link href="#">Open dag Stadsarchief Amsterdam</Card.Link>
                   </Card.Heading>
-                  {/* The Metadata carries the facets of the activity, comma separated. */}
-                  <Metadata size="small">Kunst en cultuur, Centrum</Metadata>
+                  {/*
+                   * The Metadata carries the facets of the activity. The category and the district come from
+                   * different filter fields, so a Separator sets them apart; a comma would read as two categories.
+                   */}
+                  <Metadata size="small">
+                    Kunst en cultuur
+                    <Metadata.Separator />
+                    Centrum
+                  </Metadata>
                 </Card.HeadingGroup>
                 <Column gap="small">
                   <Paragraph>Ontdek eeuwenoude kaarten, foto’s en films over Amsterdam.</Paragraph>
@@ -217,7 +224,7 @@ export const Default: StoryObj = {
                      * The visible date is prose; dateTime repeats it in the machine-readable format software parses.
                      */}
                     <time dateTime="2026-06-20">20 juni 2026</time>
-                    {/* The day, the time and the place are three kinds of metadata, so a Separator sits between them. */}
+                    {/* The day, the time and the place are three kinds, so two Separators divide them. */}
                     <Metadata.Separator />
                     10.00–16.00 uur
                     <Metadata.Separator />
@@ -389,8 +396,16 @@ export const Default: StoryObj = {
                         <Card.Heading level={3}>
                           <Card.Link href={event.href}>{event.title}</Card.Link>
                         </Card.Heading>
-                        {/* The Metadata carries the facets of the activity, comma separated. */}
-                        <Metadata size="small">{`${event.category}, ${event.district}`}</Metadata>
+                        {/*
+                         * The Metadata carries the facets of the activity. The category and the district come from
+                         * different filter fields, so a Separator sets them apart; a comma would read as two
+                         * categories.
+                         */}
+                        <Metadata size="small">
+                          {event.category}
+                          <Metadata.Separator />
+                          {event.district}
+                        </Metadata>
                       </Card.HeadingGroup>
                       <Column gap="small">
                         <Paragraph>{event.teaser}</Paragraph>
@@ -398,7 +413,7 @@ export const Default: StoryObj = {
                         <Metadata size="small">
                           {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
                           <time dateTime={event.isoDate}>{event.date}</time>
-                          {/* The day, the time and the place are three kinds of metadata, so a Separator sits between them. */}
+                          {/* The day, the time and the place are three kinds, so two Separators divide them. */}
                           {event.timeLabel && (
                             <>
                               <Metadata.Separator />
@@ -575,8 +590,15 @@ export const CardGrid: StoryObj = {
                   <Card.Heading level={3}>
                     <Card.Link href="#">Open dag Stadsarchief Amsterdam</Card.Link>
                   </Card.Heading>
-                  {/* The Metadata carries the facets of the activity, comma separated. */}
-                  <Metadata size="small">Kunst en cultuur, Centrum</Metadata>
+                  {/*
+                   * The Metadata carries the facets of the activity. The category and the district come from
+                   * different filter fields, so a Separator sets them apart; a comma would read as two categories.
+                   */}
+                  <Metadata size="small">
+                    Kunst en cultuur
+                    <Metadata.Separator />
+                    Centrum
+                  </Metadata>
                 </Card.HeadingGroup>
                 <Column gap="small">
                   <Paragraph>Ontdek eeuwenoude kaarten, foto’s en films over Amsterdam.</Paragraph>
@@ -586,7 +608,7 @@ export const CardGrid: StoryObj = {
                      * The visible date is prose; dateTime repeats it in the machine-readable format software parses.
                      */}
                     <time dateTime="2026-06-20">20 juni 2026</time>
-                    {/* The day, the time and the place are three kinds of metadata, so a Separator sits between them. */}
+                    {/* The day, the time and the place are three kinds, so two Separators divide them. */}
                     <Metadata.Separator />
                     10.00–16.00 uur
                     <Metadata.Separator />
@@ -758,8 +780,16 @@ export const CardGrid: StoryObj = {
                         <Card.Heading level={3}>
                           <Card.Link href={event.href}>{event.title}</Card.Link>
                         </Card.Heading>
-                        {/* The Metadata carries the facets of the activity, comma separated. */}
-                        <Metadata size="small">{`${event.category}, ${event.district}`}</Metadata>
+                        {/*
+                         * The Metadata carries the facets of the activity. The category and the district come from
+                         * different filter fields, so a Separator sets them apart; a comma would read as two
+                         * categories.
+                         */}
+                        <Metadata size="small">
+                          {event.category}
+                          <Metadata.Separator />
+                          {event.district}
+                        </Metadata>
                       </Card.HeadingGroup>
                       <Column gap="small">
                         <Paragraph>{event.teaser}</Paragraph>
@@ -767,7 +797,7 @@ export const CardGrid: StoryObj = {
                         <Metadata size="small">
                           {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
                           <time dateTime={event.isoDate}>{event.date}</time>
-                          {/* The day, the time and the place are three kinds of metadata, so a Separator sits between them. */}
+                          {/* The day, the time and the place are three kinds, so two Separators divide them. */}
                           {event.timeLabel && (
                             <>
                               <Metadata.Separator />

--- a/storybook/src/pages/public/EventsOverviewPage/EventsOverviewPage.stories.tsx
+++ b/storybook/src/pages/public/EventsOverviewPage/EventsOverviewPage.stories.tsx
@@ -413,7 +413,10 @@ export const Default: StoryObj = {
                         <Metadata size="small">
                           {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
                           <time dateTime={event.isoDate}>{event.date}</time>
-                          {/* The day, the time and the place are three kinds, so two Separators divide them. */}
+                          {/*
+                           * A Separator divides the day, the time and the place, each of which is a kind of its
+                           * own. An activity with no time leaves one out, so two Separators never meet.
+                           */}
                           {event.timeLabel && (
                             <>
                               <Metadata.Separator />
@@ -797,7 +800,10 @@ export const CardGrid: StoryObj = {
                         <Metadata size="small">
                           {/* The visible date is prose; dateTime repeats it in the machine-readable format software parses. */}
                           <time dateTime={event.isoDate}>{event.date}</time>
-                          {/* The day, the time and the place are three kinds, so two Separators divide them. */}
+                          {/*
+                           * A Separator divides the day, the time and the place, each of which is a kind of its
+                           * own. An activity with no time leaves one out, so two Separators never meet.
+                           */}
                           {event.timeLabel && (
                             <>
                               <Metadata.Separator />

--- a/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.docs.mdx
+++ b/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.docs.mdx
@@ -48,6 +48,13 @@ Without it the results have no columns of their own, and nothing in them can lin
 The articles are a list, so give them a Subgrid of their own inside that one: a `ul` with every Cell in it an `li`.
 The sentence announcing the total and the Pagination are not part of that list, so they stay outside it.
 
+Give each article the facets it was filtered by at the top of the Card.
+A [Metadata](/docs/components-text-metadata--docs) in the Card Heading Group carries those values: here the kind of news and the district.
+
+Set the two apart with a Metadata Separator rather than with punctuation of your own.
+They come from different filter fields, so they are two kinds of metadata rather than two values of one kind, and that is what a comma between them would say instead.
+Leave the Separator out where an article has no district, so no line ends in one.
+
 Announce the number of results in a `role="status"` paragraph, and name the filters that produced it.
 A visitor using a screen reader otherwise has no way to tell that ticking a checkbox changed anything.
 

--- a/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.stories.tsx
+++ b/storybook/src/pages/public/NewsOverviewPage/NewsOverviewPage.stories.tsx
@@ -166,7 +166,15 @@ export const Default: StoryObj = {
                   <Card.Heading level={3}>
                     <Card.Link href="#">Berlagebrug een aantal nachten dicht</Card.Link>
                   </Card.Heading>
-                  <Metadata size="small">Algemeen, Centrum, Werkzaamheden</Metadata>
+                  {/*
+                   * The Metadata carries the facets of the article. The kind of news and the district come from
+                   * different filter fields, so a Separator sets them apart; a comma would read as two kinds of news.
+                   */}
+                  <Metadata size="small">
+                    Algemeen
+                    <Metadata.Separator />
+                    Centrum
+                  </Metadata>
                 </Card.HeadingGroup>
                 <Column gap="small">
                   <Paragraph>
@@ -312,7 +320,21 @@ export const Default: StoryObj = {
                         <Card.Heading level={3}>
                           <Card.Link href="#">{article.title}</Card.Link>
                         </Card.Heading>
-                        <Metadata size="small">{article.category}</Metadata>
+                        {/*
+                         * The Metadata carries the facets of the article. The kind of news and the district come
+                         * from different filter fields, so a Separator sets them apart; a comma would read as two
+                         * kinds of news.
+                         */}
+                        <Metadata size="small">
+                          {article.category}
+                          {/* Leave the Separator out for news that concerns the whole city, so no line ends in one. */}
+                          {article.district && (
+                            <>
+                              <Metadata.Separator />
+                              {article.district}
+                            </>
+                          )}
+                        </Metadata>
                       </Card.HeadingGroup>
                       <Column gap="small">
                         <Paragraph>{article.teaser}</Paragraph>


### PR DESCRIPTION
# Separate facets from different filter fields with a Metadata Separator

## Links

- [Storybook on main](https://designsystem.amsterdam/)
- [Events Overview Page, Default](https://designsystem.amsterdam/?path=/story/pages-public-events-overview-page--default) and [Card Grid](https://designsystem.amsterdam/?path=/story/pages-public-events-overview-page--card-grid)
- [News Overview Page, Default](https://designsystem.amsterdam/?path=/story/pages-public-news-overview-page--default)
- [Events Overview Page documentation](https://designsystem.amsterdam/?path=/docs/pages-public-events-overview-page--docs) and [News Overview Page documentation](https://designsystem.amsterdam/?path=/docs/pages-public-news-overview-page--docs)
- [Metadata](https://designsystem.amsterdam/?path=/docs/components-text-metadata--docs) – ‘Separate two kinds of metadata with a Separator, and the values within one kind with a comma.’

## What

The Cards on the Events Overview Page and the News Overview Page joined their facets with a comma: ‘Duurzaam en milieu, Noord’ on an activity, ‘Algemeen, Centrum’ on a news article. A Metadata Separator now sets those values apart.

The example content for the news articles gains a `district` of its own. It used to hold every facet of an article in one `category` string, which left the template nothing to put a Separator between. The value ‘Werkzaamheden’ has gone with that split: it belonged to neither of the two filter fields the page offers, so there was no kind to attach it to.

Both documentation pages describe the rule now. The Events page told readers to write the two values comma separated, and the News page said nothing at all about the metadata on a Card.

## Why

The category and the district are two kinds of metadata, each coming from a filter field of its own. A comma between them reads as two values of one kind, which is what it means in ‘Belastingen, Wonen, WOZ’. The Metadata documentation has said so since the Separator was added; these two templates were the places that did not follow it.

## How

Every Card on both pages carries the same change, in the rendered story as well as in the hand-written Code Panel source: two stories on the Events Overview Page and one on the News Overview Page.

A news article about the whole city has no district, so the Separator is left out there rather than trailing at the end of the line. That is the pattern the Events Overview Page already uses for an activity without a time.

The Information Page keeps its comma. Its three values are all subjects of one kind, which is the other half of the same rule.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.* files
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

The Chromatic snapshots of both Pages stories will differ: an en dash behind a square replaces a comma on every Card.

The search results on the News Overview Page do not match the filters its status message names. That is deliberate, and predates this change: the variation shows more of the page.
