### PR TITLE
chore(docs): Reserve the CSS README for CSS-only utilities

### DIFF
--- a/documentation/definition-of-done.md
+++ b/documentation/definition-of-done.md
@@ -113,7 +113,8 @@ New components are created using our Plop templates. Extensions of existing comp
 ## Documentation
 
 - Props are typed with JSDoc descriptions.
-- A component README has been written (documentation in English, example content in Dutch).
+- A CSS-only utility has a README (documentation in English, example content in Dutch).
+  For a component with a React counterpart its TSDoc and Storybook page carry that documentation.
 - Storybook stories exist for all component variants that are relevant to our users.
 - Documentation follows Storybook conventions (Sentence case headings, Title Case component names).
 - Relevant `AGENTS.md` files are updated if conventions, file locations, or tooling changed.

--- a/packages/css/AGENTS.md
+++ b/packages/css/AGENTS.md
@@ -28,6 +28,9 @@ The full coding conventions are in [documentation/coding-conventions.md](documen
 
 ## README
 
+Only a CSS-only utility has one: it has no React component, so its README is the prose its docs page renders through `<Markdown>` in place of a TSDoc.
+A component with a React counterpart is documented in that TSDoc and on its Storybook page, so do not write a README for it.
+
 - Location: `src/components/<name>/README.md`
 - Content: guidelines, usage intent, relevant WCAG requirements.
 - Do **not** enumerate every token or list technical variants exhaustively.
@@ -37,7 +40,7 @@ The full coding conventions are in [documentation/coding-conventions.md](documen
 All CSS directories and file names use `kebab-case` (unlike React's `PascalCase`).
 
 - Component SCSS: `src/components/<name>/<name>.scss`
-- Component README: `src/components/<name>/README.md`
+- Utility README: `src/components/<name>/README.md` (CSS-only utilities only, see above)
 - Shared mixins: `src/common/<name>.scss`
 - Register new components in: `src/components/index.scss` (add `@use "<name>/<name>";`)
 

--- a/storybook/AGENTS.md
+++ b/storybook/AGENTS.md
@@ -8,11 +8,11 @@ These instructions are additive to the root [AGENTS.md](../AGENTS.md). Read that
 
 Most components have three story files in `src/components/<Name>/` (some may also have subcomponent story files):
 
-| File                      | Purpose                                      |
-| ------------------------- | -------------------------------------------- |
-| `<Name>.docs.mdx`         | Documentation page; imports the CSS README   |
-| `<Name>.stories.tsx`      | Usage examples for all relevant variants     |
-| `<Name>.test.stories.tsx` | Visual, interaction, and accessibility tests |
+| File                      | Purpose                                         |
+| ------------------------- | ----------------------------------------------- |
+| `<Name>.docs.mdx`         | Documentation page; renders the TSDoc rationale |
+| `<Name>.stories.tsx`      | Usage examples for all relevant variants        |
+| `<Name>.test.stories.tsx` | Visual, interaction, and accessibility tests    |
 
 Meta title format: `Components/<Category>/<Component Name>`
 
@@ -44,6 +44,9 @@ See [documentation/component-docs.md](../documentation/component-docs.md) for th
 
 A page template under `src/pages/` opens its docs page with an Anatomy section instead: a schematic of the page, read from the story itself.
 See [documentation/page-anatomy.md](../documentation/page-anatomy.md) for how to add one.
+
+A CSS-only utility under `src/utilities/` has no TSDoc to read from.
+Its docs page imports the README from the CSS package and renders it with `<Markdown>{README}</Markdown>` in place of `<Title />` and `<Description />`.
 
 ## Visual tests (Chromatic)
 


### PR DESCRIPTION
<!-- @license CC0-1.0 -->

# Reserve the CSS README for CSS-only utilities

## Links

- [DES-2006](https://gemeente-amsterdam.atlassian.net/browse/DES-2006)
- [#2672](https://github.com/Amsterdam/design-system/pull/2672) – the PR that removed the component READMEs and left these rules behind
- [documentation/component-docs.md](https://github.com/Amsterdam/design-system/blob/develop/documentation/component-docs.md) – already described the rule correctly and served as the reference wording

No Storybook links: this PR changes contributor documentation only, so nothing renders differently in the branch deploy.

## What

Three files told contributors that every CSS component needs a `README.md`. None of them does, and none has since June. This PR makes the instructions say what the repository actually does.

- `packages/css/AGENTS.md` – the `## README` section now opens by scoping the rule to CSS-only utilities, and the file-locations table row is renamed from "Component README" to "Utility README".
- `documentation/definition-of-done.md` – the checklist item is split: a utility needs a README, a component with a React counterpart does not.
- `storybook/AGENTS.md` – the story files table claimed a component's `<Name>.docs.mdx` "imports the CSS README". It renders the TSDoc rationale instead. A new paragraph under `## Docs` covers the utility case.

`documentation/component-docs.md` is untouched. It already described this correctly.

## Why

[#2672](https://github.com/Amsterdam/design-system/pull/2672) removed 121 obsolete component READMEs from the CSS and React packages on 10 June 2026, but changed none of the rules that require them. The instructions have contradicted the repository ever since.

That contradiction is not theoretical. It surfaced during review of the Data Summary branch, where Copilot correctly cited `packages/css/AGENTS.md:29-33` and `documentation/definition-of-done.md:113-117` to ask for a README that, by current practice, should not exist. Following the written rule produced a file that had to be removed again.

The rule is being written to match practice rather than the other way around: an audit of all 74 CSS component directories found no component in need of one.

## How

The seven CSS components that still have a README are exactly the seven directories under `storybook/src/utilities/`:

| CSS component | Storybook utility |
| ------------- | ----------------- |
| `aspect-ratio` | `AspectRatio` |
| `body` | `Body` |
| `gap` | `Gap` |
| `margin` | `Margin` |
| `prose` | `Prose` |
| `query-container` | `QueryContainer` |
| `visually-hidden` | `VisuallyHidden` |

A one-to-one match, and the reason is structural rather than coincidental. A utility has no React component, so there is no TSDoc for `<Title />` and `<Description />` to read. Its docs page imports the README with `?raw` and renders it through `<Markdown>` in its place. The other 67 components have a React counterpart and are documented in that TSDoc and on their Storybook page, so a README would be a second place to keep the same prose current.

Two commits, one per statement being corrected: the README requirement itself, then the claim about what a docs page renders.

## Checklist

Before submitting your pull request, please ensure you have done the following. Check each checkmark if you have done so or if it wasn't necessary:

- [x] Add or update unit tests
- [x] Add or update documentation
- [x] Add or update stories
- [x] Add or update exports in index.\* files
- [x] Comment `/chromatic test` and verify visual regression tests pass
- [x] Start the PR title with a Conventional Commit prefix, [as explained here](https://github.com/Amsterdam/design-system/blob/main/documentation/publishing.md?plain=1#L11).

## Additional notes

**Type is `chore`, branch group is `fix`.** `publishing.md` puts "documentation that isn't about a component" under `chore`, and these three files are contributor instructions with no consumer-visible impact, so no package needs a patch release.

**`AGENTS.md` is in `.prettierignore`** (line 25), so the story files table in `storybook/AGENTS.md` was re-padded by hand. All five rows are 79 characters. That padding is why the hunk looks larger than it is: only the `docs.mdx` cell text actually changed.

**No follow-up work.** The seven utility READMEs stay, the other 67 components stay without one, and nothing needs to be written or deleted as a result of this PR. `plopfile.mjs` already scaffolds no README for a new component, so the generator was correct all along.


[DES-2006]: https://gemeente-amsterdam.atlassian.net/browse/DES-2006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ