### PR TITLE
chore(Storybook, docs): State WCAG 2.2 Level AA as the accessibility target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ Creating files by hand means following the naming table above and each package's
 
 ## Documentation, tests, and accessibility
 
+- Accessibility standard we target: [accessibility.docs.mdx](storybook/src/docs/guidelines/accessibility.docs.mdx) — WCAG 2.2 Level AA; link success criteria to `https://www.w3.org/TR/WCAG22/#…`, never to another version or to the editor’s draft.
 - Quality checklist, including WCAG 2.2 Level AA: [definition-of-done.md](documentation/definition-of-done.md) — cross-check it before submitting work.
 - Testing: [tests.md](documentation/tests.md)
 - Component docs: [component-docs.md](documentation/component-docs.md) and [storybook.md](documentation/storybook.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Creating files by hand means following the naming table above and each package's
 
 ## Documentation, tests, and accessibility
 
-- Accessibility standard we target: [accessibility.docs.mdx](storybook/src/docs/guidelines/accessibility.docs.mdx) — WCAG 2.2 Level AA; link success criteria to `https://www.w3.org/TR/WCAG22/#…`, never to another version or to the editor’s draft.
+- Accessibility standard we target: [accessibility.docs.mdx](storybook/src/docs/guidelines/accessibility.docs.mdx) — WCAG 2.2 Level AA; do not cite individual success criteria in component documentation.
 - Quality checklist covering accessibility, tests, clean implementation, documentation, and licensing: [definition-of-done.md](documentation/definition-of-done.md) — cross-check it before submitting work.
 - Testing: [tests.md](documentation/tests.md)
 - Component docs: [component-docs.md](documentation/component-docs.md) and [storybook.md](documentation/storybook.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Creating files by hand means following the naming table above and each package's
 ## Documentation, tests, and accessibility
 
 - Accessibility standard we target: [accessibility.docs.mdx](storybook/src/docs/guidelines/accessibility.docs.mdx) — WCAG 2.2 Level AA; link success criteria to `https://www.w3.org/TR/WCAG22/#…`, never to another version or to the editor’s draft.
-- Quality checklist, including WCAG 2.2 Level AA: [definition-of-done.md](documentation/definition-of-done.md) — cross-check it before submitting work.
+- Quality checklist covering accessibility, tests, clean implementation, documentation, and licensing: [definition-of-done.md](documentation/definition-of-done.md) — cross-check it before submitting work.
 - Testing: [tests.md](documentation/tests.md)
 - Component docs: [component-docs.md](documentation/component-docs.md) and [storybook.md](documentation/storybook.md)
 - Page templates: [page-anatomy.md](documentation/page-anatomy.md)

--- a/documentation/component-docs.md
+++ b/documentation/component-docs.md
@@ -71,10 +71,7 @@ Sections are optional: omit any section that has no meaningful content for the c
    Pair with a Canvas where the feature is visual.
 7. **Design** – notable visual or interaction decisions worth explaining.
    Pair with a Canvas where the decision is visual.
-8. **Accessibility** – what the component does to meet accessibility requirements: the ARIA roles and patterns it implements, how it handles keyboard interaction, and which WCAG criteria it addresses.
-   Link each success criterion to the WCAG 2.2 Recommendation, `https://www.w3.org/TR/WCAG22/#…`, so every reference points at the version we target – see the [Accessibility guideline](https://designsystem.amsterdam/?path=/docs/docs-guidelines-accessibility--docs).
-   Mention the level of a criterion above Level AA, so readers can tell it apart from what conformance requires.
-   Omit the section if there is nothing meaningful to say.
+8. **Accessibility** – what the component does to meet accessibility requirements: the ARIA roles and patterns it implements, and how it handles keyboard interaction.
 9. **See also** – a short bullet list of links to alternatives or companions.
    Each bullet ends with a one-line reason.
 10. **Design tokens** – the auto-generated table via `<DesignTokensTable tokens={tokens} />`.

--- a/documentation/component-docs.md
+++ b/documentation/component-docs.md
@@ -72,6 +72,8 @@ Sections are optional: omit any section that has no meaningful content for the c
 7. **Design** – notable visual or interaction decisions worth explaining.
    Pair with a Canvas where the decision is visual.
 8. **Accessibility** – what the component does to meet accessibility requirements: the ARIA roles and patterns it implements, how it handles keyboard interaction, and which WCAG criteria it addresses.
+   Link each success criterion to the WCAG 2.2 Recommendation, `https://www.w3.org/TR/WCAG22/#…`, so every reference points at the version we target – see the [Accessibility guideline](https://designsystem.amsterdam/?path=/docs/docs-guidelines-accessibility--docs).
+   Mention the level of a criterion above Level AA, so readers can tell it apart from what conformance requires.
    Omit the section if there is nothing meaningful to say.
 9. **See also** – a short bullet list of links to alternatives or companions.
    Each bullet ends with a one-line reason.

--- a/documentation/definition-of-done.md
+++ b/documentation/definition-of-done.md
@@ -8,6 +8,8 @@
 
 #### Required accessibility checks
 
+These checks are how we meet [WCAG 2.2 Level AA](https://designsystem.amsterdam/?path=/docs/docs-guidelines-accessibility--docs), the version and level the design system targets.
+
 - Focus outline is visible for interactive components.
 - Content does not overflow or get cut off on smaller screens.
 - Native pointer (mouse), keyboard, and touch interactions work. For example, you can tab to interactive elements and you can pinch to zoom.

--- a/documentation/definition-of-done.md
+++ b/documentation/definition-of-done.md
@@ -8,7 +8,7 @@
 
 #### Required accessibility checks
 
-These checks are how we meet [WCAG 2.2 Level AA](https://designsystem.amsterdam/?path=/docs/docs-guidelines-accessibility--docs), the version and level the design system targets.
+These checks are part of how we meet [WCAG 2.2 Level AA](https://designsystem.amsterdam/?path=/docs/docs-guidelines-accessibility--docs), the version and level the design system targets.
 
 - Focus outline is visible for interactive components.
 - Content does not overflow or get cut off on smaller screens.

--- a/documentation/tests.md
+++ b/documentation/tests.md
@@ -51,7 +51,7 @@ The visual tests can be found in the test story `component.test.stories.tsx`, wh
 Accessibility tests are not configured on a component basis.
 The accessibility rules that the component should follow are the default ones from Storybook.
 These automated rules cover part of [WCAG 2.2 Level AA](https://designsystem.amsterdam/?path=/docs/docs-guidelines-accessibility--docs).
-The manual checks in [the definition of done](definition-of-done.md) cover the rest.
+[The definition of done](definition-of-done.md) adds manual checks for more of it.
 
 ## How we test
 

--- a/documentation/tests.md
+++ b/documentation/tests.md
@@ -48,7 +48,7 @@ The visual tests can be found in the test story `component.test.stories.tsx`, wh
 | Principle | Make sure that there are no changes which worsen the accessibility of the component. |
 | Example   | Is the contrast still high enough?                                                   |
 
-Accessibility tests are not configured on a component basis. The accessibility rules that the component should follow are the default ones from Storybook.
+Accessibility tests are not configured on a component basis. The accessibility rules that the component should follow are the default ones from Storybook. These automated rules cover part of [WCAG 2.2 Level AA](https://designsystem.amsterdam/?path=/docs/docs-guidelines-accessibility--docs); the manual checks in [the definition of done](definition-of-done.md) cover the rest.
 
 ## How we test
 

--- a/documentation/tests.md
+++ b/documentation/tests.md
@@ -48,7 +48,10 @@ The visual tests can be found in the test story `component.test.stories.tsx`, wh
 | Principle | Make sure that there are no changes which worsen the accessibility of the component. |
 | Example   | Is the contrast still high enough?                                                   |
 
-Accessibility tests are not configured on a component basis. The accessibility rules that the component should follow are the default ones from Storybook. These automated rules cover part of [WCAG 2.2 Level AA](https://designsystem.amsterdam/?path=/docs/docs-guidelines-accessibility--docs); the manual checks in [the definition of done](definition-of-done.md) cover the rest.
+Accessibility tests are not configured on a component basis.
+The accessibility rules that the component should follow are the default ones from Storybook.
+These automated rules cover part of [WCAG 2.2 Level AA](https://designsystem.amsterdam/?path=/docs/docs-guidelines-accessibility--docs).
+The manual checks in [the definition of done](definition-of-done.md) cover the rest.
 
 ## How we test
 

--- a/packages/css/AGENTS.md
+++ b/packages/css/AGENTS.md
@@ -29,7 +29,7 @@ The full coding conventions are in [documentation/coding-conventions.md](documen
 ## README
 
 - Location: `src/components/<name>/README.md`
-- Content: guidelines, usage intent, relevant WCAG requirements.
+- Content: guidelines, usage intent, what the component does for accessibility.
 - Do **not** enumerate every token or list technical variants exhaustively.
 
 ## File locations

--- a/storybook/config/preview.tsx
+++ b/storybook/config/preview.tsx
@@ -257,6 +257,7 @@ export const parameters = {
             'Getting started',
             'Release policy',
             'Browser support',
+            'Accessibility',
             'Modes',
             'Responsive design',
             'Spacing',

--- a/storybook/src/docs/guidelines/accessibility.docs.mdx
+++ b/storybook/src/docs/guidelines/accessibility.docs.mdx
@@ -10,7 +10,7 @@ We build and test every component against WCAG 2.2 Level AA.
 Target that same version and level in what you build with the design system: our components carry part of the work, the rest depends on how you compose and fill them.
 
 The [Wet Digitale Overheid](https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/wetgeving/wet-digitale-overheid-wdo/#v4) obliges government websites to meet WCAG 2.1 Level AA, and [the City’s standard for developers](https://developers.amsterdam/docs/frontend/accessibility) names that version as well.
-WCAG 2.2 carries every success criterion of 2.1 Level AA forward unchanged and adds a handful more, so meeting 2.2 Level AA meets that obligation too.
+[WCAG 2.2](https://www.w3.org/TR/WCAG22/) contains every success criterion of 2.1 and adds a few more.
 
 **Note**: Version 2.2 does drop one criterion that 2.1 lists: 4.1.1 Parsing, removed because browsers and assistive technology recover from the markup errors it described.
 Our components use valid, semantic HTML regardless, so that removal changes nothing about what we build.

--- a/storybook/src/docs/guidelines/accessibility.docs.mdx
+++ b/storybook/src/docs/guidelines/accessibility.docs.mdx
@@ -10,11 +10,9 @@ We build and test every component against WCAG 2.2 Level AA.
 Target that same version when building with the design system: our components carry part of the work, the rest depends on how you compose and fill them.
 
 The [Wet Digitale Overheid](https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/wetgeving/wet-digitale-overheid-wdo/#v4) obliges government websites to meet WCAG 2.1 Level AA, and [the City’s standard for developers](https://developers.amsterdam/docs/frontend/accessibility) names that version as well.
-[WCAG 2.2](https://www.w3.org/TR/WCAG22/) contains every success criterion of 2.1 and adds a few more.
+[WCAG 2.2](https://www.w3.org/TR/WCAG22/) adds a few success criteria to 2.1 and drops only one, 4.1.1 Parsing, that browsers made obsolete.
+Because our components use valid HTML we meet the legal obligation of 2.1.
 
-**Note**: Version 2.2 does drop one criterion that 2.1 lists: 4.1.1 Parsing, removed because browsers and assistive technology recover from the markup errors it described.
-Our components use valid, semantic HTML regardless, so that removal changes nothing about what we build.
-
-Accessibility tests run on every component in [Chromatic](https://chromatic.com) with each pull request, and the [definition of done](https://github.com/Amsterdam/design-system/blob/develop/documentation/definition-of-done.md) lists the checks we do by hand, such as screen readers, zoom, and forced colours.
-Automated rules only catch a fraction of what the standard asks of you, so the manual checks are where most of the conformance is won.
-If a component of ours falls short, please [report it](https://github.com/Amsterdam/design-system/issues) so we can address it.
+Accessibility tests run on every component in [Chromatic](https://chromatic.com) with each pull request.
+They catch only part of what the standard asks, so the [definition of done](https://github.com/Amsterdam/design-system/blob/develop/documentation/definition-of-done.md) adds checks we do by hand: screen readers, zoom, and forced colours.
+[Report a component that falls short](https://github.com/Amsterdam/design-system/issues) so we can fix it.

--- a/storybook/src/docs/guidelines/accessibility.docs.mdx
+++ b/storybook/src/docs/guidelines/accessibility.docs.mdx
@@ -7,7 +7,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 # Accessibility
 
 We build and test every component against WCAG 2.2 Level AA.
-Target that same version and level in what you build with the design system: our components carry part of the work, the rest depends on how you compose and fill them.
+Target that same version when building with the design system: our components carry part of the work, the rest depends on how you compose and fill them.
 
 The [Wet Digitale Overheid](https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/wetgeving/wet-digitale-overheid-wdo/#v4) obliges government websites to meet WCAG 2.1 Level AA, and [the City’s standard for developers](https://developers.amsterdam/docs/frontend/accessibility) names that version as well.
 [WCAG 2.2](https://www.w3.org/TR/WCAG22/) contains every success criterion of 2.1 and adds a few more.

--- a/storybook/src/docs/guidelines/accessibility.docs.mdx
+++ b/storybook/src/docs/guidelines/accessibility.docs.mdx
@@ -6,7 +6,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 # Accessibility
 
-We build and test every component against [WCAG 2.2](https://www.w3.org/TR/WCAG22/) Level AA.
+We build and test every component against WCAG 2.2 Level AA.
 Target that same version and level in what you build with the design system: our components carry part of the work, the rest depends on how you compose and fill them.
 
 The [Wet Digitale Overheid](https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/wetgeving/wet-digitale-overheid-wdo/#v4) obliges government websites to meet WCAG 2.1 Level AA, and [the City’s standard for developers](https://developers.amsterdam/docs/frontend/accessibility) names that version as well.

--- a/storybook/src/docs/guidelines/accessibility.docs.mdx
+++ b/storybook/src/docs/guidelines/accessibility.docs.mdx
@@ -1,0 +1,21 @@
+{/* @license CC0-1.0 */}
+
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Docs/Guidelines/Accessibility" />
+
+# Accessibility
+
+We build and test every component against [WCAG 2.2](https://www.w3.org/TR/WCAG22/) Level AA.
+Target that same version and level in what you build with the design system: our components carry part of the work, the rest depends on how you compose and fill them.
+
+The [Wet Digitale Overheid](https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/wetgeving/wet-digitale-overheid-wdo/#v4) obliges government websites to meet WCAG 2.1 Level AA, and [the City’s standard for developers](https://developers.amsterdam/docs/frontend/accessibility) names that version as well.
+WCAG 2.2 carries every success criterion of 2.1 Level AA forward unchanged and adds a handful more, so meeting 2.2 Level AA meets that obligation too.
+We aim at the newer version because those additions – among them a focus indicator that stays visible, and forms that ask less of memory and dexterity – reach people the older version leaves out.
+
+**Note**: Version 2.2 does drop one criterion that 2.1 lists: 4.1.1 Parsing, removed because browsers and assistive technology recover from the markup errors it described.
+Our components use valid, semantic HTML regardless, so that removal changes nothing about what we build.
+
+Accessibility tests run on every component in [Chromatic](https://chromatic.com) with each pull request, and the [definition of done](https://github.com/Amsterdam/design-system/blob/develop/documentation/definition-of-done.md) lists the checks we do by hand, such as screen readers, zoom, and forced colours.
+Automated rules only catch a fraction of what the standard asks of you, so the manual checks are where most of the conformance is won.
+If a component of ours falls short, please [report it](https://github.com/Amsterdam/design-system/issues) so we can address it.

--- a/storybook/src/docs/guidelines/accessibility.docs.mdx
+++ b/storybook/src/docs/guidelines/accessibility.docs.mdx
@@ -11,7 +11,6 @@ Target that same version and level in what you build with the design system: our
 
 The [Wet Digitale Overheid](https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/wetgeving/wet-digitale-overheid-wdo/#v4) obliges government websites to meet WCAG 2.1 Level AA, and [the City’s standard for developers](https://developers.amsterdam/docs/frontend/accessibility) names that version as well.
 WCAG 2.2 carries every success criterion of 2.1 Level AA forward unchanged and adds a handful more, so meeting 2.2 Level AA meets that obligation too.
-We aim at the newer version because those additions – among them a focus indicator that stays visible, and forms that ask less of memory and dexterity – reach people the older version leaves out.
 
 **Note**: Version 2.2 does drop one criterion that 2.1 lists: 4.1.1 Parsing, removed because browsers and assistive technology recover from the markup errors it described.
 Our components use valid, semantic HTML regardless, so that removal changes nothing about what we build.

--- a/storybook/src/docs/guidelines/accessibility.docs.mdx
+++ b/storybook/src/docs/guidelines/accessibility.docs.mdx
@@ -13,5 +13,5 @@ The [Wet Digitale Overheid](https://www.digitaleoverheid.nl/overzicht-van-alle-o
 [WCAG 2.2](https://www.w3.org/TR/WCAG22/#backwards-compatibility) is backwards compatible with 2.1, so meeting it also meets that legal minimum.
 
 Accessibility tests run in [Chromatic](https://chromatic.com) on every component with a Test story, with each pull request.
-They catch only part of what the standard asks, so the [definition of done](https://github.com/Amsterdam/design-system/blob/develop/documentation/definition-of-done.md) adds checks we do by hand: screen readers, zoom, and forced colours.
+They catch only part of what the standard asks, so the [definition of done](https://github.com/Amsterdam/design-system/blob/develop/documentation/definition-of-done.md) adds checks we do by hand, including screen readers, zoom, and forced colours.
 [Report a component that falls short](https://github.com/Amsterdam/design-system/issues) so we can fix it.

--- a/storybook/src/docs/guidelines/accessibility.docs.mdx
+++ b/storybook/src/docs/guidelines/accessibility.docs.mdx
@@ -10,9 +10,8 @@ We build and test every component against WCAG 2.2 Level AA.
 Target that same version when building with the design system: our components carry part of the work, the rest depends on how you compose and fill them.
 
 The [Wet Digitale Overheid](https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/wetgeving/wet-digitale-overheid-wdo/#v4) obliges government websites to meet WCAG 2.1 Level AA, and [the City’s standard for developers](https://developers.amsterdam/docs/frontend/accessibility) names that version as well.
-[WCAG 2.2](https://www.w3.org/TR/WCAG22/) adds a few success criteria to 2.1 and drops only one, 4.1.1 Parsing, that browsers made obsolete.
-Because our components use valid HTML we meet the legal obligation of 2.1.
+[WCAG 2.2](https://www.w3.org/TR/WCAG22/#backwards-compatibility) is backwards compatible with 2.1, so meeting it also meets that legal minimum.
 
-Accessibility tests run on every component in [Chromatic](https://chromatic.com) with each pull request.
+Accessibility tests run in [Chromatic](https://chromatic.com) on every component with a Test story, with each pull request.
 They catch only part of what the standard asks, so the [definition of done](https://github.com/Amsterdam/design-system/blob/develop/documentation/definition-of-done.md) adds checks we do by hand: screen readers, zoom, and forced colours.
 [Report a component that falls short](https://github.com/Amsterdam/design-system/issues) so we can fix it.

--- a/storybook/src/docs/guidelines/interactivity.docs.mdx
+++ b/storybook/src/docs/guidelines/interactivity.docs.mdx
@@ -35,7 +35,7 @@ Colour should not be the only indicator of interactivity so that people with dif
 ### Relevant WCAG requirements
 
 - [WCAG 1.4.1](https://www.w3.org/TR/WCAG22/#use-of-color): colour should not be the only way to indicate that something is interactive
-- [WCAG 1.4.3](https://www.w3.org/TR/WCAG21/#contrast-minimum): text has sufficient contrast with the background
+- [WCAG 1.4.3](https://www.w3.org/TR/WCAG22/#contrast-minimum): text has sufficient contrast with the background
 
 ## Format
 
@@ -43,7 +43,7 @@ Interactive elements are at least 24 by 24 pixels in size, so they are easy to u
 
 ### Relevant WCAG requirements
 
-- [WCAG 2.5.8](https://w3c.github.io/wcag/guidelines/22/#target-size-minimum): interactive elements are at least 24 by 24 pixels in size
+- [WCAG 2.5.8](https://www.w3.org/TR/WCAG22/#target-size-minimum): interactive elements are at least 24 by 24 pixels in size
 
 ## Focus indicator
 
@@ -57,8 +57,8 @@ When setting up a page, ensure that the interactive elements are in a logical or
 - [WCAG 2.4.3](https://www.w3.org/TR/WCAG22/#focus-order): interactive elements have a logical focus / tabbing order
 - [WCAG 2.4.7](https://www.w3.org/TR/WCAG22/#focus-visible): the focus indicator is visible
 - [WCAG 2.4.11](https://www.w3.org/TR/WCAG22/#focus-not-obscured-minimum): the focus indicator is not completely hidden by content
-- [WCAG 2.4.12](https://www.w3.org/TR/WCAG22/#focus-not-obscured-enhanced): the focus indicator is not partially hidden by content
-- [WCAG 2.4.13](https://www.w3.org/TR/WCAG22/#focus-appearance): the focus indicator is at least 2 pixels wide and has sufficient contrast with the element that has focus
+- [WCAG 2.4.12](https://www.w3.org/TR/WCAG22/#focus-not-obscured-enhanced): the focus indicator is not partially hidden by content – Level AAA, beyond the Level AA we target
+- [WCAG 2.4.13](https://www.w3.org/TR/WCAG22/#focus-appearance): the focus indicator is at least 2 pixels wide and has sufficient contrast with the element that has focus – Level AAA, beyond the Level AA we target
 
 ## Focus management
 

--- a/storybook/src/docs/guidelines/interactivity.docs.mdx
+++ b/storybook/src/docs/guidelines/interactivity.docs.mdx
@@ -17,12 +17,6 @@ Don’t use generic text fragments like “Click here” or “Read more” for 
 A more meaningful text helps sighted users scan the page, and screen reader users navigate between links.
 It’s also beneficial to search engines.
 
-### Relevant WCAG requirements
-
-- [WCAG 2.4.4](https://www.w3.org/TR/WCAG22/#link-purpose-in-context): it is clear to users what it means to click on a link
-- [WCAG 2.4.6](https://www.w3.org/TR/WCAG22/#headings-and-labels): use a label to describe interactive elements
-- [WCAG 2.5.3](https://www.w3.org/TR/WCAG22/#label-in-name): the accessible name of an element must contain at least the visible text of the element
-
 ## Colour
 
 To indicate that an element is interactive, we use the colour blue.
@@ -32,18 +26,9 @@ Both colours become darker on hover.
 
 Colour should not be the only indicator of interactivity so that people with difficulty perceiving colour differences can still see that an element is interactive.
 
-### Relevant WCAG requirements
-
-- [WCAG 1.4.1](https://www.w3.org/TR/WCAG22/#use-of-color): colour should not be the only way to indicate that something is interactive
-- [WCAG 1.4.3](https://www.w3.org/TR/WCAG22/#contrast-minimum): text has sufficient contrast with the background
-
 ## Format
 
 Interactive elements are at least 24 by 24 pixels in size, so they are easy to use for a large group of users.
-
-### Relevant WCAG requirements
-
-- [WCAG 2.5.8](https://www.w3.org/TR/WCAG22/#target-size-minimum): interactive elements are at least 24 by 24 pixels in size
 
 ## Focus indicator
 
@@ -51,14 +36,6 @@ We use the standard focus indicator of the web browsers.
 We only adjust the focus outline with an offset of 2 pixels to increase contrast with dark elements.
 
 When setting up a page, ensure that the interactive elements are in a logical order, usually from top to bottom and from left to right.
-
-### Relevant WCAG requirements
-
-- [WCAG 2.4.3](https://www.w3.org/TR/WCAG22/#focus-order): interactive elements have a logical focus / tabbing order
-- [WCAG 2.4.7](https://www.w3.org/TR/WCAG22/#focus-visible): the focus indicator is visible
-- [WCAG 2.4.11](https://www.w3.org/TR/WCAG22/#focus-not-obscured-minimum): the focus indicator is not completely hidden by content
-- [WCAG 2.4.12](https://www.w3.org/TR/WCAG22/#focus-not-obscured-enhanced): the focus indicator is not partially hidden by content – Level AAA, beyond the Level AA we target
-- [WCAG 2.4.13](https://www.w3.org/TR/WCAG22/#focus-appearance): the focus indicator is at least 2 pixels wide and has sufficient contrast with the element that has focus – Level AAA, beyond the Level AA we target
 
 ## Focus management
 

--- a/storybook/src/docs/guidelines/localisation.docs.mdx
+++ b/storybook/src/docs/guidelines/localisation.docs.mdx
@@ -120,7 +120,3 @@ The design system’s own directional icons handle this automatically: each carr
 
 The [Calendar](/docs/components-navigation-calendar--docs) and [Date Picker](/docs/components-forms-date-picker--docs) navigation chevrons are one example.
 When you supply your own directional icon anywhere, give it the same attribute so it mirrors as well.
-
-## Relevant WCAG requirements
-
-- [WCAG 3.1.2](https://www.w3.org/TR/WCAG22/#language-of-parts): indicate the language of any passage or phrase that differs from the page’s default language

--- a/storybook/src/docs/introduction.docs.mdx
+++ b/storybook/src/docs/introduction.docs.mdx
@@ -45,7 +45,7 @@ And once people learn one, they can use them all, while it matters less which de
 ## Accessible to everyone
 
 People can use City services whatever their ability, device, or situation.
-Every component is built and tested to meet accessibility standards (WCAG) from the start.
+Every component is built and tested to meet [WCAG 2.2 Level AA](/docs/docs-guidelines-accessibility--docs) from the start.
 We honour preferences like text size and reduced motion.
 
 ## Built in the open


### PR DESCRIPTION
## Links

- Jira: [DES-2007](https://gemeente-amsterdam.atlassian.net/browse/DES-2007?atlOrigin=eyJpIjoiZWFmOWM2NDFmZDEzNGVlM2JmNWM5ZTdjYWY2ZDkzMDYiLCJwIjoiaiJ9)
- Branch deploy: [Guidelines → Accessibility](https://designsystem.amsterdam/demo-develop/?path=/docs/docs-guidelines-accessibility--docs)
- [Wet Digitale Overheid](https://www.digitaleoverheid.nl/overzicht-van-alle-onderwerpen/wetgeving/wet-digitale-overheid-wdo/#v4) and [the City’s accessibility standard for developers](https://developers.amsterdam/docs/frontend/accessibility), the two sources that set the legal baseline

## What

A new Accessibility page under Guidelines states that we build and test against WCAG 2.2 Level AA, and how that relates to the WCAG 2.1 Level AA the law requires.

Beyond adding that page, this PR removes rather than standardises the scattered WCAG citations elsewhere:

- The Interactivity and Localisation guidelines each had a “Relevant WCAG requirements” section under several headings. Removed: they took upkeep, one held a stale link to the WCAG 2.1 Recommendation and another to an editor’s draft, and readers didn’t follow them anyway.
- The Storybook introduction, the definition of done, and the testing documentation named WCAG without a version. They now name 2.2 and link the new page.
- `component-docs.md` and `AGENTS.md` no longer ask authors to cite WCAG success criteria in a component’s Accessibility section, for the same reason the guideline sections were removed.

**Not included yet due to open discussion:** component docs (`Alert`, `Badge`, `Dialog`, and 14 others) still contain one inline WCAG citation each, left over from before this PR and from the same root cause. Removing those is a bigger edit and it’s still open whether we want it. `AGENTS.md`’s “don’t cite success criteria” rule is therefore already true for new writing but not yet true for existing docs; this PR doesn’t claim otherwise.

## Why

Nowhere in the documentation did we state which version of WCAG we hold ourselves to. The version was only implied, through the spec URL hidden inside citations to individual success criteria — 26 pointed at WCAG 2.2, one at WCAG 2.1, one at an editor’s draft. The one place that did say a version outright was `AGENTS.md`, which agents read and people do not.

Both the Wet Digitale Overheid and our own department’s standard name WCAG 2.1 Level AA, which made the implied 2.2 look like a mistake. It is a deliberate choice, now written down: 2.2 adds a few success criteria to 2.1 and drops one the web platform made obsolete, so targeting it doesn’t create a gap against the legal minimum.

Review also settled a second question along the way: do these per-criterion citations belong in the docs at all? They’re an artefact of the NLDS template this repo forked from, cost upkeep to maintain, and nobody reads them. Once that was raised, correcting 27 links to a canonical URL stopped making sense — removing them did instead.

## How

The new page follows the pattern of the existing Browser support page: state the standard directly, explain the trade-off, done. Registered in `preview.tsx`’s `storySort`, between Browser support and Modes.

## Checklist

- [x] Add or update unit tests (not applicable: documentation only)
- [x] Add or update documentation
- [x] Add or update stories (not applicable: a docs page, no stories)
- [x] Add or update exports in index.\* files (not applicable)
- [ ] Comment `/chromatic test` and verify visual regression tests pass — still to do; the introduction page copy and the sidebar order both changed
- [x] Start the PR title with a Conventional Commit prefix

## Additional notes

- The version decision is a compliance call, not a technical one. This PR implements option B from DES-2007 — target 2.2, on the reasoning above that it doesn’t open a gap against the legal 2.1 minimum.
- The “Not included yet due to open discussion” item above needs a decision before merge, or an explicit call to merge without it and track it separately.


[DES-2007]: https://gemeente-amsterdam.atlassian.net/browse/DES-2007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ