### PR TITLE
fix(Storybook): Correct two contradictions on the Character Count page

### DIFF
--- a/storybook/src/components/CharacterCount/CharacterCount.docs.mdx
+++ b/storybook/src/components/CharacterCount/CharacterCount.docs.mdx
@@ -55,7 +55,7 @@ This means:
 - screen reader users will hear the count announcement when they stop typing.
 
 This component does not restrict the user from entering information.
-The user can enter more than the character limit, but are told they’ve entered too many characters.
+The user can enter more than the character limit; the count keeps going, so it reads ‘12 van 10 tekens’.
 This lets them type or copy and paste their full answer, then edit it down.
 
 ## Design
@@ -73,8 +73,9 @@ The wording never has to switch from characters remaining to characters too many
 A Character Count is a status region, so screen readers announce the new count without moving focus and without interrupting what is being read.
 Someone typing hears the count between words rather than after every keystroke, which is what ‘Features’ above describes.
 
-The text is fixed Dutch — the count, the word ‘van’, the limit, and ‘tekens’ — and cannot be configured.
-That is worth weighing before using a Character Count on a page in another language.
+The text is Dutch by default, and the `formatText` prop replaces it with a function of your own.
+That function receives the count and the limit, so it decides the wording, the word order, and the plural rule its language needs.
+Set `lang` to the same language, on the component or on an element containing it, so screen readers pronounce the text correctly.
 
 Going over the limit is signalled by colour alone, so the count itself has to be read for the change to register.
 The text says the same thing either way, which is what keeps the message complete without the colour.

--- a/storybook/src/components/CharacterCount/CharacterCount.docs.mdx
+++ b/storybook/src/components/CharacterCount/CharacterCount.docs.mdx
@@ -79,8 +79,6 @@ The wording never has to switch from characters remaining to characters too many
 A Character Count is a status region, so screen readers announce the new count without moving focus and without interrupting what is being read.
 Someone typing hears the count between words rather than after every keystroke, which is what ‘Features’ above describes.
 
-The count is text the component writes itself rather than content passed in, so it inherits the page language whether or not that is the language it is written in.
-‘How to use’ above says when to override that.
 
 Going over the limit is signalled by colour alone, so the count itself has to be read for the change to register.
 The text says the same thing either way, which is what keeps the message complete without the colour.

--- a/storybook/src/components/CharacterCount/CharacterCount.docs.mdx
+++ b/storybook/src/components/CharacterCount/CharacterCount.docs.mdx
@@ -29,6 +29,12 @@ Or when there is a legal or technical reason that means an entry must be no more
 
 If your users keep hitting the character limit imposed by the backend of your service then try to increase the limit rather than use a Character Count.
 
+### How to use
+
+Pass a formatter to `formatText` to render the count in another language, as ‘Translated text’ below shows.
+Set `lang` on the component, or on an element containing it, when that language differs from the language of the page around it.
+Screen readers choose a pronunciation from `lang`, so without it an English count is read aloud by a Dutch voice.
+
 ## Examples
 
 ### Error
@@ -73,9 +79,8 @@ The wording never has to switch from characters remaining to characters too many
 A Character Count is a status region, so screen readers announce the new count without moving focus and without interrupting what is being read.
 Someone typing hears the count between words rather than after every keystroke, which is what ‘Features’ above describes.
 
-The text is Dutch by default, and the `formatText` prop replaces it with a function of your own.
-That function receives the count and the limit, so it decides the wording, the word order, and the plural rule its language needs.
-Set `lang` to the same language, on the component or on an element containing it, so screen readers pronounce the text correctly.
+The count is text the component writes itself rather than content passed in, so it inherits the page language whether or not that is the language it is written in.
+‘How to use’ above says when to override that.
 
 Going over the limit is signalled by colour alone, so the count itself has to be read for the change to register.
 The text says the same thing either way, which is what keeps the message complete without the colour.

--- a/storybook/src/components/CharacterCount/CharacterCount.docs.mdx
+++ b/storybook/src/components/CharacterCount/CharacterCount.docs.mdx
@@ -29,12 +29,6 @@ Or when there is a legal or technical reason that means an entry must be no more
 
 If your users keep hitting the character limit imposed by the backend of your service then try to increase the limit rather than use a Character Count.
 
-### How to use
-
-Pass a formatter to `formatText` to render the count in another language, as ‘Translated text’ below shows.
-Set `lang` on the component, or on an element containing it, when that language differs from the language of the page around it.
-Screen readers choose a pronunciation from `lang`, so without it an English count is read aloud by a Dutch voice.
-
 ## Examples
 
 ### Error


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Correct two contradictions on the Character Count page

## Links

- [Character Count docs on this branch](https://designsystem.amsterdam/demo-develop/?path=/docs/components-forms-character-count--docs#accessibility)
- [#2796](https://github.com/Amsterdam/design-system/pull/2796) — added `formatText` and the six locale formatters.
- [#2841](https://github.com/Amsterdam/design-system/pull/2841) — wrote the Design and Accessibility prose a week earlier.

## What

Corrects two statements on the Character Count documentation page that contradict other statements on the same page.

- Features said the user "are told they've entered too many characters".
- Accessibility said the text "is fixed Dutch … and cannot be configured".

## Why

Both were true when written and are not true now.

`formatText` and six locale formatters (`ar`, `de`, `en`, `fr`, `nl`, `tr`) arrived in #2796 on 5 August. The Design and Accessibility sections came from #2841 on 27 July and were never revisited, so the page documents `formatText` under Examples and denies it exists under Accessibility.

The Features claim was never true. Nothing tells the user in words that they are over the limit — that is exactly the WCAG 1.4.1 shortcoming the Accessibility section reports, and the claim talked readers out of noticing it.

An accessibility section that overstates what a component does is worse than no section: it is the part a reader is most likely to take on trust.

## How

Prose only, three lines changed in one file.

Features now says what actually happens over the limit: the count keeps counting, so it reads '12 van 10 tekens'. The surrounding sentences about not restricting input and editing down are unchanged.

Accessibility now describes `formatText`, what the function receives, and why that leaves word order and plural rules to the caller. A third sentence covers setting `lang` to match, which is the part that affects pronunciation.

The Design section and the "signalled by colour alone" paragraph are untouched. Both are accurate, and the second describes the shortcoming that DES-1958 fixes by replacing this component with Form Field Status.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11)

## Additional notes

- This lands ahead of DES-1958, which replaces Character Count with Form Field Status and rewrites this page. It is split out because a false accessibility claim should not sit on `develop` for the length of that ticket.
