### PR TITLE
fix(FormFlow): Remove default step counter, fix header a11y bug

### DIFF
--- a/storybook/src/pages/public/FormFlow/FormFlow.docs.mdx
+++ b/storybook/src/pages/public/FormFlow/FormFlow.docs.mdx
@@ -100,10 +100,11 @@ For more information:
 
 ### With a Progress Indicator
 
-Form pages carry no step counter of their own.
-A form that branches cannot state a total it keeps to, so the count drifts from the number of pages a user actually sees.
-A counter also takes up the space right above the question, and it tells users how much is left to give up on.
-Setting expectations is the job of the step list on the landing page: it is written once, on the page where users decide whether to start.
+Form pages typically carry no step counter of their own:
+
+- A form that branches cannot state a total it keeps to, so the count drifts from the number of pages a user actually sees.
+- A counter also takes up the space right above the question, and it tells users how much is left to give up on.
+- Setting expectations is the job of the step list on the landing page: it is written once, on the page where users decide whether to start.
 
 Test the form without an indicator first, and improve the order, type or number of questions before reaching for one.
 Only if users still lose track of where they are, and research on your own form shows an indicator helps, add plain text above the heading:

--- a/storybook/src/pages/public/FormFlow/FormFlow.docs.mdx
+++ b/storybook/src/pages/public/FormFlow/FormFlow.docs.mdx
@@ -36,6 +36,11 @@ Use a [Product Page](/docs/pages-public-product-page--docs) to explain the task 
 
 Ask one thing per page, and write each question as the label or legend rather than as a separate sentence above it.
 
+### Showing progress
+
+Do not put a step counter such as ‘Stap 2 van 5’ on form pages by default.
+List the steps on the landing page instead, and read [With a Progress Indicator](#with-a-progress-indicator) before adding one anyway.
+
 ## Variants
 
 ### Landing Page
@@ -92,6 +97,25 @@ For more information:
 
 - [Recover from validation errors](https://design-system.service.gov.uk/patterns/validation/)
 - [Error summary](https://design-system.service.gov.uk/components/error-summary/)
+
+### With a Progress Indicator
+
+Form pages carry no step counter of their own.
+A form that branches cannot state a total it keeps to, so the count drifts from the number of pages a user actually sees.
+A counter also takes up the space right above the question, and it tells users how much is left to give up on.
+Setting expectations is the job of the step list on the landing page: it is written once, on the page where users decide whether to start.
+
+Test the form without an indicator first, and improve the order, type or number of questions before reaching for one.
+Only if users still lose track of where they are, and research on your own form shows an indicator helps, add plain text above the heading:
+
+```tsx
+<Paragraph className="ams-mb-m">Stap 2 van 5: Uw gegevens</Paragraph>
+```
+
+Keep it plain, and state a total only for a form that asks every user the same questions in the same order.
+Leave the total out when the route varies: ‘Stap 2’ on its own stays true.
+
+For more information, see [Question pages - Using progress indicators](https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators).
 
 ## Accessibility
 

--- a/storybook/src/pages/public/FormFlow/FormFlow.docs.mdx
+++ b/storybook/src/pages/public/FormFlow/FormFlow.docs.mdx
@@ -98,7 +98,7 @@ For more information:
 - [Recover from validation errors](https://design-system.service.gov.uk/patterns/validation/)
 - [Error summary](https://design-system.service.gov.uk/components/error-summary/)
 
-### With a Progress Indicator
+### With a progress indicator
 
 Form pages typically carry no step counter of their own:
 

--- a/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
+++ b/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
@@ -194,14 +194,12 @@ export const SingleQuestion: StoryObj = {
   <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
-       * The aria-hidden heading stays out of the heading hierarchy, and aria-labelledby re-exposes its text as the
-       * header’s accessible name. That is not a labelled section, though: a header inside main is no landmark –
-       * Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is prohibited
-       * and dropped. Label a landmark instead when a named section is what you need.
+       * The task name is a caption, not a heading: the question below is the level 1 heading. A heading here
+       * would either sit above that h1 in the hierarchy, or need aria-hidden to stay out of it, which takes the
+       * name away from screen reader users. A paragraph keeps it available to everyone. The b tag only offsets it
+       * visually – it carries no emphasis, so nothing changes for a screen reader.
        */}
-      <header aria-labelledby="form-header" className="ams-mb-m">
-        <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
-      </header>
+      <Paragraph className="ams-mb-m"><b>Afspraak maken</b></Paragraph>
       {/*
        * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
        * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
@@ -263,16 +261,14 @@ export const SingleQuestion: StoryObj = {
       <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * The aria-hidden heading stays out of the heading hierarchy, and aria-labelledby re-exposes its text as
-           * the header’s accessible name. That is not a labelled section, though: a header inside main is no landmark
-           * – Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is
-           * prohibited and dropped. Label a landmark instead when a named section is what you need.
+           * The task name is a caption, not a heading: the question below is the level 1 heading. A heading here
+           * would either sit above that h1 in the hierarchy, or need aria-hidden to stay out of it, which takes the
+           * name away from screen reader users. A paragraph keeps it available to everyone. The b tag only offsets it
+           * visually – it carries no emphasis, so nothing changes for a screen reader.
            */}
-          <header aria-labelledby="form-header" className="ams-mb-m">
-            <Heading aria-hidden id="form-header" level={2} size="level-4">
-              Afspraak maken
-            </Heading>
-          </header>
+          <Paragraph className="ams-mb-m">
+            <b>Afspraak maken</b>
+          </Paragraph>
           {/*
            * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
            * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
@@ -344,14 +340,12 @@ export const SingleQuestionWithSubquestions: StoryObj = {
   <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
     <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
       {/*
-       * The aria-hidden heading stays out of the heading hierarchy, and aria-labelledby re-exposes its text as the
-       * header’s accessible name. That is not a labelled section, though: a header inside main is no landmark –
-       * Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is prohibited
-       * and dropped. Label a landmark instead when a named section is what you need.
+       * The task name is a caption, not a heading: the question below is the level 1 heading. A heading here
+       * would either sit above that h1 in the hierarchy, or need aria-hidden to stay out of it, which takes the
+       * name away from screen reader users. A paragraph keeps it available to everyone. The b tag only offsets it
+       * visually – it carries no emphasis, so nothing changes for a screen reader.
        */}
-      <header aria-labelledby="form-header" className="ams-mb-m">
-        <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
-      </header>
+      <Paragraph className="ams-mb-m"><b>Afspraak maken</b></Paragraph>
       {/*
        * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
        * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
@@ -427,16 +421,14 @@ export const SingleQuestionWithSubquestions: StoryObj = {
       <Grid as="main" paddingBottom="2x-large" paddingTop="x-large">
         <Grid.Cell span={{ narrow: 4, medium: 6, wide: 7 }} start={{ narrow: 1, medium: 2, wide: 3 }}>
           {/*
-           * The aria-hidden heading stays out of the heading hierarchy, and aria-labelledby re-exposes its text as
-           * the header’s accessible name. That is not a labelled section, though: a header inside main is no landmark
-           * – Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is
-           * prohibited and dropped. Label a landmark instead when a named section is what you need.
+           * The task name is a caption, not a heading: the question below is the level 1 heading. A heading here
+           * would either sit above that h1 in the hierarchy, or need aria-hidden to stay out of it, which takes the
+           * name away from screen reader users. A paragraph keeps it available to everyone. The b tag only offsets it
+           * visually – it carries no emphasis, so nothing changes for a screen reader.
            */}
-          <header aria-labelledby="form-header" className="ams-mb-m">
-            <Heading aria-hidden id="form-header" level={2} size="level-4">
-              Afspraak maken
-            </Heading>
-          </header>
+          <Paragraph className="ams-mb-m">
+            <b>Afspraak maken</b>
+          </Paragraph>
           {/*
            * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
            * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
@@ -701,14 +693,12 @@ export const WithValidationError: StoryObj = {
         headingLevel={2}
       />
       {/*
-       * The aria-hidden heading stays out of the heading hierarchy, and aria-labelledby re-exposes its text as the
-       * header’s accessible name. That is not a labelled section, though: a header inside main is no landmark –
-       * Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is prohibited
-       * and dropped. Label a landmark instead when a named section is what you need.
+       * The task name is a caption, not a heading: the question below is the level 1 heading. A heading here
+       * would either sit above that h1 in the hierarchy, or need aria-hidden to stay out of it, which takes the
+       * name away from screen reader users. A paragraph keeps it available to everyone. The b tag only offsets it
+       * visually – it carries no emphasis, so nothing changes for a screen reader.
        */}
-      <header aria-labelledby="form-header" className="ams-mb-m">
-        <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
-      </header>
+      <Paragraph className="ams-mb-m"><b>Afspraak maken</b></Paragraph>
       {/*
        * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
        * required, and nothing explains why a pattern is not met, so errors are not identified accessibly
@@ -794,16 +784,14 @@ export const WithValidationError: StoryObj = {
             headingLevel={2}
           />
           {/*
-           * The aria-hidden heading stays out of the heading hierarchy, and aria-labelledby re-exposes its text as
-           * the header’s accessible name. That is not a labelled section, though: a header inside main is no landmark
-           * – Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is
-           * prohibited and dropped. Label a landmark instead when a named section is what you need.
+           * The task name is a caption, not a heading: the question below is the level 1 heading. A heading here
+           * would either sit above that h1 in the hierarchy, or need aria-hidden to stay out of it, which takes the
+           * name away from screen reader users. A paragraph keeps it available to everyone. The b tag only offsets it
+           * visually – it carries no emphasis, so nothing changes for a screen reader.
            */}
-          <header aria-labelledby="form-header" className="ams-mb-m">
-            <Heading aria-hidden id="form-header" level={2} size="level-4">
-              Afspraak maken
-            </Heading>
-          </header>
+          <Paragraph className="ams-mb-m">
+            <b>Afspraak maken</b>
+          </Paragraph>
           {/*
            * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
            * required, and nothing explains why a pattern is not met, so errors are not identified accessibly

--- a/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
+++ b/storybook/src/pages/public/FormFlow/FormFlow.stories.tsx
@@ -199,15 +199,8 @@ export const SingleQuestion: StoryObj = {
        * Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is prohibited
        * and dropped. Label a landmark instead when a named section is what you need.
        */}
-      <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
+      <header aria-labelledby="form-header" className="ams-mb-m">
         <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
-        {/*
-         * First test the form without a progress indicator to see whether it is simple enough to go without
-         * one, and try improving the order, type or number of questions first. Only if people still have
-         * difficulty, add a plain indicator like this, and state a total only if you can do so reliably.
-         * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
-         */}
-        <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
       </header>
       {/*
        * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
@@ -275,17 +268,10 @@ export const SingleQuestion: StoryObj = {
            * – Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is
            * prohibited and dropped. Label a landmark instead when a named section is what you need.
            */}
-          <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
+          <header aria-labelledby="form-header" className="ams-mb-m">
             <Heading aria-hidden id="form-header" level={2} size="level-4">
               Afspraak maken
             </Heading>
-            {/*
-             * First test the form without a progress indicator to see whether it is simple enough to go without
-             * one, and try improving the order, type or number of questions first. Only if people still have
-             * difficulty, add a plain indicator like this, and state a total only if you can do so reliably.
-             * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
-             */}
-            <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
           </header>
           {/*
            * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
@@ -363,15 +349,8 @@ export const SingleQuestionWithSubquestions: StoryObj = {
        * Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is prohibited
        * and dropped. Label a landmark instead when a named section is what you need.
        */}
-      <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
+      <header aria-labelledby="form-header" className="ams-mb-m">
         <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
-        {/*
-         * First test the form without a progress indicator to see whether it is simple enough to go without
-         * one, and try improving the order, type or number of questions first. Only if people still have
-         * difficulty, add a plain indicator like this, and state a total only if you can do so reliably.
-         * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
-         */}
-        <Paragraph>Stap 2 van 3: Uw gegevens</Paragraph>
       </header>
       {/*
        * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
@@ -453,17 +432,10 @@ export const SingleQuestionWithSubquestions: StoryObj = {
            * – Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is
            * prohibited and dropped. Label a landmark instead when a named section is what you need.
            */}
-          <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
+          <header aria-labelledby="form-header" className="ams-mb-m">
             <Heading aria-hidden id="form-header" level={2} size="level-4">
               Afspraak maken
             </Heading>
-            {/*
-             * First test the form without a progress indicator to see whether it is simple enough to go without
-             * one, and try improving the order, type or number of questions first. Only if people still have
-             * difficulty, add a plain indicator like this, and state a total only if you can do so reliably.
-             * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
-             */}
-            <Paragraph>Stap 2 van 3: Uw gegevens</Paragraph>
           </header>
           {/*
            * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
@@ -734,15 +706,8 @@ export const WithValidationError: StoryObj = {
        * Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is prohibited
        * and dropped. Label a landmark instead when a named section is what you need.
        */}
-      <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
+      <header aria-labelledby="form-header" className="ams-mb-m">
         <Heading aria-hidden id="form-header" level={2} size="level-4">Afspraak maken</Heading>
-        {/*
-         * First test the form without a progress indicator to see whether it is simple enough to go without
-         * one, and try improving the order, type or number of questions first. Only if people still have
-         * difficulty, add a plain indicator like this, and state a total only if you can do so reliably.
-         * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
-         */}
-        <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
       </header>
       {/*
        * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is
@@ -834,17 +799,10 @@ export const WithValidationError: StoryObj = {
            * – Chromium and WebKit expose the non-landmark sectionheader role, Firefox generic, where a name is
            * prohibited and dropped. Label a landmark instead when a named section is what you need.
            */}
-          <header aria-labelledby="form-header" className="ams-mb-m ams-gap-xs">
+          <header aria-labelledby="form-header" className="ams-mb-m">
             <Heading aria-hidden id="form-header" level={2} size="level-4">
               Afspraak maken
             </Heading>
-            {/*
-             * First test the form without a progress indicator to see whether it is simple enough to go without
-             * one, and try improving the order, type or number of questions first. Only if people still have
-             * difficulty, add a plain indicator like this, and state a total only if you can do so reliably.
-             * See https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators
-             */}
-            <Paragraph>Stap 1 van 3: Afspraak</Paragraph>
           </header>
           {/*
            * Do not rely on HTML5 form validation: in many browsers not every user is told that a field is


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# fix(FormFlow): Remove default step counter, fix header a11y bug

## Links

- [DES-1977](https://gemeente-amsterdam.atlassian.net/browse/DES-1977)
- [Form Flow docs in the branch deploy](https://designsystem.amsterdam/demo-DES-1977-remove-step-counter/?path=/docs/pages-public-form-flow--docs)
- [Single Question story in the branch deploy](https://designsystem.amsterdam/demo-DES-1977-remove-step-counter/?path=/story/pages-public-form-flow--single-question)

## What

- Removed the `Stap X van Y` step counter from the Form Flow example pages (`SingleQuestion`, `SingleQuestionWithSubquestions`, `WithValidationError`).
- Added a `### Showing progress` guideline and a `### With a Progress Indicator` variant section to the Form Flow docs, explaining when a counter is still appropriate and how to add one.
- Replaced the `<header>` / `aria-hidden` `Heading` construct that showed the task name with a plain `Paragraph`.

## Why

An internal team stopped using the step counter pattern: the step number does not always match the number of pages a user sees once a form branches, it takes up space above the question, and GOV.UK's own guidance cautions against using it by default. We often follow GOV.UK's usability research, so the examples should demonstrate the recommended default (no counter, expectations set once on the landing page) rather than showing the counter in most of the example pages.

While removing the counter, the surrounding `<header aria-labelledby="form-header">` construct turned out to have a real accessibility bug. Per the [HTML–ARIA role mapping](https://www.w3.org/TR/html-aria/) and [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/header), a `<header>` nested inside `<main>` (or `article`/`section`/`nav`/`aside`) loses landmark status and takes the `generic` role instead — and MDN states outright that in this state it "cannot be labeled with `aria-label` or `aria-labelledby`". The old markup relied on exactly that, wrapping an `aria-hidden` `Heading` and trying to re-expose its text as the header's name via `aria-labelledby`. That was never valid, so the task name was hidden from screen reader users for no benefit.

## How

- Removed the counter `<Paragraph>` and its explanatory comment from all three affected stories (both the rendered `render` and the mirrored `source.code` string), and dropped the now-unneeded `ams-gap-xs` class from the header.
- Replaced the non-landmark `<header>`/`aria-hidden` `Heading` with `<Paragraph className="ams-mb-m"><b>…</b></Paragraph>`: the task name is a caption, not a heading, so it no longer competes with the page's actual `h1`, and the `<b>` restores the bold appearance without adding emphasis semantics.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

- `MultipleQuestions` still has no task-name caption at all, unlike the other three stories — open question whether to add one there for consistency, left out of this PR's scope.
- It would be good to go through the codebase for more occurrences of the non-landmark a11y issue.


[DES-1977]: https://gemeente-amsterdam.atlassian.net/browse/DES-1977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ