### PR TITLE
chore(css, react, tokens, assets): Document deprecations that shipped without a changelog entry

### DIFF
--- a/packages-proprietary/assets/CHANGELOG.md
+++ b/packages-proprietary/assets/CHANGELOG.md
@@ -100,6 +100,14 @@ The following icons will be removed on or after 2026-07-09:
 
 * Add 26 new icons, update 5, and deprecate 3 ([#2201](https://github.com/Amsterdam/design-system/issues/2201)) ([1a47b0d](https://github.com/Amsterdam/design-system/commit/1a47b0d6e6ea26f9ac9cc3f6fc98b6cf731f0163))
 
+### Deprecations
+
+The following icons have been deprecated and will be removed on or after 2026-05-01:
+
+- `CheckMarkCircle` and `CheckMarkCircleFill`, use `Success` and `SuccessFill` instead.
+- `Cogwheel` and `CogwheelFill`, use `Settings` and `SettingsFill` instead.
+- `HandWithEuroCoin`, use `PersonsWithEuroCoin` instead.
+
 ## [1.0.1](https://github.com/Amsterdam/design-system/compare/design-system-assets-v1.0.0...design-system-assets-v1.0.1) (2025-09-17)
 
 

--- a/packages-proprietary/tokens/CHANGELOG.md
+++ b/packages-proprietary/tokens/CHANGELOG.md
@@ -31,6 +31,14 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **Switch:** Use Neutral 20 for the disabled track ([#2808](https://github.com/Amsterdam/design-system/issues/2808)) ([952e857](https://github.com/Amsterdam/design-system/commit/952e857ce36a637fbcc1d071dee9b99f23890c36))
 * **Table:** Make the horizontal scroll container keyboard accessible ([#2845](https://github.com/Amsterdam/design-system/issues/2845)) ([c0159b5](https://github.com/Amsterdam/design-system/commit/c0159b59955b2be4475376b2beae8c7ba754df32))
 
+### Deprecations
+
+The following tokens have been deprecated and will be removed on or after 2027-02-08:
+
+- `ams.avatar.forced-colors.border-width`. The Avatar no longer draws a border in forced colours mode, so this token has no effect.
+- `ams.page-header.menu.item.font-family`. Use `ams.page-header.font-family` instead, which the menu items inherit.
+- `ams.search-field.input.cancel-button.color`. Use `ams.search-field.input.cancel-button.background-image` instead, which carries the colour, because a data URI cannot reference a token.
+
 ## [4.2.0](https://github.com/Amsterdam/design-system/compare/design-system-tokens-v4.1.0...design-system-tokens-v4.2.0) (2026-07-12)
 
 
@@ -113,6 +121,11 @@ The following tokens have been deprecated and will be removed on or after 2026-1
 - `ams.progress-list.step.medium.gap` and `ams.progress-list.substeps.step.indicator.medium.margin-inline-end`
 
 For tokens containing `*.medium.*` and `*.wide.*`, replace them with `*.vi-medium.*` and `*.vi-wide.*`.
+
+The following tokens have been deprecated and will be removed on or after 2026-09-13:
+
+- `ams.page-header.menu.item.color`. Use `ams.page-header.menu.link.color` instead.
+- `ams.page-header.mega-menu.button.label.open.font-weight`. The button label is no longer bold while the mega menu is open.
 
 ## [3.4.0](https://github.com/Amsterdam/design-system/compare/design-system-tokens-v3.3.0...design-system-tokens-v3.4.0) (2026-04-03)
 

--- a/packages-proprietary/tokens/CHANGELOG.md
+++ b/packages-proprietary/tokens/CHANGELOG.md
@@ -115,7 +115,7 @@ The following tokens have been deprecated and will be removed on or after 2026-1
   `ams.dialog.header.medium.padding-block`, `ams.dialog.header.medium.padding-inline`, `ams.dialog.body.medium.padding-inline`,
   `ams.dialog.footer.medium.padding-block`, `ams.dialog.footer.medium.padding-inline`
 - `ams.grid.medium.column-count`, `ams.grid.medium.padding-inline`, `ams.grid.wide.column-count`, and `ams.grid.wide.padding-inline`
-- `ams.menu.wide.max-inline-size`, `ams.menu.wide.padding-block`, `ams.menu.wide.padding-inline`, and `ams.menu-link.wide.gap`
+- `ams.menu.wide.max-inline-size`, `ams.menu.wide.padding-block`, `ams.menu.wide.padding-inline`, and `ams.menu.link.wide.gap`
 - `ams.page-footer.menu.medium.padding-inline`, `ams.page-footer.menu.wide.padding-inline`
 - `ams.page-header.medium.padding-inline`, `ams.page-header.wide.padding-inline`
 - `ams.progress-list.step.medium.gap` and `ams.progress-list.substeps.step.indicator.medium.margin-inline-end`

--- a/packages/css/CHANGELOG.md
+++ b/packages/css/CHANGELOG.md
@@ -126,6 +126,13 @@ The following deprecated CSS classes have been removed:
 - `.ams-standalone-link--with-icon`.
 - `.ams-image-slider--controls`, `.ams-image-slider__item`, and `.ams-image-slider__item--in-view`.
 
+The following class names have been deprecated and will be removed on or after 2026-09-13:
+
+- `.ams-page-header__mega-menu-button-label`
+- `.ams-page-header__mega-menu-button-hidden-label`
+
+Neither carries any styles. Remove them if you use them as hooks in your own stylesheet.
+
 ## [3.3.0](https://github.com/Amsterdam/design-system/compare/design-system-css-v3.2.1...design-system-css-v3.3.0) (2026-04-03)
 
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -30,6 +30,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **Dialog:** Make the scrollable body keyboard accessible ([#2846](https://github.com/Amsterdam/design-system/issues/2846)) ([c4be5a2](https://github.com/Amsterdam/design-system/commit/c4be5a2307fa037d191d5f183b13a667ae257c77))
 * **Table:** Make the horizontal scroll container keyboard accessible ([#2845](https://github.com/Amsterdam/design-system/issues/2845)) ([c0159b5](https://github.com/Amsterdam/design-system/commit/c0159b59955b2be4475376b2beae8c7ba754df32))
 
+### Deprecations
+
+The following API has been deprecated and will be removed on or after 2027-02-08:
+
+- The `tagline` prop of `Card.HeadingGroup`. Add a `Metadata` as a child instead.
+
 ## [4.3.0](https://github.com/Amsterdam/design-system/compare/design-system-react-v4.2.0...design-system-react-v4.3.0) (2026-07-12)
 
 
@@ -49,6 +55,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 * **Breakout:** Apply the `as` prop instead of leaking it to the DOM ([#2736](https://github.com/Amsterdam/design-system/issues/2736)) ([03702b6](https://github.com/Amsterdam/design-system/commit/03702b6ed3d24f5d286a6f09253c40cce97a51de))
 * **Calendar, Date Picker:** Localise day numerals and the range boundary separator ([#2729](https://github.com/Amsterdam/design-system/issues/2729)) ([82e85ba](https://github.com/Amsterdam/design-system/commit/82e85ba67514bc2a069734f3e076fa074bdf6b7a))
+
+### Deprecations
+
+The following API has been deprecated and will be removed on or after 2027-01-10:
+
+- The `collapsed` prop of `ProgressList.Step`. Use `expanded` instead, which takes the opposite value.
+- The `defaultCollapsed` prop of `ProgressList.Step`. Use `defaultExpanded` instead, which takes the opposite value.
 
 ## [4.2.0](https://github.com/Amsterdam/design-system/compare/design-system-react-v4.1.0...design-system-react-v4.2.0) (2026-06-23)
 


### PR DESCRIPTION
## Links

- [Storybook on main](https://designsystem.amsterdam/)
- [Release policy](https://designsystem.amsterdam/demo-deprecations-in-changelogs/?path=/docs/docs-developer-guide-release-policy--docs), which sets out the deprecation process this PR follows. The page itself is unchanged.
- The release pull requests whose bodies now carry the same entries: [#2225](https://github.com/Amsterdam/design-system/pull/2225), [#2567](https://github.com/Amsterdam/design-system/pull/2567), [#2787](https://github.com/Amsterdam/design-system/pull/2787) and [#2926](https://github.com/Amsterdam/design-system/pull/2926).

## What

This adds six `### Deprecations` sections to four changelogs, each in the release section where the deprecation actually shipped. CSS 4.0.0 gains the two Page Header mega menu class names and Tokens 4.0.0 the two Page Header tokens, all removable on or after 2026-09-13. React 4.3.0 gains the `collapsed` and `defaultCollapsed` props of Progress List Step, removable on or after 2027-01-10. React 4.4.0 gains the `tagline` prop of Card Heading Group and Tokens 4.3.0 the three tokens the unused-token check turned up, all removable on or after 2027-02-08. Assets 1.1.0 gains the five icon SVGs that were deprecated for 2026-05-01.

A second commit corrects one token name in the Tokens 4.0.0 list: `ams.menu-link.wide.gap` becomes `ams.menu.link.wide.gap`. No token has ever been called `ams.menu-link.*`.

## Why

The release policy promises that all deprecations and removals are noted in the changelogs, and that promise is what starts a consumer’s six month migration window. Release-please only writes a Deprecations section when one of us adds it by hand, so these fifteen entries reached npm announced by nothing more than a JSDoc annotation or a `$deprecated` field in the token sources. Somebody reading the changelog, which is what the policy tells them to read, would not know the clock had started.

The Assets gap is the oldest of them. Assets publishes `icons/`, so those five SVGs are public API of that package, but only the React Icons changelog had ever listed them. Both packages shipped the same change in #2201 on 26 September 2025 as a Features line, and React Icons 1.1.1 added the Deprecations section a month later while Assets never did.

## How

Every entry was placed by checking the package tags to find the release each deprecation was actually present in, rather than the release where it was noticed. The wording follows the sections already in these files, and the sections sit last within their release, after Features and Bug Fixes, which is where the existing ones sit in these four packages.

The same six insertions were applied to the release PR bodies, so the changelogs and the release pull requests stay in step. Three further wrong token names in the Tokens 4.0.0 list of #2567 were corrected there as well; only the `ams.menu-link.wide.gap` one was in the file too, which is the second commit here.

Merging this produces no release. Both commits are chores, release-please hides chores from the changelog, and it skips any package whose release notes come out empty.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

Nothing rendered changes, so there is no visual regression to review.

There is no ticket for this yet. The gaps surfaced while compiling an overview of every deprecation by the date it may be removed, which also turned up fourteen deprecations that are now past their date and waiting for a major release.
