### PR TITLE
chore: Warn instead of failing when cleanup hits the delete cap

### DIFF
--- a/.github/scripts/cleanup_common.py
+++ b/.github/scripts/cleanup_common.py
@@ -69,3 +69,16 @@ def get_required_env(name: str) -> str:
     if not value:
         raise ValueError(f"required environment variable is missing: {name}")
     return value
+
+
+def emit_warning(message: str, *, title: str) -> None:
+    """Report a warning without failing the job.
+
+    On GitHub Actions this is a `::warning::` workflow command, which shows up as
+    a yellow annotation on the run. Elsewhere it is a plain line on stdout.
+    """
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        escaped = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+        print(f"::warning title={title}::{escaped}")
+    else:
+        print(f"WARNING: {message}")

--- a/.github/scripts/cleanup_deployments.py
+++ b/.github/scripts/cleanup_deployments.py
@@ -261,9 +261,16 @@ def main() -> int:
         return 0
 
     if exceeds_delete_cap(obsolete_deployments, i_really_mean_it=args.i_really_mean_it):
+        # Lifting the cap alone would not change a dry run, which deletes
+        # nothing either way, so tell that reader to turn dry-run mode off too.
+        rerun_with = (
+            "dry_run=false and i_really_mean_it=true (--no-dry-run --i-really-mean-it)"
+            if args.dry_run
+            else "i_really_mean_it=true (--i-really-mean-it)"
+        )
         message = (
             f"Selected {len(obsolete_deployments)} deployments, over the cap of {MAX_DELETES}. "
-            "Re-run with --i-really-mean-it to remove them."
+            f"Re-run with {rerun_with} to remove them."
         )
         # A dry run deletes nothing, so the cap is a heads-up rather than a
         # failure: warn, then fall through to list the candidates. A real run

--- a/.github/scripts/cleanup_deployments.py
+++ b/.github/scripts/cleanup_deployments.py
@@ -23,7 +23,7 @@ Safety guards:
 - Aborts if the branch list comes back empty (likely API/auth issue;
   proceeding could target all demo-* deployments).
 - Aborts if more than MAX_DELETES are slated for deletion, unless
-  --i-really-mean-it is passed.
+  --i-really-mean-it is passed. A dry run only warns, since it deletes nothing.
 - Candidate selection uses branch matching and stale_days filtering.
 - Production candidates are pre-filtered by deployment state to skip any
   currently-live, in-progress, queued, or pending deployment.
@@ -38,6 +38,7 @@ import requests
 
 from cleanup_common import (
     build_session,
+    emit_warning,
     fetch_branch_short_names,
     get_required_env,
     paginate,
@@ -122,17 +123,12 @@ def select_obsolete_deployments(
     return selected
 
 
-def enforce_delete_cap(
+def exceeds_delete_cap(
     to_delete: list[tuple[int, str, datetime.datetime | None]],
     *,
     i_really_mean_it: bool,
-) -> None:
-    if len(to_delete) <= MAX_DELETES or i_really_mean_it:
-        return
-    raise RuntimeError(
-        f"would delete {len(to_delete)} deployments (cap is {MAX_DELETES}). "
-        "Re-run with --i-really-mean-it to override."
-    )
+) -> bool:
+    return len(to_delete) > MAX_DELETES and not i_really_mean_it
 
 
 def delete_obsolete_deployments(
@@ -264,13 +260,20 @@ def main() -> int:
         print("No deployments to delete.")
         return 0
 
-    try:
-        enforce_delete_cap(obsolete_deployments, i_really_mean_it=args.i_really_mean_it)
-    except RuntimeError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
-        for deployment_id, environment, _ in obsolete_deployments:
-            print(f"  - deployment {deployment_id} ({environment})", file=sys.stderr)
-        return 2
+    if exceeds_delete_cap(obsolete_deployments, i_really_mean_it=args.i_really_mean_it):
+        message = (
+            f"Selected {len(obsolete_deployments)} deployments, over the cap of {MAX_DELETES}. "
+            "Re-run with --i-really-mean-it to remove them."
+        )
+        # A dry run deletes nothing, so the cap is a heads-up rather than a
+        # failure: warn, then fall through to list the candidates. A real run
+        # still fails, because the deletions the caller asked for did not happen.
+        if not args.dry_run:
+            print(f"ERROR: {message}", file=sys.stderr)
+            for deployment_id, environment, _ in obsolete_deployments:
+                print(f"  - deployment {deployment_id} ({environment})", file=sys.stderr)
+            return 2
+        emit_warning(message, title="Delete cap exceeded")
 
     failures = delete_obsolete_deployments(session, api, obsolete_deployments, dry_run=args.dry_run)
     if failures:

--- a/.github/scripts/cleanup_environments.py
+++ b/.github/scripts/cleanup_environments.py
@@ -157,9 +157,16 @@ def main() -> int:
         return 0
 
     if exceeds_delete_cap(obsolete_envs, i_really_mean_it=args.i_really_mean_it):
+        # Lifting the cap alone would not change a dry run, which deletes
+        # nothing either way, so tell that reader to turn dry-run mode off too.
+        rerun_with = (
+            "dry_run=false and i_really_mean_it=true (--no-dry-run --i-really-mean-it)"
+            if args.dry_run
+            else "i_really_mean_it=true (--i-really-mean-it)"
+        )
         message = (
             f"Selected {len(obsolete_envs)} environments, over the cap of {MAX_DELETES}. "
-            "Re-run with --i-really-mean-it to remove them."
+            f"Re-run with {rerun_with} to remove them."
         )
         # A dry run deletes nothing, so the cap is a heads-up rather than a
         # failure: warn, then fall through to list the candidates. A real run

--- a/.github/scripts/cleanup_environments.py
+++ b/.github/scripts/cleanup_environments.py
@@ -15,7 +15,7 @@ Safety guards:
 - Aborts if the branch list comes back empty (likely an API/auth issue;
   proceeding would delete every demo-* environment).
 - Aborts if more than MAX_DELETES are slated for deletion, unless
-  --i-really-mean-it is passed.
+  --i-really-mean-it is passed. A dry run only warns, since it deletes nothing.
 """
 from __future__ import annotations
 
@@ -28,6 +28,7 @@ import requests
 
 from cleanup_common import (
     build_session,
+    emit_warning,
     fetch_branch_short_names,
     get_required_env,
     paginate,
@@ -75,17 +76,12 @@ def select_obsolete_envs(
     return selected
 
 
-def enforce_delete_cap(
+def exceeds_delete_cap(
     to_delete: list[tuple[str, datetime.datetime | None]],
     *,
     i_really_mean_it: bool,
-) -> None:
-    if len(to_delete) <= MAX_DELETES or i_really_mean_it:
-        return
-    raise RuntimeError(
-        f"would delete {len(to_delete)} environments (cap is {MAX_DELETES}). "
-        "Re-run with --i-really-mean-it to override."
-    )
+) -> bool:
+    return len(to_delete) > MAX_DELETES and not i_really_mean_it
 
 
 def delete_obsolete_envs(
@@ -160,13 +156,20 @@ def main() -> int:
         print("No environments to delete.")
         return 0
 
-    try:
-        enforce_delete_cap(obsolete_envs, i_really_mean_it=args.i_really_mean_it)
-    except RuntimeError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
-        for name, _ in obsolete_envs:
-            print(f"  - {name}", file=sys.stderr)
-        return 2
+    if exceeds_delete_cap(obsolete_envs, i_really_mean_it=args.i_really_mean_it):
+        message = (
+            f"Selected {len(obsolete_envs)} environments, over the cap of {MAX_DELETES}. "
+            "Re-run with --i-really-mean-it to remove them."
+        )
+        # A dry run deletes nothing, so the cap is a heads-up rather than a
+        # failure: warn, then fall through to list the candidates. A real run
+        # still fails, because the deletions the caller asked for did not happen.
+        if not args.dry_run:
+            print(f"ERROR: {message}", file=sys.stderr)
+            for name, _ in obsolete_envs:
+                print(f"  - {name}", file=sys.stderr)
+            return 2
+        emit_warning(message, title="Delete cap exceeded")
 
     failures = delete_obsolete_envs(session, api, obsolete_envs, dry_run=args.dry_run)
     if failures:

--- a/.github/scripts/cleanup_gh_pages_demos.sh
+++ b/.github/scripts/cleanup_gh_pages_demos.sh
@@ -16,6 +16,9 @@ shopt -s nullglob
 # - STALE_DAYS (default: 0)
 # - I_REALLY_MEAN_IT (default: false)
 #
+# More than MAX_DELETES stale directories aborts a real run, but only warns
+# during a dry run, which removes nothing anyway.
+#
 # Dry run example:
 # DRY_RUN=true I_REALLY_MEAN_IT=false .github/scripts/cleanup_gh_pages_demos.sh
 # 
@@ -28,6 +31,18 @@ DRY_RUN="${DRY_RUN:-true}"
 STALE_DAYS="${STALE_DAYS:-0}"
 I_REALLY_MEAN_IT="${I_REALLY_MEAN_IT:-false}"
 readonly MAX_DELETES=25
+
+emit_warning() {
+  local title="$1"
+  local message="$2"
+  # On GitHub Actions this shows up as a yellow annotation without failing the
+  # job; elsewhere it is a plain line on stdout.
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    echo "::warning title=${title}::${message}"
+  else
+    echo "WARNING: ${message}"
+  fi
+}
 
 validate_non_negative_int() {
   local name="$1"
@@ -162,9 +177,18 @@ enforce_delete_cap() {
     return
   fi
 
+  local message="Selected ${#OBSOLETE_DIRS[@]} demo directories, over the cap of ${MAX_DELETES}. Re-run with i_really_mean_it=true to remove them."
+
+  # A dry run removes nothing, so the cap is a heads-up rather than a failure:
+  # warn and let the listing below run. A real run still stops, because the
+  # deletions the caller asked for did not happen.
+  if [ "$DRY_RUN" = "true" ]; then
+    emit_warning "Delete cap exceeded" "$message"
+    return
+  fi
+
   local dir
-  echo "ERROR: would delete ${#OBSOLETE_DIRS[@]} directories (cap is ${MAX_DELETES})." >&2
-  echo "Re-run with i_really_mean_it=true to override." >&2
+  echo "ERROR: ${message}" >&2
   for dir in "${OBSOLETE_DIRS[@]}"; do
     echo "  - ${dir}" >&2
   done

--- a/.github/scripts/cleanup_gh_pages_demos.sh
+++ b/.github/scripts/cleanup_gh_pages_demos.sh
@@ -177,7 +177,17 @@ enforce_delete_cap() {
     return
   fi
 
-  local message="Selected ${#OBSOLETE_DIRS[@]} demo directories, over the cap of ${MAX_DELETES}. Re-run with i_really_mean_it=true to remove them."
+  # Lifting the cap alone would not change a dry run, which removes nothing
+  # either way, so tell that reader to turn dry-run mode off too. Both spellings
+  # are given: workflow inputs first, then the variables this script reads.
+  local rerun_with
+  if [ "$DRY_RUN" = "true" ]; then
+    rerun_with="dry_run=false and i_really_mean_it=true (DRY_RUN=false I_REALLY_MEAN_IT=true)"
+  else
+    rerun_with="i_really_mean_it=true (I_REALLY_MEAN_IT=true)"
+  fi
+
+  local message="Selected ${#OBSOLETE_DIRS[@]} demo directories, over the cap of ${MAX_DELETES}. Re-run with ${rerun_with} to remove them."
 
   # A dry run removes nothing, so the cap is a heads-up rather than a failure:
   # warn and let the listing below run. A real run still stops, because the

--- a/.github/workflows/remove-stale-demo-directories.yml
+++ b/.github/workflows/remove-stale-demo-directories.yml
@@ -25,7 +25,8 @@
 # kept. `0` disables age filtering.
 #
 # Safety guard: if more than 25 stale demo directories are selected, the job
-# aborts unless `i_really_mean_it=true` is provided for manual runs.
+# aborts unless `i_really_mean_it=true` is provided. A dry run removes nothing,
+# so there the cap is reported as a warning annotation and the job stays green.
 
 name: Remove stale demo directories
 

--- a/.github/workflows/remove-stale-demo-directories.yml
+++ b/.github/workflows/remove-stale-demo-directories.yml
@@ -34,15 +34,15 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "If true, only log what would be deleted."
+        description: 'Dry run (dry_run) — "true" only logs what would be deleted; "false" performs the deletions.'
         required: false
         default: "true"
       stale_days:
-        description: "Only delete directories not updated in this many days (0 = ignore age)."
+        description: 'Minimum age (stale_days) — keep directories updated within this many days; "0" ignores age.'
         required: false
         default: "0"
       i_really_mean_it:
-        description: "Allow deleting more than 25 directories in one run."
+        description: 'Lift safety cap (i_really_mean_it) — "true" allows deleting more than 25 directories in one run.'
         required: false
         default: "false"
   release:

--- a/.github/workflows/remove-stale-deployments.yml
+++ b/.github/workflows/remove-stale-deployments.yml
@@ -17,6 +17,10 @@
 #
 # The default `dry_run=true` only logs what would be deleted.
 # Pass `dry_run=false` from the Actions UI to perform deletions.
+#
+# Selecting more than 25 deployments aborts a real run unless
+# `i_really_mean_it=true` is passed. A dry run deletes nothing, so there the cap
+# is reported as a warning annotation and the job stays green.
 
 name: Remove stale deployments
 

--- a/.github/workflows/remove-stale-deployments.yml
+++ b/.github/workflows/remove-stale-deployments.yml
@@ -28,19 +28,19 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "If true, only log what would be deleted."
+        description: 'Dry run (dry_run) — "true" only logs what would be deleted; "false" performs the deletions.'
         required: false
         default: "true"
       stale_days:
-        description: "Only delete deployments not updated in this many days (0 = ignore age)."
+        description: 'Minimum age (stale_days) — keep deployments updated within this many days; "0" ignores age.'
         required: false
         default: "0"
       include_production:
-        description: "Also clean github-pages and demo-develop deployments. Off by default."
+        description: 'Include production (include_production) — "true" also cleans the github-pages and demo-develop deployments.'
         required: false
         default: "false"
       i_really_mean_it:
-        description: "Allow deleting more than 25 deployments in one run."
+        description: 'Lift safety cap (i_really_mean_it) — "true" allows deleting more than 25 deployments in one run.'
         required: false
         default: "false"
   schedule:

--- a/.github/workflows/remove-stale-environments.yml
+++ b/.github/workflows/remove-stale-environments.yml
@@ -11,6 +11,10 @@
 #
 # The default `dry_run=true` only logs what would be deleted. Pass
 # `dry_run=false` from the Actions UI to perform the deletions.
+#
+# Selecting more than 25 environments aborts a real run unless
+# `i_really_mean_it=true` is passed. A dry run deletes nothing, so there the cap
+# is reported as a warning annotation and the job stays green.
 
 name: Remove stale environments
 

--- a/.github/workflows/remove-stale-environments.yml
+++ b/.github/workflows/remove-stale-environments.yml
@@ -22,15 +22,15 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "If true, only log what would be deleted."
+        description: 'Dry run (dry_run) — "true" only logs what would be deleted; "false" performs the deletions.'
         required: false
         default: "true"
       stale_days:
-        description: "Only delete environments not updated in this many days (0 = ignore age)."
+        description: 'Minimum age (stale_days) — keep environments updated within this many days; "0" ignores age.'
         required: false
         default: "0"
       i_really_mean_it:
-        description: "Allow deleting more than 25 environments in one run."
+        description: 'Lift safety cap (i_really_mean_it) — "true" allows deleting more than 25 environments in one run.'
         required: false
         default: "false"
   schedule:

--- a/documentation/continuous-integration.md
+++ b/documentation/continuous-integration.md
@@ -48,7 +48,7 @@ Common inputs: `stale_days`, `i_really_mean_it`, and (deployments only) `include
 
 Three gotchas:
 
-- Each script refuses to remove more than 25 items in one run; pass `i_really_mean_it=true` to lift that cap.
+- Each script refuses to remove more than 25 items in one run; pass `i_really_mean_it=true` alongside `dry_run=false` to lift that cap and delete. On its own, `i_really_mean_it=true` still deletes nothing, because the run stays a dry run.
   A scheduled dry-run over the cap reports a warning annotation and still succeeds, because it deletes nothing.
   A real run over the cap fails, because the deletions you asked for did not happen.
 - Environment cleanup needs an `ENV_ADMIN_TOKEN` secret with repository Administration read/write for real deletions; without it, dry-runs work but deletions return `403`.

--- a/documentation/continuous-integration.md
+++ b/documentation/continuous-integration.md
@@ -46,8 +46,11 @@ Each runs on a schedule as a dry-run.
 To perform real deletions, dispatch from the Actions UI with `dry_run=false`.
 Common inputs: `stale_days`, `i_really_mean_it`, and (deployments only) `include_production`.
 
-Two gotchas:
+Three gotchas:
 
+- Each script refuses to remove more than 25 items in one run; pass `i_really_mean_it=true` to lift that cap.
+  A scheduled dry-run over the cap reports a warning annotation and still succeeds, because it deletes nothing.
+  A real run over the cap fails, because the deletions you asked for did not happen.
 - Environment cleanup needs an `ENV_ADMIN_TOKEN` secret with repository Administration read/write for real deletions; without it, dry-runs work but deletions return `403`.
 - `include_production=true` extends deployment cleanup to `github-pages` and `demo-develop`. The newest two deployments per environment are always protected as live + rollback target.
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Warn instead of failing when cleanup hits the delete cap

## What

Two changes to the three cleanup workflows and the scripts behind them.

The max-delete safety cap no longer fails a dry run. Selecting more than 25 items now produces a `::warning::` annotation, and the run continues into its usual `[DRY RUN] Would delete: …` listing and finishes green. A real run over the cap is untouched: `ERROR:` on stderr, the full candidate list, exit code 2. The other aborts — an empty branch list, an invalid `stale_days` — stay error-level, because those are real problems.

The four `workflow_dispatch` inputs get descriptions that name the input and spell out its values:

```text
Dry run (dry_run) — "true" only logs what would be deleted; "false" performs the deletions.
Minimum age (stale_days) — keep environments updated within this many days; "0" ignores age.
Include production (include_production) — "true" also cleans the github-pages and demo-develop deployments.
Lift safety cap (i_really_mean_it) — "true" allows deleting more than 25 environments in one run.
```

## Why

Both scheduled cleanups fail every Sunday. `Remove stale environments` runs at 04:00 UTC and `Remove stale deployments` at 05:00, both as dry runs, and both select far more than 25 items: 227 environments and 730 deployments on the run measured for this branch. A dry run deletes nothing, so exiting 2 reports a failure for a job that did exactly what it was asked to do. A weekly red cross that never means anything is a weekly red cross nobody reads, and it hides the runs that do fail.

The input descriptions matter because of what the dispatch dialog actually renders. GitHub uses `description` as the field label and never shows the input name — it only falls back to the name when the description is missing. `If true, only log what would be deleted.` gave no clue which of four boxes it belonged to, or that the box wanted the literal string `true`. The names are also what `documentation/continuous-integration.md` tells you to type for `gh workflow run -f dry_run=false`, so keeping them visible ties the two together.

## How

`enforce_delete_cap()` raised on the cap and the caller turned that into an exit code. It is now `exceeds_delete_cap()`, a predicate, and `main()` decides the severity from `dry_run`: a real run prints the error and returns 2 as before, a dry run warns and falls through to the listing that was already there. The shell script does the same with an early `return` instead of `exit 2`.

A shared `emit_warning()` in `cleanup_common.py`, mirrored in `cleanup_gh_pages_demos.sh`, writes the `::warning title=…::` workflow command when `GITHUB_ACTIONS` is set and a plain `WARNING:` line otherwise, so running the scripts locally stays readable.

The descriptions are single-quoted YAML because they contain `"true"`; Prettier prefers whichever quote needs fewer escapes and agrees. No `type:` was added to any input. Declaring `type: boolean` would render checkboxes, but the workflows branch on `github.event.inputs.dry_run == 'false'`, and a typed boolean sends a JSON boolean the string comparison no longer matches — the step would silently keep passing `--dry-run` and real deletions would never happen. That is worth doing, with the expression rewrite and a dispatch test per workflow, in its own pull request.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11)

## Additional notes

- **Tests.** These scripts have no automated suite; `.github/scripts/test-cleanup-scripts.sh` is a manual harness. Verification was manual and covered every branch: both Python scripts run as real dry runs against this repository emit the annotation on line 1 and exit 0; the real-run path, exercised with the network stubbed and 30 items, still exits 2 with the `ERROR:` line; the gh-pages script against a scratch repository with 30 stale directories warns and exits 0 on `DRY_RUN=true`, exits 2 on `DRY_RUN=false`, and deletes on `DRY_RUN=false I_REALLY_MEAN_IT=true`. `bash -n`, `py_compile` and `prettier --check` all pass, and `check-workflows.yml` runs actionlint over the changed YAML.
- **Still failing on purpose.** The release-triggered run of `Remove stale demo directories` forces `dry_run=false`, so it will keep failing on the cap — and with demos accumulating over a quarter it will hit it every time. That is the existing design: a person decides before a bulk delete. Say so if it should warn and skip instead.
- **Out of scope.** `remove-acceptance-storybook.yml` fails differently: `git rm "demo-$BRANCH_NAME" -r` exits non-zero when the directory was never created, which is what broke its 10 August run. Left alone here.
