### PR TITLE
chore(Storybook): Draw the Desktop page anatomy first where only one fits

### DIFF
--- a/storybook/src/_components/PageAnatomy/PageAnatomy.tsx
+++ b/storybook/src/_components/PageAnatomy/PageAnatomy.tsx
@@ -335,7 +335,9 @@ export const PageAnatomy = ({
   style,
   ...restProps
 }: PageAnatomyProps) => {
-  const [selected, setSelected] = useState<Breakpoint>('narrow')
+  // Desktop is drawn first, because it shows most of the anatomy: every column of the Grid, and the Cells beside one
+  // another that the narrower variants stack.
+  const [selected, setSelected] = useState<Breakpoint>('wide')
   const { problems, sections } = readPageAnatomy(readStoryTree(of, story), labels)
   const viewports = anatomyViewports({ menu, mode })
   const widest = viewports[viewports.length - 1]?.width ?? 0


### PR DESCRIPTION
## Links

- [Feature branch deploy](https://amsterdam.github.io/design-system/demo-page-anatomy-desktop-first)
- [Reading the anatomy](https://amsterdam.github.io/design-system/demo-page-anatomy-desktop-first/?path=/docs/pages-guidelines-reading-the-anatomy--docs)
- [Article Page, whose docs page draws an anatomy](https://amsterdam.github.io/design-system/demo-page-anatomy-desktop-first/?path=/docs/pages-public-article-page--docs)

## What

In a container too narrow to show the three drawings beside one another, the Page Anatomy now opens on the Desktop drawing instead of the Mobile one. The buttons above it keep their order and still choose between all three.

## Why

The drawing is a map of the page, and Desktop is the variant that shows the most of that map: every column of the Grid, and the Cells beside one another that the narrower variants stack into a single column. Opening on Mobile showed the least of the anatomy of the three, so a reader on a phone met the drawing that says the least about how the page is laid out.

## How

The initial value of the component’s state went from `narrow` to `wide`. Nothing else moved: the switcher still lists the variants from narrow to wide, and the drawings themselves are untouched.

The trade-off is scale. A drawing takes at most the width of the page it stands for, so below the breakpoint the Desktop drawing fills the container: at the 40rem where the switcher appears, that is a little over a third of its real size. The labels keep their fixed size and stay legible, but twelve columns in that width read denser than four did.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

No documentation needed editing. Reading the anatomy says the buttons choose which of the three to show, and `documentation/page-anatomy.md` says one drawing is shown at a time; both stay true.

One Chromatic snapshot changes: the last of the five cases in the Page Anatomy test story sits in a 24rem container, and it now draws Desktop rather than Mobile. That case is the deliberate stress test of the narrow layout, so it is the drawing at its smallest.

ESLint, `tsc --noEmit` and the 66 Page Anatomy tests pass. I also rendered the component to static markup to confirm the Desktop button starts pressed and the Desktop drawing carries the selected class.

This has no DES ticket.
