### PR TITLE
feat(Switch)!: Add a built-in label, placeable on either side

### DIFF
--- a/packages-proprietary/tokens/src/components/ams/switch.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/switch.tokens.json
@@ -2,13 +2,61 @@
   "ams": {
     "switch": {
       "background-color": {
-        "$value": "#767676",
-        "$type": "color"
+        "$deprecated": "Use `ams.switch.track.background-color` instead. Will be removed on or after 2027-02-13.",
+        "$value": "{ams.switch.track.background-color}",
+        "$extensions": {
+          "nl.amsterdam.type": "color"
+        }
+      },
+      "color": {
+        "$value": "{ams.color.text.default}",
+        "$extensions": {
+          "nl.amsterdam.type": "color"
+        }
       },
       "cursor": {
         "$value": "{ams.cursor.interactive}",
         "$extensions": {
           "nl.amsterdam.type": "cursor"
+        }
+      },
+      "font-family": {
+        "$value": "{ams.typography.font-family}",
+        "$extensions": {
+          "nl.amsterdam.type": "fontFamily"
+        }
+      },
+      "font-size": {
+        "$value": "{ams.typography.body-text.font-size}",
+        "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
+          "nl.amsterdam.type": "fontSize"
+        }
+      },
+      "font-weight": {
+        "$value": "{ams.typography.body-text.font-weight}",
+        "$extensions": {
+          "nl.amsterdam.type": "fontWeight"
+        }
+      },
+      "gap": {
+        "$value": "{ams.space.s}",
+        "$extensions": {
+          "nl.amsterdam.subtype": "space",
+          "nl.amsterdam.type": "dimension"
+        }
+      },
+      "inline-size": {
+        "$deprecated": "Use `ams.switch.track.inline-size` instead. Will be removed on or after 2027-02-13.",
+        "$value": "{ams.switch.track.inline-size}",
+        "$type": "dimension"
+      },
+      "line-height": {
+        "$value": "{ams.typography.body-text.line-height}",
+        "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
+          "nl.amsterdam.subtype": "lineHeight",
+          "nl.amsterdam.type": "number"
         }
       },
       "outline-offset": {
@@ -18,19 +66,72 @@
           "nl.amsterdam.type": "dimension"
         }
       },
-      "inline-size": {
-        "$value": {
-          "value": 3.5,
-          "unit": "rem"
-        },
-        "$type": "dimension"
+      "text-decoration-thickness": {
+        "$value": "{ams.links.text-decoration-thickness}",
+        "$extensions": {
+          "nl.amsterdam.subtype": "space",
+          "nl.amsterdam.type": "dimension"
+        }
+      },
+      "text-underline-offset": {
+        "$value": "{ams.links.text-underline-offset}",
+        "$extensions": {
+          "nl.amsterdam.subtype": "space",
+          "nl.amsterdam.type": "dimension"
+        }
       },
       "label": {
+        "border-width": {
+          "$deprecated": "Use `ams.switch.track.border-width` instead. Will be removed on or after 2027-02-13.",
+          "$value": "{ams.switch.track.border-width}",
+          "$extensions": {
+            "nl.amsterdam.type": "borderWidth"
+          }
+        }
+      },
+      "track": {
+        "background-color": {
+          "$value": "#767676",
+          "$type": "color"
+        },
         "border-width": {
           "$value": "{ams.border.width.m}",
           "$extensions": {
             "nl.amsterdam.hint": "Must be a single value: it is used in a calculation, which two values would invalidate.",
             "nl.amsterdam.type": "borderWidth"
+          }
+        },
+        "inline-size": {
+          "$value": {
+            "value": 3.5,
+            "unit": "rem"
+          },
+          "$type": "dimension"
+        },
+        "checked": {
+          "background-color": {
+            "$value": "{ams.color.interactive.default}",
+            "$extensions": {
+              "nl.amsterdam.type": "color"
+            }
+          }
+        },
+        "disabled": {
+          "background-color": {
+            "$value": "#d1d1d1",
+            "$description": "A lighter grey than the default track, so a disabled switch reads as distinct from an enabled one.",
+            "$extensions": {
+              "nl.amsterdam.type": "color"
+            }
+          }
+        }
+      },
+      "track-container": {
+        "block-size": {
+          "$value": "calc({ams.switch.font-size} * {ams.switch.line-height})",
+          "$description": "One line of label text, so the track centres on the first line when the label wraps.",
+          "$extensions": {
+            "nl.amsterdam.type": "dimension"
           }
         }
       },
@@ -88,7 +189,8 @@
       },
       "checked": {
         "background-color": {
-          "$value": "{ams.color.interactive.default}",
+          "$deprecated": "Use `ams.switch.track.checked.background-color` instead. Will be removed on or after 2027-02-13.",
+          "$value": "{ams.switch.track.checked.background-color}",
           "$extensions": {
             "nl.amsterdam.type": "color"
           }
@@ -96,8 +198,14 @@
       },
       "disabled": {
         "background-color": {
-          "$value": "#d1d1d1",
-          "$description": "A lighter grey than the default track, so a disabled switch reads as distinct from an enabled one.",
+          "$deprecated": "Use `ams.switch.track.disabled.background-color` instead. Will be removed on or after 2027-02-13.",
+          "$value": "{ams.switch.track.disabled.background-color}",
+          "$extensions": {
+            "nl.amsterdam.type": "color"
+          }
+        },
+        "color": {
+          "$value": "{ams.color.interactive.disabled}",
           "$extensions": {
             "nl.amsterdam.type": "color"
           }
@@ -106,6 +214,20 @@
           "$value": "{ams.cursor.disabled}",
           "$extensions": {
             "nl.amsterdam.type": "cursor"
+          }
+        }
+      },
+      "hover": {
+        "color": {
+          "$value": "{ams.color.interactive.hover}",
+          "$extensions": {
+            "nl.amsterdam.type": "color"
+          }
+        },
+        "text-decoration-line": {
+          "$value": "{ams.links.subtle.hover.text-decoration-line}",
+          "$extensions": {
+            "nl.amsterdam.type": "textDecorationLine"
           }
         }
       }

--- a/packages-proprietary/tokens/src/components/ams/switch.tokens.json
+++ b/packages-proprietary/tokens/src/components/ams/switch.tokens.json
@@ -69,6 +69,7 @@
       "text-decoration-thickness": {
         "$value": "{ams.links.text-decoration-thickness}",
         "$extensions": {
+          "nl.amsterdam.hint": "Must be a single value: it sets a longhand property, which takes only one.",
           "nl.amsterdam.subtype": "space",
           "nl.amsterdam.type": "dimension"
         }

--- a/packages/css/src/components/switch/switch.scss
+++ b/packages/css/src/components/switch/switch.scss
@@ -5,6 +5,8 @@
 
 @use "../../common/input-label-focus" as *;
 @use "../../common/hide-input" as *;
+@use "../../common/hyphenation" as *;
+@use "../../common/text-rendering" as *;
 
 .ams-switch__input {
   @include hide-input;
@@ -12,26 +14,54 @@
 }
 
 .ams-switch__label {
-  // The effective border width, shared by the track border and the thumb offset. Floored in forced colors mode below.
-  --_ams-switch-label-border-width: var(--ams-switch-label-border-width);
+  color: var(--ams-switch-color);
+  cursor: var(--ams-switch-cursor);
+  display: inline-flex;
+  flex-wrap: nowrap;
+  font-family: var(--ams-switch-font-family);
+  font-size: var(--ams-switch-font-size);
+  font-weight: var(--ams-switch-font-weight);
+  gap: var(--ams-switch-gap);
+  line-height: var(--ams-switch-line-height);
+  outline-offset: var(--ams-switch-outline-offset);
+  text-decoration-thickness: var(--ams-switch-text-decoration-thickness);
+  text-underline-offset: var(--ams-switch-text-underline-offset);
 
-  background-color: var(--ams-switch-background-color);
+  @include hyphenation;
+  @include text-rendering;
+}
+
+.ams-switch__track-container {
+  align-items: center;
+  block-size: var(--ams-switch-track-container-block-size);
+  display: flex;
+  flex: none;
+  flex-wrap: nowrap;
+}
+
+.ams-switch__track {
+  // The effective border width, shared by the track border and the thumb offset. Floored in forced colors mode below.
+  --_ams-switch-track-border-width: var(
+    --ams-switch-label-border-width /* @deprecated */,
+    var(--ams-switch-track-border-width)
+  );
+
+  background-color: var(--ams-switch-background-color /* @deprecated */, var(--ams-switch-track-background-color));
 
   // Using a transparent border to make sure the component is visible in forced colors mode.
   border-color: transparent;
   border-radius: calc(var(--ams-switch-thumb-inline-size) * 2);
   border-style: solid;
-  border-width: var(--_ams-switch-label-border-width);
+  border-width: var(--_ams-switch-track-border-width);
   box-sizing: border-box;
-  cursor: var(--ams-switch-cursor);
-  display: inline-block;
-  inline-size: var(--ams-switch-inline-size);
-  outline-offset: var(--ams-switch-outline-offset);
-  vertical-align: middle;
+  inline-size: var(--ams-switch-inline-size /* @deprecated */, var(--ams-switch-track-inline-size));
 
   // Keep at least 1px so a token set to 0 can’t hide the border.
   @media (forced-colors: active) {
-    --_ams-switch-label-border-width: max(1px, var(--ams-switch-label-border-width));
+    --_ams-switch-track-border-width: max(
+      1px,
+      var(--ams-switch-label-border-width /* @deprecated */, var(--ams-switch-track-border-width))
+    );
   }
 
   @media (prefers-reduced-motion: no-preference) {
@@ -39,9 +69,9 @@
   }
 }
 
-.ams-switch__label::before {
+.ams-switch__track::before {
   // The distance the thumb slides when the switch is checked.
-  --_ams-switch-thumb-translate: calc(100% - 2 * var(--_ams-switch-label-border-width));
+  --_ams-switch-thumb-translate: calc(100% - 2 * var(--_ams-switch-track-border-width));
 
   background-color: var(--ams-switch-thumb-background-color);
   block-size: var(--ams-switch-thumb-block-size);
@@ -61,27 +91,47 @@
   }
 }
 
+// Checked
 .ams-switch__input:checked + .ams-switch__label {
-  background-color: var(--ams-switch-checked-background-color);
-}
+  .ams-switch__track {
+    background-color: var(
+      --ams-switch-checked-background-color /* @deprecated */,
+      var(--ams-switch-track-checked-background-color)
+    );
+  }
 
-.ams-switch__input:disabled + .ams-switch__label {
-  background-color: var(--ams-switch-disabled-background-color);
-  cursor: var(--ams-switch-disabled-cursor);
-}
-
-.ams-switch__input:checked + .ams-switch__label::before {
-  transform: translate(var(--_ams-switch-thumb-translate));
+  .ams-switch__track::before {
+    transform: translate(var(--_ams-switch-thumb-translate));
+  }
 }
 
 // `translate` is physical, so the checked thumb always moves to the right. Reverse it in right-to-left
 // contexts so it travels to the inline end (the left) instead.
-.ams-switch__input:checked + .ams-switch__label:dir(rtl)::before {
+.ams-switch__input:checked + .ams-switch__label:dir(rtl) .ams-switch__track::before {
   transform: translate(calc(-1 * var(--_ams-switch-thumb-translate)));
 }
 
+// Disabled
+.ams-switch__input:disabled + .ams-switch__label {
+  color: var(--ams-switch-disabled-color);
+  cursor: var(--ams-switch-disabled-cursor);
+
+  .ams-switch__track {
+    background-color: var(
+      --ams-switch-disabled-background-color /* @deprecated */,
+      var(--ams-switch-track-disabled-background-color)
+    );
+  }
+}
+
+// Default hover
 @media (hover: hover) {
-  .ams-switch:hover .ams-switch__input:enabled + .ams-switch__label::before {
-    box-shadow: var(--ams-switch-thumb-hover-box-shadow);
+  .ams-switch__input:enabled + .ams-switch__label:hover {
+    color: var(--ams-switch-hover-color);
+    text-decoration-line: var(--ams-switch-hover-text-decoration-line);
+
+    .ams-switch__track::before {
+      box-shadow: var(--ams-switch-thumb-hover-box-shadow);
+    }
   }
 }

--- a/packages/react/src/Switch/Switch.test.tsx
+++ b/packages/react/src/Switch/Switch.test.tsx
@@ -19,6 +19,38 @@ describe('Switch', () => {
     expect(switchElement).not.toBeChecked()
   })
 
+  it('takes its accessible name from its children', () => {
+    render(<Switch>Meldingen ontvangen</Switch>)
+
+    expect(screen.getByRole('switch', { name: 'Meldingen ontvangen' })).toBeInTheDocument()
+  })
+
+  it('renders the label text after the track', () => {
+    render(<Switch>Meldingen ontvangen</Switch>)
+
+    const label = screen.getByText('Meldingen ontvangen')
+
+    expect(label.firstElementChild).toHaveClass('ams-switch__track-container')
+  })
+
+  it('renders the label text before the track', () => {
+    render(<Switch labelPosition="start">Meldingen ontvangen</Switch>)
+
+    const label = screen.getByText('Meldingen ontvangen')
+
+    expect(label.lastElementChild).toHaveClass('ams-switch__track-container')
+  })
+
+  it('triggers a change event when clicking its own label text', () => {
+    const handleChange = vi.fn()
+
+    render(<Switch onChange={handleChange}>Meldingen ontvangen</Switch>)
+
+    screen.getByText('Meldingen ontvangen').click()
+
+    expect(handleChange).toHaveBeenCalled()
+  })
+
   it('is not disabled by default', () => {
     render(<Switch />)
 

--- a/packages/react/src/Switch/Switch.tsx
+++ b/packages/react/src/Switch/Switch.tsx
@@ -8,7 +8,15 @@ import type { ForwardedRef, InputHTMLAttributes, PropsWithChildren } from 'react
 import { clsx } from 'clsx'
 import { forwardRef, useId } from 'react'
 
-export type SwitchProps = PropsWithChildren<InputHTMLAttributes<HTMLInputElement>>
+export const switchLabelPositions = ['start', 'end'] as const
+
+export type SwitchProps = {
+  /**
+   * Which side of the switch to put the label on.
+   * @default end
+   */
+  readonly labelPosition?: (typeof switchLabelPositions)[number]
+} & Readonly<PropsWithChildren<Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>>>
 
 /**
  * Toggles a binary setting immediately, without requiring form submission.
@@ -16,14 +24,22 @@ export type SwitchProps = PropsWithChildren<InputHTMLAttributes<HTMLInputElement
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-forms-switch--docs Switch docs at Amsterdam Design System}
  */
 export const Switch = forwardRef(
-  ({ className, id, ...restProps }: SwitchProps, ref: ForwardedRef<HTMLInputElement>) => {
+  ({ children, className, id, labelPosition, ...restProps }: SwitchProps, ref: ForwardedRef<HTMLInputElement>) => {
     const generatedId = useId()
     const inputId = id || generatedId
 
     return (
+      // This div is here because NVDA doesn't match the input to the label
+      // without a containing element
       <div className={clsx('ams-switch', className)}>
         <input {...restProps} className="ams-switch__input" id={inputId} ref={ref} role="switch" type="checkbox" />
-        <label className="ams-switch__label" htmlFor={inputId}></label>
+        <label className="ams-switch__label" htmlFor={inputId}>
+          {labelPosition === 'start' && children}
+          <span className="ams-switch__track-container">
+            <span className="ams-switch__track" />
+          </span>
+          {labelPosition !== 'start' && children}
+        </label>
       </div>
     )
   },

--- a/storybook/src/components/Switch/Switch.docs.mdx
+++ b/storybook/src/components/Switch/Switch.docs.mdx
@@ -73,7 +73,7 @@ Hovering puts a shadow around the thumb rather than moving or resizing it.
 
 A Switch renders a checkbox marked as a switch, so it is announced as on or off rather than as checked or unchecked, and it is operated with Space like any other checkbox.
 
-The input sits inside a `label` that holds both the track and the text, so the whole label is the target and the text is the accessible name.
+The input is associated with a `label` that holds both the track and the text, so the whole label is the target and the text is the accessible name.
 Placing the label before the switch moves it in the markup as well, so what a screen reader reads matches what the page shows.
 
 Without children a Switch has no name of its own.

--- a/storybook/src/components/Switch/Switch.docs.mdx
+++ b/storybook/src/components/Switch/Switch.docs.mdx
@@ -27,26 +27,34 @@ The action takes place immediately when the user operates the switch.
 
 ### How to use
 
-A Switch must have a label, and in most cases, this label should be visible.
+Give a Switch a label by passing it as its children.
+The label names the setting the Switch controls, not the state it is in: the Switch announces on or off by itself.
 
 ## Examples
 
+### Label before the switch
+
+Put the label on the leading side when the design calls for it, for example to line several Switches up on the same edge.
+
+<Canvas of={SwitchStories.LabelBeforeTheSwitch} />
+
 ### Disabled
 
-A disabled Switch turns its track a light grey and stops responding to the pointer.
+A disabled Switch turns its track a light grey, greys out its label and stops responding to the pointer.
 That grey replaces the colour of both settings, so the position of the thumb is the only thing that still distinguishes on from off.
 Turn on `checked` to compare the two.
 
 <Canvas of={SwitchStories.Disabled} />
 
-### With Label
-
-<Canvas of={SwitchStories.WithLabel} />
-
 ## Design
 
-The track and the thumb are the whole of a Switch: a rounded bar with a circle that slides from one end to the other, and a colour change behind it.
+The track and the thumb are the whole of the control: a rounded bar with a circle that slides from one end to the other, and a colour change behind it.
 There is no text inside it, so it needs no room for words in either state and stays the same width whichever way it is set.
+
+The label is body text beside the track, the same as a [Checkbox](/docs/components-forms-checkbox--docs) or [Radio](/docs/components-forms-radio--docs) label, so a Switch sits among them without standing out.
+Hovering underlines that text, which is how the other two announce the whole label is the target.
+
+The track sits in a box one line of text tall, so it centres on the first line and stays there when the label wraps.
 
 The thumb moves by exactly the width of the track minus its borders, so it comes to rest flush against the end rather than at a distance measured separately for each size.
 
@@ -65,11 +73,14 @@ Hovering puts a shadow around the thumb rather than moving or resizing it.
 
 A Switch renders a checkbox marked as a switch, so it is announced as on or off rather than as checked or unchecked, and it is operated with Space like any other checkbox.
 
-The visible track is an empty `label` that supplies no name.
-A Switch therefore takes its name from a [Label](/docs/components-forms-label--docs) tied to it with `htmlFor`, which is what ‘How to use’ asks for; without one it is announced as an unnamed switch.
+The input sits inside a `label` that holds both the track and the text, so the whole label is the target and the text is the accessible name.
+Placing the label before the switch moves it in the markup as well, so what a screen reader reads matches what the page shows.
+
+Without children a Switch has no name of its own.
+Give it one with a [Label](/docs/components-forms-label--docs) tied to it with `htmlFor`, or it is announced as an unnamed switch.
 
 The input is not hidden away: it is reduced to no width, which keeps it focusable, announced, and submitted with the form.
-Its focus ring is moved onto the track so the ring surrounds the switch rather than a control with no size.
+Its focus ring is moved onto the label so the ring surrounds the track and its text rather than a control with no size.
 
 ## See also
 

--- a/storybook/src/components/Switch/Switch.stories.tsx
+++ b/storybook/src/components/Switch/Switch.stories.tsx
@@ -60,13 +60,6 @@ export const LabelBeforeTheSwitch: Story = {
   },
 }
 
-export const LongLabel: Story = {
-  args: {
-    children:
-      'Stuur mij een bericht zodra er een besluit is genomen over mijn aanvraag, ook buiten kantooruren en in het weekend.',
-  },
-}
-
 export const Disabled: Story = {
   args: {
     disabled: true,

--- a/storybook/src/components/Switch/Switch.stories.tsx
+++ b/storybook/src/components/Switch/Switch.stories.tsx
@@ -6,22 +6,32 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import type { MouseEvent } from 'react'
 
-import { Label } from '@amsterdam/design-system-react'
 import { Switch } from '@amsterdam/design-system-react/src'
+import { switchLabelPositions } from '@amsterdam/design-system-react/src/Switch/Switch'
 import { useArgs } from 'storybook/preview-api'
 
-import { checkedArgType, disabledArgType } from '#storybook/_common/argTypes'
+import { checkedArgType, childrenArgType, disabledArgType, idArgType } from '#storybook/_common/argTypes'
 
 const meta = {
   title: 'Components/Forms/Switch',
   component: Switch,
   args: {
     checked: false,
+    children: 'Meldingen ontvangen',
     disabled: false,
   },
   argTypes: {
     checked: checkedArgType,
+    children: childrenArgType('The text for the label.'),
     disabled: disabledArgType,
+    id: idArgType,
+    labelPosition: {
+      control: {
+        labels: { undefined: 'end (default)' },
+        type: 'radio',
+      },
+      options: [undefined, ...switchLabelPositions.filter((position) => position !== 'end')],
+    },
     onChange: {
       action: 'changed',
       table: { disable: false },
@@ -44,32 +54,21 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
-export const Disabled: Story = {
+export const LabelBeforeTheSwitch: Story = {
   args: {
-    disabled: true,
+    labelPosition: 'start',
   },
 }
 
-export const WithLabel: Story = {
-  decorators: [
-    (Story) => (
-      <div style={{ alignItems: 'center', display: 'flex', gap: '5rem' }}>
-        <Story />
-      </div>
-    ),
-  ],
-  render: (args) => {
-    const [, setArgs] = useArgs()
+export const LongLabel: Story = {
+  args: {
+    children:
+      'Stuur mij een bericht zodra er een besluit is genomen over mijn aanvraag, ook buiten kantooruren en in het weekend.',
+  },
+}
 
-    const handleClick = (event: MouseEvent<HTMLInputElement>) => {
-      setArgs({ checked: event.currentTarget.checked })
-    }
-
-    return (
-      <>
-        <Label htmlFor="switch-with-label">Label</Label>
-        <Switch onClick={handleClick} {...args} id="switch-with-label" />
-      </>
-    )
+export const Disabled: Story = {
+  args: {
+    disabled: true,
   },
 }

--- a/storybook/src/components/Switch/Switch.test.stories.tsx
+++ b/storybook/src/components/Switch/Switch.test.stories.tsx
@@ -7,7 +7,6 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Switch } from '@amsterdam/design-system-react/src'
 
-import { disablePageLevelChecks } from '#storybook/_common/disablePageLevelChecks'
 import { renderComponentVariants } from '#storybook/_common/renderComponentVariants'
 
 import { default as switchMeta } from './Switch.stories'
@@ -22,7 +21,6 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Test: Story = {
-  parameters: disablePageLevelChecks('label'),
-  render: (args, context) => renderComponentVariants(Switch, { args }, context),
+  render: (args, context) => renderComponentVariants(Switch, { args, variants: ['disabled'] }, context),
   tags: ['!dev', '!autodocs', '!manifest'],
 }

--- a/storybook/src/modes/lo-fi/Forms.test.stories.tsx
+++ b/storybook/src/modes/lo-fi/Forms.test.stories.tsx
@@ -124,7 +124,7 @@ export const Test: Story = {
           <Checkbox invalid>Evenementen</Checkbox>
         </Field>
         <Field>
-          <Switch defaultChecked />
+          <Switch defaultChecked>Ook per e-mail</Switch>
         </Field>
       </FieldSet>
     </div>


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# feat(Switch)!: Add a built-in label, placeable on either side

## Note

This draft PR represents research for a possible new visual design for Switch. It is by no means final.

## Links

- [Switch stories in the feature branch deploy](https://designsystem.amsterdam/demo-DES-1917-switch-with-label-redesign/?path=/docs/components-forms-switch--docs) (add link once deployed)
- [Current Switch docs](https://designsystem.amsterdam/?path=/docs/components-forms-switch--docs)
- Ticket ID: DES-1917

## What

- Switch renders its own label from `children`, wrapping the track and the text in one `label` element the way Checkbox and Radio do.
- New `labelPosition?: 'start' | 'end'` prop (default `end`) puts the label on either side of the track.
- The track moves out of `.ams-switch__label` into its own `.ams-switch__track`, inside a `.ams-switch__track-container` sized to one line of text.
- Track-related design tokens move under `ams.switch.track.*`; the old names stay as deprecated aliases.
- The `WithLabel` story and its wrapping `div` with a hardcoded `5rem` gap are gone, replaced by `LabelBeforeTheSwitch`.

**Breaking:** `.ams-switch__label` used to be the track and is now the label wrapper. Anyone hooking into that class outside the React component gets label styling where they expected a track. Design tokens and CSS custom properties are *not* breaking — every renamed one keeps working through a deprecated alias.

## Why

A Switch had no label of its own, so it had to borrow the `Label` component through `htmlFor`. `Label` is block-level and bold — right above a text input, too heavy beside a switch. It also left the spacing to the consumer, which is why the story needed a flex wrapper with a `5rem` gap to look presentable.

Checkbox and Radio already solve this: the label element holds both the control's visual and its text, in body copy. Switch now matches them, so the three read as one family in a form and a Switch no longer needs any external layout to be usable.

## How

- `SwitchProps` now renders `children` (it accepted them via `PropsWithChildren` but silently dropped them) and omits `type` from the inherited input attributes, matching `CheckboxProps` and `RadioProps`.
- `labelPosition` reorders the DOM rather than reversing with CSS, so reading order always matches visual order and no modifier class is needed.
- `.ams-switch__label` picks up the Checkbox/Radio typography set: font, gap, hover underline, disabled colour, `hyphenation` and `text-rendering`.
- `.ams-switch__track-container` is one line of text tall with `align-items: center`, mirroring `.ams-checkbox__icon-container`, so the track centres on the first line and stays there when a long label wraps.
- Hover moved from `.ams-switch:hover` to `.ams-switch__label:hover`, now that the block contains text.
- Renamed tokens keep the established deprecation pattern: `$deprecated` aliases forwarding to the new names (removable on or after 2027-02-13), read in SCSS as `var(--old /* @deprecated */, var(--new))`.
- The test story dropped `disablePageLevelChecks('label')` — like Checkbox and Radio, its variants now have accessible names — and gained the `disabled` variant.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- `switchLabelPositions` is exported from `Switch.tsx` but deliberately not from the barrel, following `rowGapSizes` and `rowTags`. No `index.*` changes were needed.
- Chromatic will show diffs for every Switch snapshot: the labels are new, and the `disabled` variant was added to the test story.
- The track is `2rem` tall against a line box of `1.8rem` at narrow viewports (they match exactly at 1440px), so it overflows its container by roughly 1.6px top and bottom. I chose that over shrinking the track to keep the baseline aligned with a Checkbox in the same Column — worth a design opinion.
- The lo-fi Forms test story had a `Switch` with no label at all; it now has one.
- `pnpm run lint` and `pnpm run test` both pass locally.
