### PR TITLE
fix(Card): Document and demonstrate a Card without a link

### DIFF
--- a/packages/react/src/Card/Card.tsx
+++ b/packages/react/src/Card/Card.tsx
@@ -25,7 +25,7 @@ const CardRoot = forwardRef(({ children, className, ...restProps }: CardProps, r
 CardRoot.displayName = 'Card'
 
 /**
- * A brief section of a heading, some text, and optionally an image, that leads to a related page.
+ * A brief section of a heading, some text, and optionally an image, usually leading to a related page.
  *
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-navigation-card--docs Card docs at Amsterdam Design System}
  */

--- a/packages/react/src/Card/CardHeading.tsx
+++ b/packages/react/src/Card/CardHeading.tsx
@@ -13,7 +13,7 @@ import type { HeadingProps } from '../Heading'
 import { Heading } from '../Heading'
 
 /**
- * The heading within a Card, containing the link to the associated page.
+ * The heading within a Card, containing the link to the associated page if the Card has one.
  *
  * @see {@link https://designsystem.amsterdam/?path=/docs/components-navigation-card--docs Card docs at Amsterdam Design System}
  */

--- a/storybook/src/components/Card/Card.docs.mdx
+++ b/storybook/src/components/Card/Card.docs.mdx
@@ -75,18 +75,27 @@ Set `linkComponent` to integrate with a routing library.
 A Card needs more content than just a title.
 Add a short text and optionally an image and metadata.
 
+A Card does not need a link.
+Use one without a link for a set of blocks that carry the same kind of content and line up in a row, where each names something that has no page of its own.
+
 ### When not to use
 
 This component is not the best option if the target content does not represent an article-like page.
 In that case, use a Heading, a Paragraph and a [Standalone Link](/docs/components-navigation-standalone-link--docs) instead.
+
+Do not use a Card for a block of a heading and a set of links, such as the ones a [Navigation Page](/docs/pages-public-navigation-page--docs) is built from.
+[Prose](/docs/utilities-css-prose--docs) spaces the parts of such a block, and the `article` element of a Card would announce it as a composition of its own.
 
 ### How to use
 
 Card Heading requires a `level`, because there is no sensible default.
 The guidelines for regular [links](/docs/components-navigation-link--docs) and [headings](/docs/components-text-heading--docs) apply.
 
-Give a Card one link and no more.
+Give a Card that leads to a page one link and no more.
 The Card Link covers the whole Card to make it clickable, so a second link inside it would sit underneath and be impossible to click.
+
+Leave a Card without a link plain.
+Nothing about it should suggest that it can be clicked: no hover effect, no pointer cursor, and no arrow beside its title.
 
 ### How to write
 
@@ -124,10 +133,17 @@ For a group of links without a description, use a [Link List](/docs/components-n
 
 <Canvas of={CardStories.TopTasks} />
 
+### Without a link
+
+A Card can present something that has no page of its own, such as the phases of a project.
+Leave the Card Link out; nothing in the Card is then interactive, and the Heading Group still places the Metadata above the heading.
+
+<Canvas of={CardStories.WithoutLink} />
+
 ## Features
 
-The mandatory title of a Card is a link within a Heading.
-The link is made active across the entire area of the Card.
+The title of a Card is mandatory and takes a Heading.
+Where the Card leads to a page, that link sits within the Heading and is made active across the entire area of the Card.
 
 A Card that pairs an image with a Content lays out horizontally once its container is wide enough, and vertically below that.
 
@@ -156,7 +172,7 @@ Stretching the image instead would crop each one differently, according to how f
 ## Accessibility
 
 Visually, Card Heading has the size of a level 3 Heading by default.
-Screen reader users can navigate by heading or by link; a Card supports both because its title is a heading that contains a link.
+Screen reader users can navigate by heading or by link; a Card with a link supports both, because its title is a heading that contains one.
 A screen reader reads the title first, then the rest of the content.
 
 The layer that makes the Card clickable is empty and carries no text, so it adds nothing to the name of the link and is not announced.

--- a/storybook/src/components/Card/Card.docs.mdx
+++ b/storybook/src/components/Card/Card.docs.mdx
@@ -36,7 +36,7 @@ The heading provides screen reader users with enough context.
 
 ### Heading
 
-Contains the name and link of the Card.
+Contains the name of the Card, and its link where the Card has one.
 Accepts all props of a regular [Heading](/docs/components-text-heading--docs).
 Set its `level` to fit the document outline.
 
@@ -152,11 +152,12 @@ A Card that pairs an image with a Content lays out horizontally once its contain
 A Card has no border, no background, and no padding.
 It is a stack of parts with white space between them, so a row of Cards reads as a set of articles rather than as a row of boxes.
 
-The whole Card is made clickable by stretching an invisible layer from the link across it.
+Where a Card has a link, the whole Card is made clickable by stretching an invisible layer from the link across it.
 Only the title is the link, and everything else stays plain content, so the target grows without the accessible name growing with it.
 
-The focus ring is drawn around the entire Card instead of around the title alone, and the link’s own ring is switched off.
+In that case the focus ring is drawn around the entire Card instead of around the title alone, and the link’s own ring is switched off.
 Browsers that cannot express that condition get neither rule, so they still show the ordinary ring on the title rather than nothing at all.
+A Card without any interactive element has neither: no invisible layer, and no focus ring, because nothing inside it can receive focus.
 
 In a Heading Group the Metadata is written after the heading and displayed above it.
 The reading order and the visual order differ on purpose, which is what lets the metadata sit on top while the heading is still what gets read first.

--- a/storybook/src/components/Card/Card.stories.tsx
+++ b/storybook/src/components/Card/Card.stories.tsx
@@ -161,8 +161,9 @@ export const WithoutLink: Story = {
     layout: 'fullscreen',
   },
   render: (args) => (
-    <Grid paddingVertical="x-large">
-      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
+    // The phases run in order, so the Grid is an ordered list and every Cell in it a list item.
+    <Grid as="ol" paddingVertical="x-large">
+      <Grid.Cell as="li" span={{ narrow: 4, medium: 4, wide: 4 }}>
         <Card {...args}>
           <Card.HeadingGroup>
             <Card.Heading level={2}>Ontwerp</Card.Heading>
@@ -174,7 +175,7 @@ export const WithoutLink: Story = {
           </Paragraph>
         </Card>
       </Grid.Cell>
-      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
+      <Grid.Cell as="li" span={{ narrow: 4, medium: 4, wide: 4 }}>
         <Card>
           <Card.HeadingGroup>
             <Card.Heading level={2}>Voorbereiding</Card.Heading>
@@ -185,7 +186,7 @@ export const WithoutLink: Story = {
           </Paragraph>
         </Card>
       </Grid.Cell>
-      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
+      <Grid.Cell as="li" span={{ narrow: 4, medium: 4, wide: 4 }}>
         <Card>
           <Card.HeadingGroup>
             <Card.Heading level={2}>Uitvoering</Card.Heading>

--- a/storybook/src/components/Card/Card.stories.tsx
+++ b/storybook/src/components/Card/Card.stories.tsx
@@ -155,3 +155,48 @@ export const TopTasks: Story = {
     </Grid>
   ),
 }
+
+export const WithoutLink: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: (args) => (
+    <Grid paddingVertical="x-large">
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
+        <Card {...args}>
+          <Card.HeadingGroup>
+            <Card.Heading level={2}>Ontwerp</Card.Heading>
+            <Metadata size="small">2023-2025</Metadata>
+          </Card.HeadingGroup>
+          <Paragraph>
+            Bewoners en ondernemers dachten mee over de inrichting van de straat. Eind 2025 stelde de gemeenteraad het
+            ontwerp vast.
+          </Paragraph>
+        </Card>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
+        <Card>
+          <Card.HeadingGroup>
+            <Card.Heading level={2}>Voorbereiding</Card.Heading>
+            <Metadata size="small">2025-2027</Metadata>
+          </Card.HeadingGroup>
+          <Paragraph>
+            We verleggen kabels en leidingen en vragen de vergunningen aan. De straat blijft in deze periode bereikbaar.
+          </Paragraph>
+        </Card>
+      </Grid.Cell>
+      <Grid.Cell span={{ narrow: 4, medium: 4, wide: 4 }}>
+        <Card>
+          <Card.HeadingGroup>
+            <Card.Heading level={2}>Uitvoering</Card.Heading>
+            <Metadata size="small">2027-2029</Metadata>
+          </Card.HeadingGroup>
+          <Paragraph>
+            De straat gaat open voor de nieuwe riolering en de herinrichting. We werken in vakken van ongeveer 100
+            meter.
+          </Paragraph>
+        </Card>
+      </Grid.Cell>
+    </Grid>
+  ),
+}

--- a/storybook/src/components/Card/Card.test.stories.tsx
+++ b/storybook/src/components/Card/Card.test.stories.tsx
@@ -38,9 +38,23 @@ const NewsCard = () => (
   </Card>
 )
 
+// Without a Card Link there is no ::after overlay and no suppressed focus ring, which is its own visual variant.
+const StaticCard = () => (
+  <Card>
+    <Card.HeadingGroup>
+      <Card.Heading level={3}>Ontwerp</Card.Heading>
+      <Metadata size="small">2023-2025</Metadata>
+    </Card.HeadingGroup>
+    <div>
+      <p>Bewoners en ondernemers dachten mee over de inrichting van de straat.</p>
+    </div>
+  </Card>
+)
+
 /*
  * Both sides of the 36rem container width at which a Card with an image and a Content switches to a
  * horizontal layout. Each Card sits in its own query container, so one snapshot covers both layouts.
+ * The StaticCard has no image, so it never switches layout and needs only one container width.
  */
 export const Test: Story = {
   render: () => (
@@ -53,6 +67,9 @@ export const Test: Story = {
       </div>
       <div className="ams-query-container-inline-size" style={{ inlineSize: '48rem' }}>
         <NewsCard />
+      </div>
+      <div className="ams-query-container-inline-size" style={{ inlineSize: '24rem' }}>
+        <StaticCard />
       </div>
     </div>
   ),


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Document and demonstrate a Card without a link

## Links

- [DES-2004](https://gemeente-amsterdam.atlassian.net/browse/DES-2004)
- [Card docs, "Without a link" example](https://designsystem.amsterdam/demo-DES-2004-card-without-link-example/?path=/docs/components-navigation-card--docs)
- [Without a link story](https://designsystem.amsterdam/demo-DES-2004-card-without-link-example/?path=/story/components-navigation-card--without-link)

## What

Adds a documented example of a Card without a `Card.Link`: three Cards naming the phases of a project, each with a `Card.HeadingGroup` and a `Metadata` tagline, none of them clickable.

Updates the Card guidelines to say a link is optional rather than implied mandatory, and corrects two TSDoc descriptions (`Card`, `Card.Heading`) that stated the link as a certainty.

Explicitly rules out one adjacent case: a heading with a set of links, such as the blocks a Navigation Page is built from. Those stay Prose; a Card would wrap them in an `article` element they don't need.

## Why

`Card` never required a link in code — `Card.Heading` renders fine without a `Card.Link` inside it — but every story used one, and the docs read as though a link were mandatory ("Give a Card one link and no more"). NLDS's own vision on Cards ([discussion 422](https://github.com/orgs/nl-design-system/discussions/422#discussioncomment-17353679)) treats a Card as a structure that may or may not carry a link, and this PR brings our documentation in line with what the component already does.

This grew out of a ticket asking whether our Card should also cover Navigation Page's Link Sections (heading + Link List, no link). It shouldn't: tested that conversion directly against the real CSS and tokens and it regresses spacing, adds unneeded `article` landmarks, and produces a double focus ring when a `LinkList.Link` sits inside a Card without being a `Card.Link`. This PR only adds the case that *did* hold up: a linkless Card for content that has no page of its own.

## How

- `storybook/src/components/Card/Card.stories.tsx`: new `WithoutLink` story, three Cards in a Grid row.
- `storybook/src/components/Card/Card.docs.mdx`: "When to use", "When not to use", "How to use", "Examples", "Features", and "Accessibility" updated to describe the linkless case; explicitly warns against using it for a heading-plus-links block.
- `packages/react/src/Card/Card.tsx` and `CardHeading.tsx`: TSDoc wording no longer states the link as certain.

No changes to `Card`, `CardHeading`, or `CardLink` behaviour — the linkless case already worked.

## Checklist

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [ ] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11)

## Additional notes

- **Draft, experimental.** This is a suggestion for a linkless Card example, not a settled decision — it may change shape or get rejected once the wider "Card as Link vs. Card" question is resolved.
- Feedback wanted specifically on: whether "Without a link" is the right example content (project phases), and whether the "When not to use" line pointing at Navigation Page's Link Sections belongs here or should wait for that decision to land separately.


[DES-2004]: https://gemeente-amsterdam.atlassian.net/browse/DES-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ